### PR TITLE
chore(zk init): Removed plonk setup

### DIFF
--- a/docs/launch.md
+++ b/docs/launch.md
@@ -17,8 +17,6 @@ zk # installs and builds zk itself
 zk init
 ```
 
-During the first initialization you have to download around 8 GB of setup files, this should be done once. If you have a
-problem on this step of the initialization, see help for the `zk run plonk-setup` command.
 
 If you face any other problems with the `zk init` command, go to the [Troubleshooting](#Troubleshooting) section at the
 end of this file. There are solutions for some common error cases.

--- a/docs/launch.md
+++ b/docs/launch.md
@@ -17,7 +17,6 @@ zk # installs and builds zk itself
 zk init
 ```
 
-
 If you face any other problems with the `zk init` command, go to the [Troubleshooting](#Troubleshooting) section at the
 end of this file. There are solutions for some common error cases.
 

--- a/infrastructure/zk/src/hyperchain_wizard.ts
+++ b/infrastructure/zk/src/hyperchain_wizard.ts
@@ -565,7 +565,8 @@ async function checkBalance(wallet: ethers.Wallet, expectedBalance: BigNumber): 
     const balance = await wallet.getBalance();
     if (balance.lt(expectedBalance)) {
         console.log(
-            `Wallet ${wallet.address
+            `Wallet ${
+                wallet.address
             } has insufficient funds. Expected ${expectedBalance.toString()}, got ${balance.toString()}`
         );
         return false;

--- a/infrastructure/zk/src/hyperchain_wizard.ts
+++ b/infrastructure/zk/src/hyperchain_wizard.ts
@@ -58,7 +58,6 @@ async function initHyperchain() {
     const initArgs: InitArgs = {
         skipSubmodulesCheckout: false,
         skipEnvSetup: true,
-        skipPlonkStep: true,
         governorPrivateKeyArgs: ['--private-key', governorPrivateKey],
         deployerL2ContractInput: {
             args: ['--private-key', deployerPrivateKey],
@@ -566,8 +565,7 @@ async function checkBalance(wallet: ethers.Wallet, expectedBalance: BigNumber): 
     const balance = await wallet.getBalance();
     if (balance.lt(expectedBalance)) {
         console.log(
-            `Wallet ${
-                wallet.address
+            `Wallet ${wallet.address
             } has insufficient funds. Expected ${expectedBalance.toString()}, got ${balance.toString()}`
         );
         return false;
@@ -791,7 +789,6 @@ async function configDemoHyperchain(cmd: Command) {
     const initArgs: InitArgs = {
         skipSubmodulesCheckout: false,
         skipEnvSetup: cmd.skipEnvSetup,
-        skipPlonkStep: true,
         governorPrivateKeyArgs: ['--private-key', governorPrivateKey],
         deployerL2ContractInput: {
             args: ['--private-key', deployerPrivateKey],

--- a/infrastructure/zk/src/init.ts
+++ b/infrastructure/zk/src/init.ts
@@ -18,13 +18,8 @@ const success = chalk.green;
 const timestamp = chalk.grey;
 
 export async function init(initArgs: InitArgs = DEFAULT_ARGS) {
-    const {
-        skipSubmodulesCheckout,
-        skipEnvSetup,
-        testTokens,
-        governorPrivateKeyArgs,
-        deployerL2ContractInput
-    } = initArgs;
+    const { skipSubmodulesCheckout, skipEnvSetup, testTokens, governorPrivateKeyArgs, deployerL2ContractInput } =
+        initArgs;
 
     if (!process.env.CI && !skipEnvSetup) {
         await announced('Pulling images', docker.pull());

--- a/infrastructure/zk/src/init.ts
+++ b/infrastructure/zk/src/init.ts
@@ -21,7 +21,6 @@ export async function init(initArgs: InitArgs = DEFAULT_ARGS) {
     const {
         skipSubmodulesCheckout,
         skipEnvSetup,
-        skipPlonkStep,
         testTokens,
         governorPrivateKeyArgs,
         deployerL2ContractInput
@@ -32,7 +31,6 @@ export async function init(initArgs: InitArgs = DEFAULT_ARGS) {
         await announced('Checking environment', checkEnv());
         await announced('Checking git hooks', env.gitHooks());
         await announced('Setting up containers', up());
-        !skipPlonkStep && (await announced('Checking PLONK setup', run.plonkSetup()));
     }
     if (!skipSubmodulesCheckout) {
         await announced('Checkout system-contracts submodule', submoduleUpdate());
@@ -149,7 +147,6 @@ async function checkEnv() {
 export interface InitArgs {
     skipSubmodulesCheckout: boolean;
     skipEnvSetup: boolean;
-    skipPlonkStep: boolean;
     governorPrivateKeyArgs: any[];
     deployerL2ContractInput: {
         args: any[];
@@ -165,7 +162,6 @@ export interface InitArgs {
 const DEFAULT_ARGS: InitArgs = {
     skipSubmodulesCheckout: false,
     skipEnvSetup: false,
-    skipPlonkStep: false,
     governorPrivateKeyArgs: [],
     deployerL2ContractInput: { args: [], includePaymaster: true, includeL2WETH: true },
     testTokens: { deploy: true, args: [] }
@@ -179,7 +175,6 @@ export const initCommand = new Command('init')
         const initArgs: InitArgs = {
             skipSubmodulesCheckout: cmd.skipSubmodulesCheckout,
             skipEnvSetup: cmd.skipEnvSetup,
-            skipPlonkStep: false,
             governorPrivateKeyArgs: [],
             deployerL2ContractInput: { args: [], includePaymaster: true, includeL2WETH: true },
             testTokens: { deploy: true, args: [] }

--- a/infrastructure/zk/src/run/run.ts
+++ b/infrastructure/zk/src/run/run.ts
@@ -63,22 +63,6 @@ export async function deployTestkit(genesisRoot: string) {
     await utils.spawn(`yarn l1-contracts deploy-testkit --genesis-root ${genesisRoot}`);
 }
 
-export async function plonkSetup(powers?: number[]) {
-    if (!powers) {
-        powers = [20, 21, 22, 23, 24, 25, 26];
-    }
-    const URL = 'https://storage.googleapis.com/universal-setup';
-    fs.mkdirSync('keys/setup', { recursive: true });
-    process.chdir('keys/setup');
-    for (let i = 0; i < powers.length; i++) {
-        const power = powers[i];
-        if (!fs.existsSync(`setup_2^${power}.key`)) {
-            await utils.spawn(`curl -LO ${URL}/setup_2^${power}.key`);
-            await utils.sleep(1);
-        }
-    }
-    process.chdir(process.env.ZKSYNC_HOME as string);
-}
 
 export async function revertReason(txHash: string, web3url?: string) {
     await utils.spawn(`yarn l1-contracts ts-node scripts/revert-reason.ts ${txHash} ${web3url || ''}`);
@@ -159,16 +143,6 @@ command
         await tokenInfo(address);
     });
 
-command
-    .command('plonk-setup [powers]')
-    .description('download missing keys')
-    .action(async (powers?: string) => {
-        const powersArray = powers
-            ?.split(' ')
-            .map((x) => parseInt(x))
-            .filter((x) => !Number.isNaN(x));
-        await plonkSetup(powersArray);
-    });
 
 command
     .command('deploy-testkit')

--- a/infrastructure/zk/src/run/run.ts
+++ b/infrastructure/zk/src/run/run.ts
@@ -63,7 +63,6 @@ export async function deployTestkit(genesisRoot: string) {
     await utils.spawn(`yarn l1-contracts deploy-testkit --genesis-root ${genesisRoot}`);
 }
 
-
 export async function revertReason(txHash: string, web3url?: string) {
     await utils.spawn(`yarn l1-contracts ts-node scripts/revert-reason.ts ${txHash} ${web3url || ''}`);
 }
@@ -142,7 +141,6 @@ command
     .action(async (address: string) => {
         await tokenInfo(address);
     });
-
 
 command
     .command('deploy-testkit')


### PR DESCRIPTION
## What ❔

* Removed plonk setup (where we downloaded the CRS keys)

## Why ❔

* It is needed only for prover setup (and then this is handled within the prover_setup.ts directly)
* it will save a lot of network bandwidth and time during zk stack setup

