### PR TITLE
chore: Ability to override default CUDA arch for prover-gpu-fri

### DIFF
--- a/docker/prover-gpu-fri/Dockerfile
+++ b/docker/prover-gpu-fri/Dockerfile
@@ -2,6 +2,9 @@ FROM nvidia/cuda:12.2.0-devel-ubuntu22.04 as builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+ARG CUDA_ARCH=89
+ENV CUDAARCHS=${CUDA_ARCH}
+
 RUN apt-get update && apt-get install -y curl clang openssl libssl-dev gcc g++ \
     pkg-config build-essential libclang-dev && \
     rm -rf /var/lib/apt/lists/*
@@ -9,9 +12,6 @@ RUN apt-get update && apt-get install -y curl clang openssl libssl-dev gcc g++ \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
-
-# Building for Nvidia L4
-ENV CUDAARCHS=89
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y && \
     rustup install nightly-2023-08-21 && \
@@ -26,7 +26,7 @@ COPY . .
 
 RUN cargo build --release --features "gpu"
 
-FROM nvidia/cuda:12.0.0-devel-ubuntu22.04
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
 
 RUN apt-get update && apt-get install -y curl libpq5 ca-certificates && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## What ❔

- Adds the ability to build prover-gpu-fri Docker image for running on Nvidia GPUs that are not L4 (arch 89)
- Uses lightweight CUDA runtime image for running the binary

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
