### PR TITLE
chore: make Nix development shell work on MacOS too

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,7 +1,26 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "stable": "stable"
       }
     },
@@ -18,6 +37,21 @@
         "owner": "NixOS",
         "ref": "nixos-22.11",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
     },
     "stable": {
       "locked": {
-        "lastModified": 1683478192,
-        "narHash": "sha256-7f7RR71w0jRABDgBwjq3vE1yY3nrVJyXk8hDzu5kl1E=",
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c568239bcc990050b7aedadb7387832440ad8fb1",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,39 +2,42 @@
     description = "zkSync development shell";
     inputs = {
         stable.url = "github:NixOS/nixpkgs/nixos-22.11";
+        flake-utils.url = "github:numtide/flake-utils";
     };
-    outputs = {self, stable}: {
-        packages.x86_64-linux.default =
-        with import stable { system = "x86_64-linux"; };
-        pkgs.mkShell {
-            name = "zkSync";
-            src = ./.;
-            buildInputs = [
-                docker-compose
-                nodejs
-                yarn
-                axel
-                libclang
-                openssl
-                pkg-config
-                postgresql
-                python3
-                solc
-            ];
+    outputs = {self, stable, flake-utils}:
+        flake-utils.lib.eachDefaultSystem (system: {
+            packages.default =
+            with import stable { system = "${system}"; };
+            pkgs.mkShell {
+                name = "zkSync";
+                src = ./.;
+                buildInputs = [
+                    docker-compose
+                    nodejs
+                    yarn
+                    axel
+                    libclang
+                    openssl
+                    pkg-config
+                    postgresql
+                    python3
+                    solc
+                ];
 
-            # for RocksDB and other Rust bindgen libraries
-            LIBCLANG_PATH = lib.makeLibraryPath [ libclang.lib ];
-            BINDGEN_EXTRA_CLANG_ARGS = ''-I"${libclang.lib}/lib/clang/${libclang.version}/include"'';
+                # for RocksDB and other Rust bindgen libraries
+                LIBCLANG_PATH = lib.makeLibraryPath [ libclang.lib ];
+                BINDGEN_EXTRA_CLANG_ARGS = ''-I"${libclang.lib}/lib/clang/${libclang.version}/include"'';
 
-            shellHook = ''
-                export ZKSYNC_HOME=$PWD
-                export PATH=$ZKSYNC_HOME/bin:$PATH
-            '';
+                shellHook = ''
+                    export ZKSYNC_HOME=$PWD
+                    export PATH=$ZKSYNC_HOME/bin:$PATH
+                '';
 
-            # hardhat solc requires ld-linux
-            # Nixos has to fake it with nix-ld
-            NIX_LD_LIBRARY_PATH = lib.makeLibraryPath [];
-            NIX_LD = builtins.readFile "${stdenv.cc}/nix-support/dynamic-linker";
-        };
-    };
+                # hardhat solc requires ld-linux
+                # Nixos has to fake it with nix-ld
+                NIX_LD_LIBRARY_PATH = lib.makeLibraryPath [];
+                NIX_LD = builtins.readFile "${stdenv.cc}/nix-support/dynamic-linker";
+            };
+        }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,9 @@
                     postgresql
                     python3
                     solc
+
+                    libiconv
+                    darwin.apple_sdk.frameworks.SystemConfiguration
                 ];
 
                 # for RocksDB and other Rust bindgen libraries


### PR DESCRIPTION
Make the nix flake generic over operating systems so Mac users (like me now) can benefit from it as well.

## What this is about

You can run `nix develop --impure` to launch a shell that has all the dependencies and environment variables needed to develop on this repo. Alternatively, setup direnv and the shell will automatically open whenever you navigate to the directory.