### PR TITLE
fix(boojum): Fix VK in prover_fri_protocol_versions

### DIFF
--- a/core/lib/zksync_core/src/proof_data_handler/mod.rs
+++ b/core/lib/zksync_core/src/proof_data_handler/mod.rs
@@ -27,7 +27,7 @@ fn fri_l1_verifier_config_from_env() -> anyhow::Result<L1VerifierConfig> {
             // The base layer commitment is not used in the FRI prover verification.
             recursion_circuits_set_vks_hash: H256::zero(),
         },
-        recursion_scheduler_level_vk_hash: config.fri_recursion_scheduler_level_vk_hash,
+        recursion_scheduler_level_vk_hash: config.snark_wrapper_vk_hash,
     })
 }
 


### PR DESCRIPTION
# What ❔

Use SNARK wrapper VK instead of FRI scheduler VK in proof_data_handler

## Why ❔

It will be saved to `prover_fri_protocol_versions`, and we need them consistent with `protocol_versions`.


## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
