### PR TITLE
Update .gitmodules to use https instead of ssh and removed the binaryen dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,9 @@
-[submodule "sdk/binaryen"]
-	path = sdk/binaryen
-	url = git@github.com:WebAssembly/binaryen.git
 [submodule "etc/system-contracts"]
 	path = etc/system-contracts
-	url = git@github.com:matter-labs/era-system-contracts.git
+	url = https://github.com/matter-labs/era-system-contracts.git
 [submodule "etc/openzeppelin-contracts"]
 	path = etc/openzeppelin-contracts
-	url = git@github.com:matter-labs/era-openzeppelin.git
+	url = https://github.com/matter-labs/era-openzeppelin.git
 [submodule "contracts"]
 	path = contracts
-	url = git@github.com:matter-labs/era-contracts.git
+	url = https://github.com/matter-labs/era-contracts.git


### PR DESCRIPTION
Switching to use https instead of ssh for submodules - as many people might not have ssh access configured.

Also removed the binaryen dependency that was not used.