### PR TITLE
Implement oracle price coefficient in DB for gas_adjuster

### DIFF
--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -122,7 +122,7 @@ async fn init_tasks(
     let (stop_sender, stop_receiver) = watch::channel::<bool>(false);
     let mut healthchecks: Vec<Box<dyn CheckHealth>> = Vec::new();
     // Create components.
-    let gas_adjuster = Arc::new(MainNodeGasPriceFetcher::new(&main_node_url));
+    let gas_adjuster = Arc::new(MainNodeGasPriceFetcher::new(&main_node_url).await);
 
     let sync_state = SyncState::new();
     let action_queue = ActionQueue::new();

--- a/core/lib/dal/migrations/20230718230823_add_oracle.down.sql
+++ b/core/lib/dal/migrations/20230718230823_add_oracle.down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE oracle;

--- a/core/lib/dal/migrations/20230718230823_add_oracle.up.sql
+++ b/core/lib/dal/migrations/20230718230823_add_oracle.up.sql
@@ -1,0 +1,9 @@
+-- Your SQL goes here
+CREATE TABLE oracle
+(
+    id SERIAL NOT NULL PRIMARY KEY ,
+    gas_token_adjust_coefficient NUMERIC NOT NULL DEFAULT 1.0,
+    gas_token_adjust_coefficient_updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO oracle VALUES (1, DEFAULT, DEFAULT);

--- a/core/lib/dal/sqlx-data.json
+++ b/core/lib/dal/sqlx-data.json
@@ -894,6 +894,24 @@
     },
     "query": "\n                SELECT storage.value as \"value!\",\n                    tokens.l1_address as \"l1_address!\", tokens.l2_address as \"l2_address!\",\n                    tokens.symbol as \"symbol!\", tokens.name as \"name!\", tokens.decimals as \"decimals!\", tokens.usd_price as \"usd_price?\"\n                    FROM storage\n                INNER JOIN tokens ON\n                    storage.address = tokens.l2_address OR (storage.address = $2 AND tokens.l2_address = $3)\n                WHERE storage.hashed_key = ANY($1) AND storage.value != $4\n            "
   },
