### PR TITLE
ci: Docker login only on push to main or tag

### DIFF
--- a/.github/workflows/build-core-template.yml
+++ b/.github/workflows/build-core-template.yml
@@ -71,7 +71,7 @@ jobs:
           ci_run zk f yarn run l2-contracts build
           ci_run curl -LO https://storage.googleapis.com/matterlabs-setup-keys-us/setup-keys/setup_2\^26.key
 
-      - name: login to docker registries
+      - name: login to Docker registries
         if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         run: |
           ci_run docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-core-template.yml
+++ b/.github/workflows/build-core-template.yml
@@ -71,13 +71,17 @@ jobs:
           ci_run zk f yarn run l2-contracts build
           ci_run curl -LO https://storage.googleapis.com/matterlabs-setup-keys-us/setup-keys/setup_2\^26.key
 
+      - name: login to docker registries
+        if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+        run: |
+          ci_run docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+          ci_run gcloud auth configure-docker us-docker.pkg.dev,asia-docker.pkg.dev -q
+
       - name: update-images
         env:
           DOCKER_ACTION: ${{ inputs.action }}
           COMPONENT: ${{ matrix.component }}
         run: |
-          ci_run docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
-          ci_run gcloud auth configure-docker us-docker.pkg.dev,asia-docker.pkg.dev -q
           ci_run zk docker $DOCKER_ACTION $COMPONENT -- --public
 
       - name: Show sccache stats

--- a/.github/workflows/build-prover-template.yml
+++ b/.github/workflows/build-prover-template.yml
@@ -81,7 +81,7 @@ jobs:
           ci_run zk f yarn run l2-contracts build
           ci_run curl -LO https://storage.googleapis.com/matterlabs-setup-keys-us/setup-keys/setup_2\^26.key
 
-      - name: login to docker registries
+      - name: login to Docker registries
         if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         run: |
           ci_run docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-prover-template.yml
+++ b/.github/workflows/build-prover-template.yml
@@ -81,6 +81,12 @@ jobs:
           ci_run zk f yarn run l2-contracts build
           ci_run curl -LO https://storage.googleapis.com/matterlabs-setup-keys-us/setup-keys/setup_2\^26.key
 
+      - name: login to docker registries
+        if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+        run: |
+          ci_run docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+          ci_run gcloud auth configure-docker us-docker.pkg.dev,asia-docker.pkg.dev -q
+
       - name: update-images
         env:
           DOCKER_ACTION: ${{ inputs.action }}
@@ -98,8 +104,6 @@ jobs:
             )
         run: |
           nightly_components=${{ env.RUST_NIGHTLY_COMPONENTS }}
-          ci_run docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
-          ci_run gcloud auth configure-docker us-docker.pkg.dev,asia-docker.pkg.dev -q
 
           if [[ " ${nightly_components[*]} " =~ " ${COMPONENT} " ]]; then
             underscored_name=$(echo "$COMPONENT" | tr '-' '_')


### PR DESCRIPTION
# What ❔

Conditional Docker login in CI only on push to main branch or against tag

## Why ❔

- We should be logging in to Docker registries only when we intend to push images
- Secrets will not be available for workflows triggered against PRs created from works, so the current approach is not working anyway

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
