### PR TITLE
feat(multivm): Remove lifetime from multivm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7511,7 +7511,7 @@ checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 [[package]]
 name = "zk_evm"
 version = "1.3.1"
-source = "git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.1-rc0#877ba31cc1d82316fd924e8d83a9f5f1a77b1b9a"
+source = "git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.1-without-lifetime#07650e639ac3c9f257ec549e00e93118fb8b4c4d"
 dependencies = [
  "blake2 0.10.6",
  "k256",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7511,7 +7511,7 @@ checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 [[package]]
 name = "zk_evm"
 version = "1.3.1"
-source = "git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.1-without-lifetime#07650e639ac3c9f257ec549e00e93118fb8b4c4d"
+source = "git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.1-rc1#cec6535e2bcb1e8f0bad1befaaddec8da7f11b24"
 dependencies = [
  "blake2 0.10.6",
  "k256",

--- a/core/multivm_deps/vm_m5/Cargo.toml
+++ b/core/multivm_deps/vm_m5/Cargo.toml
@@ -17,7 +17,7 @@ zksync_config = { path = "../../lib/config" }
 zksync_state = { path = "../../lib/state" }
 zksync_storage = { path = "../../lib/storage" }
 
-zk_evm = { git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.1-rc0" }
+zk_evm = { git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.3.1-without-lifetime" }
 zksync_contracts = { path = "../../lib/contracts" }
 
 hex = "0.4"

--- a/core/multivm_deps/vm_m5/Cargo.toml
+++ b/core/multivm_deps/vm_m5/Cargo.toml
@@ -17,7 +17,7 @@ zksync_config = { path = "../../lib/config" }
 zksync_state = { path = "../../lib/state" }
 zksync_storage = { path = "../../lib/storage" }
 
-zk_evm = { git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.3.1-without-lifetime" }
+zk_evm = { git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.1-rc1" }
 zksync_contracts = { path = "../../lib/contracts" }
 
 hex = "0.4"

--- a/core/multivm_deps/vm_m5/src/pubdata_utils.rs
+++ b/core/multivm_deps/vm_m5/src/pubdata_utils.rs
@@ -11,7 +11,7 @@ use zksync_types::zkevm_test_harness::witness::sort_storage_access::sort_storage
 use zksync_types::{StorageKey, PUBLISH_BYTECODE_OVERHEAD, SYSTEM_CONTEXT_ADDRESS};
 use zksync_utils::bytecode::bytecode_len_in_bytes;
 
-impl<'a, S: Storage> VmInstance<'a, S> {
+impl<S: Storage> VmInstance<S> {
     pub fn pubdata_published(&self, from_timestamp: Timestamp) -> u32 {
         let storage_writes_pubdata_published = self.pubdata_published_for_writes(from_timestamp);
 

--- a/core/multivm_deps/vm_m5/src/refunds.rs
+++ b/core/multivm_deps/vm_m5/src/refunds.rs
@@ -8,7 +8,7 @@ use zk_evm::aux_structures::Timestamp;
 use zksync_types::U256;
 use zksync_utils::ceil_div_u256;
 
-impl<'a, S: Storage> VmInstance<'a, S> {
+impl<S: Storage> VmInstance<S> {
     pub(crate) fn tx_body_refund(
         &self,
         from_timestamp: Timestamp,

--- a/core/multivm_deps/vm_m5/src/test_utils.rs
+++ b/core/multivm_deps/vm_m5/src/test_utils.rs
@@ -91,7 +91,7 @@ pub struct VmInstanceInnerState {
     local_state: VmLocalState,
 }
 
-impl<'a, S: Storage> VmInstance<'a, S> {
+impl<S: Storage> VmInstance<S> {
     /// This method is mostly to be used in tests. It dumps the inner state of all the oracles and the VM itself.
     pub fn dump_inner_state(&self) -> VmInstanceInnerState {
         let event_sink = self.state.event_sink.clone();

--- a/core/multivm_deps/vm_m5/src/vm.rs
+++ b/core/multivm_deps/vm_m5/src/vm.rs
@@ -37,8 +37,7 @@ use crate::vm_with_bootloader::{
     OPERATOR_REFUNDS_OFFSET,
 };
 
-pub type ZkSyncVmState<'a, S> = VmState<
-    'a,
+pub type ZkSyncVmState<S> = VmState<
     StorageOracle<S>,
     SimpleMemory,
     InMemoryEventSink,
@@ -79,9 +78,9 @@ pub enum MultiVMSubversion {
 }
 
 #[derive(Debug)]
-pub struct VmInstance<'a, S: Storage> {
+pub struct VmInstance<S: Storage> {
     pub gas_limit: u32,
-    pub state: ZkSyncVmState<'a, S>,
+    pub state: ZkSyncVmState<S>,
     pub execution_mode: TxExecutionMode,
     pub block_context: DerivedBlockContext,
     pub(crate) bootloader_state: BootloaderState,
@@ -188,7 +187,7 @@ fn vm_may_have_ended_inner<const B: bool, S: Storage>(
         vm.local_state.callstack.get_current_stack().pc.as_u64(),
     ) {
         (true, 0) => {
-            let returndata = dump_memory_page_using_primitive_value(vm.memory, r1);
+            let returndata = dump_memory_page_using_primitive_value(&vm.memory, r1);
 
             Some(NewVmExecutionResult::Ok(returndata))
         }
@@ -198,7 +197,7 @@ fn vm_may_have_ended_inner<const B: bool, S: Storage>(
             if vm.local_state.flags.overflow_or_less_than_flag {
                 Some(NewVmExecutionResult::Panic)
             } else {
-                let returndata = dump_memory_page_using_primitive_value(vm.memory, r1);
+                let returndata = dump_memory_page_using_primitive_value(&vm.memory, r1);
                 Some(NewVmExecutionResult::Revert(returndata))
             }
         }
@@ -319,7 +318,7 @@ pub struct VmSnapshot {
     bootloader_state: BootloaderState,
 }
 
-impl<'a, S: Storage> VmInstance<'a, S> {
+impl<S: Storage> VmInstance<S> {
     fn has_ended(&self) -> bool {
         match vm_may_have_ended_inner(&self.state) {
             None | Some(NewVmExecutionResult::MostLikelyDidNotFinish(_, _)) => false,
@@ -858,7 +857,7 @@ impl<'a, S: Storage> VmInstance<'a, S> {
 
 // Reads the bootloader memory and checks whether the execution step of the transaction
 // has failed.
-pub(crate) fn tx_has_failed<S: Storage>(state: &ZkSyncVmState<'_, S>, tx_id: u32) -> bool {
+pub(crate) fn tx_has_failed<S: Storage>(state: &ZkSyncVmState<S>, tx_id: u32) -> bool {
     let mem_slot = RESULT_SUCCESS_FIRST_SLOT + tx_id;
     let mem_value = state
         .memory

--- a/core/multivm_deps/vm_m5/src/vm_with_bootloader.rs
+++ b/core/multivm_deps/vm_m5/src/vm_with_bootloader.rs
@@ -177,14 +177,14 @@ impl Default for TxExecutionMode {
     }
 }
 
-pub fn init_vm<'a, S: Storage>(
+pub fn init_vm<S: Storage>(
     refund_state: MultiVMSubversion,
-    oracle_tools: &'a mut OracleTools<false, S>,
+    oracle_tools: OracleTools<false, S>,
     block_context: BlockContextMode,
-    block_properties: &'a BlockProperties,
+    block_properties: BlockProperties,
     execution_mode: TxExecutionMode,
     base_system_contract: &BaseSystemContracts,
-) -> Box<VmInstance<'a, S>> {
+) -> Box<VmInstance<S>> {
     init_vm_with_gas_limit(
         refund_state,
         oracle_tools,
@@ -196,15 +196,15 @@ pub fn init_vm<'a, S: Storage>(
     )
 }
 
-pub fn init_vm_with_gas_limit<'a, S: Storage>(
+pub fn init_vm_with_gas_limit<S: Storage>(
     refund_state: MultiVMSubversion,
-    oracle_tools: &'a mut OracleTools<false, S>,
+    oracle_tools: OracleTools<false, S>,
     block_context: BlockContextMode,
-    block_properties: &'a BlockProperties,
+    block_properties: BlockProperties,
     execution_mode: TxExecutionMode,
     base_system_contract: &BaseSystemContracts,
     gas_limit: u32,
-) -> Box<VmInstance<'a, S>> {
+) -> Box<VmInstance<S>> {
     init_vm_inner(
         refund_state,
         oracle_tools,
@@ -293,15 +293,15 @@ impl BlockContextMode {
 
 // This method accepts a custom bootloader code.
 // It should be used only in tests.
-pub fn init_vm_inner<'a, S: Storage>(
+pub fn init_vm_inner<S: Storage>(
     refund_state: MultiVMSubversion,
-    oracle_tools: &'a mut OracleTools<false, S>,
+    mut oracle_tools: OracleTools<false, S>,
     block_context: BlockContextMode,
-    block_properties: &'a BlockProperties,
+    block_properties: BlockProperties,
     gas_limit: u32,
     base_system_contract: &BaseSystemContracts,
     execution_mode: TxExecutionMode,
-) -> Box<VmInstance<'a, S>> {
+) -> Box<VmInstance<S>> {
     oracle_tools.decommittment_processor.populate(
         vec![(
             h256_to_u256(base_system_contract.default_aa.hash),
@@ -470,18 +470,18 @@ pub(crate) fn get_bootloader_memory_for_encoded_tx(
     memory
 }
 
-fn get_default_local_state<'a, S: Storage>(
-    tools: &'a mut OracleTools<false, S>,
-    block_properties: &'a BlockProperties,
+fn get_default_local_state<S: Storage>(
+    tools: OracleTools<false, S>,
+    block_properties: BlockProperties,
     gas_limit: u32,
-) -> ZkSyncVmState<'a, S> {
+) -> ZkSyncVmState<S> {
     let mut vm = VmState::empty_state(
-        &mut tools.storage,
-        &mut tools.memory,
-        &mut tools.event_sink,
-        &mut tools.precompiles_processor,
-        &mut tools.decommittment_processor,
-        &mut tools.witness_tracer,
+        tools.storage,
+        tools.memory,
+        tools.event_sink,
+        tools.precompiles_processor,
+        tools.decommittment_processor,
+        tools.witness_tracer,
         block_properties,
     );
 

--- a/core/multivm_deps/vm_m6/Cargo.toml
+++ b/core/multivm_deps/vm_m6/Cargo.toml
@@ -18,7 +18,7 @@ zksync_config = { path = "../../lib/config" }
 zksync_state = { path = "../../lib/state" }
 zksync_storage = { path = "../../lib/storage" }
 
-zk_evm = { git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.3.1-without-lifetime" }
+zk_evm = { git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.1-rc1" }
 zksync_contracts = { path = "../../lib/contracts" }
 
 hex = "0.4"

--- a/core/multivm_deps/vm_m6/Cargo.toml
+++ b/core/multivm_deps/vm_m6/Cargo.toml
@@ -18,7 +18,7 @@ zksync_config = { path = "../../lib/config" }
 zksync_state = { path = "../../lib/state" }
 zksync_storage = { path = "../../lib/storage" }
 
-zk_evm = { git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.1-rc0" }
+zk_evm = { git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.3.1-without-lifetime" }
 zksync_contracts = { path = "../../lib/contracts" }
 
 hex = "0.4"

--- a/core/multivm_deps/vm_m6/src/pubdata_utils.rs
+++ b/core/multivm_deps/vm_m6/src/pubdata_utils.rs
@@ -11,7 +11,7 @@ use zksync_types::zkevm_test_harness::witness::sort_storage_access::sort_storage
 use zksync_types::{StorageKey, PUBLISH_BYTECODE_OVERHEAD, SYSTEM_CONTEXT_ADDRESS};
 use zksync_utils::bytecode::bytecode_len_in_bytes;
 
-impl<H: HistoryMode, S: Storage> VmInstance<'_, S, H> {
+impl<H: HistoryMode, S: Storage> VmInstance<S, H> {
     pub fn pubdata_published(&self, from_timestamp: Timestamp) -> u32 {
         let storage_writes_pubdata_published = self.pubdata_published_for_writes(from_timestamp);
 

--- a/core/multivm_deps/vm_m6/src/refunds.rs
+++ b/core/multivm_deps/vm_m6/src/refunds.rs
@@ -8,7 +8,7 @@ use zk_evm::aux_structures::Timestamp;
 use zksync_types::U256;
 use zksync_utils::ceil_div_u256;
 
-impl<H: HistoryMode, S: Storage> VmInstance<'_, S, H> {
+impl<H: HistoryMode, S: Storage> VmInstance<S, H> {
     pub(crate) fn tx_body_refund(
         &self,
         from_timestamp: Timestamp,

--- a/core/multivm_deps/vm_m6/src/test_utils.rs
+++ b/core/multivm_deps/vm_m6/src/test_utils.rs
@@ -91,7 +91,7 @@ pub struct VmInstanceInnerState<H: HistoryMode> {
     local_state: VmLocalState,
 }
 
-impl<H: HistoryMode, S: Storage> VmInstance<'_, S, H> {
+impl<H: HistoryMode, S: Storage> VmInstance<S, H> {
     /// This method is mostly to be used in tests. It dumps the inner state of all the oracles and the VM itself.
     pub fn dump_inner_state(&self) -> VmInstanceInnerState<H> {
         let event_sink = self.state.event_sink.clone();

--- a/core/multivm_deps/vm_m6/src/utils.rs
+++ b/core/multivm_deps/vm_m6/src/utils.rs
@@ -267,7 +267,7 @@ pub(crate) fn calculate_computational_gas_used<
     T: PubdataSpentTracer<H>,
     H: HistoryMode,
 >(
-    vm: &VmInstance<'_, S, H>,
+    vm: &VmInstance<S, H>,
     tracer: &T,
     gas_remaining_before: u32,
     spent_pubdata_counter_before: u32,

--- a/core/multivm_deps/vm_m6/src/vm.rs
+++ b/core/multivm_deps/vm_m6/src/vm.rs
@@ -39,8 +39,7 @@ use crate::vm_with_bootloader::{
     OPERATOR_REFUNDS_OFFSET,
 };
 
-pub type ZkSyncVmState<'a, S, H> = VmState<
-    'a,
+pub type ZkSyncVmState<S, H> = VmState<
     StorageOracle<S, H>,
     SimpleMemory<H>,
     InMemoryEventSink<H>,
@@ -81,9 +80,9 @@ pub enum MultiVMSubversion {
 }
 
 #[derive(Debug)]
-pub struct VmInstance<'a, S: Storage, H: HistoryMode> {
+pub struct VmInstance<S: Storage, H: HistoryMode> {
     pub gas_limit: u32,
-    pub state: ZkSyncVmState<'a, S, H>,
+    pub state: ZkSyncVmState<S, H>,
     pub execution_mode: TxExecutionMode,
     pub block_context: DerivedBlockContext,
     pub(crate) bootloader_state: BootloaderState,
@@ -185,7 +184,7 @@ fn vm_may_have_ended_inner<H: HistoryMode, S: Storage>(
         vm.local_state.callstack.get_current_stack().pc.as_u64(),
     ) {
         (true, 0) => {
-            let returndata = dump_memory_page_using_primitive_value(vm.memory, r1);
+            let returndata = dump_memory_page_using_primitive_value(&vm.memory, r1);
 
             Some(NewVmExecutionResult::Ok(returndata))
         }
@@ -195,7 +194,7 @@ fn vm_may_have_ended_inner<H: HistoryMode, S: Storage>(
             if vm.local_state.flags.overflow_or_less_than_flag {
                 Some(NewVmExecutionResult::Panic)
             } else {
-                let returndata = dump_memory_page_using_primitive_value(vm.memory, r1);
+                let returndata = dump_memory_page_using_primitive_value(&vm.memory, r1);
                 Some(NewVmExecutionResult::Revert(returndata))
             }
         }
@@ -327,7 +326,7 @@ pub struct VmSnapshot {
     bootloader_state: BootloaderState,
 }
 
-impl<H: HistoryMode, S: Storage> VmInstance<'_, S, H> {
+impl<H: HistoryMode, S: Storage> VmInstance<S, H> {
     fn has_ended(&self) -> bool {
         match vm_may_have_ended_inner(&self.state) {
             None | Some(NewVmExecutionResult::MostLikelyDidNotFinish(_, _)) => false,
@@ -924,7 +923,7 @@ impl<H: HistoryMode, S: Storage> VmInstance<'_, S, H> {
     }
 }
 
-impl<S: Storage> VmInstance<'_, S, HistoryEnabled> {
+impl<S: Storage> VmInstance<S, HistoryEnabled> {
     /// Saves the snapshot of the current state of the VM that can be used
     /// to roll back its state later on.
     pub fn save_current_vm_as_snapshot(&mut self) {
@@ -986,7 +985,7 @@ impl<S: Storage> VmInstance<'_, S, HistoryEnabled> {
 // Reads the bootloader memory and checks whether the execution step of the transaction
 // has failed.
 pub(crate) fn tx_has_failed<H: HistoryMode, S: Storage>(
-    state: &ZkSyncVmState<'_, S, H>,
+    state: &ZkSyncVmState<S, H>,
     tx_id: u32,
 ) -> bool {
     let mem_slot = RESULT_SUCCESS_FIRST_SLOT + tx_id;

--- a/core/multivm_deps/vm_m6/src/vm_with_bootloader.rs
+++ b/core/multivm_deps/vm_m6/src/vm_with_bootloader.rs
@@ -212,14 +212,14 @@ impl Default for TxExecutionMode {
     }
 }
 
-pub fn init_vm<'a, S: Storage, H: HistoryMode>(
+pub fn init_vm<S: Storage, H: HistoryMode>(
     vm_subversion: MultiVMSubversion,
-    oracle_tools: &'a mut OracleTools<false, S, H>,
+    oracle_tools: OracleTools<false, S, H>,
     block_context: BlockContextMode,
-    block_properties: &'a BlockProperties,
+    block_properties: BlockProperties,
     execution_mode: TxExecutionMode,
     base_system_contract: &BaseSystemContracts,
-) -> Box<VmInstance<'a, S, H>> {
+) -> Box<VmInstance<S, H>> {
     init_vm_with_gas_limit(
         vm_subversion,
         oracle_tools,
@@ -231,15 +231,15 @@ pub fn init_vm<'a, S: Storage, H: HistoryMode>(
     )
 }
 
-pub fn init_vm_with_gas_limit<'a, S: Storage, H: HistoryMode>(
+pub fn init_vm_with_gas_limit<S: Storage, H: HistoryMode>(
     vm_subversion: MultiVMSubversion,
-    oracle_tools: &'a mut OracleTools<false, S, H>,
+    oracle_tools: OracleTools<false, S, H>,
     block_context: BlockContextMode,
-    block_properties: &'a BlockProperties,
+    block_properties: BlockProperties,
     execution_mode: TxExecutionMode,
     base_system_contract: &BaseSystemContracts,
     gas_limit: u32,
-) -> Box<VmInstance<'a, S, H>> {
+) -> Box<VmInstance<S, H>> {
     init_vm_inner(
         vm_subversion,
         oracle_tools,
@@ -328,15 +328,15 @@ impl BlockContextMode {
 
 // This method accepts a custom bootloader code.
 // It should be used only in tests.
-pub fn init_vm_inner<'a, S: Storage, H: HistoryMode>(
+pub fn init_vm_inner<S: Storage, H: HistoryMode>(
     vm_subversion: MultiVMSubversion,
-    oracle_tools: &'a mut OracleTools<false, S, H>,
+    mut oracle_tools: OracleTools<false, S, H>,
     block_context: BlockContextMode,
-    block_properties: &'a BlockProperties,
+    block_properties: BlockProperties,
     gas_limit: u32,
     base_system_contract: &BaseSystemContracts,
     execution_mode: TxExecutionMode,
-) -> Box<VmInstance<'a, S, H>> {
+) -> Box<VmInstance<S, H>> {
     oracle_tools.decommittment_processor.populate(
         vec![(
             h256_to_u256(base_system_contract.default_aa.hash),
@@ -799,18 +799,18 @@ pub(crate) fn get_bootloader_memory_for_encoded_tx(
     memory
 }
 
-fn get_default_local_state<'a, S: Storage, H: HistoryMode>(
-    tools: &'a mut OracleTools<false, S, H>,
-    block_properties: &'a BlockProperties,
+fn get_default_local_state<S: Storage, H: HistoryMode>(
+    tools: OracleTools<false, S, H>,
+    block_properties: BlockProperties,
     gas_limit: u32,
-) -> ZkSyncVmState<'a, S, H> {
+) -> ZkSyncVmState<S, H> {
     let mut vm = VmState::empty_state(
-        &mut tools.storage,
-        &mut tools.memory,
-        &mut tools.event_sink,
-        &mut tools.precompiles_processor,
-        &mut tools.decommittment_processor,
-        &mut tools.witness_tracer,
+        tools.storage,
+        tools.memory,
+        tools.event_sink,
+        tools.precompiles_processor,
+        tools.decommittment_processor,
+        tools.witness_tracer,
         block_properties,
     );
     // Override ergs limit for the initial frame.


### PR DESCRIPTION
# What ❔

Remove lifetime from multivm. Update zk_evm 1.3.1 to the version without lifetime

## Why ❔

For better compatibility with the new VM versions, i've updated zk-evm by removing lifetime from vm state 

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
