### PR TITLE
fix(boojum): remove extra code from state crate

### DIFF
--- a/core/lib/state/Cargo.toml
+++ b/core/lib/state/Cargo.toml
@@ -26,7 +26,6 @@ metrics = "0.21"
 
 [dev-dependencies]
 db_test_macro = { path = "../db_test_macro" }
-itertools = "0.10.3"
 
 rand = "0.8.5"
 tempfile = "3.0.2"

--- a/core/lib/state/src/in_memory.rs
+++ b/core/lib/state/src/in_memory.rs
@@ -77,7 +77,7 @@ impl InMemoryStorage {
 
         let last_enum_index_set = state.len() as u64;
         Self {
-            state: state.into_iter().collect(),
+            state,
             factory_deps,
             last_enum_index_set,
         }

--- a/core/lib/state/src/rocksdb/mod.rs
+++ b/core/lib/state/src/rocksdb/mod.rs
@@ -185,7 +185,10 @@ impl RocksdbStorage {
             "Secondary storage for L1 batch #{latest_l1_batch_number} initialized, size is {estimated_size}"
         );
 
-        self.save_missing_enum_indices(conn).await;
+        // Enum indices must be at the storage. Run migration till the end.
+        while self.enum_migration_start_from().is_some() {
+            self.save_missing_enum_indices(conn).await;
+        }
     }
 
     async fn apply_storage_logs(


### PR DESCRIPTION
# What ❔

- Removes some code that is not needed anymore.
- RocksDB enum_index migration is run till the end when storage is initializing. 

## Why ❔

- Remove not needed code
- Ensure RocksDB has enum indices on boojnet before they are actually used

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
