### PR TITLE
fix(db): drop constraint prover_jobs_fri_l1_batch_number_fkey

### DIFF
--- a/core/lib/dal/migrations/20231009073918_drop-prover_jobs_fri_l1_batch_number_fkey.down.sql
+++ b/core/lib/dal/migrations/20231009073918_drop-prover_jobs_fri_l1_batch_number_fkey.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE prover_jobs_fri ADD CONSTRAINT prover_jobs_fri_l1_batch_number_fkey
+    FOREIGN KEY (l1_batch_number) REFERENCES l1_batches (number);

--- a/core/lib/dal/migrations/20231009073918_drop-prover_jobs_fri_l1_batch_number_fkey.up.sql
+++ b/core/lib/dal/migrations/20231009073918_drop-prover_jobs_fri_l1_batch_number_fkey.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE prover_jobs_fri DROP CONSTRAINT IF EXISTS prover_jobs_fri_l1_batch_number_fkey;


### PR DESCRIPTION
# What ❔

`prover_jobs_fri_l1_batch_number_fkey` is dropped.

## Why ❔

`prover_jobs_fri` is filled only in prover DB, while `l1_batches` -- only in core DB, so we can't have the constraint.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
