### PR TITLE
fix(house_keeper): Emit the correct circuit_id for aggregation round 2

### DIFF
--- a/core/lib/zksync_core/src/house_keeper/fri_prover_queue_monitor.rs
+++ b/core/lib/zksync_core/src/house_keeper/fri_prover_queue_monitor.rs
@@ -33,7 +33,7 @@ impl PeriodicJob for FriProverStatsReporter {
         let mut conn = self.prover_connection_pool.access_storage().await.unwrap();
         let stats = conn.fri_prover_jobs_dal().get_prover_jobs_stats().await;
 
-        for ((mut circuit_id, aggregation_round), stats) in stats.into_iter() {
+        for ((circuit_id, aggregation_round), stats) in stats.into_iter() {
             // BEWARE, HERE BE DRAGONS.
             // In database, the circuit_id stored is the circuit for which the aggregation is done,
             // not the circuit which is running.


### PR DESCRIPTION
## What ❔

This is us hardcoding the circuit_id to 2 for aggregation_round 2. This fix is useless as soon as we change the config (not expected anytime soon).

A real fix will follow where we address what is saved in database layer and this patch will be removed altogether.

## Why ❔

This is necessary to enable autoscaler to work (emits the correct data for prover groups, which in turn can be picked by autoscaler).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
