### PR TITLE
fix(proof_data_handler): Feature flag state_diff_hash check

### DIFF
--- a/core/lib/zksync_core/src/proof_data_handler/request_processor.rs
+++ b/core/lib/zksync_core/src/proof_data_handler/request_processor.rs
@@ -192,24 +192,26 @@ impl RequestProcessor {
                 let system_logs = serialize_commitments(&l1_batch.header.system_logs);
                 let system_logs_hash = H256(keccak256(&system_logs));
 
-                let state_diff_hash = l1_batch
-                    .header
-                    .system_logs
-                    .into_iter()
-                    .find(|elem| elem.0.key == u256_to_h256(2.into()))
-                    .expect("No state diff hash key")
-                    .0
-                    .value;
+                if !is_pre_boojum {
+                    let state_diff_hash = l1_batch
+                        .header
+                        .system_logs
+                        .into_iter()
+                        .find(|elem| elem.0.key == u256_to_h256(2.into()))
+                        .expect("No state diff hash key")
+                        .0
+                        .value;
 
-                if state_diff_hash != state_diff_hash_from_prover
-                    || system_logs_hash != system_logs_hash_from_prover
-                {
-                    let server_values = format!("system_logs_hash = {system_logs_hash}, state_diff_hash = {state_diff_hash}");
-                    let prover_values = format!("system_logs_hash = {system_logs_hash_from_prover}, state_diff_hash = {state_diff_hash_from_prover}");
-                    panic!(
-                        "Auxilary output doesn't match, server values: {} prover values: {}",
-                        server_values, prover_values
-                    );
+                    if state_diff_hash != state_diff_hash_from_prover
+                        || system_logs_hash != system_logs_hash_from_prover
+                    {
+                        let server_values = format!("system_logs_hash = {system_logs_hash}, state_diff_hash = {state_diff_hash}");
+                        let prover_values = format!("system_logs_hash = {system_logs_hash_from_prover}, state_diff_hash = {state_diff_hash_from_prover}");
+                        panic!(
+                            "Auxilary output doesn't match, server values: {} prover values: {}",
+                            server_values, prover_values
+                        );
+                    }
                 }
                 storage
                     .proof_generation_dal()


### PR DESCRIPTION
## What ❔

Feature flag `state_diff_hash` check to boojum only.

## Why ❔

This work is needed only on boojum capable deployments. Outside that, check `.expect("No state diff hash key")` will always fail.

Discussion [here](https://matter-labs-workspace.slack.com/archives/C05EB746E8G/p1701080840186819).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
