### PR TITLE
refactor: Removed unused fields from SyncBlock

### DIFF
--- a/core/lib/dal/sqlx-data.json
+++ b/core/lib/dal/sqlx-data.json
@@ -2542,134 +2542,6 @@
     },
     "query": "SELECT MAX(number) as \"number\" FROM miniblocks"
   },
-  "3365f652e8e0070672ab522bd60f92d002dac7bb782763575a0337a8b5502994": {
-    "describe": {
-      "columns": [
-        {
-          "name": "number",
-          "ordinal": 0,
-          "type_info": "Int8"
-        },
-        {
-          "name": "l1_batch_number!",
-          "ordinal": 1,
-          "type_info": "Int8"
-        },
-        {
-          "name": "last_batch_miniblock?",
-          "ordinal": 2,
-          "type_info": "Int8"
-        },
-        {
-          "name": "timestamp",
-          "ordinal": 3,
-          "type_info": "Int8"
-        },
-        {
-          "name": "root_hash?",
-          "ordinal": 4,
-          "type_info": "Bytea"
-        },
-        {
-          "name": "commit_tx_hash?",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "committed_at?",
-          "ordinal": 6,
-          "type_info": "Timestamp"
-        },
-        {
-          "name": "prove_tx_hash?",
-          "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "proven_at?",
-          "ordinal": 8,
-          "type_info": "Timestamp"
-        },
-        {
-          "name": "execute_tx_hash?",
-          "ordinal": 9,
-          "type_info": "Text"
-        },
-        {
-          "name": "executed_at?",
-          "ordinal": 10,
-          "type_info": "Timestamp"
-        },
-        {
-          "name": "l1_gas_price",
-          "ordinal": 11,
-          "type_info": "Int8"
-        },
-        {
-          "name": "l2_fair_gas_price",
-          "ordinal": 12,
-          "type_info": "Int8"
-        },
-        {
-          "name": "bootloader_code_hash",
-          "ordinal": 13,
-          "type_info": "Bytea"
-        },
-        {
-          "name": "default_aa_code_hash",
-          "ordinal": 14,
-          "type_info": "Bytea"
-        },
-        {
-          "name": "virtual_blocks",
-          "ordinal": 15,
-          "type_info": "Int8"
-        },
-        {
-          "name": "hash",
-          "ordinal": 16,
-          "type_info": "Bytea"
-        },
-        {
-          "name": "protocol_version!",
-          "ordinal": 17,
-          "type_info": "Int4"
-        },
-        {
-          "name": "fee_account_address?",
-          "ordinal": 18,
-          "type_info": "Bytea"
-        }
-      ],
-      "nullable": [
-        false,
-        null,
-        null,
-        false,
-        false,
-        false,
-        true,
-        false,
-        true,
-        false,
-        true,
-        false,
-        false,
-        true,
-        true,
-        false,
-        false,
-        true,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Int8"
-        ]
-      }
-    },
-    "query": "\n                SELECT miniblocks.number,\n                    COALESCE(miniblocks.l1_batch_number, (SELECT (max(number) + 1) FROM l1_batches)) as \"l1_batch_number!\",\n                    (SELECT max(m2.number) FROM miniblocks m2 WHERE miniblocks.l1_batch_number = m2.l1_batch_number) as \"last_batch_miniblock?\",\n                    miniblocks.timestamp,\n                    miniblocks.hash as \"root_hash?\",\n                    commit_tx.tx_hash as \"commit_tx_hash?\",\n                    commit_tx.confirmed_at as \"committed_at?\",\n                    prove_tx.tx_hash as \"prove_tx_hash?\",\n                    prove_tx.confirmed_at as \"proven_at?\",\n                    execute_tx.tx_hash as \"execute_tx_hash?\",\n                    execute_tx.confirmed_at as \"executed_at?\",\n                    miniblocks.l1_gas_price,\n                    miniblocks.l2_fair_gas_price,\n                    miniblocks.bootloader_code_hash,\n                    miniblocks.default_aa_code_hash,\n                    miniblocks.virtual_blocks,\n                    miniblocks.hash,\n                    miniblocks.protocol_version as \"protocol_version!\",\n                    l1_batches.fee_account_address as \"fee_account_address?\"\n                FROM miniblocks\n                LEFT JOIN l1_batches ON miniblocks.l1_batch_number = l1_batches.number\n                LEFT JOIN eth_txs_history as commit_tx ON (l1_batches.eth_commit_tx_id = commit_tx.eth_tx_id AND commit_tx.confirmed_at IS NOT NULL)\n                LEFT JOIN eth_txs_history as prove_tx ON (l1_batches.eth_prove_tx_id = prove_tx.eth_tx_id AND prove_tx.confirmed_at IS NOT NULL)\n                LEFT JOIN eth_txs_history as execute_tx ON (l1_batches.eth_execute_tx_id = execute_tx.eth_tx_id AND execute_tx.confirmed_at IS NOT NULL)\n                WHERE miniblocks.number = $1\n            "
-  },
   "357347157ed8ff19d223c54533c3a85bd7e64a37514d657f8d49bd6eb5be1806": {
     "describe": {
       "columns": [
@@ -3860,6 +3732,98 @@
       }
     },
     "query": "UPDATE eth_txs SET has_failed = TRUE WHERE id = $1"
+  },
+  "5190fad25f0c476380af4013761d42ae97dbd55f87e38ceec33f8e148c5cbb14": {
+    "describe": {
+      "columns": [
+        {
+          "name": "number",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "l1_batch_number!",
+          "ordinal": 1,
+          "type_info": "Int8"
+        },
+        {
+          "name": "last_batch_miniblock?",
+          "ordinal": 2,
+          "type_info": "Int8"
+        },
+        {
+          "name": "timestamp",
+          "ordinal": 3,
+          "type_info": "Int8"
+        },
+        {
+          "name": "root_hash?",
+          "ordinal": 4,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "l1_gas_price",
+          "ordinal": 5,
+          "type_info": "Int8"
+        },
+        {
+          "name": "l2_fair_gas_price",
+          "ordinal": 6,
+          "type_info": "Int8"
+        },
+        {
+          "name": "bootloader_code_hash",
+          "ordinal": 7,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "default_aa_code_hash",
+          "ordinal": 8,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "virtual_blocks",
+          "ordinal": 9,
+          "type_info": "Int8"
+        },
+        {
+          "name": "hash",
+          "ordinal": 10,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "protocol_version!",
+          "ordinal": 11,
+          "type_info": "Int4"
+        },
+        {
+          "name": "fee_account_address?",
+          "ordinal": 12,
+          "type_info": "Bytea"
+        }
+      ],
+      "nullable": [
+        false,
+        null,
+        null,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      }
+    },
+    "query": "\n                SELECT miniblocks.number,\n                    COALESCE(miniblocks.l1_batch_number, (SELECT (max(number) + 1) FROM l1_batches)) as \"l1_batch_number!\",\n                    (SELECT max(m2.number) FROM miniblocks m2 WHERE miniblocks.l1_batch_number = m2.l1_batch_number) as \"last_batch_miniblock?\",\n                    miniblocks.timestamp,\n                    miniblocks.hash as \"root_hash?\",\n                    miniblocks.l1_gas_price,\n                    miniblocks.l2_fair_gas_price,\n                    miniblocks.bootloader_code_hash,\n                    miniblocks.default_aa_code_hash,\n                    miniblocks.virtual_blocks,\n                    miniblocks.hash,\n                    miniblocks.protocol_version as \"protocol_version!\",\n                    l1_batches.fee_account_address as \"fee_account_address?\"\n                FROM miniblocks\n                LEFT JOIN l1_batches ON miniblocks.l1_batch_number = l1_batches.number\n                WHERE miniblocks.number = $1\n            "
   },
   "51cb712685991ffd600dce59f5ed8b5a1bfce8feed46ebd02471c43802e6e65a": {
     "describe": {

--- a/core/lib/dal/src/models/storage_sync.rs
+++ b/core/lib/dal/src/models/storage_sync.rs
@@ -1,6 +1,4 @@
-use std::{convert::TryInto, str::FromStr};
-
-use sqlx::types::chrono::{DateTime, NaiveDateTime, Utc};
+use std::convert::TryInto;
 
 use zksync_contracts::BaseSystemContractsHashes;
 use zksync_types::api::en::SyncBlock;
@@ -14,12 +12,6 @@ pub struct StorageSyncBlock {
     pub last_batch_miniblock: Option<i64>,
     pub timestamp: i64,
     pub root_hash: Option<Vec<u8>>,
-    pub commit_tx_hash: Option<String>,
-    pub committed_at: Option<NaiveDateTime>,
-    pub prove_tx_hash: Option<String>,
-    pub proven_at: Option<NaiveDateTime>,
-    pub execute_tx_hash: Option<String>,
-    pub executed_at: Option<NaiveDateTime>,
     // L1 gas price assumed in the corresponding batch
     pub l1_gas_price: i64,
     // L2 gas price assumed in the corresponding batch
@@ -47,27 +39,6 @@ impl StorageSyncBlock {
                 .unwrap_or(false),
             timestamp: self.timestamp as u64,
             root_hash: self.root_hash.as_deref().map(H256::from_slice),
-            commit_tx_hash: self
-                .commit_tx_hash
-                .as_deref()
-                .map(|hash| H256::from_str(hash).expect("Incorrect commit_tx hash")),
-            committed_at: self
-                .committed_at
-                .map(|committed_at| DateTime::<Utc>::from_naive_utc_and_offset(committed_at, Utc)),
-            prove_tx_hash: self
-                .prove_tx_hash
-                .as_deref()
-                .map(|hash| H256::from_str(hash).expect("Incorrect prove_tx hash")),
-            proven_at: self
-                .proven_at
-                .map(|proven_at| DateTime::<Utc>::from_naive_utc_and_offset(proven_at, Utc)),
-            execute_tx_hash: self
-                .execute_tx_hash
-                .as_deref()
-                .map(|hash| H256::from_str(hash).expect("Incorrect execute_tx hash")),
-            executed_at: self
-                .executed_at
-                .map(|executed_at| DateTime::<Utc>::from_naive_utc_and_offset(executed_at, Utc)),
             l1_gas_price: self.l1_gas_price as u64,
             l2_fair_gas_price: self.l2_fair_gas_price as u64,
             // TODO (SMA-1635): Make these filed non optional in database

--- a/core/lib/dal/src/sync_dal.rs
+++ b/core/lib/dal/src/sync_dal.rs
@@ -29,12 +29,6 @@ impl SyncDal<'_, '_> {
                     (SELECT max(m2.number) FROM miniblocks m2 WHERE miniblocks.l1_batch_number = m2.l1_batch_number) as "last_batch_miniblock?",
                     miniblocks.timestamp,
                     miniblocks.hash as "root_hash?",
-                    commit_tx.tx_hash as "commit_tx_hash?",
-                    commit_tx.confirmed_at as "committed_at?",
-                    prove_tx.tx_hash as "prove_tx_hash?",
-                    prove_tx.confirmed_at as "proven_at?",
-                    execute_tx.tx_hash as "execute_tx_hash?",
-                    execute_tx.confirmed_at as "executed_at?",
                     miniblocks.l1_gas_price,
                     miniblocks.l2_fair_gas_price,
                     miniblocks.bootloader_code_hash,
@@ -45,9 +39,6 @@ impl SyncDal<'_, '_> {
                     l1_batches.fee_account_address as "fee_account_address?"
                 FROM miniblocks
                 LEFT JOIN l1_batches ON miniblocks.l1_batch_number = l1_batches.number
-                LEFT JOIN eth_txs_history as commit_tx ON (l1_batches.eth_commit_tx_id = commit_tx.eth_tx_id AND commit_tx.confirmed_at IS NOT NULL)
-                LEFT JOIN eth_txs_history as prove_tx ON (l1_batches.eth_prove_tx_id = prove_tx.eth_tx_id AND prove_tx.confirmed_at IS NOT NULL)
-                LEFT JOIN eth_txs_history as execute_tx ON (l1_batches.eth_execute_tx_id = execute_tx.eth_tx_id AND execute_tx.confirmed_at IS NOT NULL)
                 WHERE miniblocks.number = $1
             "#,
             block_number.0 as i64

--- a/core/lib/types/src/api/en.rs
+++ b/core/lib/types/src/api/en.rs
@@ -1,6 +1,5 @@
 //! API types related to the External Node specific methods.
 
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use zk_evm::ethereum_types::Address;
 use zksync_basic_types::{L1BatchNumber, MiniblockNumber, H256};
@@ -27,21 +26,6 @@ pub struct SyncBlock {
     pub timestamp: u64,
     /// Hash of the L2 block (not the Merkle root hash).
     pub root_hash: Option<H256>,
-    /// Hash of the block's commit transaction on L1.
-    /// May be `None` if the corresponsing L1 batch is not committed yet.
-    pub commit_tx_hash: Option<H256>,
-    /// Timestamp of the commit transaction, as provided by the main node.
-    pub committed_at: Option<DateTime<Utc>>,
-    /// Hash of the block's prove transaction on L1.
-    /// May be `None` if the corresponsing L1 batch is not proven yet.
-    pub prove_tx_hash: Option<H256>,
-    /// Timestamp of the prove transaction, as provided by the main node.
-    pub proven_at: Option<DateTime<Utc>>,
-    /// Hash of the block's execute transaction on L1.
-    /// May be `None` if the corresponsing L1 batch is not executed yet.
-    pub execute_tx_hash: Option<H256>,
-    /// Timestamp of the execute transaction, as provided by the main node.
-    pub executed_at: Option<DateTime<Utc>>,
     /// L1 gas price used as VM parameter for the L1 batch corresponding to this L2 block.
     pub l1_gas_price: u64,
     /// L2 gas price used as VM parameter for the L1 batch corresponding to this L2 block.


### PR DESCRIPTION
# What ❔

Removed unused fields from SyncBlock.
It is a backward compatible change, because the removed fields were optional.

## Why ❔

We decrease the public api surface this way.