### PR TITLE
ci: Automatically extract Prover FRI GPU keys ids from JSONs

### DIFF
--- a/.github/workflows/build-docker-from-tag.yml
+++ b/.github/workflows/build-docker-from-tag.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: [ubuntu-latest]
     outputs:
       image_tag_suffix: ${{ steps.set.outputs.image_tag_suffix }}
+      prover_fri_cpu_key_id: ${{ steps.extract-prover-fri-setup-key-ids.outputs.cpu_short_commit_sha }}
+      prover_fri_gpu_key_id: ${{ steps.extract-prover-fri-setup-key-ids.outputs.gpu_short_commit_sha }}
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
         with:
@@ -41,6 +43,20 @@ jobs:
           fi
           version=$(cut -d "-" -f2 <<< ${git_tag})
           echo "image_tag_suffix=${version}" >> $GITHUB_OUTPUT
+
+      - name: Generate outputs with Prover FRI setup data keys IDs
+        id: extract-prover-fri-setup-key-ids
+        run: |
+          declare -A json_files=(
+            ["cpu"]="setup-data-cpu-keys.json"
+            ["gpu"]="setup-data-gpu-keys.json"
+          )
+          for type in "${!json_files[@]}"; do
+            file=${json_files[$type]}
+            value=$(jq -r '.us' "./prover/$file")
+            short_sha=$(echo $value | sed 's|gs://matterlabs-setup-data-us/\(.*\)/|\1|')
+            echo "name=${type}_short_commit_sha::$short_sha" >> $GITHUB_OUTPUT
+          done
 
   build-push-core-images:
     name: Build and push image
@@ -84,5 +100,5 @@ jobs:
     uses: ./.github/workflows/build-prover-fri-gpu-gar.yml
     if: contains(github.ref_name, 'prover')
     with:
-      setup_keys_id: 2d33a27-gpu
+      setup_keys_id: ${{ needs.setup.outputs.prover_fri_gpu_key_id }}
       image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}

--- a/.github/workflows/build-docker-from-tag.yml
+++ b/.github/workflows/build-docker-from-tag.yml
@@ -55,7 +55,7 @@ jobs:
             file=${json_files[$type]}
             value=$(jq -r '.us' "./prover/$file")
             short_sha=$(echo $value | sed 's|gs://matterlabs-setup-data-us/\(.*\)/|\1|')
-            echo "name=${type}_short_commit_sha::$short_sha" >> $GITHUB_OUTPUT
+            echo "${type}_short_commit_sha=$short_sha" >> $GITHUB_OUTPUT"
           done
 
   build-push-core-images:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
               - 'prover/**'
               - '!prover/CHANGELOG.md'
               - '!prover/setup-data-cpu-keys.json'
+              - '!prover/setup-data-gpu-keys.json'
               - 'docker/prover*/**'
               - '.github/workflows/build-prover-template.yml'
               - '.github/workflows/ci-prover-reusable.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
               - 'prover/**'
               - '!prover/CHANGELOG.md'
               - '!prover/setup-data-cpu-keys.json'
-              - '!prover/setup-data-gpu-keys.json'
               - 'docker/prover*/**'
               - '.github/workflows/build-prover-template.yml'
               - '.github/workflows/ci-prover-reusable.yml'

--- a/.github/workflows/release-test-stage.yml
+++ b/.github/workflows/release-test-stage.yml
@@ -66,7 +66,7 @@ jobs:
             file=${json_files[$type]}
             value=$(jq -r '.us' "./prover/$file")
             short_sha=$(echo $value | sed 's|gs://matterlabs-setup-data-us/\(.*\)/|\1|')
-            echo "name=${type}_short_commit_sha::$short_sha" >> $GITHUB_OUTPUT
+            echo "${type}_short_commit_sha=$short_sha" >> $GITHUB_OUTPUT"
           done
 
   build-push-core-images:

--- a/.github/workflows/release-test-stage.yml
+++ b/.github/workflows/release-test-stage.yml
@@ -27,7 +27,8 @@ jobs:
         uses: tj-actions/changed-files@v37
         with:
           files_yaml: |
-            # If you want to exclude some files, please adjust here.
+            # TODO: make it more granular, as already implemented in CI workflow
+            # We don't want to be rebuilding and redeploying all the Docker images when eg. only document have changed
             prover:
               - prover/**
             core:
@@ -40,6 +41,8 @@ jobs:
     runs-on: [matterlabs-deployer-stage]
     outputs:
       image_tag_suffix: ${{ steps.generate-tag-suffix.outputs.image_tag_suffix }}
+      prover_fri_cpu_key_id: ${{ steps.extract-prover-fri-setup-key-ids.outputs.cpu_short_commit_sha }}
+      prover_fri_gpu_key_id: ${{ steps.extract-prover-fri-setup-key-ids.outputs.gpu_short_commit_sha }}
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
         with:
@@ -51,6 +54,20 @@ jobs:
           sha=$(git rev-parse --short HEAD)
           ts=$(date +%s%N | cut -b1-13)
           echo "image_tag_suffix=${sha}-${ts}" >> $GITHUB_OUTPUT
+
+      - name: Generate outputs with Prover FRI setup data keys IDs
+        id: extract-prover-fri-setup-key-ids
+        run: |
+          declare -A json_files=(
+            ["cpu"]="setup-data-cpu-keys.json"
+            ["gpu"]="setup-data-gpu-keys.json"
+          )
+          for type in "${!json_files[@]}"; do
+            file=${json_files[$type]}
+            value=$(jq -r '.us' "./prover/$file")
+            short_sha=$(echo $value | sed 's|gs://matterlabs-setup-data-us/\(.*\)/|\1|')
+            echo "name=${type}_short_commit_sha::$short_sha" >> $GITHUB_OUTPUT
+          done
 
   build-push-core-images:
     name: Build and push images
@@ -94,5 +111,5 @@ jobs:
     uses: ./.github/workflows/build-prover-fri-gpu-gar.yml
     if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.all == 'true'
     with:
-      setup_keys_id: 2d33a27-gpu
+      setup_keys_id: ${{ needs.setup.outputs.prover_fri_gpu_key_id }}
       image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}


### PR DESCRIPTION
# What ❔

This complements recent addition and automatic post-generation update of [JSON file with current setup data keys commit SHA GCS directory](https://github.com/matter-labs/zksync-era/blob/main/prover/setup-data-gpu-keys.json)

We will now dynamically fetch setup keys commit for specific code commit we're building against, instead of manually creating PRs with setup data key bumps.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
