### PR TITLE
feat(state-keeper): Disable some seal criteria for boojum

### DIFF
--- a/core/lib/constants/src/ethereum.rs
+++ b/core/lib/constants/src/ethereum.rs
@@ -10,7 +10,9 @@ pub static ETHEREUM_ADDRESS: Address = Address::zero();
 /// to be published inside the body of transaction (i.e. excluding of factory deps).
 pub const GUARANTEED_PUBDATA_PER_L1_BATCH: u64 = 4000;
 
-/// The maximum number of pubdata per L1 batch.
+/// The maximum number of pubdata per L1 batch. This limit is due to the fact that the Ethereum
+/// nodes do not accept transactions that have more than 128kb of pubdata.
+/// The 8kb margin is left in case of any inpreciseness of the pubdata calculation.
 pub const MAX_PUBDATA_PER_L1_BATCH: u64 = 120000;
 
 // TODO: import from zkevm_opcode_defs once VM1.3 is supported

--- a/core/lib/types/src/storage/writes/mod.rs
+++ b/core/lib/types/src/storage/writes/mod.rs
@@ -4,13 +4,14 @@ use crate::H256;
 use serde::{Deserialize, Serialize};
 use zksync_basic_types::{Address, U256};
 
-use self::compression::{compress_with_best_strategy, COMPRESSION_VERSION_NUMBER};
+pub(crate) use self::compression::{compress_with_best_strategy, COMPRESSION_VERSION_NUMBER};
 
 mod compression;
 
-const BYTES_PER_ENUMERATION_INDEX: u8 = 4;
-// Total byte size of all fields in StateDiffRecord struct
-// 20 + 32 + 32 +8 + 32 + 32
+/// The number of bytes being used for state diff enumeration indices. Applicable to repeated writes.
+pub const BYTES_PER_ENUMERATION_INDEX: u8 = 4;
+/// Total byte size of all fields in StateDiffRecord struct
+/// 20 + 32 + 32 + 8 + 32 + 32
 const STATE_DIFF_RECORD_SIZE: usize = 156;
 
 // 2 * 136 - the size that allows for two keccak rounds.

--- a/core/lib/zksync_core/src/api_server/tx_sender/mod.rs
+++ b/core/lib/zksync_core/src/api_server/tx_sender/mod.rs
@@ -907,7 +907,13 @@ impl<G: L1GasPriceProvider> TxSender<G> {
         };
 
         let seal_data = SealData::for_transaction(transaction, tx_metrics);
