### PR TITLE
chore: Fix broken link in repositories.md

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -51,7 +51,7 @@
 | [local-setup](https://github.com/matter-labs/local-setup)       | Docker-based zk server (together with L1), that can be used for local testing |
 | [zksolc-bin](https://github.com/matter-labs/zksolc-bin)         | repository with solc compiler binaries                                        |
 | [zkvyper-bin](https://github.com/matter-labs/zkvyper-bin)       | repository with vyper compiler binaries                                       |
-| [zksync-cli](<(https://github.com/matter-labs/zksync-cli)>)     | Command line tool to interact with zksync                                     |
+| [zksync-cli](https://github.com/matter-labs/zksync-cli)     | Command line tool to interact with zksync                                     |
 | [hardhat-zksync](https://github.com/matter-labs/hardhat-zksync) | Plugins for hardhat                                                           |
 
 ### Examples & documentation

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -51,7 +51,7 @@
 | [local-setup](https://github.com/matter-labs/local-setup)       | Docker-based zk server (together with L1), that can be used for local testing |
 | [zksolc-bin](https://github.com/matter-labs/zksolc-bin)         | repository with solc compiler binaries                                        |
 | [zkvyper-bin](https://github.com/matter-labs/zkvyper-bin)       | repository with vyper compiler binaries                                       |
-| [zksync-cli](https://github.com/matter-labs/zksync-cli)     | Command line tool to interact with zksync                                     |
+| [zksync-cli](https://github.com/matter-labs/zksync-cli)         | Command line tool to interact with zksync                                     |
 | [hardhat-zksync](https://github.com/matter-labs/hardhat-zksync) | Plugins for hardhat                                                           |
 
 ### Examples & documentation


### PR DESCRIPTION

Hello, 

## Description
This change is made to ensure that developers, contributors can access the correct documentation. 

## Changes Made
This pull request fixes a broken link.   

## Why
The broken link was causing confusion and potentially preventing developers, contributors from accessing the zksync-cli. 

Correct link: https://github.com/matter-labs/zksync-cli

## Testing Done

- Manually reviewed the documentation and verified the correct link. 
- No additional dependencies or changes are required.
- This fix is straightforward and does not impact any other functionalities.

Thank you.


## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
