### PR TITLE
chore: Remove era-reviewers from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,3 @@
-* @matter-labs/era-reviewers
 .github/release-please/** @RomanBrodetski @perekopskiy @Deniallugo @popzxc
 **/CHANGELOG.md @RomanBrodetski @perekopskiy @Deniallugo @popzxc
 CODEOWNERS @RomanBrodetski @perekopskiy @Deniallugo @popzxc


### PR DESCRIPTION
## What ❔

Removes era-reviewers group from codeowners.

## Why ❔

- Too noisy.
- We have internal processes for that anyways.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
