### PR TITLE
feat: explicit toolchain in clippy (zk lint rust) execution

### DIFF
--- a/infrastructure/zk/src/lint.ts
+++ b/infrastructure/zk/src/lint.ts
@@ -39,7 +39,7 @@ async function lintSystemContracts(check: boolean = false) {
 function clippyRustToolchain(): string {
     //There are no specific reasons to run this particular version other than because clippy is not very stable
     // and even the same clippy sem-ver version can result in different output based on compiler version
-    return 'nightly-2023-08-21';
+    return '1.74.0';
 }
 async function clippy() {
     process.chdir(process.env.ZKSYNC_HOME!);

--- a/infrastructure/zk/src/lint.ts
+++ b/infrastructure/zk/src/lint.ts
@@ -43,7 +43,7 @@ function clippyRustToolchain(): string {
 }
 async function clippy() {
     process.chdir(process.env.ZKSYNC_HOME!);
-    await utils.spawn(`cargo ${clippyRustToolchain()} clippy --tests -- -D warnings`);
+    await utils.spawn(`cargo +${clippyRustToolchain()} clippy --tests -- -D warnings`);
 }
 
 async function proverClippy() {

--- a/infrastructure/zk/src/lint.ts
+++ b/infrastructure/zk/src/lint.ts
@@ -36,14 +36,19 @@ async function lintSystemContracts(check: boolean = false) {
     await utils.spawn(`yarn --silent --cwd etc/system-contracts lint:${check ? 'check' : 'fix'}`);
 }
 
+function clippyRustToolchain(): string {
+    //There are no specific reasons to run this particular version other than because clippy is not very stable
+    // and even the same clippy sem-ver version can result in different output based on compiler version
+    return 'nightly-2023-08-21';
+}
 async function clippy() {
     process.chdir(process.env.ZKSYNC_HOME!);
-    await utils.spawn('cargo clippy --tests -- -D warnings');
+    await utils.spawn(`cargo ${clippyRustToolchain()} clippy --tests -- -D warnings`);
 }
 
 async function proverClippy() {
     process.chdir(process.env.ZKSYNC_HOME! + '/prover');
-    await utils.spawn('cargo clippy --tests -- -D warnings -A incomplete_features');
+    await utils.spawn(`cargo +${clippyRustToolchain()} clippy --tests -- -D warnings -A incomplete_features`);
 }
 
 const ARGS = [...EXTENSIONS, 'rust', 'prover', 'l1-contracts', 'l2-contracts', 'system-contracts'];

--- a/infrastructure/zk/src/lint.ts
+++ b/infrastructure/zk/src/lint.ts
@@ -39,7 +39,7 @@ async function lintSystemContracts(check: boolean = false) {
 function clippyRustToolchain(): string {
     //There are no specific reasons to run this particular version other than because clippy is not very stable
     // and even the same clippy sem-ver version can result in different output based on compiler version
-    return '1.74.0';
+    return 'nightly-2023-08-21';
 }
 async function clippy() {
     process.chdir(process.env.ZKSYNC_HOME!);


### PR DESCRIPTION
## What ❔

Provide explicit toolchain version when executing clippy so that linting locally has the same effect as when run on CI

## Why ❔

It's too easy now to use `zk lint rust `so that it outputs errors that are different than those in CI (especially that the setup-dev.md does not ask to install specific rust version, and there are multiple versions of rust used in different dockerfiles in our repo), this change makes this command more stable

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
