### PR TITLE
ci: Fix image in docker-compose-cpu-runner.yml

### DIFF
--- a/docker-compose-cpu-runner.yml
+++ b/docker-compose-cpu-runner.yml
@@ -6,7 +6,7 @@ services:
       - PLUGIN_CONFIG
 
   zk:
-    image: "matterlabs/zk-environment:latest2.0-lightweight"
+    image: "matterlabs/zk-environment:latest2.0-lightweight-nightly"
     depends_on:
       - geth
       - postgres


### PR DESCRIPTION
# What ❔

Subj

## Why ❔

Prover FRI is currently running on nightly Rust hence requires using zk-env Rust nigtly image

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
