### PR TITLE
fix(db): Fix write stalls in RocksDB (again)

### DIFF
--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -191,6 +191,11 @@ pub struct OptionalENConfig {
     #[serde(default = "OptionalENConfig::default_merkle_tree_block_cache_size_mb")]
     merkle_tree_block_cache_size_mb: usize,
 
+    /// Byte capacity of memtables (recent, non-persisted changes to RocksDB). Setting this to a reasonably
+    /// large value (order of 512 MiB) is helpful for large DBs that experience write stalls.
+    #[serde(default = "OptionalENConfig::default_merkle_tree_memtable_capacity_mb")]
+    merkle_tree_memtable_capacity_mb: usize,
+
     // Other config settings
     /// Port on which the Prometheus exporter server is listening.
     pub prometheus_port: Option<u16>,
@@ -274,6 +279,10 @@ impl OptionalENConfig {
         128
     }
 
+    const fn default_merkle_tree_memtable_capacity_mb() -> usize {
+        256
+    }
+
     const fn default_fee_history_limit() -> u64 {
         1_024
     }
@@ -316,6 +325,11 @@ impl OptionalENConfig {
     /// Returns the size of block cache for Merkle tree in bytes.
     pub fn merkle_tree_block_cache_size(&self) -> usize {
         self.merkle_tree_block_cache_size_mb * BYTES_IN_MEGABYTE
+    }
+
+    /// Returns the memtable capacity for Merkle tree in bytes.
+    pub fn merkle_tree_memtable_capacity(&self) -> usize {
+        self.merkle_tree_memtable_capacity_mb * BYTES_IN_MEGABYTE
     }
 
     pub fn api_namespaces(&self) -> Vec<Namespace> {

--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -138,6 +138,7 @@ async fn init_tasks(
         max_l1_batches_per_iter: config.optional.max_l1_batches_per_tree_iter,
         multi_get_chunk_size: config.optional.merkle_tree_multi_get_chunk_size,
         block_cache_capacity: config.optional.merkle_tree_block_cache_size(),
+        memtable_capacity: config.optional.merkle_tree_memtable_capacity(),
     })
     .await;
     healthchecks.push(Box::new(metadata_calculator.tree_health_check()));

--- a/core/lib/config/src/configs/database.rs
+++ b/core/lib/config/src/configs/database.rs
@@ -38,6 +38,10 @@ pub struct MerkleTreeConfig {
     /// The default value is 128 MB.
     #[serde(default = "MerkleTreeConfig::default_block_cache_size_mb")]
     pub block_cache_size_mb: usize,
+    /// Byte capacity of memtables (recent, non-persisted changes to RocksDB). Setting this to a reasonably
+    /// large value (order of 512 MiB) is helpful for large DBs that experience write stalls.
+    #[serde(default = "MerkleTreeConfig::default_memtable_capacity_mb")]
+    pub memtable_capacity_mb: usize,
     /// Maximum number of L1 batches to be processed by the Merkle tree at a time.
     #[serde(default = "MerkleTreeConfig::default_max_l1_batches_per_iter")]
     pub max_l1_batches_per_iter: usize,
@@ -51,6 +55,7 @@ impl Default for MerkleTreeConfig {
             mode: MerkleTreeMode::default(),
             multi_get_chunk_size: Self::default_multi_get_chunk_size(),
             block_cache_size_mb: Self::default_block_cache_size_mb(),
+            memtable_capacity_mb: Self::default_memtable_capacity_mb(),
             max_l1_batches_per_iter: Self::default_max_l1_batches_per_iter(),
         }
     }
@@ -73,6 +78,10 @@ impl MerkleTreeConfig {
         128
     }
 
+    const fn default_memtable_capacity_mb() -> usize {
+        256
+    }
+
     const fn default_max_l1_batches_per_iter() -> usize {
         20
     }
@@ -80,6 +89,11 @@ impl MerkleTreeConfig {
     /// Returns the size of block cache size for Merkle tree in bytes.
     pub fn block_cache_size(&self) -> usize {
         self.block_cache_size_mb * super::BYTES_IN_MEGABYTE
+    }
+
+    /// Returns the memtable capacity in bytes.
+    pub fn memtable_capacity(&self) -> usize {
+        self.memtable_capacity_mb * super::BYTES_IN_MEGABYTE
     }
 }
 

--- a/core/lib/merkle_tree/examples/loadtest/main.rs
+++ b/core/lib/merkle_tree/examples/loadtest/main.rs
@@ -16,7 +16,7 @@ use zksync_crypto::hasher::blake2::Blake2Hasher;
 use zksync_merkle_tree::{
     Database, HashTree, MerkleTree, MerkleTreePruner, PatchSet, RocksDBWrapper, TreeInstruction,
 };
-use zksync_storage::RocksDB;
+use zksync_storage::{RocksDB, RocksDBOptions};
 use zksync_types::{AccountTreeId, Address, StorageKey, H256, U256};
 
 mod batch;
@@ -81,12 +81,15 @@ impl Cli {
                 "Created temp dir for RocksDB: {}",
                 dir.path().to_string_lossy()
             );
-            rocksdb = if let Some(block_cache_capacity) = self.block_cache {
-                let db = RocksDB::with_cache(dir.path(), Some(block_cache_capacity));
-                RocksDBWrapper::from(db)
-            } else {
-                RocksDBWrapper::new(dir.path())
-            };
+            let db = RocksDB::with_options(
+                dir.path(),
+                RocksDBOptions {
+                    block_cache_capacity: self.block_cache,
+                    ..RocksDBOptions::default()
+                },
+            );
+            rocksdb = RocksDBWrapper::from(db);
+
             if let Some(chunk_size) = self.chunk_size {
                 rocksdb.set_multi_get_chunk_size(chunk_size);
             }

--- a/core/lib/merkle_tree/src/storage/rocksdb.rs
+++ b/core/lib/merkle_tree/src/storage/rocksdb.rs
@@ -35,6 +35,10 @@ impl NamedColumnFamily for MerkleTreeColumnFamily {
             Self::StaleKeys => "stale_keys",
         }
     }
+
+    fn requires_tuning(&self) -> bool {
+        matches!(self, Self::Tree)
+    }
 }
 
 /// Main [`Database`] implementation wrapping a [`RocksDB`] reference.

