### PR TITLE
ci: Trigger docs CI on markdown files in any dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,8 @@ jobs:
               - '.github/workflows/build-core-template.yml'
               - '.github/workflows/ci-core-reusable.yml'
             docs:
-              - '*.md'
-              - '*.MD'
+              - '**/*.md'
+              - '**/*.MD'
               - '.github/workflows/ci-docs-reusable.yml'
 
   ci-for-core:


### PR DESCRIPTION
# What ❔

Current regex only triggers Docs CI if markdown file is changed in root of the repo, this change fixes that behaviour

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
