### PR TITLE
fix(ci): Use public setup-data bucket in building prover images

### DIFF
--- a/.github/workflows/build-prover-fri-gpu-gar.yml
+++ b/.github/workflows/build-prover-fri-gpu-gar.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Download Setup data
         run: |
-          gsutil -m rsync -r gs://matterlabs-zksync-v2-infra-blob-store/prover_setup_data/${{ inputs.setup_keys_id }} docker/prover-gpu-fri-gar
+          gsutil -m rsync -r gs://matterlabs-setup-data-us/${{ inputs.setup_keys_id }} docker/prover-gpu-fri-gar
 
       - name: Login to us-central1 GAR
         run: |


### PR DESCRIPTION
# What ❔

Use public setup-data bucket in backed-in prover images 

## Why ❔


## Checklist

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
