### PR TITLE
ci: Bump vyper to 0.3.10

### DIFF
--- a/core/tests/ts-integration/hardhat.config.ts
+++ b/core/tests/ts-integration/hardhat.config.ts
@@ -23,6 +23,6 @@ export default {
         version: '0.8.21'
     },
     vyper: {
-        version: '0.3.10'
+        version: '0.3.9'
     }
 };

--- a/core/tests/ts-integration/hardhat.config.ts
+++ b/core/tests/ts-integration/hardhat.config.ts
@@ -23,6 +23,6 @@ export default {
         version: '0.8.21'
     },
     vyper: {
-        version: '0.3.3'
+        version: '0.3.10'
     }
 };


### PR DESCRIPTION
# What ❔

Bruteforce attempts to fix Vyper version download by @nomiclabs/hardhat-vyper

## Why ❔

CI is dead, we need to fix it.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
