### PR TITLE
chore: update 'list_of_opcodes' link in how_l2_messaging_works.md

### DIFF
--- a/docs/advanced/how_l2_messaging_works.md
+++ b/docs/advanced/how_l2_messaging_works.md
@@ -187,7 +187,7 @@ transmitted to L1 for final verification.
 [l1_messenger]:
   https://github.com/matter-labs/era-system-contracts/blob/f01df555c03860b6093dd669d119eed4d9f8ec99/contracts/L1Messenger.sol#L22
 [list_of_opcodes]:
-  https://github.com/matter-labs/system-contracts/blob/e96dfe0b5093fa95c2fb340c0411c646327db921/contracts/libraries/SystemContractsCaller.sol#L12
+  https://github.com/matter-labs/era-system-contracts/blob/e96dfe0b5093fa95c2fb340c0411c646327db921/contracts/libraries/SystemContractsCaller.sol#L12
 [opcode_catch_compiler]: https://github.com/matter-labs/era-compiler-llvm-context/blob/main/src/evm/call.rs#L39
 [iterate_over_events]:
   https://github.com/matter-labs/zksync-2-dev/blob/43d7bd587a84b1b4489f4c6a4169ccb90e0df467/core/lib/types/src/event.rs#L147


### PR DESCRIPTION
chore: update 'list_of_opcodes' link in how_l2_messaging_works.md

# What ❔

- update 'list_of_opcodes' link in how_l2_messaging_works.md

## Why ❔

- Unreachable link

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
