### PR TITLE
fix(path): update gpu prover setup data path to remove extra gpu suffix

### DIFF
--- a/prover/setup-data-gpu-keys.json
+++ b/prover/setup-data-gpu-keys.json
@@ -1,5 +1,5 @@
 {
-  "us": "gs://matterlabs-setup-data-us/8a40dc3-gpu-gpu/",
-  "europe": "gs://matterlabs-setup-data-europe/8a40dc3-gpu-gpu/",
-  "asia": "gs://matterlabs-setup-data-asia/8a40dc3-gpu-gpu/"
+  "us": "gs://matterlabs-setup-data-us/8a40dc3-gpu/",
+  "europe": "gs://matterlabs-setup-data-europe/8a40dc3-gpu/",
+  "asia": "gs://matterlabs-setup-data-asia/8a40dc3-gpu/"
 }


### PR DESCRIPTION
## What ❔

update gpu prover setup data path to remove extra gpu suffix until automation is fixed.

## Why ❔

* required for building GPU fri prover

## Checklist


- [* ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ *] Tests for the changes have been added / updated.
- [ *] Documentation comments have been added / updated.
- [ *] Code has been formatted via `zk fmt` and `zk lint`.
