### PR TITLE
ci: Fix permissions for Workflow to label external contributions

### DIFF
--- a/.github/workflows/label-extenal-contributions.yml
+++ b/.github/workflows/label-extenal-contributions.yml
@@ -1,8 +1,11 @@
 name: Workflow to label external contributions
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review]
+
+permissions:
+  issues: write
 
 jobs:
   label:


### PR DESCRIPTION
# What ❔

Fixes workflow permissions

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).

