### PR TITLE
ci: Add docker-compose for jobs with CUDA 11.8

### DIFF
--- a/docker-compose-gpu-runner-cuda-11-8.yml
+++ b/docker-compose-gpu-runner-cuda-11-8.yml
@@ -1,0 +1,30 @@
+version: '3.2'
+services:
+  zk:
+    image: "matterlabs/zk-environment:latest2.0"
+    container_name: zk
+    security_opt:
+      - seccomp:unconfined
+    command: tail -f /dev/null
+    volumes:
+      - .:/usr/src/zksync
+      - /usr/src/cache:/usr/src/cache
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /usr/src/keys:/mnt/prover_setup_keys
+    environment:
+      - CACHE_DIR=/usr/src/cache
+      - SCCACHE_CACHE_SIZE=50g
+      - SCCACHE_GCS_BUCKET=matterlabs-infra-sccache-storage
+      - SCCACHE_GCS_SERVICE_ACCOUNT=gha-ci-runners@matterlabs-infra.iam.gserviceaccount.com
+      - SCCACHE_ERROR_LOG=/tmp/sccache_log.txt
+      - SCCACHE_GCS_RW_MODE=READ_WRITE
+      - CI=1
+      - GITHUB_WORKSPACE=$GITHUB_WORKSPACE
+    env_file:
+      - ./.env
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+

--- a/docker-compose-gpu-runner-cuda-11-8.yml
+++ b/docker-compose-gpu-runner-cuda-11-8.yml
@@ -1,8 +1,16 @@
 version: '3.2'
 services:
+  geth:
+    image: "matterlabs/geth:latest"
+    environment:
+      - PLUGIN_CONFIG
+
   zk:
     image: "matterlabs/zk-environment:latest2.0"
     container_name: zk
+    depends_on:
+      - geth
+      - postgres
     security_opt:
       - seccomp:unconfined
     command: tail -f /dev/null
@@ -28,3 +36,9 @@ services:
           devices:
             - capabilities: [gpu]
 
+  postgres:
+    image: "postgres:14"
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust


### PR DESCRIPTION
# What ❔

Docker-compose for jobs with CUDA 11.8

## Why ❔

Some jobs can't be run on newer version of CUDA

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
