### PR TITLE
fix: bump zksolc from yanked version to 1.3.16

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -118,10 +118,10 @@ jobs:
           mv solc-linux-amd64-v0.8.21+commit.d9974bed $(pwd)/etc/solc-bin/0.8.21/solc
           chmod +x $(pwd)/etc/solc-bin/0.8.21/solc
 
-          mkdir -p $(pwd)/etc/zksolc-bin/v1.3.15
-          wget https://github.com/matter-labs/zksolc-bin/raw/main/linux-amd64/zksolc-linux-amd64-musl-v1.3.15
-          mv zksolc-linux-amd64-musl-v1.3.15 $(pwd)/etc/zksolc-bin/v1.3.15/zksolc
-          chmod +x $(pwd)/etc/zksolc-bin/v1.3.15/zksolc
+          mkdir -p $(pwd)/etc/zksolc-bin/v1.3.16
+          wget https://github.com/matter-labs/zksolc-bin/raw/main/linux-amd64/zksolc-linux-amd64-musl-v1.3.16
+          mv zksolc-linux-amd64-musl-v1.3.16 $(pwd)/etc/zksolc-bin/v1.3.16/zksolc
+          chmod +x $(pwd)/etc/zksolc-bin/v1.3.16/zksolc
 
           mkdir -p $(pwd)/etc/vyper-bin/0.3.3
           wget -O vyper0.3.3 https://github.com/vyperlang/vyper/releases/download/v0.3.3/vyper.0.3.3%2Bcommit.48e326f0.linux
@@ -216,10 +216,10 @@ jobs:
           mv solc-linux-amd64-v0.8.21+commit.d9974bed $(pwd)/etc/solc-bin/0.8.21/solc
           chmod +x $(pwd)/etc/solc-bin/0.8.21/solc
 
