### PR TITLE
fix(CI): push FRI docker image to asia + europe

### DIFF
--- a/.github/workflows/build-prover-fri-gpu-gar.yml
+++ b/.github/workflows/build-prover-fri-gpu-gar.yml
@@ -45,12 +45,22 @@ jobs:
           tags: |
             us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/prover-fri-gpu-gar:2.0-${{ inputs.image_tag_suffix }}
 
-      - name: Login to asia-southeast1 GAR
+      - name: Login to Asia GAR
         run: |
           gcloud auth print-access-token --lifetime=7200 --impersonate-service-account=gha-ci-runners@matterlabs-infra.iam.gserviceaccount.com | docker login -u oauth2accesstoken --password-stdin https://asia-docker.pkg.dev
 
-      - name: Build and push to asia-southeast1 GAR
+      - name: Build and push to Asia GAR
         run: |
           docker buildx imagetools create \
             --tag asia-docker.pkg.dev/matterlabs-infra/matterlabs-docker/prover-fri-gpu-gar:2.0-${{ inputs.image_tag_suffix }} \
+            us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/prover-fri-gpu-gar:2.0-${{ inputs.image_tag_suffix }}
+
+      - name: Login to Europe GAR
+        run: |
+          gcloud auth print-access-token --lifetime=7200 --impersonate-service-account=gha-ci-runners@matterlabs-infra.iam.gserviceaccount.com | docker login -u oauth2accesstoken --password-stdin https://europe-docker.pkg.dev
+
+      - name: Build and push to Europe GAR
+        run: |
+          docker buildx imagetools create \
+            --tag europe-docker.pkg.dev/matterlabs-infra/matterlabs-docker/prover-fri-gpu-gar:2.0-${{ inputs.image_tag_suffix }} \
             us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/prover-fri-gpu-gar:2.0-${{ inputs.image_tag_suffix }}

--- a/.github/workflows/build-prover-fri-gpu-gar.yml
+++ b/.github/workflows/build-prover-fri-gpu-gar.yml
@@ -44,3 +44,13 @@ jobs:
           push: true
           tags: |
             us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/prover-fri-gpu-gar:2.0-${{ inputs.image_tag_suffix }}
+
+      - name: Login to asia-southeast1 GAR
+        run: |
+          gcloud auth print-access-token --lifetime=7200 --impersonate-service-account=gha-ci-runners@matterlabs-infra.iam.gserviceaccount.com | docker login -u oauth2accesstoken --password-stdin https://asia-docker.pkg.dev
+
+      - name: Build and push to asia-southeast1 GAR
+        run: |
+          docker buildx imagetools create \
+            --tag asia-docker.pkg.dev/matterlabs-infra/matterlabs-docker/prover-fri-gpu-gar:2.0-${{ inputs.image_tag_suffix }} \
+            us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/prover-fri-gpu-gar:2.0-${{ inputs.image_tag_suffix }}


### PR DESCRIPTION
# What ❔

push FRI docker image to Asia and Europe

## Why ❔
ability to spawn FRI provers in other region

## Checklist


- [ *] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ *] Tests for the changes have been added / updated.
- [ *] Documentation comments have been added / updated.
- [* ] Code has been formatted via `zk fmt` and `zk lint`.
