### PR TITLE
fix(job-processor): `max_attepts_reached` metric

### DIFF
--- a/core/lib/queued_job_processor/src/lib.rs
+++ b/core/lib/queued_job_processor/src/lib.rs
@@ -109,6 +109,16 @@ pub trait JobProcessor: Sync + Send {
         task: JoinHandle<anyhow::Result<Self::JobArtifacts>>,
     ) -> anyhow::Result<()> {
         let attempts = self.get_job_attempts(&job_id).await?;
+        let max_attempts = self.max_attempts();
+        if attempts == max_attempts {
+            METRICS.max_attempts_reached[&(Self::SERVICE_NAME, format!("{job_id:?}"))].inc();
+            tracing::error!(
+                "Max attempts ({max_attempts}) reached for {} job {:?}",
+                Self::SERVICE_NAME,
+                job_id,
+            );
+        }
+
         let result = loop {
             tracing::trace!(
                 "Polling {} task with id {:?}. Is finished: {}",
@@ -144,15 +154,6 @@ pub trait JobProcessor: Sync + Send {
             error_message
         );
 
-        let max_attempts = self.max_attempts();
-        if attempts == max_attempts {
-            METRICS.max_attempts_reached[&(Self::SERVICE_NAME, format!("{job_id:?}"))].inc();
-            tracing::error!(
-                "Max attempts ({max_attempts}) reached for {} job {:?}",
-                Self::SERVICE_NAME,
-                job_id,
-            );
-        }
         self.save_failure(job_id, started_at, error_message).await;
         Ok(())
     }


### PR DESCRIPTION
## What ❔

`max_attepts_reached` metric is now reported on job start rather failure. With this change metric will be reported not only if last attempt failed but also if it got stuck/stopped/etc.

## Why ❔

Reporting `max_attepts_reached` metric for all cases.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
