### PR TITLE
fix(db): Fix root cause of RocksDB misbehavior

### DIFF
--- a/core/lib/storage/src/db.rs
+++ b/core/lib/storage/src/db.rs
@@ -203,6 +203,16 @@ impl RocksDBInner {
     }
 }
 
+impl Drop for RocksDBInner {
+    fn drop(&mut self) {
+        tracing::debug!(
+            "Canceling background compactions / flushes for DB `{}`",
+            self.db_name
+        );
+        self.db.cancel_all_background_work(true);
+    }
+}
+
 /// Configuration for retries when RocksDB writes are stalled.
 #[derive(Debug, Clone, Copy)]
 pub struct StalledWritesRetries {
@@ -557,12 +567,6 @@ impl RocksDB<()> {
             num_instances = cvar.wait(num_instances).unwrap();
         }
         tracing::info!("All the RocksDB instances are dropped");
-    }
-}
-
-impl<CF> Drop for RocksDB<CF> {
-    fn drop(&mut self) {
-        self.inner.db.cancel_all_background_work(true);
     }
 }
 


### PR DESCRIPTION
# What ❔

Fixes (hopefully) the root cause of recent RocksDB misbehavior. After recent refactoring, it improperly cancels background compactions / flushes each time a `RocksDB` instance is dropped, which leads to compactions / flushes being constantly interrupted. (After refactoring, `RocksDB` instances are `Clone`eable and act essentially as `Arc` wrappers; a new instance is created and dropped, in particular, [when processing](https://github.com/matter-labs/zksync-era/blob/ec41692063909742005acd656694a8f0838fcf33/core/lib/zksync_core/src/metadata_calculator/updater.rs#L385) each chunk of L1 batches.) A proper solution, implemented by this PR, is to cancel background work when dropping an internal, non-`Arc`'d DB instance.

## Why ❔

That's a bug that makes RocksDB behave *very* unstably, as witnessed by recent issues with it.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `zk fmt` and `zk lint`.