### PR TITLE
ci: switch default rust to nightly for prover builds

### DIFF
--- a/.github/workflows/build-prover-template.yml
+++ b/.github/workflows/build-prover-template.yml
@@ -46,6 +46,7 @@ jobs:
     env:
       image_tag: ${{ inputs.image_tag }}
       IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
+      RUNNER_COMPOSE_FILE: "docker-compose-runner-nightly.yml"
     runs-on: [matterlabs-ci-runner]
     needs: [era-bellman-cuda]
     strategy:
@@ -126,7 +127,6 @@ jobs:
             if [ "$underscored_name" == "prover_gpu_fri" ]; then
               underscored_name="prover_fri"
             fi
-            ci_run rustup default nightly-2023-07-21
             ci_run echo [workspace] > Cargo.toml
             ci_run echo members = [\"prover/${underscored_name}\"] >> Cargo.toml
             ci_run cp prover/Cargo.lock Cargo.lock

--- a/.github/workflows/ci-prover-reusable.yml
+++ b/.github/workflows/ci-prover-reusable.yml
@@ -5,51 +5,33 @@ on:
 jobs:
   unit-tests:
     runs-on: [matterlabs-ci-runner]
+    env:
+      RUNNER_COMPOSE_FILE: "docker-compose-runner-nightly.yml"
 
     steps:
-      - name: Prepare environment
-        run: |
-          sudo apt update && sudo apt install -y \
-            pkg-config libclang-dev build-essential lldb lld \
-            clang openssl libssl-dev gcc g++ pkg-config libclang-dev curl wget
-
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
         with:
           submodules: "recursive"
-
-      - name: Use Node.js 18.18.0
-        uses: actions/setup-node@v2
-        with:
-          node-version: '18.18.0'
-
-      - name: Install Rust nightly-2023-07-21
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2023-07-21
-          override: true
 
       - name: Setup environment
         run: |
           echo ZKSYNC_HOME=$(pwd) >> $GITHUB_ENV
           echo $(pwd)/bin >> $GITHUB_PATH
           echo IN_DOCKER=1 >> .env
-          npm install -g yarn
-          cargo install sqlx-cli --version 0.5.13
 
       - name: Start services
         run: |
-          docker-compose -f docker-compose-runner.yml pull
-          docker-compose -f docker-compose-runner.yml up --build -d zk
+          docker-compose -f ${RUNNER_COMPOSE_FILE} pull
+          docker-compose -f ${RUNNER_COMPOSE_FILE} up --build -d geth zk postgres
           ci_run sccache --start-server
 
       - name: Init
         run: |
-          zk
-          zk config compile
-          zk db setup
+          ci_run zk
+          ci_run zk config compile
+          ci_run zk db setup
 
       - name: Prover unit tests
         run: |
-          cd prover
           # Not all tests are enabled since, prover and setup_key_generator_and_server requires bellman-cuda to be present
-          zk f cargo +nightly-2023-07-21 test --release -p zksync_witness_generator -p vk_setup_data_generator_server_fri -p zksync_prover_fri -p zksync_witness_vector_generator -p zksync_prover_fri_utils
+          ci_run bash -c "cd prover && zk f cargo test --release -p zksync_witness_generator -p vk_setup_data_generator_server_fri -p zksync_prover_fri -p zksync_witness_vector_generator -p zksync_prover_fri_utils"

--- a/bin/ci_run
+++ b/bin/ci_run
@@ -2,5 +2,5 @@
 
 # Runs the command from within CI docker-compose environment.
 cd $ZKSYNC_HOME
-
-docker-compose -f docker-compose-runner.yml exec -T zk $@
+compose_file="${RUNNER_COMPOSE_FILE:-docker-compose-runner.yml}"
+docker-compose -f $compose_file exec -T zk $@

--- a/docker-compose-runner-nightly.yml
+++ b/docker-compose-runner-nightly.yml
@@ -1,0 +1,17 @@
+version: '3.2'
+services:
+  zk:
+    image: matterlabs/zksync_rust:nightly
+    extends:
+      file: docker-compose-runner.yml
+      service: zk
+
+  postgres:
+    extends:
+      file: docker-compose-runner.yml
+      service: postgres
+
+  geth:
+    extends:
+      file: docker-compose-runner.yml
+      service: geth


### PR DESCRIPTION
Switch default rust target to nightly for prover builds.