### PR TITLE
fix(prover): increase DB polling interval for witness vector generators

### DIFF
--- a/prover/witness_vector_generator/src/generator.rs
+++ b/prover/witness_vector_generator/src/generator.rs
@@ -77,6 +77,8 @@ impl JobProcessor for WitnessVectorGenerator {
     type Job = ProverJob;
     type JobId = u32;
     type JobArtifacts = WitnessVectorArtifacts;
+
+    const POLLING_INTERVAL_MS: u64 = 15000;
     const SERVICE_NAME: &'static str = "WitnessVectorGenerator";
 
     async fn get_next_job(&self) -> anyhow::Result<Option<(Self::JobId, Self::Job)>> {


### PR DESCRIPTION
Prover DB is under heavy load. 

The query that witness vectors generators run to get a new prover job is slow. In theory we shouldn't be running any witness vectors gens for circuits that don't have any jobs queued, but query insights suggest otherwise.

This increases the polling interval - so that even if there are no jobs, we don't perform the query too often