### PR TITLE
Fix getSignInput when gas parameters are 0

### DIFF
--- a/sdk/zksync-web3.js/src/signer.ts
+++ b/sdk/zksync-web3.js/src/signer.ts
@@ -35,9 +35,9 @@ export class EIP712Signer {
     }
 
     static getSignInput(transaction: TransactionRequest) {
-        const maxFeePerGas = transaction.maxFeePerGas || transaction.gasPrice;
-        const maxPriorityFeePerGas = transaction.maxPriorityFeePerGas || maxFeePerGas;
-        const gasPerPubdataByteLimit = transaction.customData?.gasPerPubdata || DEFAULT_GAS_PER_PUBDATA_LIMIT;
+        const maxFeePerGas = transaction.maxFeePerGas ?? transaction.gasPrice ?? 0;
+        const maxPriorityFeePerGas = transaction.maxPriorityFeePerGas ?? maxFeePerGas;
+        const gasPerPubdataByteLimit = transaction.customData?.gasPerPubdata ?? DEFAULT_GAS_PER_PUBDATA_LIMIT;
         const signInput = {
             txType: transaction.type,
             from: transaction.from,


### PR DESCRIPTION
Hi, Sergio from Argent here.
I think zeroes were not handled correctly when building the eip712 data. In my opinion the fallbacks are ok when the function caller didn't specify a value. But if we call the function with an explicit zero, it shouldn't be replaced by something else.

In general it doesn't make to have zeroes in those fields but the fields can be zero if the transaction is executed using `executeTransactionFromOutside` (https://github.com/matter-labs/zksync-era/blob/48fe6e27110c1fe1a438c5375fb256890e8017b1/core/tests/ts-integration/contracts/custom-account/custom-account.sol#L68)
