### PR TITLE
fix(vm): Make execution status and stop reason public

### DIFF
--- a/core/lib/vm/src/lib.rs
+++ b/core/lib/vm/src/lib.rs
@@ -15,7 +15,10 @@ pub use errors::{
 
 pub use tracers::{
     call::CallTracer,
-    traits::{BoxedTracer, DynTracer, ExecutionEndTracer, ExecutionProcessing, VmTracer},
+    traits::{
+        BoxedTracer, DynTracer, ExecutionEndTracer, ExecutionProcessing, TracerExecutionStatus,
+        TracerExecutionStopReason, VmTracer,
+    },
     utils::VmExecutionStopReason,
     validation::ViolatedValidationRule,
     StorageInvocations, ValidationError, ValidationTracer, ValidationTracerParams,


### PR DESCRIPTION
# What ❔

* TracerExecutionStatus and TracerExecutionStopReason are part of the ExecutionEndTracer trait, but they were not publicly available.

## Why ❔

* This breaks external implementations of the ExecutionEndTracer