-        if let Some(reason) = ConditionalSealer::find_unexecutable_reason(sk_config, &seal_data) {
+        // Using `ProtocolVersionId::latest()` for a short period we might end up in a scenario where the StateKeeper is still pre-boojum
+        // but the API assumes we are post boojum. In this situation we will determine a tx as being executable but the StateKeeper will
+        // still reject them as it's not.
+        let protocol_version = ProtocolVersionId::latest();
+        if let Some(reason) =
+            ConditionalSealer::find_unexecutable_reason(sk_config, &seal_data, protocol_version)
+        {
             let message = format!(
                 "Tx is Unexecutable because of {reason}; inputs for decision: {seal_data:?}"
             );

--- a/core/lib/zksync_core/src/gas_tracker/mod.rs
+++ b/core/lib/zksync_core/src/gas_tracker/mod.rs
@@ -103,7 +103,16 @@ pub(crate) fn commit_gas_count_for_l1_batch(
     let total_factory_deps_len: u32 = sorted_factory_deps
         .map(|factory_dep| factory_dep.len() as u32)
         .sum();
-    let additional_calldata_bytes = metadata.initial_writes_compressed.len() as u32
+
+    // Boojum upgrade changes how storage writes are communicated/compressed.
+    let state_diff_size = if header.protocol_version.unwrap().is_pre_boojum() {
+        metadata.initial_writes_compressed.len() as u32
+            + metadata.repeated_writes_compressed.len() as u32
+    } else {
+        metadata.state_diffs_compressed.len() as u32
+    };
+
+    let additional_calldata_bytes = state_diff_size
         + metadata.repeated_writes_compressed.len() as u32
         + metadata.l2_l1_messages_compressed.len() as u32
         + total_messages_len

--- a/core/lib/zksync_core/src/state_keeper/keeper.rs
+++ b/core/lib/zksync_core/src/state_keeper/keeper.rs
@@ -653,6 +653,7 @@ impl ZkSyncStateKeeper {
                         updates_manager.pending_executed_transactions_len() + 1,
                         &block_data,
                         &tx_data,
+                        updates_manager.protocol_version(),
                     )
                 } else {
                     SealResolution::NoSeal

--- a/core/lib/zksync_core/src/state_keeper/seal_criteria/conditional_sealer.rs
+++ b/core/lib/zksync_core/src/state_keeper/seal_criteria/conditional_sealer.rs
@@ -4,6 +4,7 @@
 //! which unconditionally follows the instructions from the main node).
 
 use zksync_config::configs::chain::StateKeeperConfig;
+use zksync_types::ProtocolVersionId;
 
 use super::{criteria, SealCriterion, SealData, SealResolution, AGGREGATION_METRICS};
 
@@ -22,12 +23,20 @@ impl ConditionalSealer {
     pub(crate) fn find_unexecutable_reason(
         config: &StateKeeperConfig,
         data: &SealData,
+        protocol_version: ProtocolVersionId,
     ) -> Option<&'static str> {
         for sealer in &Self::default_sealers() {
             const MOCK_BLOCK_TIMESTAMP: u128 = 0;
             const TX_COUNT: usize = 1;
 
-            let resolution = sealer.should_seal(config, MOCK_BLOCK_TIMESTAMP, TX_COUNT, data, data);
+            let resolution = sealer.should_seal(
+                config,
+                MOCK_BLOCK_TIMESTAMP,
+                TX_COUNT,
+                data,
+                data,
+                protocol_version,
+            );
             if matches!(resolution, SealResolution::Unexecutable(_)) {
                 return Some(sealer.prom_criterion_name());
             }
@@ -55,6 +64,7 @@ impl ConditionalSealer {
         tx_count: usize,
         block_data: &SealData,
         tx_data: &SealData,
+        protocol_version: ProtocolVersionId,
     ) -> SealResolution {
         tracing::trace!(
             "Determining seal resolution for L1 batch #{l1_batch_number} with {tx_count} transactions \
@@ -70,6 +80,7 @@ impl ConditionalSealer {
                 tx_count,
                 block_data,
                 tx_data,
+                protocol_version,
             );
             match &seal_resolution {
                 SealResolution::IncludeAndSeal

--- a/core/lib/zksync_core/src/state_keeper/seal_criteria/criteria/gas.rs
+++ b/core/lib/zksync_core/src/state_keeper/seal_criteria/criteria/gas.rs
@@ -1,3 +1,5 @@
+use zksync_types::ProtocolVersionId;
+
 use crate::{
     gas_tracker::new_block_gas_count,
     state_keeper::seal_criteria::{SealCriterion, SealData, SealResolution, StateKeeperConfig},
@@ -20,6 +22,7 @@ impl SealCriterion for GasCriterion {
         _tx_count: usize,
         block_data: &SealData,
         tx_data: &SealData,
+        _protocol_version_id: ProtocolVersionId,
     ) -> SealResolution {
         let tx_bound =
             (config.max_single_tx_gas as f64 * config.reject_tx_at_gas_percentage).round() as u32;
@@ -67,6 +70,7 @@ mod tests {
                 ..SealData::default()
             },
             &SealData::default(),
+            ProtocolVersionId::latest(),
         );
         assert_eq!(empty_block_resolution, SealResolution::NoSeal);
 
@@ -88,6 +92,7 @@ mod tests {
                 gas_count: tx_gas,
                 ..SealData::default()
             },
+            ProtocolVersionId::latest(),
         );
         assert_eq!(
             huge_transaction_resolution,
@@ -114,6 +119,7 @@ mod tests {
                 gas_count: tx_gas,
                 ..SealData::default()
             },
+            ProtocolVersionId::latest(),
         );
         assert_eq!(resolution_after_first_tx, SealResolution::NoSeal);
 
@@ -129,6 +135,7 @@ mod tests {
                 gas_count: tx_gas,
                 ..SealData::default()
             },
+            ProtocolVersionId::latest(),
         );
         assert_eq!(resolution_after_second_tx, SealResolution::ExcludeAndSeal);
 
@@ -157,6 +164,7 @@ mod tests {
                 gas_count: tx_gas,
                 ..SealData::default()
             },
+            ProtocolVersionId::latest(),
         );
         assert_eq!(resolution_after_first_tx, SealResolution::IncludeAndSeal);
     }

--- a/core/lib/zksync_core/src/state_keeper/seal_criteria/criteria/geometry_seal_criteria.rs
+++ b/core/lib/zksync_core/src/state_keeper/seal_criteria/criteria/geometry_seal_criteria.rs
@@ -74,11 +74,11 @@ impl MetricExtractor for RepeatedWritesCriterion {
     const PROM_METRIC_CRITERION_NAME: &'static str = "repeated_storage_writes";
 
     fn limit_per_block(protocol_version_id: ProtocolVersionId) -> usize {
-        if !protocol_version_id.is_pre_boojum() {
+        if protocol_version_id.is_pre_boojum() {
+            GEOMETRY_CONFIG.limit_for_repeated_writes_pubdata_hasher as usize
+        } else {
             // In boojum there is no limit for repeated writes.
             usize::MAX
-        } else {
-            GEOMETRY_CONFIG.limit_for_repeated_writes_pubdata_hasher as usize
         }
     }
 
@@ -91,11 +91,11 @@ impl MetricExtractor for InitialWritesCriterion {
     const PROM_METRIC_CRITERION_NAME: &'static str = "initial_storage_writes";
 
     fn limit_per_block(protocol_version_id: ProtocolVersionId) -> usize {
-        if !protocol_version_id.is_pre_boojum() {
+        if protocol_version_id.is_pre_boojum() {
+            GEOMETRY_CONFIG.limit_for_initial_writes_pubdata_hasher as usize
+        } else {
             // In boojum there is no limit for initial writes.
             usize::MAX
-        } else {
-            GEOMETRY_CONFIG.limit_for_initial_writes_pubdata_hasher as usize
         }
     }
 
@@ -139,11 +139,11 @@ impl MetricExtractor for L2ToL1LogsCriterion {
     const PROM_METRIC_CRITERION_NAME: &'static str = "l2_to_l1_logs";
 
     fn limit_per_block(protocol_version_id: ProtocolVersionId) -> usize {
-        if !protocol_version_id.is_pre_boojum() {
+        if protocol_version_id.is_pre_boojum() {
+            GEOMETRY_CONFIG.limit_for_l1_messages_merklizer as usize
+        } else {
             // In boojum there is no limit for L2 to L1 logs.
             usize::MAX
-        } else {
-            GEOMETRY_CONFIG.limit_for_l1_messages_merklizer as usize
         }
     }
 

--- a/core/lib/zksync_core/src/state_keeper/seal_criteria/criteria/pubdata_bytes.rs
+++ b/core/lib/zksync_core/src/state_keeper/seal_criteria/criteria/pubdata_bytes.rs
@@ -1,4 +1,4 @@
-use zksync_types::MAX_PUBDATA_PER_L1_BATCH;
+use zksync_types::{ProtocolVersionId, MAX_PUBDATA_PER_L1_BATCH};
 
 use crate::state_keeper::seal_criteria::{
     SealCriterion, SealData, SealResolution, StateKeeperConfig,
@@ -15,6 +15,7 @@ impl SealCriterion for PubDataBytesCriterion {
         _tx_count: usize,
         block_data: &SealData,
         tx_data: &SealData,
+        _protocol_version: ProtocolVersionId,
     ) -> SealResolution {
         let max_pubdata_per_l1_batch = MAX_PUBDATA_PER_L1_BATCH as usize;
         let reject_bound =
@@ -69,6 +70,7 @@ mod tests {
                 ..SealData::default()
             },
             &SealData::default(),
+            ProtocolVersionId::latest(),
         );
         assert_eq!(empty_block_resolution, SealResolution::NoSeal);
 
@@ -89,6 +91,7 @@ mod tests {
                 ..SealData::default()
             },
             &SealData::default(),
+            ProtocolVersionId::latest(),
         );
         assert_eq!(full_block_resolution, SealResolution::IncludeAndSeal);
 
@@ -105,6 +108,7 @@ mod tests {
                 ..SealData::default()
             },
             &SealData::default(),
+            ProtocolVersionId::latest(),
         );
         assert_eq!(full_block_resolution, SealResolution::ExcludeAndSeal);
     }

--- a/core/lib/zksync_core/src/state_keeper/seal_criteria/criteria/slots.rs
+++ b/core/lib/zksync_core/src/state_keeper/seal_criteria/criteria/slots.rs
@@ -1,3 +1,5 @@
+use zksync_types::ProtocolVersionId;
+
 use crate::state_keeper::seal_criteria::{
     SealCriterion, SealData, SealResolution, StateKeeperConfig,
 };
@@ -14,6 +16,7 @@ impl SealCriterion for SlotsCriterion {
         tx_count: usize,
         _block_data: &SealData,
         _tx_data: &SealData,
+        _protocol_version: ProtocolVersionId,
     ) -> SealResolution {
         if tx_count >= config.transaction_slots {
             SealResolution::IncludeAndSeal
@@ -42,6 +45,7 @@ mod tests {
             config.transaction_slots - 1,
             &SealData::default(),
             &SealData::default(),
+            ProtocolVersionId::latest(),
         );
         assert_eq!(almost_full_block_resolution, SealResolution::NoSeal);
 
@@ -51,6 +55,7 @@ mod tests {
             config.transaction_slots,
             &SealData::default(),
             &SealData::default(),
+            ProtocolVersionId::latest(),
         );
         assert_eq!(full_block_resolution, SealResolution::IncludeAndSeal);
     }

--- a/core/lib/zksync_core/src/state_keeper/seal_criteria/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/seal_criteria/mod.rs
@@ -18,7 +18,7 @@ use zksync_types::{
     block::BlockGasCount,
     fee::TransactionExecutionMetrics,
     tx::tx_execution_info::{DeduplicatedWritesMetrics, ExecutionMetrics},
-    Transaction,
+    ProtocolVersionId, Transaction,
 };
 use zksync_utils::time::millis_since;
 
@@ -111,6 +111,7 @@ pub(super) trait SealCriterion: fmt::Debug + Send + 'static {
         tx_count: usize,
         block_data: &SealData,
         tx_data: &SealData,
+        protocol_version: ProtocolVersionId,
     ) -> SealResolution;
 
     // We need self here only for rust restrictions for creating an object from trait


### PR DESCRIPTION
# What ❔

Disables `InitialWritesCriterion`, `RepeatedWritesCriterion`, `L2ToL1LogsCriterion` for post-boojum blocks by setting limit to `usize::max`.

## Why ❔

Some circuits are no longer single-instance in boojum

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
