### PR TITLE
chore(metrics): Rename job attempts label

### DIFF
--- a/core/lib/queued_job_processor/src/lib.rs
+++ b/core/lib/queued_job_processor/src/lib.rs
@@ -16,9 +16,9 @@ const ATTEMPT_BUCKETS: Buckets = Buckets::exponential(1.0..=64.0, 2.0);
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "job_processor")]
 struct JobProcessorMetrics {
-    #[metrics(labels = ["service", "job_id"])]
+    #[metrics(labels = ["service_name", "job_id"])]
     max_attempts_reached: LabeledFamily<(&'static str, String), Counter, 2>,
-    #[metrics(labels = ["service"], buckets = ATTEMPT_BUCKETS)]
+    #[metrics(labels = ["service_name"], buckets = ATTEMPT_BUCKETS)]
     attempts: LabeledFamily<&'static str, Histogram<usize>>,
 }
 


### PR DESCRIPTION
## What ❔

Label `service` renamed to `service_name`.

## Why ❔

Our metrics scraping agent overwrites `service` with different value.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
