### PR TITLE
fix: fix the broken link for get_txs_fee_in_wei

### DIFF
--- a/docs/advanced/gas_and_fees.md
+++ b/docs/advanced/gas_and_fees.md
@@ -130,5 +130,5 @@ There are a few reasons why refunds might be 'larger' on zkSync (i.e., why we mi
   https://github.com/matter-labs/zksync-2-dev/blob/d590b3f0965a23eb0011779aab829d86d4fdc1d1/core/bin/zksync_core/src/l1_gas_price/gas_adjuster/mod.rs#L25
   'gas_adjuster'
 [get_txs_fee_in_wei]:
-  https://github.com/matter-labs/zksync-2-dev/blob/d590b3f0965a23eb0011779aab829d86d4fdc1d1/core/bin/zksync_core/src/api_server/tx_sender/mod.rs#L450
+  https://github.com/matter-labs/zksync-era/blob/d590b3f0965a23eb0011779aab829d86d4fdc1d1/core/bin/zksync_core/src/api_server/tx_sender/mod.rs#L450
   'get_txs_fee_in_wei'


### PR DESCRIPTION
fix: fix the broken link for get_txs_fee_in_wei

# What ❔

- fix the broken link for get_txs_fee_in_wei

## Why ❔

- Documentation error

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
