### PR TITLE
refactor(multivm): remove necessary data

### DIFF
--- a/core/lib/multivm/src/glue/init_vm.rs
+++ b/core/lib/multivm/src/glue/init_vm.rs
@@ -1,21 +1,33 @@
 use super::GlueInto;
 use crate::glue::history_mode::HistoryMode;
-use crate::vm_instance::{VmInstanceData, VmInstanceVersion};
+use crate::vm_instance::VmInstanceVersion;
 use crate::VmInstance;
 use vm_latest::{L1BatchEnv, SystemEnv};
-use zksync_state::ReadStorage;
+use zksync_state::{ReadStorage, StoragePtr, StorageView};
+use zksync_types::VmVersion;
 use zksync_utils::h256_to_u256;
 
 impl<S: ReadStorage, H: HistoryMode> VmInstance<S, H> {
     pub fn new(
         l1_batch_env: L1BatchEnv,
         system_env: SystemEnv,
-        initial_version: VmInstanceData<S, H>,
+        storage_view: StoragePtr<StorageView<S>>,
     ) -> Self {
-        match initial_version {
-            VmInstanceData::M5(data) => {
+        let protocol_version = system_env.version;
+        let vm_version: VmVersion = protocol_version.into();
+        Self::new_with_specific_version(l1_batch_env, system_env, storage_view, vm_version)
+    }
+
+    pub fn new_with_specific_version(
+        l1_batch_env: L1BatchEnv,
+        system_env: SystemEnv,
+        storage_view: StoragePtr<StorageView<S>>,
+        vm_version: VmVersion,
+    ) -> Self {
+        match vm_version {
+            VmVersion::M5WithoutRefunds => {
                 let oracle_tools =
-                    vm_m5::OracleTools::new(data.storage_view.clone(), data.sub_version);
+                    vm_m5::OracleTools::new(storage_view.clone(), vm_m5::vm::MultiVMSubversion::V1);
                 let block_properties = vm_m5::zk_evm::block_properties::BlockProperties {
                     default_aa_code_hash: h256_to_u256(
                         system_env.base_system_smart_contracts.default_aa.hash,
@@ -23,7 +35,7 @@ impl<S: ReadStorage, H: HistoryMode> VmInstance<S, H> {
                     zkporter_is_available: false,
                 };
                 let inner_vm = vm_m5::vm_with_bootloader::init_vm_with_gas_limit(
-                    data.sub_version,
+                    vm_m5::vm::MultiVMSubversion::V1,
                     oracle_tools,
                     l1_batch_env.glue_into(),
                     block_properties,
@@ -37,11 +49,33 @@ impl<S: ReadStorage, H: HistoryMode> VmInstance<S, H> {
                     last_tx_compressed_bytecodes: vec![],
                 }
             }
-            VmInstanceData::M6(data) => {
-                let oracle_tools = vm_m6::OracleTools::new(
-                    data.storage_view.clone(),
-                    data.history_mode.glue_into(),
+            VmVersion::M5WithRefunds => {
+                let oracle_tools =
+                    vm_m5::OracleTools::new(storage_view.clone(), vm_m5::vm::MultiVMSubversion::V2);
+                let block_properties = vm_m5::zk_evm::block_properties::BlockProperties {
+                    default_aa_code_hash: h256_to_u256(
+                        system_env.base_system_smart_contracts.default_aa.hash,
+                    ),
+                    zkporter_is_available: false,
+                };
+                let inner_vm = vm_m5::vm_with_bootloader::init_vm_with_gas_limit(
+                    vm_m5::vm::MultiVMSubversion::V2,
+                    oracle_tools,
+                    l1_batch_env.glue_into(),
+                    block_properties,
+                    system_env.execution_mode.glue_into(),
+                    &system_env.base_system_smart_contracts.clone().glue_into(),
+                    system_env.gas_limit,
                 );
+                VmInstance {
+                    vm: VmInstanceVersion::VmM5(inner_vm),
+                    system_env,
+                    last_tx_compressed_bytecodes: vec![],
+                }
+            }
+            VmVersion::M6Initial => {
+                let oracle_tools =
+                    vm_m6::OracleTools::new(storage_view.clone(), H::VmM6Mode::default());
                 let block_properties = vm_m6::zk_evm::block_properties::BlockProperties {
                     default_aa_code_hash: h256_to_u256(
                         system_env.base_system_smart_contracts.default_aa.hash,
@@ -50,7 +84,7 @@ impl<S: ReadStorage, H: HistoryMode> VmInstance<S, H> {
                 };
 
                 let inner_vm = vm_m6::vm_with_bootloader::init_vm_with_gas_limit(
-                    data.sub_version,
+                    vm_m6::vm::MultiVMSubversion::V1,
                     oracle_tools,
                     l1_batch_env.glue_into(),
                     block_properties,
@@ -64,9 +98,33 @@ impl<S: ReadStorage, H: HistoryMode> VmInstance<S, H> {
                     last_tx_compressed_bytecodes: vec![],
                 }
             }
+            VmVersion::M6BugWithCompressionFixed => {
+                let oracle_tools =
+                    vm_m6::OracleTools::new(storage_view.clone(), H::VmM6Mode::default());
+                let block_properties = vm_m6::zk_evm::block_properties::BlockProperties {
+                    default_aa_code_hash: h256_to_u256(
+                        system_env.base_system_smart_contracts.default_aa.hash,
+                    ),
+                    zkporter_is_available: false,
+                };
 
-            VmInstanceData::Vm1_3_2(data) => {
-                let oracle_tools = vm_1_3_2::OracleTools::new(data.storage_view.clone());
+                let inner_vm = vm_m6::vm_with_bootloader::init_vm_with_gas_limit(
+                    vm_m6::vm::MultiVMSubversion::V2,
+                    oracle_tools,
+                    l1_batch_env.glue_into(),
+                    block_properties,
+                    system_env.execution_mode.glue_into(),
+                    &system_env.base_system_smart_contracts.clone().glue_into(),
+                    system_env.gas_limit,
+                );
+                VmInstance {
+                    vm: VmInstanceVersion::VmM6(inner_vm),
+                    system_env,
+                    last_tx_compressed_bytecodes: vec![],
+                }
+            }
+            VmVersion::Vm1_3_2 => {
+                let oracle_tools = vm_1_3_2::OracleTools::new(storage_view.clone());
                 let block_properties = vm_1_3_2::BlockProperties {
                     default_aa_code_hash: h256_to_u256(
                         system_env.base_system_smart_contracts.default_aa.hash,
@@ -87,11 +145,11 @@ impl<S: ReadStorage, H: HistoryMode> VmInstance<S, H> {
                     last_tx_compressed_bytecodes: vec![],
                 }
             }
-            VmInstanceData::VmVirtualBlocks(data) => {
+            VmVersion::VmVirtualBlocks => {
                 let vm = vm_virtual_blocks::Vm::new(
                     l1_batch_env.glue_into(),
                     system_env.clone().glue_into(),
-                    data.storage_view.clone(),
+                    storage_view.clone(),
                     H::VmVirtualBlocksMode::default(),
                 );
                 let vm = VmInstanceVersion::VmVirtualBlocks(Box::new(vm));
@@ -101,11 +159,11 @@ impl<S: ReadStorage, H: HistoryMode> VmInstance<S, H> {
                     last_tx_compressed_bytecodes: vec![],
                 }
             }
-            VmInstanceData::VmVirtualBlocksRefundsEnhancement(data) => {
+            VmVersion::VmVirtualBlocksRefundsEnhancement => {
                 let vm = vm_latest::Vm::new(
                     l1_batch_env.glue_into(),
                     system_env.clone(),
-                    data.storage_view.clone(),
+                    storage_view.clone(),
                     H::VmVirtualBlocksRefundsEnhancement::default(),
                 );
                 let vm = VmInstanceVersion::VmVirtualBlocksRefundsEnhancement(Box::new(vm));

--- a/core/lib/multivm/src/lib.rs
+++ b/core/lib/multivm/src/lib.rs
@@ -3,7 +3,7 @@ pub use crate::{
         block_properties::BlockProperties, history_mode::HistoryMode, oracle_tools::OracleTools,
         tracer::MultivmTracer,
     },
-    vm_instance::{VmInstance, VmInstanceData},
+    vm_instance::VmInstance,
 };
 pub use zksync_types::vm_version::VmVersion;
 

--- a/core/lib/zksync_core/src/api_server/execution_sandbox/apply.rs
+++ b/core/lib/zksync_core/src/api_server/execution_sandbox/apply.rs
@@ -6,7 +6,7 @@
 //!
 //! This module is intended to be blocking.
 
-use multivm::{VmInstance, VmInstanceData};
+use multivm::VmInstance;
 use std::time::{Duration, Instant};
 use vm::{constants::BLOCK_GAS_LIMIT, HistoryDisabled, L1BatchEnv, L2BlockEnv, SystemEnv};
 
@@ -197,12 +197,12 @@ pub(super) fn apply_vm_in_sandbox<T>(
     };
 
     let storage_view = storage_view.to_rc_ptr();
-    let initial_version = VmInstanceData::new_for_specific_vm_version(
+    let mut vm = Box::new(VmInstance::new_with_specific_version(
+        l1_batch_env,
+        system_env,
         storage_view.clone(),
-        HistoryDisabled,
         protocol_version.into_api_vm_version(),
-    );
-    let mut vm = Box::new(VmInstance::new(l1_batch_env, system_env, initial_version));
+    ));
 
     metrics::histogram!("api.web3.sandbox", stage_started_at.elapsed(), "stage" => "initialization");
     span.exit();

--- a/core/lib/zksync_core/src/state_keeper/batch_executor/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/batch_executor/mod.rs
@@ -9,7 +9,7 @@ use tokio::{
     task::JoinHandle,
 };
 
-use multivm::{MultivmTracer, VmInstance, VmInstanceData};
+use multivm::{MultivmTracer, VmInstance};
 use vm::{
     CallTracer, ExecutionResult, FinishedL1Batch, Halt, HistoryEnabled, L1BatchEnv, L2BlockEnv,
     SystemEnv, VmExecutionResultAndLogs,
@@ -292,8 +292,7 @@ impl BatchExecutor {
 
         let storage_view = StorageView::new(secondary_storage).to_rc_ptr();
 
-        let instance_data = VmInstanceData::new(storage_view.clone(), &system_env, HistoryEnabled);
-        let mut vm = VmInstance::new(l1_batch_params, system_env, instance_data);
+        let mut vm = VmInstance::new(l1_batch_params, system_env, storage_view.clone());
 
         while let Some(cmd) = self.commands.blocking_recv() {
             match cmd {


### PR DESCRIPTION
# What ❔

Remove necessary data struct from multivm.

## Why ❔

We've managed to remove lifetime and now VM instance can create all necessary types just inside VMInstance

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
