### PR TITLE
fix: zksync-cli commands restructure

### DIFF
--- a/docs/advanced/02_deposits.md
+++ b/docs/advanced/02_deposits.md
@@ -57,10 +57,10 @@ and now let's bridge it over to L2.
 
 ## Bridging over to L2
 
-We'll use the zksync-cli from: <https://github.com/matter-labs/zksync-cli> and then run:
+For an easy way to bridge we'll use [zkSync CLI](https://github.com/matter-labs/zksync-cli)
 
 ```shell
-npx zksync-cli deposit --chain=local-dockerized
+npx zksync-cli bridge deposit --chain=local-dockerized
 # Amount of ETH to deposit: 3
 # Private key of the sender: 0x5090c024edb3bdf4ce2ebc2da96bedee925d9d77d729687e5e2d56382cf0a5a6
 # Recipient address on L2: 0x618263CE921F7dd5F4f40C29f6c524Aaf97b9bbd

--- a/docs/advanced/03_withdrawals.md
+++ b/docs/advanced/03_withdrawals.md
@@ -4,7 +4,7 @@ Assuming that you have completed [part 1](01_initialization.md) and [part 2](02_
 tokens back by simply calling the zksync-cli:
 
 ```bash
-npx zksync-cli withdraw --chain=local-dockerized
+npx zksync-cli bridge withdraw --chain=local-dockerized
 ```
 
 And providing the account name (public address) and private key.
@@ -15,7 +15,7 @@ they didn't** - what happened?
 Actually we'll have to run one additional step:
 
 ```bash
-npx zksync-cli withdraw-finalize --chain=local-dockerized
+npx zksync-cli bridge withdraw-finalize --chain=local-dockerized
 ```
 
 and pass the transaction that we received from the first call, into the `withdraw-finalize` call.


### PR DESCRIPTION
# What ❔
Update examples of using zkSync CLI according to the command restructure from https://github.com/matter-labs/zksync-cli/pull/64

## Why ❔

Make examples up-to-date with latest version of zkSync CLI
