### PR TITLE
ci: Add all CI condition trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       core: ${{ steps.changed-files.outputs.core_any_changed }}
       prover: ${{ steps.changed-files.outputs.prover_any_changed }}
       docs: ${{ steps.changed-files.outputs.docs_any_changed }}
-      other: ${{ steps.changed-files.outputs.prover_other_changed_files }}
+      other: ${{ steps.calc-other.outputs.other_changed }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -51,6 +51,34 @@ jobs:
               - '**/*.MD'
               - '.github/workflows/ci-docs-reusable.yml'
 
+      - name: Calculate "other" changed files
+        id: calc-other
+        run: |
+          core_other_files="${{ steps.changed-files.outputs.core_other_changed_files }}"
+          prover_other_files="${{ steps.changed-files.outputs.prover_other_changed_files }}"
+          docs_other_files="${{ steps.changed-files.outputs.docs_other_changed_files }}"
+
+          core_all_files="${{ steps.changed-files.outputs.core_all_changed_files }}"
+          prover_all_files="${{ steps.changed-files.outputs.prover_all_changed_files }}"
+          docs_all_files="${{ steps.changed-files.outputs.docs_all_changed_files }}"
+
+          # Concatenate all 'other' files and 'all' files, remove duplicates
+          all_other_files=$(echo "$core_other_files $prover_other_files $docs_other_files" | tr ' ' '\n' | sort -u)
+          all_all_files=$(echo "$core_all_files $prover_all_files $docs_all_files" | tr ' ' '\n' | sort -u)
+
+          # Find unique 'other' files
+          unique_other_files=$(comm -23 <(echo "$all_other_files") <(echo "$all_all_files"))
+
+          if [ -n "$unique_other_files" ]; then
+            echo "other_changed=true"
+            echo "other_changed=true" >> $GITHUB_ENV
+            echo "::set-output name=other_changed::true"
+          else
+            echo "other_changed=false"
+            echo "other_changed=false" >> $GITHUB_ENV
+            echo "::set-output name=other_changed::false"
+          fi
+
   debug-outputs:
     name: Debug outputs
     runs-on: ubuntu-latest
@@ -63,12 +91,12 @@ jobs:
   ci-for-core:
     name: CI for Core Components
     needs: changed_files
-    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other != ''
+    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other_changed == 'true'
     uses: ./.github/workflows/ci-core-reusable.yml
 
   ci-for-prover:
     needs: changed_files
-    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other != ''
+    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other_changed == 'true'
     name: CI for Prover Components
     uses: ./.github/workflows/ci-prover-reusable.yml
 
@@ -81,7 +109,7 @@ jobs:
   build-core-images:
     name: Build core images
     needs: changed_files
-    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other != ''
+    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other_changed == 'true'
     uses: ./.github/workflows/build-core-template.yml
     with:
       image_tag: ${{ needs.setup.outputs.image_tag }}
@@ -94,7 +122,7 @@ jobs:
   build-prover-images:
     name: Build prover images
     needs: changed_files
-    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other != ''
+    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other_changed == 'true'
     uses: ./.github/workflows/build-prover-template.yml
     with:
       image_tag: ${{ needs.setup.outputs.image_tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       core: ${{ steps.changed-files.outputs.core_any_changed }}
       prover: ${{ steps.changed-files.outputs.prover_any_changed }}
       docs: ${{ steps.changed-files.outputs.docs_any_changed }}
-      other: ${{ steps.calc-other.outputs.other_changed }}
+      all: ${{ steps.changed-files.outputs.all_any_changed }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -32,107 +32,91 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v39
         with:
-          json: true
+          json: true"
           files_yaml: |
             prover:
               - 'prover/**'
               - 'docker/prover*/**'
               - '.github/workflows/build-prover-template.yml'
               - '.github/workflows/ci-prover-reusable.yml'
+              - 'docker-compose-runner-nightly.yml'
             core:
               - 'core/**'
+              - 'contracts/**'
               - 'docker/contract-verifier/**'
               - 'docker/cross-external-nodes-checker/**'
               - 'docker/external-node/**'
               - 'docker/server/**'
               - '.github/workflows/build-core-template.yml'
               - '.github/workflows/ci-core-reusable.yml'
+              - 'docker-compose-runner.yml'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
             docs:
               - '**/*.md'
               - '**/*.MD'
               - '.github/workflows/ci-docs-reusable.yml'
-      - run: echo ${{ steps.changed-files.outputs.all_changed_files }}
+            all:
+              - '.github/workflows/ci.yml'
+              - 'bin/**'
+              - 'etc/**'
 
-      # - name: Calculate "other" changed files
-      #   id: calc-other
-      #   run: |
-      #     core_other_files="${{ steps.changed-files.outputs.core_other_changed_files }}"
-      #     prover_other_files="${{ steps.changed-files.outputs.prover_other_changed_files }}"
-      #     docs_other_files="${{ steps.changed-files.outputs.docs_other_changed_files }}"
+  ci-for-core:
+    name: CI for Core Components
+    needs: changed_files
+    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.all == 'true'
+    uses: ./.github/workflows/ci-core-reusable.yml
 
-      #     core_all_files="${{ steps.changed-files.outputs.core_all_changed_files }}"
-      #     prover_all_files="${{ steps.changed-files.outputs.prover_all_changed_files }}"
-      #     docs_all_files="${{ steps.changed-files.outputs.docs_all_changed_files }}"
+  ci-for-prover:
+    needs: changed_files
+    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.all == 'true'
+    name: CI for Prover Components
+    uses: ./.github/workflows/ci-prover-reusable.yml
 
-      #     # Concatenate all 'other' files and 'all' files, remove duplicates
-      #     all_other_files=$(echo "$core_other_files $prover_other_files $docs_other_files" | tr ' ' '\n' | sort -u)
-      #     all_all_files=$(echo "$core_all_files $prover_all_files $docs_all_files" | tr ' ' '\n' | sort -u)
+  ci-for-docs:
+    needs: changed_files
+    if: needs.changed_files.outputs.docs == 'true'
+    name: CI for Docs
+    uses: ./.github/workflows/ci-docs-reusable.yml
 
-      #     # Find unique 'other' files
-      #     unique_other_files=$(comm -23 <(echo "$all_other_files") <(echo "$all_all_files"))
+  build-core-images:
+    name: Build core images
+    needs: changed_files
+    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.all == 'true'
+    uses: ./.github/workflows/build-core-template.yml
+    with:
+      image_tag: ${{ needs.setup.outputs.image_tag }}
+      image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}
+      action: "build"
+    secrets:
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      #     if [ -n "$unique_other_files" ]; then
-      #       echo 'other_changed=true' >> $GITHUB_OUTPUT
-      #     else
-      #       echo 'other_changed=false' >> $GITHUB_OUTPUT
-      #     fi
+  build-prover-images:
+    name: Build prover images
+    needs: changed_files
+    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.all == 'all'
+    uses: ./.github/workflows/build-prover-template.yml
+    with:
+      image_tag: ${{ needs.setup.outputs.image_tag }}
+      image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}
+      action: "build"
+      ERA_BELLMAN_CUDA_RELEASE: ${{ vars.ERA_BELLMAN_CUDA_RELEASE }}
+    secrets:
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  # ci-for-core:
-  #   name: CI for Core Components
-  #   needs: changed_files
-  #   if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other == 'true'
-  #   uses: ./.github/workflows/ci-core-reusable.yml
-
-  # ci-for-prover:
-  #   needs: changed_files
-  #   if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other == 'true'
-  #   name: CI for Prover Components
-  #   uses: ./.github/workflows/ci-prover-reusable.yml
-
-  # ci-for-docs:
-  #   needs: changed_files
-  #   if: needs.changed_files.outputs.docs == 'true'
-  #   name: CI for Docs
-  #   uses: ./.github/workflows/ci-docs-reusable.yml
-
-  # build-core-images:
-  #   name: Build core images
-  #   needs: changed_files
-  #   if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other == 'true'
-  #   uses: ./.github/workflows/build-core-template.yml
-  #   with:
-  #     image_tag: ${{ needs.setup.outputs.image_tag }}
-  #     image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}
-  #     action: "build"
-  #   secrets:
-  #     DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-  #     DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-
-  # build-prover-images:
-  #   name: Build prover images
-  #   needs: changed_files
-  #   if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other == 'true'
-  #   uses: ./.github/workflows/build-prover-template.yml
-  #   with:
-  #     image_tag: ${{ needs.setup.outputs.image_tag }}
-  #     image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}
-  #     action: "build"
-  #     ERA_BELLMAN_CUDA_RELEASE: ${{ vars.ERA_BELLMAN_CUDA_RELEASE }}
-  #   secrets:
-  #     DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-  #     DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-
-  # ci-success:
-  #   name: Github Status Check
-  #   runs-on: ubuntu-latest
-  #   if: always() && !cancelled()
-  #   needs: [ci-for-core, ci-for-prover, ci-for-docs, build-core-images, build-prover-images]
-  #   steps:
-  #     - name: Status
-  #       run: |
-  #         # This will check all jobs status in the `needs` list, and fail job if one is failed.
-  #         # Since we split prover and core to different flows, this job will be only as Required Status Check in the Pull Request.
-  #         if [[ ${{ contains(join(needs.*.result, ','), 'failure') }} == "true" ]]; then
-  #           echo "Intentionally failing to block PR from merging"
-  #           exit 1
-  #         fi
+  ci-success:
+    name: Github Status Check
+    runs-on: ubuntu-latest
+    if: always() && !cancelled()
+    needs: [ci-for-core, ci-for-prover, ci-for-docs, build-core-images, build-prover-images]
+    steps:
+      - name: Status
+        run: |
+          # This will check all jobs status in the `needs` list, and fail job if one is failed.
+          # Since we split prover and core to different flows, this job will be only as Required Status Check in the Pull Request.
+          if [[ ${{ contains(join(needs.*.result, ','), 'failure') }} == "true" ]]; then
+            echo "Intentionally failing to block PR from merging"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v39
         with:
+          json: true"
           files_yaml: |
             prover:
               - 'prover/**'
@@ -50,30 +51,31 @@ jobs:
               - '**/*.md'
               - '**/*.MD'
               - '.github/workflows/ci-docs-reusable.yml'
+      - run: echo ${{ steps.changed-files.outputs.all_changed_files }}
 
-      - name: Calculate "other" changed files
-        id: calc-other
-        run: |
-          core_other_files="${{ steps.changed-files.outputs.core_other_changed_files }}"
-          prover_other_files="${{ steps.changed-files.outputs.prover_other_changed_files }}"
-          docs_other_files="${{ steps.changed-files.outputs.docs_other_changed_files }}"
+      # - name: Calculate "other" changed files
+      #   id: calc-other
+      #   run: |
+      #     core_other_files="${{ steps.changed-files.outputs.core_other_changed_files }}"
+      #     prover_other_files="${{ steps.changed-files.outputs.prover_other_changed_files }}"
+      #     docs_other_files="${{ steps.changed-files.outputs.docs_other_changed_files }}"
 
-          core_all_files="${{ steps.changed-files.outputs.core_all_changed_files }}"
-          prover_all_files="${{ steps.changed-files.outputs.prover_all_changed_files }}"
-          docs_all_files="${{ steps.changed-files.outputs.docs_all_changed_files }}"
+      #     core_all_files="${{ steps.changed-files.outputs.core_all_changed_files }}"
+      #     prover_all_files="${{ steps.changed-files.outputs.prover_all_changed_files }}"
+      #     docs_all_files="${{ steps.changed-files.outputs.docs_all_changed_files }}"
 
-          # Concatenate all 'other' files and 'all' files, remove duplicates
-          all_other_files=$(echo "$core_other_files $prover_other_files $docs_other_files" | tr ' ' '\n' | sort -u)
-          all_all_files=$(echo "$core_all_files $prover_all_files $docs_all_files" | tr ' ' '\n' | sort -u)
+      #     # Concatenate all 'other' files and 'all' files, remove duplicates
+      #     all_other_files=$(echo "$core_other_files $prover_other_files $docs_other_files" | tr ' ' '\n' | sort -u)
+      #     all_all_files=$(echo "$core_all_files $prover_all_files $docs_all_files" | tr ' ' '\n' | sort -u)
 
-          # Find unique 'other' files
-          unique_other_files=$(comm -23 <(echo "$all_other_files") <(echo "$all_all_files"))
+      #     # Find unique 'other' files
+      #     unique_other_files=$(comm -23 <(echo "$all_other_files") <(echo "$all_all_files"))
 
-          if [ -n "$unique_other_files" ]; then
-            echo 'other_changed=true' >> $GITHUB_OUTPUT
-          else
-            echo 'other_changed=false' >> $GITHUB_OUTPUT
-          fi
+      #     if [ -n "$unique_other_files" ]; then
+      #       echo 'other_changed=true' >> $GITHUB_OUTPUT
+      #     else
+      #       echo 'other_changed=false' >> $GITHUB_OUTPUT
+      #     fi
 
   ci-for-core:
     name: CI for Core Components

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v39
         with:
-          json: true"
           files_yaml: |
             prover:
               - 'prover/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       core: ${{ steps.changed-files.outputs.core_any_changed }}
       prover: ${{ steps.changed-files.outputs.prover_any_changed }}
       docs: ${{ steps.changed-files.outputs.docs_any_changed }}
-      other: ${{ steps.changed-files.outputs.other_changed_files }}
+      other: ${{ steps.changed-files.outputs.test_other_changed_files }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
   build-prover-images:
     name: Build prover images
     needs: changed_files
-    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.all == 'all'
+    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.all == 'true'
     uses: ./.github/workflows/build-prover-template.yml
     with:
       image_tag: ${{ needs.setup.outputs.image_tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,62 +77,62 @@ jobs:
       #       echo 'other_changed=false' >> $GITHUB_OUTPUT
       #     fi
 
-  ci-for-core:
-    name: CI for Core Components
-    needs: changed_files
-    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other == 'true'
-    uses: ./.github/workflows/ci-core-reusable.yml
+  # ci-for-core:
+  #   name: CI for Core Components
+  #   needs: changed_files
+  #   if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other == 'true'
+  #   uses: ./.github/workflows/ci-core-reusable.yml
 
-  ci-for-prover:
-    needs: changed_files
-    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other == 'true'
-    name: CI for Prover Components
-    uses: ./.github/workflows/ci-prover-reusable.yml
+  # ci-for-prover:
+  #   needs: changed_files
+  #   if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other == 'true'
+  #   name: CI for Prover Components
+  #   uses: ./.github/workflows/ci-prover-reusable.yml
 
-  ci-for-docs:
-    needs: changed_files
-    if: needs.changed_files.outputs.docs == 'true'
-    name: CI for Docs
-    uses: ./.github/workflows/ci-docs-reusable.yml
+  # ci-for-docs:
+  #   needs: changed_files
+  #   if: needs.changed_files.outputs.docs == 'true'
+  #   name: CI for Docs
+  #   uses: ./.github/workflows/ci-docs-reusable.yml
 
-  build-core-images:
-    name: Build core images
-    needs: changed_files
-    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other == 'true'
-    uses: ./.github/workflows/build-core-template.yml
-    with:
-      image_tag: ${{ needs.setup.outputs.image_tag }}
-      image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}
-      action: "build"
-    secrets:
-      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+  # build-core-images:
+  #   name: Build core images
+  #   needs: changed_files
+  #   if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other == 'true'
+  #   uses: ./.github/workflows/build-core-template.yml
+  #   with:
+  #     image_tag: ${{ needs.setup.outputs.image_tag }}
+  #     image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}
+  #     action: "build"
+  #   secrets:
+  #     DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+  #     DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  build-prover-images:
-    name: Build prover images
-    needs: changed_files
-    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other == 'true'
-    uses: ./.github/workflows/build-prover-template.yml
-    with:
-      image_tag: ${{ needs.setup.outputs.image_tag }}
-      image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}
-      action: "build"
-      ERA_BELLMAN_CUDA_RELEASE: ${{ vars.ERA_BELLMAN_CUDA_RELEASE }}
-    secrets:
-      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+  # build-prover-images:
+  #   name: Build prover images
+  #   needs: changed_files
+  #   if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other == 'true'
+  #   uses: ./.github/workflows/build-prover-template.yml
+  #   with:
+  #     image_tag: ${{ needs.setup.outputs.image_tag }}
+  #     image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}
+  #     action: "build"
+  #     ERA_BELLMAN_CUDA_RELEASE: ${{ vars.ERA_BELLMAN_CUDA_RELEASE }}
+  #   secrets:
+  #     DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+  #     DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  ci-success:
-    name: Github Status Check
-    runs-on: ubuntu-latest
-    if: always() && !cancelled()
-    needs: [ci-for-core, ci-for-prover, ci-for-docs, build-core-images, build-prover-images]
-    steps:
-      - name: Status
-        run: |
-          # This will check all jobs status in the `needs` list, and fail job if one is failed.
-          # Since we split prover and core to different flows, this job will be only as Required Status Check in the Pull Request.
-          if [[ ${{ contains(join(needs.*.result, ','), 'failure') }} == "true" ]]; then
-            echo "Intentionally failing to block PR from merging"
-            exit 1
-          fi
+  # ci-success:
+  #   name: Github Status Check
+  #   runs-on: ubuntu-latest
+  #   if: always() && !cancelled()
+  #   needs: [ci-for-core, ci-for-prover, ci-for-docs, build-core-images, build-prover-images]
+  #   steps:
+  #     - name: Status
+  #       run: |
+  #         # This will check all jobs status in the `needs` list, and fail job if one is failed.
+  #         # Since we split prover and core to different flows, this job will be only as Required Status Check in the Pull Request.
+  #         if [[ ${{ contains(join(needs.*.result, ','), 'failure') }} == "true" ]]; then
+  #           echo "Intentionally failing to block PR from merging"
+  #           exit 1
+  #         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       core: ${{ steps.changed-files.outputs.core_any_changed }}
       prover: ${{ steps.changed-files.outputs.prover_any_changed }}
       docs: ${{ steps.changed-files.outputs.docs_any_changed }}
-      other: ${{ steps.changed-files.outputs.test_other_changed_files }}
+      other: ${{ steps.changed-files.outputs.prover_other_changed_files }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v39
         with:
-          json: true"
+          json: true
           files_yaml: |
             prover:
               - 'prover/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,12 +91,12 @@ jobs:
   ci-for-core:
     name: CI for Core Components
     needs: changed_files
-    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other_changed == 'true'
+    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other == 'true'
     uses: ./.github/workflows/ci-core-reusable.yml
 
   ci-for-prover:
     needs: changed_files
-    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other_changed == 'true'
+    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other == 'true'
     name: CI for Prover Components
     uses: ./.github/workflows/ci-prover-reusable.yml
 
@@ -109,7 +109,7 @@ jobs:
   build-core-images:
     name: Build core images
     needs: changed_files
-    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other_changed == 'true'
+    if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.other == 'true'
     uses: ./.github/workflows/build-core-template.yml
     with:
       image_tag: ${{ needs.setup.outputs.image_tag }}
@@ -122,7 +122,7 @@ jobs:
   build-prover-images:
     name: Build prover images
     needs: changed_files
-    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other_changed == 'true'
+    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.other == 'true'
     uses: ./.github/workflows/build-prover-template.yml
     with:
       image_tag: ${{ needs.setup.outputs.image_tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,13 +70,9 @@ jobs:
           unique_other_files=$(comm -23 <(echo "$all_other_files") <(echo "$all_all_files"))
 
           if [ -n "$unique_other_files" ]; then
-            echo "other_changed=true"
-            echo "other_changed=true" >> $GITHUB_ENV
-            echo "::set-output name=other_changed::true"
+            echo 'other_changed=true' >> $GITHUB_OUTPUT
           else
-            echo "other_changed=false"
-            echo "other_changed=false" >> $GITHUB_ENV
-            echo "::set-output name=other_changed::false"
+            echo 'other_changed=false' >> $GITHUB_OUTPUT
           fi
 
   debug-outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,15 +75,6 @@ jobs:
             echo 'other_changed=false' >> $GITHUB_OUTPUT
           fi
 
-  debug-outputs:
-    name: Debug outputs
-    runs-on: ubuntu-latest
-    needs: changed_files
-    steps:
-      - name: Debug
-        run: |
-          echo ${{ needs.changed_files.outputs.other }}
-
   ci-for-core:
     name: CI for Core Components
     needs: changed_files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
               - 'docker-compose-runner-nightly.yml'
             core:
               - 'core/**'
-              - 'contracts/**'
               - 'docker/contract-verifier/**'
               - 'docker/cross-external-nodes-checker/**'
               - 'docker/external-node/**'
@@ -59,6 +58,8 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'bin/**'
               - 'etc/**'
+              - 'contracts/**'
+              - 'infrastructure/zk/**'
 
   ci-for-core:
     name: CI for Core Components

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,15 @@ jobs:
               - '**/*.MD'
               - '.github/workflows/ci-docs-reusable.yml'
 
+  debug-outputs:
+    name: Debug outputs
+    runs-on: ubuntu-latest
+    needs: changed_files
+    steps:
+      - name: Debug
+        run: |
+          echo ${{ needs.changed_files.outputs.other }}
+
   ci-for-core:
     name: CI for Core Components
     needs: changed_files

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'core/**'
       - 'prover/**'
+      - 'codecov.yml'
 
 jobs:
   generate:


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Run all CI jobs when some global dependencies change

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

When want to validate all CI jobs when dependencies for everything change

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
