### PR TITLE
update heavy-ops to fix building circuit-synthesizer

### DIFF
--- a/core/bin/circuit_synthesizer/Cargo.lock
+++ b/core/bin/circuit_synthesizer/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 [[package]]
 name = "api"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#ce5ba80e0a046a2351e12766fd2241c6510f0026"
+source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#fda73622aac502ed5944bf135e31a6be9355886b"
 dependencies = [
  "bellman_ce",
  "cfg-if 1.0.0",
@@ -3626,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "prover-service"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#ce5ba80e0a046a2351e12766fd2241c6510f0026"
+source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#fda73622aac502ed5944bf135e31a6be9355886b"
 dependencies = [
  "api",
  "bincode",

--- a/core/bin/prover/Cargo.lock
+++ b/core/bin/prover/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 [[package]]
 name = "api"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#ce5ba80e0a046a2351e12766fd2241c6510f0026"
+source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#fda73622aac502ed5944bf135e31a6be9355886b"
 dependencies = [
  "bellman_ce",
  "cfg-if 1.0.0",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "gpu-ffi"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#ce5ba80e0a046a2351e12766fd2241c6510f0026"
+source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#fda73622aac502ed5944bf135e31a6be9355886b"
 dependencies = [
  "bindgen",
  "crossbeam 0.8.2",
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "gpu-prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#ce5ba80e0a046a2351e12766fd2241c6510f0026"
+source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#fda73622aac502ed5944bf135e31a6be9355886b"
 dependencies = [
  "bit-vec",
  "cfg-if 1.0.0",
@@ -3731,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "prover-service"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#ce5ba80e0a046a2351e12766fd2241c6510f0026"
+source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#fda73622aac502ed5944bf135e31a6be9355886b"
 dependencies = [
  "api",
  "bincode",

--- a/core/bin/setup_key_generator_and_server/Cargo.lock
+++ b/core/bin/setup_key_generator_and_server/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 [[package]]
 name = "api"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#ce5ba80e0a046a2351e12766fd2241c6510f0026"
+source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#fda73622aac502ed5944bf135e31a6be9355886b"
 dependencies = [
  "bellman_ce",
  "cfg-if 1.0.0",
@@ -1483,7 +1483,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "gpu-ffi"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#ce5ba80e0a046a2351e12766fd2241c6510f0026"
+source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#fda73622aac502ed5944bf135e31a6be9355886b"
 dependencies = [
  "bindgen",
  "crossbeam 0.8.2",
@@ -1496,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "gpu-prover"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#ce5ba80e0a046a2351e12766fd2241c6510f0026"
+source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#fda73622aac502ed5944bf135e31a6be9355886b"
 dependencies = [
  "bit-vec",
  "cfg-if 1.0.0",
@@ -2870,7 +2870,7 @@ dependencies = [
 [[package]]
 name = "prover-service"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#ce5ba80e0a046a2351e12766fd2241c6510f0026"
+source = "git+https://github.com/matter-labs/era-heavy-ops-service.git?branch=main#fda73622aac502ed5944bf135e31a6be9355886b"
 dependencies = [
  "api",
  "bincode",


### PR DESCRIPTION
## Fix the below build failure for circuit-synthesizer
```
error[E0412]: cannot find type `OldWorker` in this scope
  --> /home/a_chandrakar_matterlabs_dev/.cargo/git/checkouts/era-heavy-ops-service-54439bd555659c38/ce5ba80/api/src/legacy.rs:7:13
   |
7  |     worker: OldWorker,
   |             ^^^^^^^^^ help: a struct with a similar name exists: `Worker`
   |
  ::: /home/a_chandrakar_matterlabs_dev/.cargo/git/checkouts/bellman-7a75f3b44e91e034/3aa6226/src/multicore.rs:23:1
```