### PR TITLE
ci: Downgrade node to 18 in zk-env

### DIFF
--- a/docker/zk-environment/Dockerfile
+++ b/docker/zk-environment/Dockerfile
@@ -71,7 +71,7 @@ RUN add-apt-repository "deb [arch=${ARCH}] https://download.docker.com/linux/ubu
 RUN apt update; apt install -y docker-ce-cli
 
 # Install node and yarn
-ENV NODE_MAJOR=20
+ENV NODE_MAJOR=18
 RUN mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \


### PR DESCRIPTION
# What ❔

Subj

## Why ❔

All of our JS machinery is now expecting Node 18, so this aligns Node version with what's considered being "our" version

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
