### PR TITLE
perf: remove unnecessary to_vec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8182,18 +8182,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.11"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c19fae0c8a9efc6a8281f2e623db8af1db9e57852e04cde3e754dd2dc29340f"
+checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.11"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc56589e9ddd1f1c28d4b4b5c773ce232910a6bb67a70133d61c9e347585efe9"
+checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",

--- a/core/lib/utils/src/misc.rs
+++ b/core/lib/utils/src/misc.rs
@@ -26,7 +26,7 @@ pub fn expand_memory_contents(packed: &[(usize, U256)], memory_size_bytes: usize
         value.to_big_endian(&mut result[(offset * 32)..(offset + 1) * 32]);
     }
 
-    result.to_vec()
+    result
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What ❔

Remove unnecessary method call

## Why ❔

It might improve performance but probably not. Better to not have it anyway.
