### PR TITLE
fix:  docs typo error

### DIFF
--- a/docs/guides/advanced/compression.md
+++ b/docs/guides/advanced/compression.md
@@ -31,7 +31,7 @@ Dictionary would be:
 3 -> 0xC (count: 1)
 ```
 
-Note that '1' maps to '0xD', as it occurs twice, and first occurrence is earlier than first occurence of 0xB, that also
+Note that '1' maps to '0xD', as it occurs twice, and first occurrence is earlier than first occurrence of 0xB, that also
 occurs twice.
 
 Compressed bytecode:

--- a/docs/guides/advanced/contracts.md
+++ b/docs/guides/advanced/contracts.md
@@ -70,7 +70,7 @@ override getDeployTransaction(..) {
 }
 ```
 
-Also `ContractDeployer` adding a special prefix for all the new contract addresses. This means that contract addesses
+Also `ContractDeployer` adding a special prefix for all the new contract addresses. This means that contract addresses
 WILL be different on `zkSync` and Ethereum (and also leaves us the possibility of adding Ethereum addresses in the
 future if needed).
 

--- a/docs/guides/advanced/contracts.md
+++ b/docs/guides/advanced/contracts.md
@@ -86,7 +86,7 @@ changed - so updating the same slot multiple times doesn't increase the amount o
 
 ### Account abstraction and some method calls
 
-As `zkSync` has a built-in AccountAbstration (more on this in a separate article) - you shouldn't depend on some of the
+As `zkSync` has a built-in AccountAbstraction (more on this in a separate article) - you shouldn't depend on some of the
 solidity functions (like `ecrecover` - that checks the keys, or `tx.origin`) - in all the cases, the compiler will try
 to warn you.
 

--- a/docs/guides/advanced/deeper_overview.md
+++ b/docs/guides/advanced/deeper_overview.md
@@ -69,7 +69,7 @@ pub struct SelectionGate {
 }
 ```
 
-Internaly the `Variable` object is `pub struct Variable(pub(crate) u64);` - so it is an index to the position within the
+Internally the `Variable` object is `pub struct Variable(pub(crate) u64);` - so it is an index to the position within the
 constraint system object.
 
 And now let's see how we can add this gate into the system.

--- a/docs/guides/advanced/how_transaction_works.md
+++ b/docs/guides/advanced/how_transaction_works.md
@@ -74,7 +74,7 @@ The transaction can have three different results in state keeper:
 - Success
 - Failure (but still included in the block, and gas was charged)
 - Rejection - when it fails validation, and cannot be included in the block. This last case should (in theory) never
-  happen - as we cannot charge the fee in such scenario, and it opens the possiblity for the DDoS attack.
+  happen - as we cannot charge the fee in such scenario, and it opens the possibility for the DDoS attack.
 
 [transaction_request_from_bytes]:
   https://github.com/matter-labs/zksync-era/blob/main/core/lib/types/src/transaction_request.rs#L196

--- a/infrastructure/zk/src/status.ts
+++ b/infrastructure/zk/src/status.ts
@@ -4,7 +4,7 @@ import { Pool } from 'pg';
 import { ethers } from 'ethers';
 import { assert } from 'console';
 
-// Postgres connection pool - must be intialized later - as the ENV variables are set later.
+// Postgres connection pool - must be initialized later - as the ENV variables are set later.
 let pool: Pool | null = null;
 
 const GETTER_ABI = [
@@ -15,12 +15,12 @@ const GETTER_ABI = [
 
 const VERIFIER_ABI = ['function verificationKeyHash() view returns (bytes32)'];
 
-export async function query(text: string, params?: any[]): Promise<any> {
+export async function query(text: string, params?: any[]){
     const res = await pool!.query(text, params);
     return res;
 }
 
-async function queryAndReturnRows(text: string, params?: any[]): Promise<any> {
+async function queryAndReturnRows(text: string, params?: any[]){
     const result = await query(text, params);
     return result.rows;
 }


### PR DESCRIPTION
## What ❔

- Fix docs typo error.
- Remove useless any.

## Why ❔
- The docs will be read by many people, so be careful
- If you used async. We don't need to write `Promise<any>`. Or you defined type.The type is automatically inferred

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