-          mkdir -p $(pwd)/etc/zksolc-bin/v1.3.15
-          wget https://github.com/matter-labs/zksolc-bin/raw/main/linux-amd64/zksolc-linux-amd64-musl-v1.3.15
-          mv zksolc-linux-amd64-musl-v1.3.15 $(pwd)/etc/zksolc-bin/v1.3.15/zksolc
-          chmod +x $(pwd)/etc/zksolc-bin/v1.3.15/zksolc
+          mkdir -p $(pwd)/etc/zksolc-bin/v1.3.16
+          wget https://github.com/matter-labs/zksolc-bin/raw/main/linux-amd64/zksolc-linux-amd64-musl-v1.3.16
+          mv zksolc-linux-amd64-musl-v1.3.16 $(pwd)/etc/zksolc-bin/v1.3.16/zksolc
+          chmod +x $(pwd)/etc/zksolc-bin/v1.3.16/zksolc
 
           mkdir -p $(pwd)/etc/vyper-bin/0.3.3
           wget -O vyper0.3.3 https://github.com/vyperlang/vyper/releases/download/v0.3.3/vyper.0.3.3%2Bcommit.48e326f0.linux

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -160,7 +160,7 @@
 
 * **API:** new translator for virtual blocks for zks_getLogs endpoint ([#2505](https://github.com/matter-labs/zksync-2-dev/issues/2505)) ([35b0553](https://github.com/matter-labs/zksync-2-dev/commit/35b05537dc8fecf11be477bd156da332d75b1320))
 * **contract-verifier:** Add zkvyper v1.3.11 ([#2554](https://github.com/matter-labs/zksync-2-dev/issues/2554)) ([711c5db](https://github.com/matter-labs/zksync-2-dev/commit/711c5db4bd48e9b4b166256e8c9554ef0e54fad8))
-* **contract-verifier:** Support verification for zksolc v1.3.15  ([#2546](https://github.com/matter-labs/zksync-2-dev/issues/2546)) ([adea3ef](https://github.com/matter-labs/zksync-2-dev/commit/adea3efd39099ef9599e24d47de6c7cffe6b0287))
+* **contract-verifier:** Support verification for zksolc v1.3.16  ([#2546](https://github.com/matter-labs/zksync-2-dev/issues/2546)) ([adea3ef](https://github.com/matter-labs/zksync-2-dev/commit/adea3efd39099ef9599e24d47de6c7cffe6b0287))
 * Decrease crate versions back to 0.1.0 ([#2528](https://github.com/matter-labs/zksync-2-dev/issues/2528)) ([adb7614](https://github.com/matter-labs/zksync-2-dev/commit/adb76142882dde197cd64b1aaaffb01906427054))
 * **prover-fri:** Restrict prover to pick jobs for which they have vk's ([#2541](https://github.com/matter-labs/zksync-2-dev/issues/2541)) ([cedba03](https://github.com/matter-labs/zksync-2-dev/commit/cedba03ea66fc0da479e60d5ca30d8f67e32358a))
 * **vm:** Make execute interface more obvious ([#2536](https://github.com/matter-labs/zksync-2-dev/issues/2536)) ([4cb18cb](https://github.com/matter-labs/zksync-2-dev/commit/4cb18cb06e87628ad122fc9857c789d1411a7f77))

--- a/core/tests/ts-integration/hardhat.config.ts
+++ b/core/tests/ts-integration/hardhat.config.ts
@@ -4,7 +4,7 @@ import '@matterlabs/hardhat-zksync-vyper';
 
 export default {
     zksolc: {
-        version: '1.3.15',
+        version: '1.3.16',
         compilerSource: 'binary',
         settings: {
             isSystem: true

--- a/core/tests/ts-integration/scripts/compile-yul.ts
+++ b/core/tests/ts-integration/scripts/compile-yul.ts
@@ -4,7 +4,7 @@ import { spawn as _spawn } from 'child_process';
 
 import { getZksolcPath, getZksolcUrl, saltFromUrl } from '@matterlabs/hardhat-zksync-solc';
 
-const COMPILER_VERSION = '1.3.15';
+const COMPILER_VERSION = '1.3.16';
 const IS_COMPILER_PRE_RELEASE = false;
 
 async function compilerLocation(): Promise<string> {

--- a/core/tests/ts-integration/tests/api/contract-verification.test.ts
+++ b/core/tests/ts-integration/tests/api/contract-verification.test.ts
@@ -22,7 +22,7 @@ const contracts = {
 // Regular expression to match ISO dates.
 const DATE_REGEX = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{6})?/;
 
-const ZKSOLC_VERSION = 'v1.3.15';
+const ZKSOLC_VERSION = 'v1.3.16';
 const SOLC_VERSION = '0.8.21';
 
 const ZKVYPER_VERSION = 'v1.3.11';

--- a/docker/contract-verifier/Dockerfile
+++ b/docker/contract-verifier/Dockerfile
@@ -22,9 +22,9 @@ FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y curl libpq5 ca-certificates wget python3 && rm -rf /var/lib/apt/lists/*
 
-# install zksolc 1.3.0-1.3.15
-RUN for VERSION in $(seq -f "v1.3.%g" 0 15); do \
-    if [ "$VERSION" = "v1.3.12" ]; then \
+# install zksolc 1.3.0-1.3.16
+RUN for VERSION in $(seq -f "v1.3.%g" 0 16); do \
+    if [ "$VERSION" = "v1.3.12" ] || [ "$VERSION" = "v1.3.15" ]; then \
     continue; \
     fi; \
     mkdir -p /etc/zksolc-bin/$VERSION && \

--- a/docker/zk-environment/Dockerfile
+++ b/docker/zk-environment/Dockerfile
@@ -110,9 +110,9 @@ RUN cargo install cargo-nextest
 # Obtain `solc` 0.8.20.
 COPY --from=solidity-builder /solidity/build/solc/solc /usr/bin/
 RUN chmod +x /usr/bin/solc
-# Obtain `zksolc` 1.3.15.
-RUN wget -c https://github.com/matter-labs/zksolc-bin/raw/main/linux-${ARCH}/zksolc-linux-${ARCH}-musl-v1.3.15 \
-    && mv zksolc-linux-${ARCH}-musl-v1.3.15 /usr/bin/zksolc \
+# Obtain `zksolc` 1.3.16.
+RUN wget -c https://github.com/matter-labs/zksolc-bin/raw/main/linux-${ARCH}/zksolc-linux-${ARCH}-musl-v1.3.16 \
+    && mv zksolc-linux-${ARCH}-musl-v1.3.16 /usr/bin/zksolc \
     && chmod +x /usr/bin/zksolc
 
 # Somehow it is installed with some other packages

--- a/docs/advanced/01_initialization.md
+++ b/docs/advanced/01_initialization.md
@@ -142,7 +142,7 @@ this is the contract that our server is 'listening' on).
 Ok - so let's sum up what we have:
 
 - a postgres running in docker (main database)
-- a local instance of ethereum (get running in docker)
+- a local instance of ethereum (geth running in docker)
   - which also has a bunch of 'magic' contracts deployed
   - and two accounts with lots of tokens
 - and a server process


### PR DESCRIPTION
# What ❔

Bumps the zksolc version to 1.3.16 because 1.3.15 was being used. Assuming this is a more involved process than just bumping this, but figured I'd PR in anyway in case it helped speed anything up. Also, couldn't quickly figure out how to test `docker/contract-verifier/Dockerfile` as it's broken for me for unrelated parts.

Also fixes a typo in the init docs, I can separate it if wanted.

## Why ❔

Broken on a fresh install because of yanked version https://github.com/matter-labs/zksolc-bin/commit/2a29ad1d8920550d9aeef195f22c8f0ca14e5626

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
