### PR TITLE
chore(codeowners): Update Owner Team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @matter-labs/core
+* @matter-labs/era-reviewers
 .github/release-please/** @RomanBrodetski @perekopskiy @Deniallugo @popzxc
 **/CHANGELOG.md @RomanBrodetski @perekopskiy @Deniallugo @popzxc
 CODEOWNERS @RomanBrodetski @perekopskiy @Deniallugo @popzxc


### PR DESCRIPTION
# What ❔

This PR replaces the core team in codeowners with the newly created era-reviewers team.

## Why ❔

To tighten who can approve PRs and not spam the rest.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
