### PR TITLE
feat: flag for prover setup running `zk init`

### DIFF
--- a/infrastructure/zk/src/init.ts
+++ b/infrastructure/zk/src/init.ts
@@ -165,7 +165,7 @@ export interface InitArgs {
 const DEFAULT_ARGS: InitArgs = {
     skipSubmodulesCheckout: false,
     skipEnvSetup: false,
-    skipPlonkStep: false,
+    skipPlonkStep: true,
     governorPrivateKeyArgs: [],
     deployerL2ContractInput: { args: [], includePaymaster: true, includeL2WETH: true },
     testTokens: { deploy: true, args: [] }

--- a/infrastructure/zk/src/init.ts
+++ b/infrastructure/zk/src/init.ts
@@ -174,12 +174,13 @@ const DEFAULT_ARGS: InitArgs = {
 export const initCommand = new Command('init')
     .option('--skip-submodules-checkout')
     .option('--skip-env-setup')
+    .option('--prover-setup')
     .description('perform zksync network initialization for development')
     .action(async (cmd: Command) => {
         const initArgs: InitArgs = {
             skipSubmodulesCheckout: cmd.skipSubmodulesCheckout,
             skipEnvSetup: cmd.skipEnvSetup,
-            skipPlonkStep: false,
+            skipPlonkStep: !cmd.proverSetup,
             governorPrivateKeyArgs: [],
             deployerL2ContractInput: { args: [], includePaymaster: true, includeL2WETH: true },
             testTokens: { deploy: true, args: [] }


### PR DESCRIPTION
## What ❔

This PR skips plonk setup by default and adds a new flag for `init` command named `--prover-setup`

## Why ❔

The `init` command takes considerable time during the plonk setup step. To speed things up, it's beneficial to execute this step only when required. Utilizing the `--prover-setup` flag specifically triggers the plonk step, ensuring that the plonk keys are generated only when running the prover alongside the server.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
