### PR TITLE
[blocked] Double the amount of bootloader tx slots and memory

### DIFF
--- a/core/lib/constants/src/crypto.rs
+++ b/core/lib/constants/src/crypto.rs
@@ -19,7 +19,7 @@ pub const MAX_BYTES_PER_PACKED_SLOT: u64 = 65;
 pub static GAS_PER_SLOT: Lazy<BigUint> =
     Lazy::new(|| BigUint::from(MAX_BYTES_PER_PACKED_SLOT) * BigUint::from(GAS_PER_PUBDATA_BYTE));
 
-pub const MAX_TXS_IN_BLOCK: usize = 1024;
+pub const MAX_TXS_IN_BLOCK: usize = 2048;
 
 pub const MAX_NEW_FACTORY_DEPS: usize = 32;
 
@@ -28,5 +28,5 @@ pub const PAD_MSG_BEFORE_HASH_BITS_LEN: usize = 736;
 /// The size of the bootloader memory in bytes which is used by the protocol.
 /// While the maximal possible size is a lot higher, we restrict ourselves to a certain limit to reduce
 /// the requirements on RAM.
-pub const USED_BOOTLOADER_MEMORY_BYTES: usize = 1 << 24;
+pub const USED_BOOTLOADER_MEMORY_BYTES: usize = 1 << 25;
 pub const USED_BOOTLOADER_MEMORY_WORDS: usize = USED_BOOTLOADER_MEMORY_BYTES / 32;

--- a/core/lib/multivm/src/versions/vm_latest/constants.rs
+++ b/core/lib/multivm/src/versions/vm_latest/constants.rs
@@ -98,7 +98,7 @@ pub const VM_HOOK_POSITION: u32 = RESULT_SUCCESS_FIRST_SLOT - 1;
 pub const VM_HOOK_PARAMS_COUNT: u32 = 2;
 pub const VM_HOOK_PARAMS_START_POSITION: u32 = VM_HOOK_POSITION - VM_HOOK_PARAMS_COUNT;
 
-pub(crate) const MAX_MEM_SIZE_BYTES: u32 = 16777216; // 2^24
+pub(crate) const MAX_MEM_SIZE_BYTES: u32 = 1 << 25; // 2^25
 
 /// Arbitrary space in memory closer to the end of the page
 pub const RESULT_SUCCESS_FIRST_SLOT: u32 =

--- a/etc/env/base/chain.toml
+++ b/etc/env/base/chain.toml
@@ -14,7 +14,7 @@ zksync_network_id=270
 fee_account_addr="0xde03a0B5963f75f1C8485B355fF6D30f3093BDE7"
 
 # Denotes the amount of slots for transactions in the block.
-transaction_slots=250
+transaction_slots=2048
 
 max_allowed_l2_tx_gas_limit=4000000000
 block_commit_deadline_ms=2500


### PR DESCRIPTION
## What ❔

Double the amount of bootloader tx slots and memory.
Only merge after https://github.com/matter-labs/era-contracts/pull/112 and https://github.com/matter-labs/era-system-contracts/pull/85 are merged into their respective dev branches and then into this branch.

## Why ❔

With pubdata compression we can now accommodate larger L1 batches.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
