### PR TITLE
fix(core)!: Actually generate an Ethereum-compatible signature.

### DIFF
--- a/core/lib/eth_signer/src/pk_signer.rs
+++ b/core/lib/eth_signer/src/pk_signer.rs
@@ -36,7 +36,12 @@ impl EthereumSigner for PrivateKeySigner {
     /// The sign method calculates an Ethereum specific signature with:
     /// sign(keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))).
     async fn sign_message(&self, message: &[u8]) -> Result<PackedEthSignature, SignerError> {
-        let signature = PackedEthSignature::sign(&self.private_key, message)
+        let prefix = format!("\x19Ethereum Signed Message:\n{}", message.len());
+        let mut bytes = Vec::with_capacity(prefix.len() + message.len());
+        bytes.extend_from_slice(prefix.as_bytes());
+        bytes.extend_from_slice(message);
+
+        let signature = PackedEthSignature::sign(&self.private_key, &bytes)
             .map_err(|err| SignerError::SigningFailed(err.to_string()))?;
         Ok(signature)
     }


### PR DESCRIPTION
Add the missing '\x19Ethereum ...' prefix and message length before hashing and signing.

## What ❔

Reconcile comment and implementation. The `sign_message` function now generates an Ethereum-compatible signature for the input `message`.

## Why ❔

At a minimum, the comment and implementation disagreed (comment said "this generates an Ethereum-compatible signature, which it didn't actually do; the implementation just hashed `message` w/o adding the prefix and message length). I opted to fix the implementation (instead of adjusting the comment), as this seemed the more apt way forward to me.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
