### PR TITLE
feat(en): Cache blocks in `fetch_l2_block`

### DIFF
--- a/core/lib/zksync_core/src/sync_layer/external_io.rs
+++ b/core/lib/zksync_core/src/sync_layer/external_io.rs
@@ -543,8 +543,8 @@ impl StateKeeperIO for ExternalIO {
 
         self.sync_state
             .set_local_block(self.current_miniblock_number);
-        self.current_miniblock_number += 1;
         tracing::info!("Miniblock {} is sealed", self.current_miniblock_number);
+        self.current_miniblock_number += 1;
     }
 
     async fn seal_l1_batch(


### PR DESCRIPTION
# What ❔

- `fetch_l2_block` saves blocks in cache
- fixed log in `ExternalIO:: seal_miniblock`

## Why ❔

Making cache client to behave traditional way, i.e. cache results got from server. This will also fix invariant that previous block is always (except for first iteration after start) kept in cache and fix sporadic panics caused by inconsistent API responses
 
## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
