### PR TITLE
chore(zk): clean volumes directory from container to fix permissions on linux

### DIFF
--- a/infrastructure/zk/src/down.ts
+++ b/infrastructure/zk/src/down.ts
@@ -4,7 +4,7 @@ import * as utils from './utils';
 export async function down() {
     await utils.spawn('docker compose down -v');
     await utils.spawn('docker compose rm -s -f -v');
-    await utils.spawn('docker run -v ./volumes:/volumes postgres:14 bash -c "rm -rf /volumes/*"');
+    await utils.spawn('docker run --rm -v ./volumes:/volumes postgres:14 bash -c "rm -rf /volumes/*"');
 }
 
 export const command = new Command('down').description('stop development containers').action(down);

--- a/infrastructure/zk/src/down.ts
+++ b/infrastructure/zk/src/down.ts
@@ -4,7 +4,7 @@ import * as utils from './utils';
 export async function down() {
     await utils.spawn('docker compose down -v');
     await utils.spawn('docker compose rm -s -f -v');
-    await utils.spawn('rm -rf ./volumes/');
+    await utils.spawn('docker run -v ./volumes:/volumes postgres:14 bash -c "rm -rf /volumes/*"');
 }
 
 export const command = new Command('down').description('stop development containers').action(down);


### PR DESCRIPTION
## What ❔

Currently zk init may fail on linux due to docker creating files with root permissions.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
