### PR TITLE
fix(db-query): use nested query for requeuing FRI prover jobs

### DIFF
--- a/core/lib/dal/sqlx-data.json
+++ b/core/lib/dal/sqlx-data.json
@@ -2957,6 +2957,39 @@
     },
     "query": "SELECT * FROM protocol_versions ORDER BY id DESC LIMIT 1"
   },
+  "3665394a2f91f1a07c2c517ae9e75434f9ec12ed4debf370662b8104e015c75f": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "status",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "attempts",
+          "ordinal": 2,
+          "type_info": "Int2"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Interval",
+          "Int2"
+        ]
+      }
+    },
+    "query": "\n                UPDATE prover_jobs_fri\n                SET status = 'queued', attempts = attempts + 1, updated_at = now(), processing_started_at = now()\n                WHERE id in (\n                    SELECT id\n                    FROM prover_jobs_fri\n                    WHERE (status = 'in_progress' AND  processing_started_at <= now() - $1::interval AND attempts < $2)\n                    OR (status = 'in_gpu_proof' AND  processing_started_at <= now() - $1::interval AND attempts < $2)\n                    OR (status = 'failed' AND attempts < $2)\n                    FOR UPDATE SKIP LOCKED\n                )\n                RETURNING id, status, attempts\n                "
+  },
   "36c483775b604324eacd7e5aac591b927cc32abb89fe1b0c5cf4b0383e9bd443": {
     "describe": {
       "columns": [
@@ -6385,39 +6418,6 @@
       }
     },
     "query": "\n                    SELECT id, circuit_input_blob_url FROM prover_jobs\n                    WHERE status='successful' AND is_blob_cleaned=FALSE\n                    AND circuit_input_blob_url is NOT NULL\n                    AND updated_at < NOW() - INTERVAL '30 days'\n                    LIMIT $1;\n                "
-  },
-  "892ad2bed255401e020b4cf89c9e43e32c333dc6627e1e2d2535e13b73d1c508": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Int8"
-        },
-        {
-          "name": "status",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "attempts",
-          "ordinal": 2,
-          "type_info": "Int2"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Interval",
-          "Int2"
-        ]
-      }
-    },
-    "query": "\n                UPDATE prover_jobs_fri\n                SET status = 'queued', attempts = attempts + 1, updated_at = now(), processing_started_at = now()\n                WHERE (status = 'in_progress' AND  processing_started_at <= now() - $1::interval AND attempts < $2)\n                OR (status = 'in_gpu_proof' AND  processing_started_at <= now() - $1::interval AND attempts < $2)\n                OR (status = 'failed' AND attempts < $2)\n                RETURNING id, status, attempts\n                "
   },
   "8996a1794585dfe0f9c16a11e113831a63d5d944bc8061d7caa25ea33f12b19d": {
     "describe": {

--- a/core/lib/dal/src/fri_prover_dal.rs
+++ b/core/lib/dal/src/fri_prover_dal.rs
@@ -214,9 +214,14 @@ impl FriProverDal<'_, '_> {
                 "
                 UPDATE prover_jobs_fri
                 SET status = 'queued', attempts = attempts + 1, updated_at = now(), processing_started_at = now()
-                WHERE (status = 'in_progress' AND  processing_started_at <= now() - $1::interval AND attempts < $2)
-                OR (status = 'in_gpu_proof' AND  processing_started_at <= now() - $1::interval AND attempts < $2)
-                OR (status = 'failed' AND attempts < $2)
+                WHERE id in (
+                    SELECT id
+                    FROM prover_jobs_fri
+                    WHERE (status = 'in_progress' AND  processing_started_at <= now() - $1::interval AND attempts < $2)
+                    OR (status = 'in_gpu_proof' AND  processing_started_at <= now() - $1::interval AND attempts < $2)
+                    OR (status = 'failed' AND attempts < $2)
+                    FOR UPDATE SKIP LOCKED
+                )
                 RETURNING id, status, attempts
                 ",
                 &processing_timeout,


### PR DESCRIPTION
# What ❔
use nested query for re-queuing jobs FRI prover


## Why ❔

* This is expected to make the UPDATE faster as per discussion with DBA.
* The concurrent updates to db would be faster.

## Checklist

- [* ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [* ] Tests for the changes have been added / updated.
- [ *] Documentation comments have been added / updated.
- [ *] Code has been formatted via `zk fmt` and `zk lint`.
