### PR TITLE
add `eth_multiCall` method

### DIFF
--- a/core/bin/zksync_core/src/api_server/execution_sandbox/mod.rs
+++ b/core/bin/zksync_core/src/api_server/execution_sandbox/mod.rs
@@ -270,4 +270,8 @@ impl BlockArgs {
             block_timestamp_s,
         }))
     }
+
+    pub fn get_block_timestamp(&self) -> u64 {
+        self.block_timestamp_s.unwrap_or_default()
+    }
 }

--- a/core/lib/types/src/lib.rs
+++ b/core/lib/types/src/lib.rs
@@ -37,6 +37,7 @@ pub mod fee;
 pub mod l1;
 pub mod l2;
 pub mod l2_to_l1_log;
+pub mod multicall;
 pub mod priority_op_onchain_data;
 pub mod protocol_version;
 pub mod storage;

--- a/core/lib/types/src/multicall.rs
+++ b/core/lib/types/src/multicall.rs
@@ -1,0 +1,47 @@
+use crate::Bytes;
+use serde::{Deserialize, Serialize};
+
+#[repr(i32)]
+pub enum MulticallErrCode {
+    FastFail = -40015,
+    CallFail = -40012,
+}
+
+/// MultiCall
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
+pub struct MultiCallResp {
+    /// Result
+    pub results: Vec<CallResult>,
+    /// Stats
+    pub stats: MultiCallStats,
+}
+
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
+pub struct CallResult {
+    /// Code
+    pub code: i32,
+    /// Err
+    pub err: String,
+    /// Result
+    pub result: Bytes,
+    /// GasUsed
+    pub gas_used: i64,
+    /// TimeCost
+    pub time_cost: f64,
+}
+
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
+pub struct MultiCallStats {
+    /// BlockNum
+    pub block_num: i64,
+    /// BlockTime
+    pub block_time: i64,
+    /// Success
+    pub success: bool,
+}


### PR DESCRIPTION
This pr add`eth_multicall` method, which allows for executing multiple `eth_call` within a single RPC request.