+  "1a263861d700cbfa50fac265da5535b9edb0d33f4428a295b1a66d30621db9b0": {
+    "describe": {
+      "columns": [
+        {
+          "name": "gas_token_adjust_coefficient",
+          "ordinal": 0,
+          "type_info": "Numeric"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "SELECT gas_token_adjust_coefficient FROM oracle"
+  },
   "1a91acea72e56513a2a9e667bd5a2c171baa5fec01c51dcb7c7cf33f736c854d": {
     "describe": {
       "columns": [
@@ -2730,6 +2748,18 @@
       }
     },
     "query": "\n                    UPDATE transactions\n                    SET \n                        l1_batch_number = $3,\n                        l1_batch_tx_index = data_table.l1_batch_tx_index,\n                        updated_at = now()\n                    FROM\n                        (SELECT\n                                UNNEST($1::int[]) AS l1_batch_tx_index,\n                                UNNEST($2::bytea[]) AS hash\n                        ) AS data_table\n                    WHERE transactions.hash=data_table.hash \n                "
+  },
+  "3c800b8c221baf1a48573d20d9d0d0ec625434b044407a940f38f921f5973db2": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Numeric"
+        ]
+      }
+    },
+    "query": "INSERT INTO oracle VALUES (1, $1, now()) ON CONFLICT (id) DO UPDATE SET gas_token_adjust_coefficient = $1, gas_token_adjust_coefficient_updated_at = now()"
   },
   "3d41f05e1d5c5a74e0605e66fe08e09f14b8bf0269e5dcde518aa08db92a3ea0": {
     "describe": {

--- a/core/lib/dal/src/lib.rs
+++ b/core/lib/dal/src/lib.rs
@@ -27,6 +27,7 @@ use crate::gpu_prover_queue_dal::GpuProverQueueDal;
 use crate::proof_generation_dal::ProofGenerationDal;
 use crate::protocol_versions_dal::ProtocolVersionsDal;
 use crate::protocol_versions_web3_dal::ProtocolVersionsWeb3Dal;
+use crate::oracle_dal::OracleDal;
 use crate::prover_dal::ProverDal;
 use crate::storage_dal::StorageDal;
 use crate::storage_logs_dal::StorageLogsDal;
@@ -60,6 +61,7 @@ mod models;
 pub mod proof_generation_dal;
 pub mod protocol_versions_dal;
 pub mod protocol_versions_web3_dal;
+pub mod oracle_dal;
 pub mod prover_dal;
 pub mod storage_dal;
 pub mod storage_logs_dal;
@@ -278,5 +280,9 @@ impl<'a> StorageProcessor<'a> {
 
     pub fn fri_gpu_prover_queue_dal(&mut self) -> FriGpuProverQueueDal<'_, 'a> {
         FriGpuProverQueueDal { storage: self }
+    }
+
+    pub fn oracle_dal(&mut self) -> OracleDal<'_, 'a> {
+        OracleDal { storage: self }
     }
 }

--- a/core/lib/dal/src/models/mod.rs
+++ b/core/lib/dal/src/models/mod.rs
@@ -4,6 +4,7 @@ pub mod storage_event;
 pub mod storage_fee_monitor;
 pub mod storage_log;
 pub mod storage_protocol_version;
+pub mod storage_oracle;
 pub mod storage_prover_job_info;
 pub mod storage_sync;
 pub mod storage_token;

--- a/core/lib/dal/src/models/storage_oracle.rs
+++ b/core/lib/dal/src/models/storage_oracle.rs
@@ -1,0 +1,6 @@
+use sqlx::types::{chrono::NaiveDateTime, BigDecimal};
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct StorageOracle {
+    pub gas_token_adjust_coefficient: BigDecimal,
+    pub gas_token_adjust_coefficient_updated_at: NaiveDateTime,
+}

--- a/core/lib/dal/src/oracle_dal.rs
+++ b/core/lib/dal/src/oracle_dal.rs
@@ -1,0 +1,32 @@
+use crate::{SqlxError, StorageProcessor};
+use num::{rational::Ratio, BigUint};
+use zksync_utils::{big_decimal_to_ratio, ratio_to_big_decimal};
+
+pub(crate) const COEFFICIENT_PRECISION: usize = 10;
+
+#[derive(Debug)]
+pub struct OracleDal<'a, 'c> {
+    pub storage: &'a mut StorageProcessor<'c>,
+}
+
+impl OracleDal<'_, '_> {
+    pub async fn update_adjust_coefficient(&mut self, adjust_coefficient: &Ratio<BigUint>) {
+        sqlx::query!(
+            "INSERT INTO oracle VALUES (1, $1, now()) \
+             ON CONFLICT (id) \
+             DO UPDATE SET gas_token_adjust_coefficient = $1, gas_token_adjust_coefficient_updated_at = now()",
+            ratio_to_big_decimal(adjust_coefficient, COEFFICIENT_PRECISION)
+        )
+        .execute(self.storage.conn())
+        .await
+        .unwrap();
+    }
+
+    pub async fn get_adjust_coefficient(&mut self) -> Result<Ratio<BigUint>, SqlxError> {
+        let oracle = sqlx::query!("SELECT gas_token_adjust_coefficient FROM oracle")
+            .fetch_one(self.storage.conn())
+            .await?;
+
+        Ok(big_decimal_to_ratio(&oracle.gas_token_adjust_coefficient).unwrap())
+    }
+}


### PR DESCRIPTION
In complement to this proposal

https://github.com/matter-labs/era-contracts/issues/15

We need to multiply the gas_adjuster by a coefficient so that the gas price can reflect the price of the base token

This PR do the following

- Create a new value in DB called `gas_token_adjust_coefficient` that an external oracle can update 
- The gas adjuster will fetch this value in DB and multiple the gas price with this coefficient in `estimate_effective_gas_price` 
- Default value is 1 so it is a non breaking change