### PR TITLE
fix(boojum): Don't pass aggregation_results as recursive aggregation inputs

### DIFF
--- a/core/lib/types/src/aggregated_operations.rs
+++ b/core/lib/types/src/aggregated_operations.rs
@@ -93,19 +93,14 @@ impl L1BatchProofOperation {
             assert_eq!(self.l1_batches.len(), 1);
 
             let L1BatchProofForL1 {
-                aggregation_result_coords,
+                aggregation_result_coords: _,
                 scheduler_proof,
             } = self.proofs.first().unwrap();
 
             let (_inputs, proof) = serialize_proof(scheduler_proof);
 
             let proof_input = Token::Tuple(vec![
-                Token::Array(
-                    aggregation_result_coords
-                        .iter()
-                        .map(|bytes| Token::Uint(U256::from_big_endian(bytes)))
-                        .collect(),
-                ),
+                Token::Array(vec![]),
                 Token::Array(proof.into_iter().map(Token::Uint).collect()),
             ]);
 


### PR DESCRIPTION
# What ❔

* We were passing incorrect argument to the prover

## Why ❔

* to make prover work, the original problem was a simple bug/typo.
