### PR TITLE
Fix a path matching bug

### DIFF
--- a/core/lib/contracts/src/lib.rs
+++ b/core/lib/contracts/src/lib.rs
@@ -147,7 +147,7 @@ pub fn read_sys_contract_bytecode(directory: &str, name: &str, lang: ContractLan
     match lang {
         ContractLanguage::Sol => {
             read_bytecode(format!(
-                "etc/system-contracts/artifacts-zk/cache-zk/solpp-generated-contracts/{0}{1}.sol/{1}.json",
+                "etc/system-contracts/artifacts-zk/cache-zk/solpp-generated-contracts/{0}/{1}.sol/{1}.json",
                 directory, name
             ))
         },


### PR DESCRIPTION
for https://github.com/matter-labs/zksync-era/issues/18

but I am not sure how to test it. `cargo build --release` does not seem to regenerate the `zksync_server` binary. am I missing anything @RomanBrodetski @perekopskiy?