### PR TITLE
chore(en): Update `default_enum_index_migration_chunk_size`

### DIFF
--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -287,7 +287,7 @@ impl OptionalENConfig {
     }
 
     const fn default_enum_index_migration_chunk_size() -> usize {
-        1000
+        5000
     }
 
     pub fn polling_interval(&self) -> Duration {


### PR DESCRIPTION
# What ❔

`default_enum_index_migration_chunk_size` is updated, so migration speed is acceptable with default settings.

## Why ❔

Migration speed should be acceptable with default settings.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
