### PR TITLE
Support the OpenEthereum-style's trace_transaction

### DIFF
--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -67,7 +67,8 @@ async fn build_state_keeper(
     let max_allowed_l2_tx_gas_limit = u32::MAX.into();
     let validation_computational_gas_limit = u32::MAX;
     // We only need call traces on the external node if the `debug_` namespace is enabled.
-    let save_call_traces = config.optional.api_namespaces().contains(&Namespace::Debug);
+    let save_call_traces = config.optional.api_namespaces().contains(&Namespace::Debug)
+        || config.optional.api_namespaces().contains(&Namespace::Trace);
 
     // Only supply MultiVM config if the corresponding feature is enabled.
     let multivm_config = use_multivm.then(|| {

--- a/core/bin/zksync_core/src/api_server/web3/backend_jsonrpc/namespaces/mod.rs
+++ b/core/bin/zksync_core/src/api_server/web3/backend_jsonrpc/namespaces/mod.rs
@@ -2,5 +2,6 @@ pub mod debug;
 pub mod en;
 pub mod eth;
 pub mod net;
+pub mod trace;
 pub mod web3;
 pub mod zks;

--- a/core/bin/zksync_core/src/api_server/web3/backend_jsonrpc/namespaces/trace.rs
+++ b/core/bin/zksync_core/src/api_server/web3/backend_jsonrpc/namespaces/trace.rs
@@ -1,0 +1,20 @@
+// External uses
+use crate::api_server::web3::namespaces::TraceNamespace;
+use jsonrpc_core::{BoxFuture, Result};
+use jsonrpc_derive::rpc;
+
+use crate::l1_gas_price::L1GasPriceProvider;
+use zksync_types::{api::OpenEthActionTrace, H256};
+
+#[rpc]
+pub trait TraceNamespaceT {
+    #[rpc(name = "trace_transaction")]
+    fn trace_transaction(&self, tx_hash: H256) -> BoxFuture<Result<Vec<OpenEthActionTrace>>>;
+}
+
+impl<G: L1GasPriceProvider + Send + Sync + 'static> TraceNamespaceT for TraceNamespace<G> {
+    fn trace_transaction(&self, tx_hash: H256) -> BoxFuture<Result<Vec<OpenEthActionTrace>>> {
+        let self_ = self.clone();
+        Box::pin(async move { Ok(self_.trace_transaction_impl(tx_hash).await) })
+    }
+}

--- a/core/bin/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/mod.rs
+++ b/core/bin/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/mod.rs
@@ -3,5 +3,6 @@ pub mod en;
 pub mod eth;
 pub mod eth_subscribe;
 pub mod net;
+pub mod trace;
 pub mod web3;
 pub mod zks;

--- a/core/bin/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/trace.rs
+++ b/core/bin/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/trace.rs
@@ -1,0 +1,15 @@
+use zksync_types::{api::OpenEthActionTrace, H256};
+use zksync_web3_decl::{
+    jsonrpsee::core::{async_trait, RpcResult},
+    namespaces::trace::TraceNamespaceServer,
+};
+
+use crate::api_server::web3::namespaces::TraceNamespace;
+use crate::l1_gas_price::L1GasPriceProvider;
+
+#[async_trait]
+impl<G: L1GasPriceProvider + Send + Sync + 'static> TraceNamespaceServer for TraceNamespace<G> {
+    async fn trace_transaction(&self, tx_hash: H256) -> RpcResult<Vec<OpenEthActionTrace>> {
+        Ok(self.trace_transaction_impl(tx_hash).await)
+    }
+}

--- a/core/bin/zksync_core/src/api_server/web3/namespaces/mod.rs
+++ b/core/bin/zksync_core/src/api_server/web3/namespaces/mod.rs
@@ -11,6 +11,7 @@ mod en;
 mod eth;
 mod eth_subscribe;
 mod net;
+mod trace;
 mod web3;
 mod zks;
 
@@ -20,6 +21,7 @@ pub use self::{
     eth::EthNamespace,
     eth_subscribe::{EthSubscribe, SubscriptionMap},
     net::NetNamespace,
+    trace::TraceNamespace,
     web3::Web3Namespace,
     zks::ZksNamespace,
 };

--- a/core/bin/zksync_core/src/api_server/web3/namespaces/trace.rs
+++ b/core/bin/zksync_core/src/api_server/web3/namespaces/trace.rs
@@ -1,0 +1,83 @@
+use crate::api_server::web3::{backend_jsonrpc::error::internal_error, RpcState};
+use crate::l1_gas_price::L1GasPriceProvider;
+use zksync_types::{
+    api::{flat_call, OpenEthActionTrace},
+    H256,
+};
+
+#[derive(Debug)]
+pub struct TraceNamespace<G> {
+    pub state: RpcState<G>,
+}
+impl<G> Clone for TraceNamespace<G> {
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+        }
+    }
+}
+
+impl<G: L1GasPriceProvider> TraceNamespace<G> {
+    pub fn new(state: RpcState<G>) -> Self {
+        Self { state }
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn trace_transaction_impl(&self, tx_hash: H256) -> Vec<OpenEthActionTrace> {
+        let mut transaction = self
+            .state
+            .connection_pool
+            .access_storage_tagged("api")
+            .await
+            .transactions_web3_dal()
+            .get_transaction(tx_hash.into(), self.state.api_config.l2_chain_id)
+            .await
+            .map_err(|err| internal_error("trace", err));
+
+        if let Some(proxy) = &self.state.tx_sender.0.proxy {
+            // We're running an external node - check the proxy cache in
+            // case the transaction was proxied but not yet synced back to us
+            if let Ok(Some(_tx)) = &transaction {
+            } else {
+                if let Some(tx) = proxy.find_tx(tx_hash).await {
+                    transaction = Ok(Some(tx.into()));
+                }
+                if !matches!(transaction, Ok(Some(_))) {
+                    // If the transaction is not in the db or cache, query main node
+                    transaction = proxy
+                        .request_tx(tx_hash.into())
+                        .await
+                        .map_err(|err| internal_error("trace_transaction", err));
+                }
+            }
+        }
+
+        if !matches!(transaction, Ok(Some(_))) {
+            return vec![];
+        }
+        let transaction = transaction.unwrap().unwrap();
+
+        let call_trace = self
+            .state
+            .connection_pool
+            .access_storage_tagged("api")
+            .await
+            .transactions_dal()
+            .get_call_trace(tx_hash)
+            .await;
+        if call_trace.is_none() {
+            return vec![];
+        }
+
+        let call_trace = call_trace.unwrap();
+
+        flat_call(
+            call_trace,
+            transaction.transaction_index.unwrap().as_usize(),
+            tx_hash,
+            transaction.block_number.unwrap().as_u64(),
+            transaction.block_hash.unwrap(),
+            &mut Vec::new(),
+        )
+    }
+}

--- a/core/lib/web3_decl/src/namespaces/mod.rs
+++ b/core/lib/web3_decl/src/namespaces/mod.rs
@@ -3,6 +3,7 @@ pub mod en;
 pub mod eth;
 pub mod eth_subscribe;
 pub mod net;
+pub mod trace;
 pub mod web3;
 pub mod zks;
 
@@ -10,12 +11,14 @@ pub mod zks;
 #[cfg(feature = "server")]
 pub use self::{
     debug::DebugNamespaceServer, en::EnNamespaceServer, eth::EthNamespaceServer,
-    net::NetNamespaceServer, web3::Web3NamespaceServer, zks::ZksNamespaceServer,
+    net::NetNamespaceServer, trace::TraceNamespaceServer, web3::Web3NamespaceServer,
+    zks::ZksNamespaceServer,
 };
 
 // Client trait re-exports.
 #[cfg(feature = "client")]
 pub use self::{
     debug::DebugNamespaceClient, en::EnNamespaceClient, eth::EthNamespaceClient,
-    net::NetNamespaceClient, web3::Web3NamespaceClient, zks::ZksNamespaceClient,
+    net::NetNamespaceClient, trace::TraceNamespaceClient, web3::Web3NamespaceClient,
+    zks::ZksNamespaceClient,
 };

--- a/core/lib/web3_decl/src/namespaces/trace.rs
+++ b/core/lib/web3_decl/src/namespaces/trace.rs
@@ -1,0 +1,20 @@
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+
+use zksync_types::{api::OpenEthActionTrace, H256};
+
+#[cfg_attr(
+    all(feature = "client", feature = "server"),
+    rpc(server, client, namespace = "trace")
+)]
+#[cfg_attr(
+    all(feature = "client", not(feature = "server")),
+    rpc(client, namespace = "trace")
+)]
+#[cfg_attr(
+    all(not(feature = "client"), feature = "server"),
+    rpc(server, namespace = "trace")
+)]
+pub trait TraceNamespace {
+    #[method(name = "trace_transaction")]
+    async fn trace_transaction(&self, tx_hash: H256) -> RpcResult<Vec<OpenEthActionTrace>>;
+}


### PR DESCRIPTION
This PR implements the OpenEthereum-style's `trace_transaction` API. It accepts the transaction's hash as an argument and returns a list of traces in the order called by the transaction.