### PR TITLE
docs: incorrect link reference in 02_deposit.md

### DIFF
--- a/docs/advanced/02_deposits.md
+++ b/docs/advanced/02_deposits.md
@@ -127,7 +127,7 @@ the requests to different contracts (facets) that can be independently updated a
 ![Diamond proxy layout](https://user-images.githubusercontent.com/128217157/229521292-1532a59b-665c-4cc4-8342-d25ad45a8fcd.png)
 
 You can find more detailed description in
-[Contract docs](https://github.com/matter-labs/zksync-2-contracts/blob/main/docs/Overview.md)
+[Contract docs](https://github.com/matter-labs/era-contracts/blob/main/docs/Overview.md)
 
 #### requestL2Transaction Function details
 


### PR DESCRIPTION
# What ❔

Change link for Contract docs in 02_deposit.md.

## Why ❔

The previous link is 404'ing

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ X] Tests for the changes have been added / updated.
- [ X] Documentation comments have been added / updated.
- [ X] Code has been formatted via `zk fmt` and `zk lint`.
