### PR TITLE
feat: Add a setup Makefile target to install all dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: deps
+
+deps:
+	./install_deps.sh

--- a/docs/setup-dev.md
+++ b/docs/setup-dev.md
@@ -55,6 +55,18 @@ at this step.
 
 If logging out does not help, restarting the computer should.
 
+## Installation script
+
+Once docker is installed, if you are on `macOS` or `ubuntu`/`debian`, the rest of the dependencies below can be installed by running:
+
+```
+make deps
+```
+
+Note: on `macOS` you also need [homebrew](https://brew.sh/) installed on your system.
+
+If you are on a different operating system or prefer to install dependencies manually, keep reading below.
+
 ## `Node` & `Yarn`
 
 1. Install `Node` (requires version `v18.18.0`). Since our team attempts to always use the latest LTS version of

--- a/docs/setup-dev.md
+++ b/docs/setup-dev.md
@@ -57,7 +57,8 @@ If logging out does not help, restarting the computer should.
 
 ## Installation script
 
-Once docker is installed, if you are on `macOS` or `ubuntu`/`debian`, the rest of the dependencies below can be installed by running:
+Once docker is installed, if you are on `macOS` or `ubuntu`/`debian`, the rest of the dependencies below can be
+installed by running:
 
 ```
 make deps

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -e
+
+ZKSYNC_HOME="$(pwd)"
+OS=$(uname -s)
+
+export ZKSYNC_HOME=$ZKSYNC_HOME
+export PATH="$ZKSYNC_HOME/bin:$PATH"
+
+if [ "$OS" = "Darwin" ]
+then
+	brew install axel openssl postgresql tmux node@18
+	brew link node@18 --overwrite
+	curl -L https://github.com/matter-labs/zksolc-bin/releases/download/v1.3.16/zksolc-macosx-arm64-v1.3.16 --output zksolc
+	chmod a+x zksolc
+	curl -L https://github.com/ethereum/solidity/releases/download/v0.8.19/solc-macos --output solc
+	chmod a+x solc
+	mkdir -p $HOME/Library/Application\ Support/eth-compilers
+	mv solc $HOME/Library/Application\ Support/eth-compilers
+	mv zksolc $HOME/Library/Application\ Support/eth-compilers
+else
+	curl -s https://raw.githubusercontent.com/nodesource/distributions/master/scripts/nsolid_setup_deb.sh | sh -s "18"
+	sudo apt update
+	sudo apt install -y axel libssl-dev nsolid postgresql tmux git build-essential pkg-config cmake clang lldb lld
+	curl -fsSL https://get.docker.com | sh
+	curl -SL https://github.com/docker/compose/releases/download/v2.23.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+	curl -L https://github.com/matter-labs/zksolc-bin/releases/download/v1.3.16/zksolc-linux-amd64-musl-v1.3.16 --output zksolc
+	curl -L https://github.com/ethereum/solidity/releases/download/v0.8.19/solc-static-linux --output solc
+	chmod a+x solc
+	chmod a+x /usr/local/bin/docker-compose
+	chmod a+x zksolc
+	mkdir -p $(HOME)/.config
+	mv solc $(HOME)/.config
+	mv zksolc $(HOME)/.config
+	npm i -g npm@9
+	npm install --global yarn
+fi
+
+if [ ! -n "$(which cargo)" ]; then
+	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+fi
+
+. $HOME/.cargo/env
+cargo install sqlx-cli --version 0.5.13;
+
+if [ "$OS" = "Linux" ]; then
+	sudo service postgresql stop
+fi
+
+git checkout boojum-integration
+cd "$ZKSYNC_HOME"
+
+yarn policies set-version 1.22.19
+rustup install nightly-2023-07-21
+. $HOME/.cargo/env
+
+zk
+zk init

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -42,7 +42,7 @@ if [ ! -n "$(which cargo)" ]; then
 fi
 
 . $HOME/.cargo/env
-cargo install sqlx-cli --version 0.5.13;
+cargo install sqlx-cli --version 0.5.13
 
 if [ "$OS" = "Linux" ]; then
 	sudo service postgresql stop
@@ -56,4 +56,3 @@ rustup install nightly-2023-07-21
 . $HOME/.cargo/env
 
 zk
-zk init

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -43,11 +43,6 @@ fi
 
 . $HOME/.cargo/env
 cargo install sqlx-cli --version 0.5.13
-
-if [ "$OS" = "Linux" ]; then
-	sudo service postgresql stop
-fi
-
 git checkout boojum-integration
 cd "$ZKSYNC_HOME"
 


### PR DESCRIPTION
## What ❔

Running `make deps` now installs all the dependencies required to run the stack. For now supports both `macOS` and `ubuntu`/`debian`.

## Why ❔

## Checklist

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
