### PR TITLE
ci: Separate CI for docs, more granular CI triggers for core/prover

### DIFF
--- a/.github/workflows/ci-docs-reusable.yml
+++ b/.github/workflows/ci-docs-reusable.yml
@@ -24,5 +24,6 @@ jobs:
 
       - name: Lints
         run: |
+          ci_run zk run yarn
           ci_run zk lint md --check
 

--- a/.github/workflows/ci-docs-reusable.yml
+++ b/.github/workflows/ci-docs-reusable.yml
@@ -1,0 +1,28 @@
+name: Workflow template for CI jobs against docs
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    runs-on: [matterlabs-ci-runner]
+
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
+        with:
+          submodules: "recursive"
+
+      - name: Setup environment
+        run: |
+          echo ZKSYNC_HOME=$(pwd) >> $GITHUB_ENV
+          echo $(pwd)/bin >> $GITHUB_PATH
+          echo IN_DOCKER=1 >> .env
+
+      - name: Start services
+        run: |
+          docker-compose -f docker-compose-runner.yml pull
+          docker-compose -f docker-compose-runner.yml up --build -d zk
+
+      - name: Lints
+        run: |
+          ci_run zk lint md --check
+

--- a/.github/workflows/ci-docs-reusable.yml
+++ b/.github/workflows/ci-docs-reusable.yml
@@ -24,6 +24,6 @@ jobs:
 
       - name: Lints
         run: |
-          ci_run zk run yarn
+          ci_run zk
           ci_run zk lint md --check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
     name: Github Status Check
     runs-on: ubuntu-latest
     if: always() && !cancelled()
-    needs: [ci-for-core, ci-for-prover, build-core-images, build-prover-images]
+    needs: [ci-for-core, ci-for-prover, ci-for-docs, build-core-images, build-prover-images]
     steps:
       - name: Status
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
             docs:
               - '*.md'
               - '*.MD'
+              - '.github/workflows/ci-docs-reusable.yml'
 
   ci-for-core:
     name: CI for Core Components

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: [matterlabs-default-infra-runners]
     name: Get changed files
     outputs:
