### PR TITLE
fix(db): Fix write stalls in RocksDB (for real this time)

### DIFF
--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -194,10 +194,9 @@ pub struct OptionalENConfig {
     /// large value (order of 512 MiB) is helpful for large DBs that experience write stalls.
     #[serde(default = "OptionalENConfig::default_merkle_tree_memtable_capacity_mb")]
     merkle_tree_memtable_capacity_mb: usize,
-    /// Timeout to wait for the Merkle tree database to run compaction on startup so that it doesn't have
-    /// stopped writes.
-    #[serde(default = "OptionalENConfig::default_merkle_tree_init_stopped_writes_timeout_sec")]
-    merkle_tree_init_stopped_writes_timeout_sec: u64,
+    /// Timeout to wait for the Merkle tree database to run compaction on stalled writes.
+    #[serde(default = "OptionalENConfig::default_merkle_tree_stalled_writes_timeout_sec")]
+    merkle_tree_stalled_writes_timeout_sec: u64,
 
     // Other config settings
     /// Port on which the Prometheus exporter server is listening.
@@ -286,7 +285,7 @@ impl OptionalENConfig {
         256
     }
 
-    const fn default_merkle_tree_init_stopped_writes_timeout_sec() -> u64 {
+    const fn default_merkle_tree_stalled_writes_timeout_sec() -> u64 {
         30
     }
 
@@ -339,10 +338,9 @@ impl OptionalENConfig {
         self.merkle_tree_memtable_capacity_mb * BYTES_IN_MEGABYTE
     }
 
-    /// Returns the timeout to wait for the Merkle tree database to run compaction on startup so that
-    /// it doesn't have stopped writes.
-    pub fn merkle_tree_init_stopped_writes_timeout(&self) -> Duration {
-        Duration::from_secs(self.merkle_tree_init_stopped_writes_timeout_sec)
+    /// Returns the timeout to wait for the Merkle tree database to run compaction on stalled writes.
+    pub fn merkle_tree_stalled_writes_timeout(&self) -> Duration {
+        Duration::from_secs(self.merkle_tree_stalled_writes_timeout_sec)
     }
 
     pub fn api_namespaces(&self) -> Vec<Namespace> {

--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -190,11 +190,14 @@ pub struct OptionalENConfig {
     /// The default value is 128 MiB.
     #[serde(default = "OptionalENConfig::default_merkle_tree_block_cache_size_mb")]
     merkle_tree_block_cache_size_mb: usize,
-
     /// Byte capacity of memtables (recent, non-persisted changes to RocksDB). Setting this to a reasonably
     /// large value (order of 512 MiB) is helpful for large DBs that experience write stalls.
     #[serde(default = "OptionalENConfig::default_merkle_tree_memtable_capacity_mb")]
     merkle_tree_memtable_capacity_mb: usize,
+    /// Timeout to wait for the Merkle tree database to run compaction on startup so that it doesn't have
+    /// stopped writes.
+    #[serde(default = "OptionalENConfig::default_merkle_tree_init_stopped_writes_timeout_sec")]
+    merkle_tree_init_stopped_writes_timeout_sec: u64,
 
     // Other config settings
     /// Port on which the Prometheus exporter server is listening.
@@ -283,6 +286,10 @@ impl OptionalENConfig {
         256
     }
 
+    const fn default_merkle_tree_init_stopped_writes_timeout_sec() -> u64 {
+        30
+    }
+
     const fn default_fee_history_limit() -> u64 {
         1_024
     }
@@ -330,6 +337,12 @@ impl OptionalENConfig {
     /// Returns the memtable capacity for Merkle tree in bytes.
     pub fn merkle_tree_memtable_capacity(&self) -> usize {
         self.merkle_tree_memtable_capacity_mb * BYTES_IN_MEGABYTE
+    }
+
+    /// Returns the timeout to wait for the Merkle tree database to run compaction on startup so that
+    /// it doesn't have stopped writes.
+    pub fn merkle_tree_init_stopped_writes_timeout(&self) -> Duration {
+        Duration::from_secs(self.merkle_tree_init_stopped_writes_timeout_sec)
     }
 
     pub fn api_namespaces(&self) -> Vec<Namespace> {

--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -146,7 +146,7 @@ async fn init_tasks(
         multi_get_chunk_size: config.optional.merkle_tree_multi_get_chunk_size,
         block_cache_capacity: config.optional.merkle_tree_block_cache_size(),
         memtable_capacity: config.optional.merkle_tree_memtable_capacity(),
-        init_stopped_writes_timeout: config.optional.merkle_tree_init_stopped_writes_timeout(),
+        stalled_writes_timeout: config.optional.merkle_tree_stalled_writes_timeout(),
     })
     .await;
     healthchecks.push(Box::new(metadata_calculator.tree_health_check()));

--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -146,6 +146,7 @@ async fn init_tasks(
         multi_get_chunk_size: config.optional.merkle_tree_multi_get_chunk_size,
         block_cache_capacity: config.optional.merkle_tree_block_cache_size(),
         memtable_capacity: config.optional.merkle_tree_memtable_capacity(),
+        init_stopped_writes_timeout: config.optional.merkle_tree_init_stopped_writes_timeout(),
     })
     .await;
     healthchecks.push(Box::new(metadata_calculator.tree_health_check()));

--- a/core/lib/storage/src/lib.rs
+++ b/core/lib/storage/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod db;
 mod metrics;
 
-pub use db::{RocksDB, RocksDBOptions};
+pub use db::{RocksDB, RocksDBOptions, StalledWritesRetries};
 pub use rocksdb;

--- a/core/lib/zksync_core/src/metadata_calculator/mod.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/mod.rs
@@ -75,6 +75,9 @@ pub struct MetadataCalculatorConfig<'a> {
     /// Capacity of RocksDB memtables. Can be set to a reasonably large value (order of 512 MiB)
     /// to mitigate write stalls.
     pub memtable_capacity: usize,
+    /// Timeout to wait for the Merkle tree database to run compaction on startup so that it doesn't have
+    /// stopped writes.
+    pub init_stopped_writes_timeout: Duration,
 }
 
 impl<'a> MetadataCalculatorConfig<'a> {
@@ -91,6 +94,7 @@ impl<'a> MetadataCalculatorConfig<'a> {
             multi_get_chunk_size: db_config.merkle_tree.multi_get_chunk_size,
             block_cache_capacity: db_config.merkle_tree.block_cache_size(),
             memtable_capacity: db_config.merkle_tree.memtable_capacity(),
+            init_stopped_writes_timeout: db_config.merkle_tree.init_stopped_writes_timeout(),
         }
     }
 }

--- a/core/lib/zksync_core/src/metadata_calculator/mod.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/mod.rs
@@ -75,9 +75,8 @@ pub struct MetadataCalculatorConfig<'a> {
     /// Capacity of RocksDB memtables. Can be set to a reasonably large value (order of 512 MiB)
     /// to mitigate write stalls.
     pub memtable_capacity: usize,
-    /// Timeout to wait for the Merkle tree database to run compaction on startup so that it doesn't have
-    /// stopped writes.
-    pub init_stopped_writes_timeout: Duration,
+    /// Timeout to wait for the Merkle tree database to run compaction on stalled writes.
+    pub stalled_writes_timeout: Duration,
 }
 
 impl<'a> MetadataCalculatorConfig<'a> {
@@ -94,7 +93,7 @@ impl<'a> MetadataCalculatorConfig<'a> {
             multi_get_chunk_size: db_config.merkle_tree.multi_get_chunk_size,
             block_cache_capacity: db_config.merkle_tree.block_cache_size(),
             memtable_capacity: db_config.merkle_tree.memtable_capacity(),
-            init_stopped_writes_timeout: db_config.merkle_tree.init_stopped_writes_timeout(),
+            stalled_writes_timeout: db_config.merkle_tree.stalled_writes_timeout(),
         }
     }
 }

--- a/core/lib/zksync_core/src/metadata_calculator/updater.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/updater.rs
@@ -45,7 +45,7 @@ impl TreeUpdater {
             config.multi_get_chunk_size,
             config.block_cache_capacity,
             config.memtable_capacity,
-            config.init_stopped_writes_timeout,
+            config.stalled_writes_timeout,
         )
         .await;
         Self {

--- a/core/lib/zksync_core/src/metadata_calculator/updater.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/updater.rs
@@ -45,6 +45,7 @@ impl TreeUpdater {
             config.multi_get_chunk_size,
             config.block_cache_capacity,
             config.memtable_capacity,
+            config.init_stopped_writes_timeout,
         )
         .await;
         Self {


### PR DESCRIPTION
# What ❔

[A previous fix](https://github.com/matter-labs/zksync-era/pull/265) didn't really work judging by Merkle tree behavior on the stage env. This PR makes the initialization timeout configurable (and increases the default value from 10s to 30s; 30s is approximately equal to the compaction duration) and slightly increases the number of retries on stalled writes.

## Why ❔

Having write stalls leads to panics and is obviously bad.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.