### PR TITLE
Update More zk_evm Dependencies

### DIFF
--- a/prover/prover/Cargo.toml
+++ b/prover/prover/Cargo.toml
@@ -26,7 +26,7 @@ setup_key_generator_and_server = { path = "../setup_key_generator_and_server", v
 
 
 api = { git = "https://github.com/matter-labs/era-heavy-ops-service.git", branch = "v1.3.3", features=["gpu"], default-features=false}
-prover-service = { git = "https://github.com/matter-labs/era-heavy-ops-service.git", branch = "v1.3.3", features=["gpu"], default-features=false}
+prover-service = { git = "https://github.com/matter-labs/era-heavy-ops-service.git", tag = "v1.3.3-rc1", features=["gpu"], default-features=false}
 
 zkevm_test_harness = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", tag = "v1.3.3-rc1"}
 

--- a/prover/setup_key_generator_and_server/Cargo.toml
+++ b/prover/setup_key_generator_and_server/Cargo.toml
@@ -23,8 +23,8 @@ vlog = { path = "../../core/lib/vlog", version = "1.0" }
 zksync_config = { path = "../../core/lib/config", version = "1.0" }
 
 circuit_testing = {git = "https://github.com/matter-labs/era-circuit_testing.git", branch = "main"}
-api = { git = "https://github.com/matter-labs/era-heavy-ops-service.git", branch = "v1.3.3", features=["gpu"], default-features=false}
-prover-service = { git = "https://github.com/matter-labs/era-heavy-ops-service.git", branch = "v1.3.3", features=["gpu"], default-features=false}
+api = { git = "https://github.com/matter-labs/era-heavy-ops-service.git", tag = "v1.3.3-rc1", features=["gpu"], default-features=false}
+prover-service = { git = "https://github.com/matter-labs/era-heavy-ops-service.git", tag = "v1.3.3-rc1", features=["gpu"], default-features=false}
 zkevm_test_harness = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", tag = "v1.3.3-rc1"}
 
 


### PR DESCRIPTION
### What

This PR modifies more indirect clients of zk_evm branch v1.3.3 which are dependencies of zksync-era to use it at the v1.3.3-rc0 tag.