### PR TITLE
fix(metadata-calculator): Do not require events_queue for old batches

### DIFF
--- a/core/lib/commitment_utils/src/lib.rs
+++ b/core/lib/commitment_utils/src/lib.rs
@@ -2,21 +2,18 @@
 use zkevm_test_harness::witness::utils::{
     events_queue_commitment_fixed, initial_heap_content_commitment_fixed,
 };
-use zksync_types::{LogQuery, ProtocolVersionId, H256, U256, USED_BOOTLOADER_MEMORY_BYTES};
+use zksync_types::{LogQuery, H256, U256, USED_BOOTLOADER_MEMORY_BYTES};
 use zksync_utils::expand_memory_contents;
 
-pub fn events_queue_commitment(
-    events_queue: &Vec<LogQuery>,
-    protocol_version: ProtocolVersionId,
-) -> Option<H256> {
-    (!protocol_version.is_pre_boojum()).then(|| H256(events_queue_commitment_fixed(events_queue)))
+pub fn events_queue_commitment(events_queue: &Vec<LogQuery>, is_pre_boojum: bool) -> Option<H256> {
+    (!is_pre_boojum).then(|| H256(events_queue_commitment_fixed(events_queue)))
 }
 
 pub fn bootloader_initial_content_commitment(
     initial_bootloader_contents: &[(usize, U256)],
-    protocol_version: ProtocolVersionId,
+    is_pre_boojum: bool,
 ) -> Option<H256> {
-    (!protocol_version.is_pre_boojum()).then(|| {
+    (!is_pre_boojum).then(|| {
         let full_bootloader_memory =
             expand_memory_contents(initial_bootloader_contents, USED_BOOTLOADER_MEMORY_BYTES);
         H256(initial_heap_content_commitment_fixed(

--- a/core/lib/dal/src/blocks_dal.rs
+++ b/core/lib/dal/src/blocks_dal.rs
@@ -582,7 +582,7 @@ impl BlocksDal<'_, '_> {
         number: L1BatchNumber,
         metadata: &L1BatchMetadata,
         previous_root_hash: H256,
-        protocol_version: ProtocolVersionId,
+        is_pre_boojum: bool,
     ) -> anyhow::Result<()> {
         let mut transaction = self.storage.start_transaction().await?;
 
@@ -615,7 +615,7 @@ impl BlocksDal<'_, '_> {
         .execute(transaction.conn())
         .await?;
 
-        if metadata.events_queue_commitment.is_some() || protocol_version.is_pre_boojum() {
+        if metadata.events_queue_commitment.is_some() || is_pre_boojum {
             // Save `commitment`, `aux_data_hash`, `events_queue_commitment`, `bootloader_initial_content_commitment`.
             sqlx::query!(
                 "INSERT INTO commitments (l1_batch_number, events_queue_commitment, bootloader_initial_content_commitment) \

--- a/core/lib/types/src/commitment.rs
+++ b/core/lib/types/src/commitment.rs
@@ -25,7 +25,7 @@ use crate::{
         compress_state_diffs, InitialStorageWrite, RepeatedStorageWrite, StateDiffRecord,
         PADDED_ENCODED_STORAGE_DIFF_LEN_BYTES,
     },
-    ProtocolVersionId, H256, KNOWN_CODES_STORAGE_ADDRESS, U256,
+    H256, KNOWN_CODES_STORAGE_ADDRESS, U256,
 };
 
 /// Type that can be serialized for commitment.
@@ -341,7 +341,7 @@ struct L1BatchAuxiliaryOutput {
     bootloader_heap_hash: H256,
     #[allow(dead_code)]
     events_state_queue_hash: H256,
-    protocol_version: ProtocolVersionId,
+    is_pre_boojum: bool,
 }
 
 impl L1BatchAuxiliaryOutput {
@@ -354,7 +354,7 @@ impl L1BatchAuxiliaryOutput {
         state_diffs: Vec<StateDiffRecord>,
         bootloader_heap_hash: H256,
         events_state_queue_hash: H256,
-        protocol_version: ProtocolVersionId,
+        is_pre_boojum: bool,
     ) -> Self {
         let state_diff_hash_from_logs = system_logs.iter().find_map(|log| {
             if log.0.key == u256_to_h256(STATE_DIFF_HASH_KEY.into()) {
@@ -378,7 +378,7 @@ impl L1BatchAuxiliaryOutput {
             repeated_writes_compressed,
             system_logs_compressed,
             state_diffs_packed,
-        ) = if protocol_version.is_pre_boojum() {
+        ) = if is_pre_boojum {
             (
                 pre_boojum_serialize_commitments(&l2_l1_logs),
                 pre_boojum_serialize_commitments(&initial_writes),
@@ -404,7 +404,7 @@ impl L1BatchAuxiliaryOutput {
         let repeated_writes_hash = H256::from(keccak256(&repeated_writes_compressed));
         let state_diffs_hash = H256::from(keccak256(&(state_diffs_packed)));
 
-        let serialized_logs = if protocol_version.is_pre_boojum() {
+        let serialized_logs = if is_pre_boojum {
             &l2_l1_logs_compressed[4..]
         } else {
             &l2_l1_logs_compressed
@@ -414,7 +414,7 @@ impl L1BatchAuxiliaryOutput {
             .chunks(UserL2ToL1Log::SERIALIZED_SIZE)
             .map(|chunk| <[u8; UserL2ToL1Log::SERIALIZED_SIZE]>::try_from(chunk).unwrap());
         // ^ Skip first 4 bytes of the serialized logs (i.e., the number of logs).
-        let min_tree_size = if protocol_version.is_pre_boojum() {
+        let min_tree_size = if is_pre_boojum {
             L2ToL1Log::PRE_BOOJUM_MIN_L2_L1_LOGS_TREE_SIZE
         } else {
             L2ToL1Log::MIN_L2_L1_LOGS_TREE_SIZE
@@ -453,7 +453,7 @@ impl L1BatchAuxiliaryOutput {
 
             bootloader_heap_hash,
             events_state_queue_hash,
-            protocol_version,
+            is_pre_boojum,
         }
     }
 
@@ -462,7 +462,7 @@ impl L1BatchAuxiliaryOutput {
         const SERIALIZED_SIZE: usize = 128;
         let mut result = Vec::with_capacity(SERIALIZED_SIZE);
 
-        if self.protocol_version.is_pre_boojum() {
+        if self.is_pre_boojum {
             result.extend(self.l2_l1_logs_merkle_root.as_bytes());
             result.extend(self.l2_l1_logs_linear_hash.as_bytes());
             result.extend(self.initial_writes_hash.as_bytes());
@@ -566,7 +566,7 @@ impl L1BatchCommitment {
         state_diffs: Vec<StateDiffRecord>,
         bootloader_heap_hash: H256,
         events_state_queue_hash: H256,
-        protocol_version: ProtocolVersionId,
+        is_pre_boojum: bool,
     ) -> Self {
         let meta_parameters = L1BatchMetaParameters {
             zkporter_is_available: ZKPORTER_IS_AVAILABLE,
@@ -596,7 +596,7 @@ impl L1BatchCommitment {
                 state_diffs,
                 bootloader_heap_hash,
                 events_state_queue_hash,
-                protocol_version,
+                is_pre_boojum,
             ),
             meta_parameters,
         }
@@ -671,7 +671,7 @@ mod tests {
     };
     use crate::l2_to_l1_log::{L2ToL1Log, UserL2ToL1Log};
     use crate::writes::{InitialStorageWrite, RepeatedStorageWrite};
-    use crate::{ProtocolVersionId, H256, U256};
+    use crate::{H256, U256};
 
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize)]
@@ -754,7 +754,7 @@ mod tests {
             vec![],
             H256::zero(),
             H256::zero(),
-            ProtocolVersionId::latest(),
+            false,
         );
 
         let commitment = L1BatchCommitment {

--- a/core/lib/zksync_core/src/eth_sender/tests.rs
+++ b/core/lib/zksync_core/src/eth_sender/tests.rs
@@ -897,7 +897,7 @@ async fn insert_l1_batch(tester: &EthSenderTester, number: L1BatchNumber) -> L1B
             header.number,
             &default_l1_batch_metadata(),
             Default::default(),
-            Default::default(),
+            false,
         )
         .await
         .unwrap();

--- a/core/lib/zksync_core/src/gas_tracker/mod.rs
+++ b/core/lib/zksync_core/src/gas_tracker/mod.rs
@@ -111,7 +111,11 @@ pub(crate) fn commit_gas_count_for_l1_batch(
         .sum();
 
     // Boojum upgrade changes how storage writes are communicated/compressed.
-    let state_diff_size = if header.protocol_version.unwrap().is_pre_boojum() {
+    let is_pre_boojum = header
+        .protocol_version
+        .map(|v| v.is_pre_boojum())
+        .unwrap_or(true);
+    let state_diff_size = if is_pre_boojum {
         metadata.initial_writes_compressed.len() as u32
             + metadata.repeated_writes_compressed.len() as u32
     } else {

--- a/core/lib/zksync_core/src/genesis.rs
+++ b/core/lib/zksync_core/src/genesis.rs
@@ -111,7 +111,7 @@ pub async fn ensure_genesis_state(
         vec![],
         H256::zero(),
         H256::zero(),
-        *protocol_version,
+        protocol_version.is_pre_boojum(),
     );
 
     save_genesis_l1_batch_metadata(

--- a/core/lib/zksync_core/src/metadata_calculator/mod.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/mod.rs
@@ -185,6 +185,11 @@ impl MetadataCalculator {
         events_queue_commitment: Option<H256>,
         bootloader_initial_content_commitment: Option<H256>,
     ) -> L1BatchMetadata {
+        let is_pre_boojum = header
+            .protocol_version
+            .map(|v| v.is_pre_boojum())
+            .unwrap_or(true);
+
         let merkle_root_hash = tree_metadata.root_hash;
 
         let commitment = L1BatchCommitment::new(
@@ -199,12 +204,12 @@ impl MetadataCalculator {
             tree_metadata.state_diffs,
             bootloader_initial_content_commitment.unwrap_or_default(),
             events_queue_commitment.unwrap_or_default(),
-            header.protocol_version.unwrap(),
+            is_pre_boojum,
         );
         let commitment_hash = commitment.hash();
         tracing::trace!("L1 batch commitment: {commitment:?}");
 
-        let l2_l1_messages_compressed = if header.protocol_version.unwrap().is_pre_boojum() {
+        let l2_l1_messages_compressed = if is_pre_boojum {
             commitment.l2_l1_logs_compressed().to_vec()
         } else {
             commitment.system_logs_compressed().to_vec()

--- a/core/lib/zksync_core/src/metadata_calculator/updater.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/updater.rs
@@ -244,10 +244,10 @@ impl TreeUpdater {
             .blocks_dal()
             .get_events_queue(header.number)
             .await
-            .unwrap()
             .unwrap();
-        let events_queue_commitment =
-            events_queue_commitment(&events_queue, header.protocol_version.unwrap());
+        let events_queue_commitment = events_queue.and_then(|events_queue| {
+            events_queue_commitment(&events_queue, header.protocol_version.unwrap())
+        });
         events_queue_commitment_latency.observe();
 
         let bootloader_commitment_latency =

--- a/core/lib/zksync_core/src/state_keeper/io/tests/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/tests/mod.rs
@@ -353,12 +353,7 @@ async fn test_miniblock_and_l1_batch_processing(
     // Save metadata for the genesis L1 batch so that we don't hang in `seal_l1_batch`.
     let metadata = create_l1_batch_metadata(0);
     conn.blocks_dal()
-        .save_l1_batch_metadata(
-            L1BatchNumber(0),
-            &metadata,
-            H256::zero(),
-            ProtocolVersionId::latest(),
-        )
+        .save_l1_batch_metadata(L1BatchNumber(0), &metadata, H256::zero(), false)
         .await
         .unwrap();
     drop(conn);

--- a/core/lib/zksync_core/src/sync_layer/tests.rs
+++ b/core/lib/zksync_core/src/sync_layer/tests.rs
@@ -411,12 +411,7 @@ async fn mock_l1_batch_hash_computation(pool: ConnectionPool, number: u32) {
         let metadata = create_l1_batch_metadata(number);
         storage
             .blocks_dal()
-            .save_l1_batch_metadata(
-                L1BatchNumber(1),
-                &metadata,
-                H256::zero(),
-                ProtocolVersionId::latest(),
-            )
+            .save_l1_batch_metadata(L1BatchNumber(1), &metadata, H256::zero(), false)
             .await
             .unwrap();
         break;


### PR DESCRIPTION
## What ❔

- `events_queue_commitment` is not calculated if `events_queue` is missing
- `metadata_calculator` doesn't require `header.protocol_version` is present

## Why ❔

`events_queue` is missing for old batches, `header.protocol_version` is none for old batches in ENs databases

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
