### PR TITLE
fix: Versioned L1 batch metadata

### DIFF
--- a/core/lib/types/src/l2_to_l1_log.rs
+++ b/core/lib/types/src/l2_to_l1_log.rs
@@ -31,6 +31,10 @@ impl L2ToL1Log {
     /// for a certain batch.
     pub const MIN_L2_L1_LOGS_TREE_SIZE: usize = 2048;
 
+    /// Determines the minimum number of items in the Merkle tree built from L2-to-L1 logs
+    /// for a pre-boojum batch.
+    pub const PRE_BOOJUM_MIN_L2_L1_LOGS_TREE_SIZE: usize = 512;
+
     pub fn from_slice(data: &[u8]) -> Self {
         assert_eq!(data.len(), Self::SERIALIZED_SIZE);
         Self {

--- a/core/lib/zksync_core/src/genesis.rs
+++ b/core/lib/zksync_core/src/genesis.rs
@@ -111,6 +111,7 @@ pub async fn ensure_genesis_state(
         vec![],
         H256::zero(),
         H256::zero(),
+        *protocol_version,
     );
 
     save_genesis_l1_batch_metadata(

--- a/core/lib/zksync_core/src/metadata_calculator/mod.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/mod.rs
@@ -199,10 +199,16 @@ impl MetadataCalculator {
             tree_metadata.state_diffs,
             bootloader_initial_content_commitment.unwrap_or_default(),
             events_queue_commitment.unwrap_or_default(),
+            header.protocol_version.unwrap(),
         );
         let commitment_hash = commitment.hash();
         tracing::trace!("L1 batch commitment: {commitment:?}");
 
+        let l2_l1_messages_compressed = if header.protocol_version.unwrap().is_pre_boojum() {
+            commitment.l2_l1_logs_compressed().to_vec()
+        } else {
+            commitment.system_logs_compressed().to_vec()
+        };
         let metadata = L1BatchMetadata {
             root_hash: merkle_root_hash,
             rollup_last_leaf_index: tree_metadata.rollup_last_leaf_index,
@@ -210,7 +216,7 @@ impl MetadataCalculator {
             initial_writes_compressed: commitment.initial_writes_compressed().to_vec(),
             repeated_writes_compressed: commitment.repeated_writes_compressed().to_vec(),
             commitment: commitment_hash.commitment,
-            l2_l1_messages_compressed: commitment.system_logs_compressed().to_vec(),
+            l2_l1_messages_compressed,
             l2_l1_merkle_root: commitment.l2_l1_logs_merkle_root(),
             block_meta_params: commitment.meta_parameters(),
             aux_data_hash: commitment_hash.aux_output,


### PR DESCRIPTION
## What ❔

L1 batch metadata is calculated differently for pre-boojum and post-boojum batches.

## Why ❔

L1 batch metadata backward compatibility

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
