### PR TITLE
fix: error when running `zk init`

### DIFF
--- a/infrastructure/zk/src/down.ts
+++ b/infrastructure/zk/src/down.ts
@@ -4,7 +4,7 @@ import * as utils from './utils';
 export async function down() {
     await utils.spawn('docker compose down -v');
     await utils.spawn('docker compose rm -s -f -v');
-    await utils.spawn('docker run --rm -v ./volumes:/volumes postgres:14 bash -c "rm -rf /volumes/*"');
+    await utils.spawn('docker run --rm -v volumes:/volumes postgres:14 bash -c "rm -rf /volumes/*"');
 }
 
 export const command = new Command('down').description('stop development containers').action(down);


### PR DESCRIPTION
Resolves #689.

## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

This PR fixes `zk init` cmd. Updating the path to the volume passed to the `docker run --rm -v` cmd in `infrastructure/zk/src/down.ts`.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

The change mentioned above is made because the command `docker run -v` does not accept a relative paths but absolute paths, and `./volumes/...` is being passed on line 7 of the mentioned file.

If you clone this repo and run `zk init` after installing `zk`, you'll see something like this:

```
docker: Error response from daemon: create ./volumes: "./volumes" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
See 'docker run --help'.
Error: Child process exited with code 125
error Command failed with exit code 1.
```

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
