### PR TITLE
ci: Worklow to mark PRs from forks with external-contribution label

### DIFF
--- a/.github/workflows/label-extenal-contributions.yml
+++ b/.github/workflows/label-extenal-contributions.yml
@@ -1,7 +1,7 @@
 name: Workflow to label external contributions
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, ready_for_review]
 
 jobs:

--- a/.github/workflows/label-extenal-contributions.yml
+++ b/.github/workflows/label-extenal-contributions.yml
@@ -2,7 +2,7 @@ name: Workflow to label external contributions
 
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened]
 
 jobs:
   label:

--- a/.github/workflows/label-extenal-contributions.yml
+++ b/.github/workflows/label-extenal-contributions.yml
@@ -1,0 +1,29 @@
+name: Workflow to label external contributions
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Add external-contribution label
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+        REPO_FULL_NAME=$(jq --raw-output .repository.full_name "$GITHUB_EVENT_PATH")
+        IS_FORK=$(jq --raw-output .pull_request.head.repo.fork "$GITHUB_EVENT_PATH")
+
+        if [[ "$IS_FORK" == "true" ]]; then
+            echo "This PR is created from a fork."
+            curl \
+            -X POST \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/$REPO_FULL_NAME/issues/$PR_NUMBER/labels" \
+            -d '{"labels": ["external-contribution"]}'
+        else
+            echo "This PR is not created from a fork."
+        fi

--- a/.github/workflows/label-extenal-contributions.yml
+++ b/.github/workflows/label-extenal-contributions.yml
@@ -2,7 +2,7 @@ name: Workflow to label external contributions
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, ready_for_review]
 
 jobs:
   label:


### PR DESCRIPTION
# What ❔

Subj

## Why ❔

To be able to filter out all externally contributed PRs to then have filtering/notifications for them

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
