### PR TITLE
fix(metadata-calculator): Save commitment for pre-boojum

### DIFF
--- a/core/lib/dal/src/blocks_dal.rs
+++ b/core/lib/dal/src/blocks_dal.rs
@@ -582,6 +582,7 @@ impl BlocksDal<'_, '_> {
         number: L1BatchNumber,
         metadata: &L1BatchMetadata,
         previous_root_hash: H256,
+        protocol_version: ProtocolVersionId,
     ) -> anyhow::Result<()> {
         let mut transaction = self.storage.start_transaction().await?;
 
@@ -614,7 +615,7 @@ impl BlocksDal<'_, '_> {
         .execute(transaction.conn())
         .await?;
 
-        if metadata.events_queue_commitment.is_some() {
+        if metadata.events_queue_commitment.is_some() || protocol_version.is_pre_boojum() {
             // Save `commitment`, `aux_data_hash`, `events_queue_commitment`, `bootloader_initial_content_commitment`.
             sqlx::query!(
                 "INSERT INTO commitments (l1_batch_number, events_queue_commitment, bootloader_initial_content_commitment) \

--- a/core/lib/zksync_core/src/eth_sender/tests.rs
+++ b/core/lib/zksync_core/src/eth_sender/tests.rs
@@ -897,6 +897,7 @@ async fn insert_l1_batch(tester: &EthSenderTester, number: L1BatchNumber) -> L1B
             header.number,
             &default_l1_batch_metadata(),
             Default::default(),
+            Default::default(),
         )
         .await
         .unwrap();

--- a/core/lib/zksync_core/src/metadata_calculator/updater.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/updater.rs
@@ -167,7 +167,12 @@ impl TreeUpdater {
             let save_postgres_latency = METRICS.start_stage(TreeUpdateStage::SavePostgres);
             storage
                 .blocks_dal()
-                .save_l1_batch_metadata(l1_batch_number, &metadata, previous_root_hash)
+                .save_l1_batch_metadata(
+                    l1_batch_number,
+                    &metadata,
+                    previous_root_hash,
+                    header.protocol_version.unwrap(),
+                )
                 .await
                 .unwrap();
             // ^ Note that `save_l1_batch_metadata()` will not blindly overwrite changes if L1 batch

--- a/core/lib/zksync_core/src/state_keeper/io/tests/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/tests/mod.rs
@@ -353,7 +353,12 @@ async fn test_miniblock_and_l1_batch_processing(
     // Save metadata for the genesis L1 batch so that we don't hang in `seal_l1_batch`.
     let metadata = create_l1_batch_metadata(0);
     conn.blocks_dal()
-        .save_l1_batch_metadata(L1BatchNumber(0), &metadata, H256::zero())
+        .save_l1_batch_metadata(
+            L1BatchNumber(0),
+            &metadata,
+            H256::zero(),
+            ProtocolVersionId::latest(),
+        )
         .await
         .unwrap();
     drop(conn);

--- a/core/lib/zksync_core/src/sync_layer/tests.rs
+++ b/core/lib/zksync_core/src/sync_layer/tests.rs
@@ -411,7 +411,12 @@ async fn mock_l1_batch_hash_computation(pool: ConnectionPool, number: u32) {
         let metadata = create_l1_batch_metadata(number);
         storage
             .blocks_dal()
-            .save_l1_batch_metadata(L1BatchNumber(1), &metadata, H256::zero())
+            .save_l1_batch_metadata(
+                L1BatchNumber(1),
+                &metadata,
+                H256::zero(),
+                ProtocolVersionId::latest(),
+            )
             .await
             .unwrap();
         break;


### PR DESCRIPTION
## What ❔

Saves commitment for pre-boojum batches unconditionally

## Why ❔

They don't have `events_queue_commitment` but `commitment` should be saved anyway

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