-      core: ${{ steps.changed-files.outputs.core_any_changed }}
-      prover: ${{ steps.changed-files.outputs.prover_any_changed }}
-      docs: ${{ steps.changed-files.outputs.docs_any_changed }}
-      other: ${{ steps.changed-files.outputs.other_changed_files }}
+      core: ${{ steps.changed-files.outputs.test_core_any_changed }}
+      prover: ${{ steps.changed-files.outputs.test_prover_any_changed }}
+      docs: ${{ steps.changed-files.outputs.test_docs_any_changed }}
+      other: ${{ steps.changed-files.outputs.test_other_changed_files }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       core: ${{ steps.changed-files.outputs.core_any_changed }}
       prover: ${{ steps.changed-files.outputs.prover_any_changed }}
-      all: ${{ steps.changed-files.outputs.all_any_changed }}
+      other: ${{ steps.changed-files.outputs.other_changed_files }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -52,25 +52,25 @@ jobs:
   ci-for-core:
     name: CI for Core Components
     needs: changed_files
-    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other_modified_files != ''
+    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other != ''
     uses: ./.github/workflows/ci-core-reusable.yml
 
   ci-for-prover:
     needs: changed_files
-    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other_modified_files != ''
+    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other != ''
     name: CI for Prover Components
     uses: ./.github/workflows/ci-prover-reusable.yml
 
   ci-for-docs:
     needs: changed_files
-    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other_modified_files != ''
+    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other != ''
     name: CI for Docs
     uses: ./.github/workflows/ci-docs-reusable.yml
 
   build-core-images:
     name: Build core images
     needs: changed_files
-    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other_modified_files != ''
+    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other != ''
     uses: ./.github/workflows/build-core-template.yml
     with:
       image_tag: ${{ needs.setup.outputs.image_tag }}
@@ -83,7 +83,7 @@ jobs:
   build-prover-images:
     name: Build prover images
     needs: changed_files
-    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other_modified_files != ''
+    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other != ''
     uses: ./.github/workflows/build-prover-template.yml
     with:
       image_tag: ${{ needs.setup.outputs.image_tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
   ci-for-docs:
     needs: changed_files
-    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other != ''
+    if: needs.changed_files.outputs.docs == 'true'
     name: CI for Docs
     uses: ./.github/workflows/ci-docs-reusable.yml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,33 +35,42 @@ jobs:
             prover:
               - 'prover/**'
               - 'docker/prover*/**'
-              - '!.github/release-please/manifest.json'
+              - '.github/workflows/build-prover-template.yml'
+              - '.github/workflows/ci-prover-reusable.yml'
             core:
               - 'core/**'
-            all:
-              - '!core/**'
-              - '!prover/**'
-              - '!docker/prover*/**'
-              - '!.github/workflows/zk-environment.publish.yml'
-              - '!docker/zk-environment/Dockerfile'
-              - '!docker/zk-environment-cuda-12-0/Dockerfile'
+              - 'docker/contract-verifier/**'
+              - 'docker/cross-external-nodes-checker/**'
+              - 'docker/external-node/**'
+              - 'docker/server/**'
+              - '.github/workflows/build-core-template.yml'
+              - '.github/workflows/ci-core-reusable.yml'
+            docs:
+              - '*.md'
+              - '*.MD'
 
   ci-for-core:
     name: CI for Core Components
     needs: changed_files
-    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.all == 'true'
+    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other_modified_files != ''
     uses: ./.github/workflows/ci-core-reusable.yml
 
   ci-for-prover:
     needs: changed_files
-    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.all == 'true'
+    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other_modified_files != ''
     name: CI for Prover Components
     uses: ./.github/workflows/ci-prover-reusable.yml
+
+  ci-for-docs:
+    needs: changed_files
+    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other_modified_files != ''
+    name: CI for Docs
+    uses: ./.github/workflows/ci-docs-reusable.yml
 
   build-core-images:
     name: Build core images
     needs: changed_files
-    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.all == 'true'
+    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other_modified_files != ''
     uses: ./.github/workflows/build-core-template.yml
     with:
       image_tag: ${{ needs.setup.outputs.image_tag }}
@@ -74,7 +83,7 @@ jobs:
   build-prover-images:
     name: Build prover images
     needs: changed_files
-    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.all == 'true'
+    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other_modified_files != ''
     uses: ./.github/workflows/build-prover-template.yml
     with:
       image_tag: ${{ needs.setup.outputs.image_tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     outputs:
       core: ${{ steps.changed-files.outputs.core_any_changed }}
       prover: ${{ steps.changed-files.outputs.prover_any_changed }}
+      docs: ${{ steps.changed-files.outputs.docs_any_changed }}
       other: ${{ steps.changed-files.outputs.other_changed_files }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: [matterlabs-default-infra-runners]
     name: Get changed files
     outputs:
-      core: ${{ steps.changed-files.outputs.test_core_any_changed }}
-      prover: ${{ steps.changed-files.outputs.test_prover_any_changed }}
-      docs: ${{ steps.changed-files.outputs.test_docs_any_changed }}
-      other: ${{ steps.changed-files.outputs.test_other_changed_files }}
+      core: ${{ steps.changed-files.outputs.core_any_changed }}
+      prover: ${{ steps.changed-files.outputs.prover_any_changed }}
+      docs: ${{ steps.changed-files.outputs.docs_any_changed }}
+      other: ${{ steps.changed-files.outputs.other_changed_files }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "**"
+    paths:
+      - 'core/**'
+      - 'prover/**'
 
 jobs:
   generate:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ The following PGP key may be used to communicate sensitive information to develo
 
 Fingerprint: `5FED B2D0 EA2C 4906 DD66 71D7 A2C5 0B40 CE3C F297`
 
-```
+```text
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQINBGEBmQkBEAD6tlkBEZFMvR8kOgxXX857nC2+oTik6TopJz4uCskuqDaeldMy


### PR DESCRIPTION
# What ❔

- Trigger lightweight CI if only markdown is changed in PR
- Improve "fallback" to running "all" CI
- More granular conditions to run core and prover CI

## Why ❔

Faster CI, less runner time

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
