### PR TITLE
feat(state-keeper): Remove computational gas limit from boojum protocol version

### DIFF
--- a/core/lib/zksync_core/src/state_keeper/seal_criteria/criteria/geometry_seal_criteria.rs
+++ b/core/lib/zksync_core/src/state_keeper/seal_criteria/criteria/geometry_seal_criteria.rs
@@ -119,15 +119,20 @@ impl MetricExtractor for MaxCyclesCriterion {
 impl MetricExtractor for ComputationalGasCriterion {
     const PROM_METRIC_CRITERION_NAME: &'static str = "computational_gas";
 
-    fn limit_per_block(_protocol_version_id: ProtocolVersionId) -> usize {
-        // We subtract constant to take into account that circuits may be not fully filled.
-        // This constant should be greater than number of circuits types
-        // but we keep it larger to be on the safe side.
-        const MARGIN_NUMBER_OF_CIRCUITS: usize = 100;
-        const MAX_NUMBER_OF_MUTLIINSTANCE_CIRCUITS: usize =
-            SCHEDULER_UPPER_BOUND as usize - MARGIN_NUMBER_OF_CIRCUITS;
+    fn limit_per_block(protocol_version_id: ProtocolVersionId) -> usize {
+        if protocol_version_id.is_pre_boojum() {
+            // We subtract constant to take into account that circuits may be not fully filled.
+            // This constant should be greater than number of circuits types
+            // but we keep it larger to be on the safe side.
+            const MARGIN_NUMBER_OF_CIRCUITS: usize = 100;
+            const MAX_NUMBER_OF_MUTLIINSTANCE_CIRCUITS: usize =
+                SCHEDULER_UPPER_BOUND as usize - MARGIN_NUMBER_OF_CIRCUITS;
 
-        MAX_NUMBER_OF_MUTLIINSTANCE_CIRCUITS * ERGS_PER_CIRCUIT as usize
+            MAX_NUMBER_OF_MUTLIINSTANCE_CIRCUITS * ERGS_PER_CIRCUIT as usize
+        } else {
+            // In boojum there is no limit for computational gas.
+            usize::MAX
+        }
     }
 
     fn extract(metrics: &ExecutionMetrics, _writes: &DeduplicatedWritesMetrics) -> usize {


### PR DESCRIPTION
**What**

Removes `ComputationalGasCriterion` from post-Boojum versions

**Why**

* There is no limit on total number of circuits in post-Boojum
* We want to test proving logic when we spend a lot of comp. gas in one l1 batch (this will result in tens of thousands of prover jobs - we want to test the system under that circumstances)


Safety: we do need to properly test this on stage before we upgrade mainnet. We should also discuss if want to introduce _some_ limit - even though there is no hard limit