### PR TITLE
fix(en): Downgrade miniblock hash equality assertion to warning

### DIFF
--- a/core/lib/zksync_core/src/sync_layer/fetcher.rs
+++ b/core/lib/zksync_core/src/sync_layer/fetcher.rs
@@ -130,10 +130,15 @@ impl FetcherCursor {
         assert_eq!(block.number, self.next_miniblock);
         let local_block_hash = block.compute_hash(self.prev_miniblock_hash);
         if let Some(reference_hash) = block.reference_hash {
-            assert_eq!(
-                local_block_hash, reference_hash,
-                "Mismatch between the locally computed and received miniblock hash for {block:?}"
-            );
+            if local_block_hash != reference_hash {
+                // This is a warning, not an assertion because hash mismatch may occur after a reorg.
+                // Indeed, `self.prev_miniblock_hash` may differ from the hash of the updated previous miniblock.
+                tracing::warn!(
+                    "Mismatch between the locally computed and received miniblock hash for {block:?}; \
+                     local_block_hash = {local_block_hash:?}, prev_miniblock_hash = {:?}",
+                    self.prev_miniblock_hash
+                );
+            }
         }
 
         let mut new_actions = Vec::new();


### PR DESCRIPTION
## What ❔

Subject.

## Why ❔

There is a valid scenario in which we might get miniblock hash mismatch, namely after a reorg.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.