### PR TITLE
chore(en): Add sepolia en config

### DIFF
--- a/docs/guides/external-node/02_configuration.md
+++ b/docs/guides/external-node/02_configuration.md
@@ -2,7 +2,7 @@
 
 This document outlines various configuration options for the EN. Currently, the EN requires the definition of numerous
 environment variables. To streamline this process, we provide prepared configs for the zkSync Era - for both
-[mainnet](prepared_configs/mainnet-config.env) and [testnet](prepared_configs/testnet-config.env). You can use these
+[mainnet](prepared_configs/mainnet-config.env) and [testnet](prepared_configs/testnet-sepolia-config.env). You can use these
 files as a starting point and modify only the necessary sections.
 
 ## Database
@@ -20,7 +20,7 @@ recommended to use an NVME SSD for RocksDB. RocksDB requires two variables to be
 ## L1 Web3 client
 
 EN requires a connection to an Ethereum node. The corresponding env variable is `EN_ETH_CLIENT_URL`. Make sure to set
-the URL corresponding to the correct L1 network (L1 mainnet for L2 mainnet and L1 goerli for L2 testnet).
+the URL corresponding to the correct L1 network (L1 mainnet for L2 mainnet and L1 sepolia for L2 testnet).
 
 Note: Currently, the EN makes 2 requests to the L1 per L1 batch, so the Web3 client usage for a synced node should not
 be high. However, during the synchronization phase the new batches would be persisted on the EN quickly, so make sure

--- a/docs/guides/external-node/02_configuration.md
+++ b/docs/guides/external-node/02_configuration.md
@@ -2,8 +2,8 @@
 
 This document outlines various configuration options for the EN. Currently, the EN requires the definition of numerous
 environment variables. To streamline this process, we provide prepared configs for the zkSync Era - for both
-[mainnet](prepared_configs/mainnet-config.env) and [testnet](prepared_configs/testnet-sepolia-config.env). You can use these
-files as a starting point and modify only the necessary sections.
+[mainnet](prepared_configs/mainnet-config.env) and [testnet](prepared_configs/testnet-sepolia-config.env). You can use
+these files as a starting point and modify only the necessary sections.
 
 ## Database
 

--- a/docs/guides/external-node/prepared_configs/testnet-goerli-config-deprecated.env
+++ b/docs/guides/external-node/prepared_configs/testnet-goerli-config-deprecated.env
@@ -78,13 +78,13 @@ RUST_LIB_BACKTRACE=1
 # ------------------------------------------------------------------------
 
 # URL of the main zkSync node.
-EN_MAIN_NODE_URL=https://zksync2-mainnet.zksync.io
+EN_MAIN_NODE_URL=https://zksync2-testnet.zksync.dev
 
-EN_L2_CHAIN_ID=324
-EN_L1_CHAIN_ID=1
+EN_L2_CHAIN_ID=280
+EN_L1_CHAIN_ID=5
 
 # Optional, required only if sentry is configured. 
-EN_SENTRY_ENVIRONMENT=zksync_mainnet
+EN_SENTRY_ENVIRONMENT=zksync_testnet
 
 # ------------------------------------------------------------------------
 # -------------- THE FOLLOWING VARIABLES ARE NOT USED --------------------

--- a/docs/guides/external-node/prepared_configs/testnet-sepolia-config.env
+++ b/docs/guides/external-node/prepared_configs/testnet-sepolia-config.env
@@ -78,13 +78,10 @@ RUST_LIB_BACKTRACE=1
 # ------------------------------------------------------------------------
 
 # URL of the main zkSync node.
-EN_MAIN_NODE_URL=https://zksync2-testnet.zksync.dev
+EN_MAIN_NODE_URL=https://sepolia.era.zksync.dev
 
-EN_L2_CHAIN_ID=280
-EN_L1_CHAIN_ID=5
-
-EN_BOOTLOADER_HASH=0x010007794e73f682ad6d27e86b6f71bbee875fc26f5708d1713e7cfd476098d3
-EN_DEFAULT_AA_HASH=0x0100067d861e2f5717a12c3e869cfb657793b86bbb0caa05cc1421f16c5217bc
+EN_L2_CHAIN_ID=300
+EN_L1_CHAIN_ID=11155111
 
 # Optional, required only if sentry is configured. 
 EN_SENTRY_ENVIRONMENT=zksync_testnet


### PR DESCRIPTION
## What ❔

- marks goerli testnet EN config as deprecated
- adds sepolia testnet EN config
- removes `EN_BOOTLOADER_HASH`, `EN_DEFAULT_AA_HASH` from configs as these vars are not used anymore

## Why ❔

Prepare docs for sepolia testnet EN launch

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
