### PR TITLE
feat(en): Support arbitrary genesis block for external nodes

### DIFF
--- a/core/lib/types/src/block.rs
+++ b/core/lib/types/src/block.rs
@@ -89,7 +89,7 @@ pub struct MiniblockHeader {
 }
 
 /// Consensus-related L2 block (= miniblock) fields.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ConsensusBlockFields {
     /// Hash of the previous consensus block.
     pub parent: validator::BlockHeaderHash,
@@ -99,12 +99,14 @@ pub struct ConsensusBlockFields {
 
 impl ProtoFmt for ConsensusBlockFields {
     type Proto = crate::proto::ConsensusBlockFields;
-    fn read(r: &Self::Proto) -> anyhow::Result<Self> {
+
+    fn read(proto: &Self::Proto) -> anyhow::Result<Self> {
         Ok(Self {
-            parent: read_required(&r.parent).context("parent")?,
-            justification: read_required(&r.justification).context("justification")?,
+            parent: read_required(&proto.parent).context("parent")?,
+            justification: read_required(&proto.justification).context("justification")?,
         })
     }
+
     fn build(&self) -> Self::Proto {
         Self::Proto {
             parent: Some(self.parent.build()),

--- a/core/lib/zksync_core/src/consensus/payload.rs
+++ b/core/lib/zksync_core/src/consensus/payload.rs
@@ -6,7 +6,7 @@ use zksync_types::api::en::SyncBlock;
 use zksync_types::{Address, L1BatchNumber, Transaction, H256};
 
 /// L2 block (= miniblock) payload.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) struct Payload {
     pub hash: H256,
     pub l1_batch_number: L1BatchNumber,

--- a/core/lib/zksync_core/src/sync_layer/external_io.rs
+++ b/core/lib/zksync_core/src/sync_layer/external_io.rs
@@ -556,6 +556,8 @@ impl StateKeeperIO for ExternalIO {
         // Mimic the metric emitted by the main node to reuse existing Grafana charts.
         APP_METRICS.block_number[&BlockStage::Sealed].set(self.current_l1_batch_number.0.into());
 
+        self.sync_state
+            .set_local_block(self.current_miniblock_number);
         self.current_miniblock_number += 1; // Due to fictive miniblock being sealed.
         self.current_l1_batch_number += 1;
         Ok(())

--- a/core/lib/zksync_core/src/sync_layer/fetcher.rs
+++ b/core/lib/zksync_core/src/sync_layer/fetcher.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use zksync_dal::StorageProcessor;
 use zksync_types::{
     api::en::SyncBlock, block::ConsensusBlockFields, Address, L1BatchNumber, MiniblockNumber,
-    ProtocolVersionId, H256,
+    ProtocolVersionId,
 };
 use zksync_web3_decl::jsonrpsee::core::Error as RpcError;
 
@@ -29,7 +29,6 @@ pub(super) struct FetchedBlock {
     pub last_in_batch: bool,
     pub protocol_version: ProtocolVersionId,
     pub timestamp: u64,
-    pub hash: H256,
     pub l1_gas_price: u64,
     pub l2_fair_gas_price: u64,
     pub virtual_blocks: u32,
@@ -38,15 +37,14 @@ pub(super) struct FetchedBlock {
     pub consensus: Option<ConsensusBlockFields>,
 }
 
-impl FetchedBlock {
-    fn from_sync_block(block: SyncBlock) -> Self {
+impl From<SyncBlock> for FetchedBlock {
+    fn from(block: SyncBlock) -> Self {
         Self {
             number: block.number,
             l1_batch_number: block.l1_batch_number,
             last_in_batch: block.last_in_batch,
             protocol_version: block.protocol_version,
             timestamp: block.timestamp,
-            hash: block.hash.unwrap_or_default(),
             l1_gas_price: block.l1_gas_price,
             l2_fair_gas_price: block.l2_fair_gas_price,
             virtual_blocks: block.virtual_blocks.unwrap_or(0),
@@ -64,7 +62,6 @@ impl FetchedBlock {
 pub struct FetcherCursor {
     // Fields are public for testing purposes.
     pub(super) next_miniblock: MiniblockNumber,
-    pub(super) prev_miniblock_hash: H256,
     pub(super) l1_batch: L1BatchNumber,
 }
 
@@ -93,7 +90,6 @@ impl FetcherCursor {
 
         // Miniblocks are always fully processed.
         let next_miniblock = last_miniblock_header.number + 1;
-        let prev_miniblock_hash = last_miniblock_header.hash;
         // Decide whether the next batch should be explicitly opened or not.
         let l1_batch = if was_new_batch_open {
             // No `OpenBatch` action needed.
@@ -106,7 +102,6 @@ impl FetcherCursor {
         Ok(Self {
             next_miniblock,
             l1_batch,
-            prev_miniblock_hash,
         })
     }
 
@@ -136,7 +131,6 @@ impl FetcherCursor {
                 protocol_version: block.protocol_version,
                 // `block.virtual_blocks` can be `None` only for old VM versions where it's not used, so it's fine to provide any number.
                 first_miniblock_info: (block.number, block.virtual_blocks),
-                prev_miniblock_hash: self.prev_miniblock_hash,
             });
             FETCHER_METRICS.l1_batch[&L1BatchStage::Open].set(block.l1_batch_number.0.into());
             self.l1_batch += 1;
@@ -168,7 +162,6 @@ impl FetcherCursor {
             new_actions.push(SyncAction::SealMiniblock(block.consensus));
         }
         self.next_miniblock += 1;
-        self.prev_miniblock_hash = block.hash;
 
         new_actions
     }
@@ -280,8 +273,7 @@ impl MainNodeFetcher {
         request_latency.observe();
 
         let block_number = block.number;
-        let fetched_block = FetchedBlock::from_sync_block(block);
-        let new_actions = self.cursor.advance(fetched_block);
+        let new_actions = self.cursor.advance(block.into());
 
         tracing::info!(
             "New miniblock: {block_number} / {}",

--- a/core/lib/zksync_core/src/sync_layer/gossip/buffered/tests.rs
+++ b/core/lib/zksync_core/src/sync_layer/gossip/buffered/tests.rs
@@ -11,6 +11,7 @@ use zksync_concurrency::{
     ctx::{self, channel},
     scope,
     sync::{self, watch},
+    testonly::abort_on_panic,
     time,
 };
 use zksync_consensus_roles::validator::{BlockHeader, BlockNumber, FinalBlock, Payload};
@@ -131,6 +132,7 @@ async fn test_buffered_storage(
     block_interval: time::Duration,
     shuffle_blocks: impl FnOnce(&mut StdRng, &mut [FinalBlock]),
 ) {
+    abort_on_panic();
     let ctx = &ctx::test_root(&ctx::RealClock);
     let rng = &mut ctx.rng();
 

--- a/core/lib/zksync_core/src/sync_layer/gossip/conversions.rs
+++ b/core/lib/zksync_core/src/sync_layer/gossip/conversions.rs
@@ -42,7 +42,6 @@ impl FetchedBlock {
             last_in_batch,
             protocol_version: ProtocolVersionId::latest(), // FIXME
             timestamp: payload.timestamp,
-            hash: payload.hash,
             l1_gas_price: payload.l1_gas_price,
             l2_fair_gas_price: payload.l2_fair_gas_price,
             virtual_blocks: payload.virtual_blocks,

--- a/core/lib/zksync_core/src/sync_layer/gossip/mod.rs
+++ b/core/lib/zksync_core/src/sync_layer/gossip/mod.rs
@@ -67,7 +67,9 @@ async fn run_gossip_fetcher_inner(
     let cursor = FetcherCursor::new(&mut storage).await?;
     drop(storage);
 
-    let store = PostgresBlockStorage::new(pool, actions, cursor);
+    let store =
+        PostgresBlockStorage::new(ctx, pool, actions, cursor, &executor_config.genesis_block)
+            .await?;
     let buffered = Arc::new(Buffered::new(store));
     let store = buffered.inner();
     let executor = Executor::new(executor_config, node_key, buffered.clone())

--- a/core/lib/zksync_core/src/sync_layer/gossip/storage/mod.rs
+++ b/core/lib/zksync_core/src/sync_layer/gossip/storage/mod.rs
@@ -154,6 +154,9 @@ impl PostgresBlockStorage {
                 return Err(StorageError::Database(err));
             }
         } else {
+            tracing::info!(
+                "Postgres doesn't have consensus fields for genesis block; saving {expected_consensus_fields:?}"
+            );
             ctx.wait(storage.blocks_dal().set_miniblock_consensus_fields(
                 MiniblockNumber(block_number),
                 &expected_consensus_fields,

--- a/core/lib/zksync_core/src/sync_layer/gossip/storage/tests.rs
+++ b/core/lib/zksync_core/src/sync_layer/gossip/storage/tests.rs
@@ -2,7 +2,7 @@
 
 use rand::{thread_rng, Rng};
 
-use zksync_concurrency::scope;
+use zksync_concurrency::{scope, testonly::abort_on_panic};
 use zksync_consensus_roles::validator;
 use zksync_types::L2ChainId;
 
@@ -23,6 +23,7 @@ const TEST_TIMEOUT: time::Duration = time::Duration::seconds(10);
 
 #[tokio::test]
 async fn block_store_basics_for_postgres() {
+    abort_on_panic();
     let pool = ConnectionPool::test_pool().await;
     run_state_keeper_with_multiple_miniblocks(pool.clone()).await;
 
@@ -58,6 +59,7 @@ async fn block_store_basics_for_postgres() {
 
 #[tokio::test]
 async fn subscribing_to_block_updates_for_postgres() {
+    abort_on_panic();
     let pool = ConnectionPool::test_pool().await;
     let mut storage = pool.access_storage().await.unwrap();
     if storage.blocks_dal().is_genesis_needed().await.unwrap() {
@@ -101,6 +103,7 @@ async fn subscribing_to_block_updates_for_postgres() {
 
 #[tokio::test]
 async fn processing_new_blocks() {
+    abort_on_panic();
     let pool = ConnectionPool::test_pool().await;
     run_state_keeper_with_multiple_miniblocks(pool.clone()).await;
 
@@ -144,6 +147,7 @@ async fn processing_new_blocks() {
 
 #[tokio::test]
 async fn ensuring_consensus_fields_for_genesis_block() {
+    abort_on_panic();
     let ctx = &ctx::test_root(&ctx::RealClock);
     let pool = ConnectionPool::test_pool().await;
     let mut storage = pool.access_storage().await.unwrap();
@@ -202,6 +206,7 @@ async fn ensuring_consensus_fields_for_genesis_block() {
 
 #[tokio::test]
 async fn genesis_block_payload_mismatch() {
+    abort_on_panic();
     let ctx = &ctx::test_root(&ctx::RealClock);
     let pool = ConnectionPool::test_pool().await;
     let mut storage = pool.access_storage().await.unwrap();
@@ -240,6 +245,7 @@ async fn genesis_block_payload_mismatch() {
 
 #[tokio::test]
 async fn missing_genesis_block() {
+    abort_on_panic();
     let ctx = &ctx::test_root(&ctx::RealClock);
     let pool = ConnectionPool::test_pool().await;
     let mut storage = pool.access_storage().await.unwrap();
@@ -264,6 +270,7 @@ async fn missing_genesis_block() {
 
 #[tokio::test]
 async fn using_non_zero_genesis_block() {
+    abort_on_panic();
     let ctx = &ctx::test_root(&ctx::RealClock);
     let pool = ConnectionPool::test_pool().await;
     run_state_keeper_with_multiple_miniblocks(pool.clone()).await;

--- a/core/lib/zksync_core/src/sync_layer/gossip/storage/tests.rs
+++ b/core/lib/zksync_core/src/sync_layer/gossip/storage/tests.rs
@@ -30,7 +30,7 @@ async fn block_store_basics_for_postgres() {
     let cursor = FetcherCursor::new(&mut storage).await.unwrap();
     drop(storage);
     let (actions_sender, _) = ActionQueue::new();
-    let storage = PostgresBlockStorage::new(pool.clone(), actions_sender, cursor);
+    let storage = PostgresBlockStorage::new_unchecked(pool.clone(), actions_sender, cursor);
 
     let ctx = &ctx::test_root(&ctx::RealClock);
     let genesis_block = BlockStore::first_block(&storage, ctx).await.unwrap();
@@ -64,7 +64,7 @@ async fn subscribing_to_block_updates_for_postgres() {
     // `ContiguousBlockStore`), but for testing subscriptions this is fine.
     drop(storage);
     let (actions_sender, _) = ActionQueue::new();
-    let storage = PostgresBlockStorage::new(pool.clone(), actions_sender, cursor);
+    let storage = PostgresBlockStorage::new_unchecked(pool.clone(), actions_sender, cursor);
     let mut subscriber = storage.subscribe_to_block_writes();
 
     let ctx = &ctx::test_root(&ctx::RealClock);
@@ -110,7 +110,7 @@ async fn processing_new_blocks() {
     drop(storage);
 
     let (actions_sender, mut actions) = ActionQueue::new();
-    let storage = PostgresBlockStorage::new(pool.clone(), actions_sender, cursor);
+    let storage = PostgresBlockStorage::new_unchecked(pool.clone(), actions_sender, cursor);
     let ctx = &ctx::test_root(&ctx::RealClock);
     let ctx = &ctx.with_timeout(TEST_TIMEOUT);
     storage

--- a/core/lib/zksync_core/src/sync_layer/gossip/storage/tests.rs
+++ b/core/lib/zksync_core/src/sync_layer/gossip/storage/tests.rs
@@ -298,4 +298,33 @@ async fn using_non_zero_genesis_block() {
         let missing_block = store.block(ctx, BlockNumber(number)).await.unwrap();
         assert!(missing_block.is_none());
     }
+
+    let missing_blocks = store
+        .missing_block_numbers(ctx, BlockNumber(0)..BlockNumber(5))
+        .await
+        .unwrap();
+    assert_eq!(
+        missing_blocks,
+        [
+            BlockNumber(0),
+            BlockNumber(1),
+            BlockNumber(3),
+            BlockNumber(4)
+        ]
+    );
+    let missing_blocks = store
+        .missing_block_numbers(ctx, BlockNumber(0)..BlockNumber(2))
+        .await
+        .unwrap();
+    assert_eq!(missing_blocks, [BlockNumber(0), BlockNumber(1)]);
+    let missing_blocks = store
+        .missing_block_numbers(ctx, BlockNumber(2)..BlockNumber(5))
+        .await
+        .unwrap();
+    assert_eq!(missing_blocks, [BlockNumber(3), BlockNumber(4)]);
+    let missing_blocks = store
+        .missing_block_numbers(ctx, BlockNumber(2)..BlockNumber(3))
+        .await
+        .unwrap();
+    assert_eq!(missing_blocks, []);
 }

--- a/core/lib/zksync_core/src/sync_layer/gossip/tests.rs
+++ b/core/lib/zksync_core/src/sync_layer/gossip/tests.rs
@@ -3,12 +3,16 @@
 use assert_matches::assert_matches;
 use test_casing::{test_casing, Product};
 
+use std::ops;
+
 use zksync_concurrency::{ctx, scope, time};
 use zksync_consensus_executor::testonly::FullValidatorConfig;
 use zksync_consensus_roles::validator::{self, FinalBlock};
 use zksync_consensus_storage::{InMemoryStorage, WriteBlockStore};
 use zksync_dal::{ConnectionPool, StorageProcessor};
-use zksync_types::{block::ConsensusBlockFields, Address, L1BatchNumber, MiniblockNumber};
+use zksync_types::{
+    api::en::SyncBlock, block::ConsensusBlockFields, Address, L1BatchNumber, MiniblockNumber, H256,
+};
 
 use super::*;
 use crate::{
@@ -26,30 +30,36 @@ use crate::{
 const CLOCK_SPEEDUP: i64 = 20;
 const POLL_INTERVAL: time::Duration = time::Duration::milliseconds(50 * CLOCK_SPEEDUP);
 
+async fn load_sync_block(storage: &mut StorageProcessor<'_>, number: u32) -> SyncBlock {
+    storage
+        .sync_dal()
+        .sync_block(MiniblockNumber(number), Address::default(), true)
+        .await
+        .unwrap()
+        .unwrap_or_else(|| panic!("no sync block #{number}"))
+}
+
 /// Loads a block from the storage and converts it to a `FinalBlock`.
 pub(super) async fn load_final_block(
     storage: &mut StorageProcessor<'_>,
     number: u32,
 ) -> FinalBlock {
-    let sync_block = storage
-        .sync_dal()
-        .sync_block(MiniblockNumber(number), Address::default(), true)
-        .await
-        .unwrap()
-        .unwrap_or_else(|| panic!("no sync block #{number}"));
+    let sync_block = load_sync_block(storage, number).await;
     conversions::sync_block_to_consensus_block(sync_block).unwrap()
+}
+
+fn convert_sync_blocks(sync_blocks: Vec<SyncBlock>) -> Vec<FinalBlock> {
+    sync_blocks
+        .into_iter()
+        .map(|sync_block| conversions::sync_block_to_consensus_block(sync_block).unwrap())
+        .collect()
 }
 
 pub(super) async fn block_payload(
     storage: &mut StorageProcessor<'_>,
     number: u32,
 ) -> consensus::Payload {
-    let sync_block = storage
-        .sync_dal()
-        .sync_block(MiniblockNumber(number), Address::default(), true)
-        .await
-        .unwrap()
-        .unwrap_or_else(|| panic!("no sync block #{number}"));
+    let sync_block = load_sync_block(storage, number).await;
     consensus::Payload::try_from(sync_block).unwrap()
 }
 
@@ -57,11 +67,11 @@ pub(super) async fn block_payload(
 pub(super) async fn add_consensus_fields(
     storage: &mut StorageProcessor<'_>,
     validator_key: &validator::SecretKey,
-    count: u32,
+    block_numbers: ops::Range<u32>,
 ) {
     let mut prev_block_hash = validator::BlockHeaderHash::from_bytes([0; 32]);
     let validator_set = validator::ValidatorSet::new([validator_key.public()]).unwrap();
-    for number in 0..count {
+    for number in block_numbers {
         let payload = block_payload(storage, number).await.encode();
         let block_header = validator::BlockHeader {
             parent: prev_block_hash,
@@ -87,6 +97,33 @@ pub(super) async fn add_consensus_fields(
             .await
             .unwrap();
         prev_block_hash = block_header.hash();
+    }
+}
+
+/// Creates a genesis block for the consensus with the specified number / payload authored by a single validator.
+pub(super) fn create_genesis_block(
+    validator_key: &validator::SecretKey,
+    number: u64,
+    payload: validator::Payload,
+) -> FinalBlock {
+    let block_header = validator::BlockHeader {
+        parent: validator::BlockHeaderHash::from_bytes([0; 32]),
+        number: validator::BlockNumber(number),
+        payload: payload.hash(),
+    };
+    let validator_set = validator::ValidatorSet::new([validator_key.public()]).unwrap();
+    let replica_commit = validator::ReplicaCommit {
+        protocol_version: validator::CURRENT_VERSION,
+        view: validator::ViewNumber(number),
+        proposal: block_header,
+    };
+    let replica_commit = validator_key.sign_msg(replica_commit);
+    let justification =
+        validator::CommitQC::from(&[replica_commit], &validator_set).expect("Failed creating QC");
+    FinalBlock {
+        header: block_header,
+        payload,
+        justification,
     }
 }
 
@@ -152,8 +189,9 @@ async fn syncing_via_gossip_fetcher(delay_first_block: bool, delay_second_block:
     let validator_set = validator.node_config.validators.clone();
     let external_node = validator.connect_full_node(rng);
 
-    let (genesis_block, blocks) =
-        get_blocks_and_reset_storage(storage, &validator.validator_key).await;
+    let genesis_block = validator.node_config.genesis_block.clone();
+    add_consensus_fields(&mut storage, &validator.validator_key, 0..3).await;
+    let blocks = convert_sync_blocks(reset_storage(storage).await);
     let [first_block, second_block] = blocks.as_slice() else {
         unreachable!("Unexpected blocks in storage: {blocks:?}");
     };
@@ -231,21 +269,16 @@ async fn syncing_via_gossip_fetcher(delay_first_block: bool, delay_second_block:
     }
 }
 
-async fn get_blocks_and_reset_storage(
-    mut storage: StorageProcessor<'_>,
-    validator_key: &validator::SecretKey,
-) -> (FinalBlock, Vec<FinalBlock>) {
+/// Returns the removed blocks.
+async fn reset_storage(mut storage: StorageProcessor<'_>) -> Vec<SyncBlock> {
     let sealed_miniblock_number = storage
         .blocks_dal()
         .get_sealed_miniblock_number()
         .await
         .unwrap();
-    add_consensus_fields(&mut storage, validator_key, sealed_miniblock_number.0 + 1).await;
-    let genesis_block = load_final_block(&mut storage, 0).await;
-
-    let mut blocks = Vec::with_capacity(sealed_miniblock_number.0 as usize);
+    let mut blocks = vec![];
     for number in 1..=sealed_miniblock_number.0 {
-        blocks.push(load_final_block(&mut storage, number).await);
+        blocks.push(load_sync_block(&mut storage, number).await);
     }
 
     storage
@@ -262,7 +295,7 @@ async fn get_blocks_and_reset_storage(
         .delete_l1_batches(L1BatchNumber(0))
         .await
         .unwrap();
-    (genesis_block, blocks)
+    blocks
 }
 
 #[test_casing(4, [3, 2, 1, 0])]
@@ -283,8 +316,9 @@ async fn syncing_via_gossip_fetcher_with_multiple_l1_batches(initial_block_count
     let validator_set = validator.node_config.validators.clone();
     let external_node = validator.connect_full_node(rng);
 
-    let (genesis_block, blocks) =
-        get_blocks_and_reset_storage(storage, &validator.validator_key).await;
+    let genesis_block = validator.node_config.genesis_block.clone();
+    add_consensus_fields(&mut storage, &validator.validator_key, 0..4).await;
+    let blocks = convert_sync_blocks(reset_storage(storage).await);
     assert_eq!(blocks.len(), 3); // 2 real + 1 fictive blocks
     tracing::trace!("Node storage reset");
     let (initial_blocks, delayed_blocks) = blocks.split_at(initial_block_count);
@@ -312,9 +346,8 @@ async fn syncing_via_gossip_fetcher_with_multiple_l1_batches(initial_block_count
             Ok(())
         });
 
-        let cloned_pool = pool.clone();
         s.spawn_bg(async {
-            mock_l1_batch_hash_computation(cloned_pool, 1).await;
+            mock_l1_batch_hash_computation(pool.clone(), 1).await;
             Ok(())
         });
         s.spawn_bg(run_gossip_fetcher_inner(
@@ -338,5 +371,140 @@ async fn syncing_via_gossip_fetcher_with_multiple_l1_batches(initial_block_count
     for number in [1, 2, 3] {
         let block = load_final_block(&mut storage, number).await;
         block.justification.verify(&validator_set, 1).unwrap();
+    }
+}
+
+#[test_casing(2, [1, 2])]
+#[tokio::test]
+async fn syncing_from_non_zero_block(first_block_number: u32) {
+    zksync_concurrency::testonly::abort_on_panic();
+    let pool = ConnectionPool::test_pool().await;
+    let tx_hashes = run_state_keeper_with_multiple_l1_batches(pool.clone()).await;
+    let tx_hashes: Vec<_> = tx_hashes.iter().map(Vec::as_slice).collect();
+
+    let mut storage = pool.access_storage().await.unwrap();
+    let genesis_block_payload = block_payload(&mut storage, first_block_number)
+        .await
+        .encode();
+    let ctx = &ctx::test_root(&ctx::AffineClock::new(CLOCK_SPEEDUP as f64));
+    let rng = &mut ctx.rng();
+    let mut validator =
+        FullValidatorConfig::for_single_validator(rng, genesis_block_payload.clone());
+    // Override the genesis block since it has an incorrect block number.
+    let genesis_block = create_genesis_block(
+        &validator.validator_key,
+        first_block_number.into(),
+        genesis_block_payload,
+    );
+    validator.node_config.genesis_block = genesis_block.clone();
+    let validator_set = validator.node_config.validators.clone();
+    let external_node = validator.connect_full_node(rng);
+
+    add_consensus_fields(
+        &mut storage,
+        &validator.validator_key,
+        first_block_number..4,
+    )
+    .await;
+    let mut initial_blocks = reset_storage(storage).await;
+    let delayed_blocks = initial_blocks.split_off(first_block_number as usize);
+    assert!(!initial_blocks.is_empty());
+    assert!(!delayed_blocks.is_empty());
+    let delayed_blocks = convert_sync_blocks(delayed_blocks);
+
+    // Re-insert initial blocks to the storage. This allows to more precisely emulate node syncing
+    // (e.g., missing L1 batch relation for the latest blocks).
+    insert_sync_blocks(pool.clone(), initial_blocks, &tx_hashes).await;
+    tracing::trace!("Re-inserted blocks to node storage");
+
+    let validator_storage = Arc::new(InMemoryStorage::new(genesis_block));
+    let validator = Executor::new(
+        validator.node_config,
+        validator.node_key,
+        validator_storage.clone(),
+    )
+    .unwrap();
+
+    let tx_hashes = if first_block_number >= 2 {
+        &tx_hashes[1..] // Skip transactions in L1 batch #1, since they won't be executed
+    } else {
+        &tx_hashes
+    };
+    let (actions_sender, actions) = ActionQueue::new();
+    let state_keeper = StateKeeperHandles::new(pool.clone(), actions, tx_hashes).await;
+    scope::run!(ctx, |ctx, s| async {
+        s.spawn_bg(validator.run(ctx));
+        s.spawn_bg(async {
+            for block in &delayed_blocks {
+                ctx.sleep(POLL_INTERVAL).await?;
+                validator_storage.put_block(ctx, block).await?;
+            }
+            Ok(())
+        });
+
+        if first_block_number < 2 {
+            // L1 batch #1 will be sealed during the state keeper operation; we need to emulate
+            // computing metadata for it.
+            s.spawn_bg(async {
+                mock_l1_batch_hash_computation(pool.clone(), 1).await;
+                Ok(())
+            });
+        }
+
+        s.spawn_bg(run_gossip_fetcher_inner(
+            ctx,
+            pool.clone(),
+            actions_sender,
+            external_node.node_config,
+            external_node.node_key,
+        ));
+
+        state_keeper
+            .wait(|state| state.get_local_block() == MiniblockNumber(3))
+            .await;
+        Ok(())
+    })
+    .await
+    .unwrap();
+
+    // Check that received blocks have consensus fields persisted.
+    let mut storage = pool.access_storage().await.unwrap();
+    for number in first_block_number..4 {
+        let block = load_final_block(&mut storage, number).await;
+        block.justification.verify(&validator_set, 1).unwrap();
+    }
+}
+
+async fn insert_sync_blocks(pool: ConnectionPool, blocks: Vec<SyncBlock>, tx_hashes: &[&[H256]]) {
+    let expected_block_number = blocks.last().expect("blocks cannot be empty").number;
+    let sealed_l1_batches = blocks
+        .iter()
+        .filter_map(|block| block.last_in_batch.then_some(block.l1_batch_number));
+    let sealed_l1_batches: Vec<_> = sealed_l1_batches.collect();
+
+    let mut fetcher = FetcherCursor::new(&mut pool.access_storage().await.unwrap())
+        .await
+        .unwrap();
+    let (actions_sender, actions) = ActionQueue::new();
+    let state_keeper = StateKeeperHandles::new(pool.clone(), actions, tx_hashes).await;
+    for block in blocks {
+        let block_actions = fetcher.advance(block.into());
+        actions_sender.push_actions(block_actions).await;
+    }
+
+    let hash_tasks: Vec<_> = sealed_l1_batches
+        .into_iter()
+        .map(|l1_batch_number| {
+            tokio::spawn(mock_l1_batch_hash_computation(
+                pool.clone(),
+                l1_batch_number.0,
+            ))
+        })
+        .collect();
+    state_keeper
+        .wait(|state| state.get_local_block() == expected_block_number)
+        .await;
+    for hash_task in hash_tasks {
+        hash_task.await.unwrap();
     }
 }

--- a/core/lib/zksync_core/src/sync_layer/gossip/tests.rs
+++ b/core/lib/zksync_core/src/sync_layer/gossip/tests.rs
@@ -33,7 +33,7 @@ pub(super) async fn load_final_block(
 ) -> FinalBlock {
     let sync_block = storage
         .sync_dal()
-        .sync_block(MiniblockNumber(number), Address::repeat_byte(1), true)
+        .sync_block(MiniblockNumber(number), Address::default(), true)
         .await
         .unwrap()
         .unwrap_or_else(|| panic!("no sync block #{number}"));
@@ -46,7 +46,7 @@ pub(super) async fn block_payload(
 ) -> consensus::Payload {
     let sync_block = storage
         .sync_dal()
-        .sync_block(MiniblockNumber(number), Address::repeat_byte(1), true)
+        .sync_block(MiniblockNumber(number), Address::default(), true)
         .await
         .unwrap()
         .unwrap_or_else(|| panic!("no sync block #{number}"));

--- a/core/lib/zksync_core/src/sync_layer/gossip/tests.rs
+++ b/core/lib/zksync_core/src/sync_layer/gossip/tests.rs
@@ -5,7 +5,7 @@ use test_casing::{test_casing, Product};
 
 use std::ops;
 
-use zksync_concurrency::{ctx, scope, time};
+use zksync_concurrency::{ctx, scope, testonly::abort_on_panic, time};
 use zksync_consensus_executor::testonly::FullValidatorConfig;
 use zksync_consensus_roles::validator::{self, FinalBlock};
 use zksync_consensus_storage::{InMemoryStorage, WriteBlockStore};
@@ -177,7 +177,7 @@ pub(super) async fn assert_second_block_actions(actions: &mut ActionQueue) -> Ve
 #[test_casing(4, Product(([false, true], [false, true])))]
 #[tokio::test]
 async fn syncing_via_gossip_fetcher(delay_first_block: bool, delay_second_block: bool) {
-    zksync_concurrency::testonly::abort_on_panic();
+    abort_on_panic();
     let pool = ConnectionPool::test_pool().await;
     let tx_hashes = run_state_keeper_with_multiple_miniblocks(pool.clone()).await;
 
@@ -302,7 +302,7 @@ async fn reset_storage(mut storage: StorageProcessor<'_>) -> Vec<SyncBlock> {
 #[tokio::test]
 async fn syncing_via_gossip_fetcher_with_multiple_l1_batches(initial_block_count: usize) {
     assert!(initial_block_count <= 3);
-    zksync_concurrency::testonly::abort_on_panic();
+    abort_on_panic();
 
     let pool = ConnectionPool::test_pool().await;
     let tx_hashes = run_state_keeper_with_multiple_l1_batches(pool.clone()).await;
@@ -377,7 +377,7 @@ async fn syncing_via_gossip_fetcher_with_multiple_l1_batches(initial_block_count
 #[test_casing(2, [1, 2])]
 #[tokio::test]
 async fn syncing_from_non_zero_block(first_block_number: u32) {
-    zksync_concurrency::testonly::abort_on_panic();
+    abort_on_panic();
     let pool = ConnectionPool::test_pool().await;
     let tx_hashes = run_state_keeper_with_multiple_l1_batches(pool.clone()).await;
     let tx_hashes: Vec<_> = tx_hashes.iter().map(Vec::as_slice).collect();

--- a/core/lib/zksync_core/src/sync_layer/sync_action.rs
+++ b/core/lib/zksync_core/src/sync_layer/sync_action.rs
@@ -2,7 +2,7 @@ use tokio::sync::mpsc;
 
 use zksync_types::{
     block::ConsensusBlockFields, Address, L1BatchNumber, MiniblockNumber, ProtocolVersionId,
-    Transaction, H256,
+    Transaction,
 };
 
 use super::metrics::QUEUE_METRICS;
@@ -137,7 +137,6 @@ pub(crate) enum SyncAction {
         protocol_version: ProtocolVersionId,
         // Miniblock number and virtual blocks count.
         first_miniblock_info: (MiniblockNumber, u32),
-        prev_miniblock_hash: H256,
     },
     Miniblock {
         number: MiniblockNumber,
@@ -180,7 +179,6 @@ mod tests {
             operator_address: Default::default(),
             protocol_version: ProtocolVersionId::latest(),
             first_miniblock_info: (1.into(), 1),
-            prev_miniblock_hash: H256::default(),
         }
     }
 

--- a/core/lib/zksync_core/src/sync_layer/tests.rs
+++ b/core/lib/zksync_core/src/sync_layer/tests.rs
@@ -137,7 +137,6 @@ fn open_l1_batch(number: u32, timestamp: u64, first_miniblock_number: u32) -> Sy
         operator_address: Default::default(),
         protocol_version: ProtocolVersionId::latest(),
         first_miniblock_info: (MiniblockNumber(first_miniblock_number), 1),
-        prev_miniblock_hash: H256::default(),
     }
 }
 
@@ -404,7 +403,7 @@ pub(super) async fn mock_l1_batch_hash_computation(pool: ConnectionPool, number:
         let metadata = create_l1_batch_metadata(number);
         storage
             .blocks_dal()
-            .save_l1_batch_metadata(L1BatchNumber(1), &metadata, H256::zero(), false)
+            .save_l1_batch_metadata(L1BatchNumber(number), &metadata, H256::zero(), false)
             .await
             .unwrap();
         break;
@@ -574,15 +573,6 @@ async fn fetcher_with_real_server() {
     // Fill in transactions grouped in multiple miniblocks in the storage.
     let tx_hashes = run_state_keeper_with_multiple_miniblocks(pool.clone()).await;
     let mut tx_hashes = VecDeque::from(tx_hashes);
-    let mut connection = pool.access_storage().await.unwrap();
-    let genesis_miniblock_hash = connection
-        .blocks_dal()
-        .get_miniblock_header(MiniblockNumber(0))
-        .await
-        .unwrap()
-        .expect("No genesis miniblock")
-        .hash;
-    drop(connection);
 
     // Start the API server.
     let network_config = NetworkConfig::for_tests();
@@ -598,7 +588,6 @@ async fn fetcher_with_real_server() {
     let client = <dyn MainNodeClient>::json_rpc(&format!("http://{server_addr}/")).unwrap();
     let fetcher_cursor = FetcherCursor {
         next_miniblock: MiniblockNumber(1),
-        prev_miniblock_hash: genesis_miniblock_hash,
         l1_batch: L1BatchNumber(0),
     };
     let fetcher = fetcher_cursor.into_fetcher(


### PR DESCRIPTION
## What ❔

Support non-zero genesis block specified in executor configuration. Check whether this block exists on initialization; validate its correspondence if it does, and persist consensus fields if it doesn't.

## Why ❔

This is necessary to support gossip-based syncing in practice; we likely won't back-sign all blocks in all envs.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.