--- a/core/lib/storage/src/lib.rs
+++ b/core/lib/storage/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod db;
 mod metrics;
 
-pub use db::RocksDB;
+pub use db::{RocksDB, RocksDBOptions};
 pub use rocksdb;

--- a/core/lib/storage/src/metrics.rs
+++ b/core/lib/storage/src/metrics.rs
@@ -1,7 +1,7 @@
 //! General-purpose RocksDB metrics. All metrics code in the crate should be in this module.
 
 use once_cell::sync::Lazy;
-use vise::{Buckets, Collector, EncodeLabelSet, Family, Gauge, Histogram, Metrics, Unit};
+use vise::{Buckets, Collector, Counter, EncodeLabelSet, Family, Gauge, Histogram, Metrics, Unit};
 
 use std::{
     collections::HashMap,
@@ -41,11 +41,17 @@ pub(crate) struct RocksdbMetrics {
     /// Size of a serialized `WriteBatch` written to a RocksDB instance.
     #[metrics(buckets = BYTE_SIZE_BUCKETS)]
     write_batch_size: Family<DbLabel, Histogram<usize>>,
+    /// Number of stalled writes for a RocksDB instance.
+    write_stalled: Family<DbLabel, Counter>,
 }
 
 impl RocksdbMetrics {
     pub(crate) fn report_batch_size(&self, db: &'static str, batch_size: usize) {
         self.write_batch_size[&db.into()].observe(batch_size);
+    }
+
+    pub(crate) fn report_stalled_write(&self, db: &'static str) {
+        self.write_stalled[&db.into()].inc();
     }
 }
 
@@ -58,8 +64,10 @@ pub(crate) static METRICS: vise::Global<RocksdbMetrics> = vise::Global::new();
 pub(crate) struct RocksdbSizeMetrics {
     /// Boolean gauge indicating whether writing to the column family is currently stopped.
     pub writes_stopped: Family<RocksdbLabels, Gauge<u64>>,
-    /// Number of immutable memtables.
+    /// Number of immutable memtables. Large value increases risks of write stalls.
     pub immutable_mem_tables: Family<RocksdbLabels, Gauge<u64>>,
+    /// Number of level-0 SST files. Large value increases risks of write stalls.
+    pub level0_files: Family<RocksdbLabels, Gauge<u64>>,
     /// Number of memtable flushes running for the column family.
     pub running_flushes: Family<RocksdbLabels, Gauge<u64>>,
     /// Number of compactions running for the column family.

--- a/core/lib/zksync_core/src/metadata_calculator/mod.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/mod.rs
@@ -70,8 +70,11 @@ pub struct MetadataCalculatorConfig<'a> {
     /// Chunk size for multi-get operations. Can speed up loading data for the Merkle tree on some environments,
     /// but the effects vary wildly depending on the setup (e.g., the filesystem used).
     pub multi_get_chunk_size: usize,
-    /// Capacity of RocksDB block cache in bytes. Reasonable values range from ~100 MB to several GB.
+    /// Capacity of RocksDB block cache in bytes. Reasonable values range from ~100 MiB to several GB.
     pub block_cache_capacity: usize,
+    /// Capacity of RocksDB memtables. Can be set to a reasonably large value (order of 512 MiB)
+    /// to mitigate write stalls.
+    pub memtable_capacity: usize,
 }
 
 impl<'a> MetadataCalculatorConfig<'a> {
@@ -87,6 +90,7 @@ impl<'a> MetadataCalculatorConfig<'a> {
             max_l1_batches_per_iter: db_config.merkle_tree.max_l1_batches_per_iter,
             multi_get_chunk_size: db_config.merkle_tree.multi_get_chunk_size,
             block_cache_capacity: db_config.merkle_tree.block_cache_size(),
+            memtable_capacity: db_config.merkle_tree.memtable_capacity(),
         }
     }
 }

--- a/core/lib/zksync_core/src/metadata_calculator/updater.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/updater.rs
@@ -44,6 +44,7 @@ impl TreeUpdater {
             mode,
             config.multi_get_chunk_size,
             config.block_cache_capacity,
+            config.memtable_capacity,
         )
         .await;
         Self {


### PR DESCRIPTION
# What ❔

RocksDB write stalls are still happening, this time for a different reason. Previously, they were caused by too many immutable memtables, this time – by too many level-0 SST files. This PR:

- Tunes RocksDB options some more (the main tuning point is [optimizing level-style compaction](https://docs.rs/rocksdb/latest/rocksdb/struct.Options.html#method.optimize_level_style_compaction)).
- Increases the number of retries on stall and introduces exponential backoff.
- Introduces a dozen of RocksDB metrics that should help monitoring RocksDB health.

## Why ❔

Having write stalls leads to panics and is obviously bad.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.