### PR TITLE
fix: Add exec to replace shell inside entrypoint with the actual binary

### DIFF
--- a/docker/external-node/entrypoint.sh
+++ b/docker/external-node/entrypoint.sh
@@ -5,4 +5,4 @@ set -e
 # Prepare the database if it's not ready. No-op if the DB is prepared.
 sqlx database setup
 # Run the external node.
-zksync_external_node
+exec zksync_external_node

--- a/docker/local-node/entrypoint.sh
+++ b/docker/local-node/entrypoint.sh
@@ -43,4 +43,4 @@ fi
 # start server
 source /etc/env/dev.env
 source /etc/env/.init.env
-zksync_server
+exec zksync_server


### PR DESCRIPTION
# What ❔

Replaces container shell with EN and local-env executables in corresponding Docker images to eg. properly handle termination signals.

More details in original PR: https://github.com/matter-labs/zksync-era/pull/76

Courtesy of https://github.com/voron
Thanks for the contribution, and sorry it took so long to review - we've been busy with FOSS'ing our repos.

## Why ❔

https://github.com/matter-labs/zksync-era/pull/76#issue-1849818996

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
