### PR TITLE
fix(state-keeper): Add L2ToL1LogsCriterion

### DIFF
--- a/core/lib/zksync_core/src/state_keeper/seal_criteria/conditional_sealer.rs
+++ b/core/lib/zksync_core/src/state_keeper/seal_criteria/conditional_sealer.rs
@@ -101,6 +101,7 @@ impl ConditionalSealer {
             Box::new(criteria::MaxCyclesCriterion),
             Box::new(criteria::ComputationalGasCriterion),
             Box::new(criteria::TxEncodingSizeCriterion),
+            Box::new(criteria::L2ToL1LogsCriterion),
         ]
     }
 }

--- a/core/lib/zksync_core/src/state_keeper/seal_criteria/criteria/geometry_seal_criteria.rs
+++ b/core/lib/zksync_core/src/state_keeper/seal_criteria/criteria/geometry_seal_criteria.rs
@@ -20,6 +20,8 @@ pub struct InitialWritesCriterion;
 pub struct MaxCyclesCriterion;
 #[derive(Debug, Default)]
 pub struct ComputationalGasCriterion;
+#[derive(Debug, Default)]
+pub struct L2ToL1LogsCriterion;
 
 trait MetricExtractor {
     const PROM_METRIC_CRITERION_NAME: &'static str;
@@ -116,6 +118,18 @@ impl MetricExtractor for ComputationalGasCriterion {
 
     fn extract(metrics: &ExecutionMetrics, _writes: &DeduplicatedWritesMetrics) -> usize {
         metrics.computational_gas_used as usize
+    }
+}
+
+impl MetricExtractor for L2ToL1LogsCriterion {
+    const PROM_METRIC_CRITERION_NAME: &'static str = "l2_to_l1_logs";
+
+    fn limit_per_block() -> usize {
+        GEOMETRY_CONFIG.limit_for_l1_messages_merklizer as usize
+    }
+
+    fn extract(metrics: &ExecutionMetrics, _writes: &DeduplicatedWritesMetrics) -> usize {
+        metrics.l2_l1_logs
     }
 }
 
@@ -321,5 +335,10 @@ mod tests {
     #[test]
     fn computational_gas_seal_criterion() {
         test_scenario_execution_metrics!(ComputationalGasCriterion, computational_gas_used, u32);
+    }
+
+    #[test]
+    fn l2_to_l1_logs_seal_criterion() {
+        test_scenario_execution_metrics!(L2ToL1LogsCriterion, l2_l1_logs, usize);
     }
 }

--- a/core/lib/zksync_core/src/state_keeper/seal_criteria/criteria/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/seal_criteria/criteria/mod.rs
@@ -7,7 +7,7 @@ mod tx_encoding_size;
 pub(in crate::state_keeper) use self::{
     gas::GasCriterion,
     geometry_seal_criteria::{
-        ComputationalGasCriterion, InitialWritesCriterion, MaxCyclesCriterion,
+        ComputationalGasCriterion, InitialWritesCriterion, L2ToL1LogsCriterion, MaxCyclesCriterion,
         RepeatedWritesCriterion,
     },
     pubdata_bytes::PubDataBytesCriterion,


### PR DESCRIPTION
# What ❔

Added L1 batch seal criterion for number of L2 to L1 logs

## Why ❔

Number of logs must be <= 512 per batch.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
