### PR TITLE
chore(zk): finishing migration to docker compose

### DIFF
--- a/infrastructure/zk/src/docker.ts
+++ b/infrastructure/zk/src/docker.ts
@@ -151,11 +151,11 @@ export async function push(image: string, cmd: Command) {
 }
 
 export async function restart(container: string) {
-    await utils.spawn(`docker-compose restart ${container}`);
+    await utils.spawn(`docker compose restart ${container}`);
 }
 
 export async function pull() {
-    await utils.spawn('docker-compose pull');
+    await utils.spawn('docker compose pull');
 }
 
 export const command = new Command('docker').description('docker management');

--- a/infrastructure/zk/src/init.ts
+++ b/infrastructure/zk/src/init.ts
@@ -127,7 +127,7 @@ export async function submoduleUpdate() {
 }
 
 async function checkEnv() {
-    const tools = ['node', 'yarn', 'docker', 'docker-compose', 'cargo'];
+    const tools = ['node', 'yarn', 'docker', 'cargo'];
     for (const tool of tools) {
         await utils.exec(`which ${tool}`);
     }


### PR DESCRIPTION
## What ❔

* replaced docker-compose with docker compose 

## Why ❔

* we moved to use docker compose (instead of docker-compose) - which is a newer version
