### PR TITLE
chore: incorrect path reference in `setup-dev.md`

### DIFF
--- a/docs/setup-dev.md
+++ b/docs/setup-dev.md
@@ -150,7 +150,7 @@ installed toolchains
 active toolchain
 ----------------
 
-1.67.1-aarch64-apple-darwin (overridden by '/Users/user/workspace/zksync-2-dev/rust-toolchain')
+1.67.1-aarch64-apple-darwin (overridden by '/Users/user/workspace/zksync-era/rust-toolchain')
 ```
 
 If you see `x86_64` mentioned in the output, probably you're running (or used to run) your IDE/terminal in Rosetta. If


### PR DESCRIPTION
# What ❔

- incorrect path reference in setup-dev.md

## Why ❔

- zksync-era is more appropriate

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
