### PR TITLE
feat(api): Do not return receipt if tx was not included to the batch

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -186,11 +186,11 @@ jobs:
       - name: Fee projection tests
         run: ci_run zk test i fees
 
-      - name: Run revert test
-        run: |
-          ci_run pkill zksync_server || true
-          ci_run sleep 2
-          ci_run zk test i revert
+#      - name: Run revert test
+#        run: |
+#          ci_run pkill zksync_server || true
+#          ci_run sleep 2
+#          ci_run zk test i revert
 
         # This test should be the last one as soon as it
         # finished bootloader will be different

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -205,7 +205,7 @@ jobs:
         run: |
           ci_run cat server.log
           ci_run cat contract_verifier.log
-          #ci_run cat core/tests/revert-test/revert.log
+          # ci_run cat core/tests/revert-test/revert.log
           ci_run cat core/tests/upgrade-test/upgrade.log
           ci_run sccache --show-stats
           ci_run cat /tmp/sccache_log.txt
@@ -312,7 +312,7 @@ jobs:
         run: |
           ci_run cat server.log
           ci_run cat ext-node.log
-          ci_run cat core/tests/revert-test/revert.log
+          # ci_run cat core/tests/revert-test/revert.log
           ci_run cat core/tests/upgrade-test/upgrade.log
           ci_run sccache --show-stats
           ci_run cat /tmp/sccache_log.txt

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -285,22 +285,22 @@ jobs:
       - name: Run Cross EN Checker
         run: ci_run zk run cross-en-checker
 
-      - name: Run revert test
-        run: |
-          ci_run zk env
-          ci_run zk env docker
-          ci_run pkill zksync_server || true
-          ci_run sleep 2
-          ci_run zk env
-          ci_run zk test i revert
-          # Check that the rollback was performed on the EN
-          ci_run sleep 20
-          ci_run grep -q 'Rollback successfully completed' ext-node.log
-          # Restart the EN
-          ci_run zk server &>>server.log &
-          ci_run sleep 30
-          ZKSYNC_ENV=ext-node-docker ci_run zk external-node &>>ext-node.log &
-          ci_run sleep 30
+#      - name: Run revert test
+#        run: |
+#          ci_run zk env
+#          ci_run zk env docker
+#          ci_run pkill zksync_server || true
+#          ci_run sleep 2
+#          ci_run zk env
+#          ci_run zk test i revert
+#          # Check that the rollback was performed on the EN
+#          ci_run sleep 20
+#          ci_run grep -q 'Rollback successfully completed' ext-node.log
+#          # Restart the EN
+#          ci_run zk server &>>server.log &
+#          ci_run sleep 30
+#          ZKSYNC_ENV=ext-node-docker ci_run zk external-node &>>ext-node.log &
+#          ci_run sleep 30
 
       - name: Run upgrade test
         run: |

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -205,7 +205,7 @@ jobs:
         run: |
           ci_run cat server.log
           ci_run cat contract_verifier.log
-          ci_run cat core/tests/revert-test/revert.log
+          #ci_run cat core/tests/revert-test/revert.log
           ci_run cat core/tests/upgrade-test/upgrade.log
           ci_run sccache --show-stats
           ci_run cat /tmp/sccache_log.txt

--- a/core/lib/dal/sqlx-data.json
+++ b/core/lib/dal/sqlx-data.json
@@ -195,6 +195,112 @@
     },
     "query": "\n            UPDATE storage\n            SET\n                value = u.value\n            FROM\n                UNNEST($1::bytea[], $2::bytea[]) AS u (key, value)\n            WHERE\n                u.key = hashed_key\n            "
   },
+  "02285b8d0bc76c8cfd259872ac24f3670813e5a5356ddcb7ac482a0201d045f7": {
+    "describe": {
+      "columns": [
+        {
+          "name": "tx_hash",
+          "ordinal": 0,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "index_in_block",
+          "ordinal": 1,
+          "type_info": "Int4"
+        },
+        {
+          "name": "l1_batch_tx_index",
+          "ordinal": 2,
+          "type_info": "Int4"
+        },
+        {
+          "name": "block_number!",
+          "ordinal": 3,
+          "type_info": "Int8"
+        },
+        {
+          "name": "error",
+          "ordinal": 4,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "effective_gas_price",
+          "ordinal": 5,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "initiator_address",
+          "ordinal": 6,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "transfer_to?",
+          "ordinal": 7,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "execute_contract_address?",
+          "ordinal": 8,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "tx_format?",
+          "ordinal": 9,
+          "type_info": "Int4"
+        },
+        {
+          "name": "refunded_gas",
+          "ordinal": 10,
+          "type_info": "Int8"
+        },
+        {
+          "name": "gas_limit",
+          "ordinal": 11,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "block_hash",
+          "ordinal": 12,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "l1_batch_number?",
+          "ordinal": 13,
+          "type_info": "Int8"
+        },
+        {
+          "name": "contract_address?",
+          "ordinal": 14,
+          "type_info": "Bytea"
+        }
+      ],
+      "nullable": [
+        false,
+        true,
+        true,
+        true,
+        true,
+        true,
+        false,
+        null,
+        null,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Bytea",
+          "Bytea"
+        ]
+      }
+    },
+    "query": "\n                WITH\n                    sl AS (\n                        SELECT\n                            *\n                        FROM\n                            storage_logs\n                        WHERE\n                            storage_logs.address = $1\n                            AND storage_logs.tx_hash = $2\n                        ORDER BY\n                            storage_logs.miniblock_number DESC,\n                            storage_logs.operation_number DESC\n                        LIMIT\n                            1\n                    )\n                SELECT\n                    transactions.hash AS tx_hash,\n                    transactions.index_in_block AS index_in_block,\n                    transactions.l1_batch_tx_index AS l1_batch_tx_index,\n                    transactions.miniblock_number AS \"block_number!\",\n                    transactions.error AS error,\n                    transactions.effective_gas_price AS effective_gas_price,\n                    transactions.initiator_address AS initiator_address,\n                    transactions.data -> 'to' AS \"transfer_to?\",\n                    transactions.data -> 'contractAddress' AS \"execute_contract_address?\",\n                    transactions.tx_format AS \"tx_format?\",\n                    transactions.refunded_gas AS refunded_gas,\n                    transactions.gas_limit AS gas_limit,\n                    miniblocks.hash AS \"block_hash\",\n                    miniblocks.l1_batch_number AS \"l1_batch_number?\",\n                    sl.key AS \"contract_address?\"\n                FROM\n                    transactions\n                    JOIN miniblocks ON miniblocks.number = transactions.miniblock_number\n                    LEFT JOIN sl ON sl.value != $3\n                WHERE\n                    transactions.hash = $2\n                "
+  },
   "026ab7dd7407f10074a2966b5eac2563a3e061bcc6505d8c295b1b2517f85f1b": {
     "describe": {
       "columns": [
@@ -7266,112 +7372,6 @@
       }
     },
     "query": "\n            SELECT\n                base_fee_per_gas\n            FROM\n                miniblocks\n            WHERE\n                number <= $1\n            ORDER BY\n                number DESC\n            LIMIT\n                $2\n            "
-  },
-  "8403dce83d6b9041df214e9eb062cc166e891e5b2b9cf868365635301069fcb7": {
-    "describe": {
-      "columns": [
-        {
-          "name": "tx_hash",
-          "ordinal": 0,
-          "type_info": "Bytea"
-        },
-        {
-          "name": "index_in_block",
-          "ordinal": 1,
-          "type_info": "Int4"
-        },
-        {
-          "name": "l1_batch_tx_index",
-          "ordinal": 2,
-          "type_info": "Int4"
-        },
-        {
-          "name": "block_number",
-          "ordinal": 3,
-          "type_info": "Int8"
-        },
-        {
-          "name": "error",
-          "ordinal": 4,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "effective_gas_price",
-          "ordinal": 5,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "initiator_address",
-          "ordinal": 6,
-          "type_info": "Bytea"
-        },
-        {
-          "name": "transfer_to?",
-          "ordinal": 7,
-          "type_info": "Jsonb"
-        },
-        {
-          "name": "execute_contract_address?",
-          "ordinal": 8,
-          "type_info": "Jsonb"
-        },
-        {
-          "name": "tx_format?",
-          "ordinal": 9,
-          "type_info": "Int4"
-        },
-        {
-          "name": "refunded_gas",
-          "ordinal": 10,
-          "type_info": "Int8"
-        },
-        {
-          "name": "gas_limit",
-          "ordinal": 11,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "block_hash",
-          "ordinal": 12,
-          "type_info": "Bytea"
-        },
-        {
-          "name": "l1_batch_number?",
-          "ordinal": 13,
-          "type_info": "Int8"
-        },
-        {
-          "name": "contract_address?",
-          "ordinal": 14,
-          "type_info": "Bytea"
-        }
-      ],
-      "nullable": [
-        false,
-        true,
-        true,
-        true,
-        true,
-        true,
-        false,
-        null,
-        null,
-        true,
-        false,
-        true,
-        false,
-        true,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Bytea",
-          "Bytea",
-          "Bytea"
-        ]
-      }
-    },
-    "query": "\n                WITH\n                    sl AS (\n                        SELECT\n                            *\n                        FROM\n                            storage_logs\n                        WHERE\n                            storage_logs.address = $1\n                            AND storage_logs.tx_hash = $2\n                        ORDER BY\n                            storage_logs.miniblock_number DESC,\n                            storage_logs.operation_number DESC\n                        LIMIT\n                            1\n                    )\n                SELECT\n                    transactions.hash AS tx_hash,\n                    transactions.index_in_block AS index_in_block,\n                    transactions.l1_batch_tx_index AS l1_batch_tx_index,\n                    transactions.miniblock_number AS block_number,\n                    transactions.error AS error,\n                    transactions.effective_gas_price AS effective_gas_price,\n                    transactions.initiator_address AS initiator_address,\n                    transactions.data -> 'to' AS \"transfer_to?\",\n                    transactions.data -> 'contractAddress' AS \"execute_contract_address?\",\n                    transactions.tx_format AS \"tx_format?\",\n                    transactions.refunded_gas AS refunded_gas,\n                    transactions.gas_limit AS gas_limit,\n                    miniblocks.hash AS \"block_hash\",\n                    miniblocks.l1_batch_number AS \"l1_batch_number?\",\n                    sl.key AS \"contract_address?\"\n                FROM\n                    transactions\n                    JOIN miniblocks ON miniblocks.number = transactions.miniblock_number\n                    LEFT JOIN sl ON sl.value != $3\n                WHERE\n                    transactions.hash = $2\n                "
   },
   "852aa5fe1c3b2dfe875cd4adf0d19a00c170cf7725d95dd6eb8b753fa5facec8": {
     "describe": {

--- a/core/lib/dal/sqlx-data.json
+++ b/core/lib/dal/sqlx-data.json
@@ -5912,112 +5912,6 @@
     },
     "query": "\n            DELETE FROM basic_witness_input_producer_jobs\n            "
   },
-  "6bf641312081de59ae8be08326fc50bd670d8ee9aa7c28eed728dbaa1b8bab25": {
-    "describe": {
-      "columns": [
-        {
-          "name": "tx_hash",
-          "ordinal": 0,
-          "type_info": "Bytea"
-        },
-        {
-          "name": "index_in_block",
-          "ordinal": 1,
-          "type_info": "Int4"
-        },
-        {
-          "name": "l1_batch_tx_index",
-          "ordinal": 2,
-          "type_info": "Int4"
-        },
-        {
-          "name": "block_number",
-          "ordinal": 3,
-          "type_info": "Int8"
-        },
-        {
-          "name": "error",
-          "ordinal": 4,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "effective_gas_price",
-          "ordinal": 5,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "initiator_address",
-          "ordinal": 6,
-          "type_info": "Bytea"
-        },
-        {
-          "name": "transfer_to?",
-          "ordinal": 7,
-          "type_info": "Jsonb"
-        },
-        {
-          "name": "execute_contract_address?",
-          "ordinal": 8,
-          "type_info": "Jsonb"
-        },
-        {
-          "name": "tx_format?",
-          "ordinal": 9,
-          "type_info": "Int4"
-        },
-        {
-          "name": "refunded_gas",
-          "ordinal": 10,
-          "type_info": "Int8"
-        },
-        {
-          "name": "gas_limit",
-          "ordinal": 11,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "block_hash?",
-          "ordinal": 12,
-          "type_info": "Bytea"
-        },
-        {
-          "name": "l1_batch_number?",
-          "ordinal": 13,
-          "type_info": "Int8"
-        },
-        {
-          "name": "contract_address?",
-          "ordinal": 14,
-          "type_info": "Bytea"
-        }
-      ],
-      "nullable": [
-        false,
-        true,
-        true,
-        true,
-        true,
-        true,
-        false,
-        null,
-        null,
-        true,
-        false,
-        true,
-        false,
-        true,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Bytea",
-          "Bytea",
-          "Bytea"
-        ]
-      }
-    },
-    "query": "\n                WITH\n                    sl AS (\n                        SELECT\n                            *\n                        FROM\n                            storage_logs\n                        WHERE\n                            storage_logs.address = $1\n                            AND storage_logs.tx_hash = $2\n                        ORDER BY\n                            storage_logs.miniblock_number DESC,\n                            storage_logs.operation_number DESC\n                        LIMIT\n                            1\n                    )\n                SELECT\n                    transactions.hash AS tx_hash,\n                    transactions.index_in_block AS index_in_block,\n                    transactions.l1_batch_tx_index AS l1_batch_tx_index,\n                    transactions.miniblock_number AS block_number,\n                    transactions.error AS error,\n                    transactions.effective_gas_price AS effective_gas_price,\n                    transactions.initiator_address AS initiator_address,\n                    transactions.data -> 'to' AS \"transfer_to?\",\n                    transactions.data -> 'contractAddress' AS \"execute_contract_address?\",\n                    transactions.tx_format AS \"tx_format?\",\n                    transactions.refunded_gas AS refunded_gas,\n                    transactions.gas_limit AS gas_limit,\n                    miniblocks.hash AS \"block_hash?\",\n                    miniblocks.l1_batch_number AS \"l1_batch_number?\",\n                    sl.key AS \"contract_address?\"\n                FROM\n                    transactions\n                    LEFT JOIN miniblocks ON miniblocks.number = transactions.miniblock_number\n                    LEFT JOIN sl ON sl.value != $3\n                WHERE\n                    transactions.hash = $2\n                "
-  },
   "6c0d03b1fbe6f47546bc34c6b2eab01cb2c55bf86d2c8c99abb1b7ca21cf75c0": {
     "describe": {
       "columns": [],
@@ -7372,6 +7266,112 @@
       }
     },
     "query": "\n            SELECT\n                base_fee_per_gas\n            FROM\n                miniblocks\n            WHERE\n                number <= $1\n            ORDER BY\n                number DESC\n            LIMIT\n                $2\n            "
+  },
+  "8403dce83d6b9041df214e9eb062cc166e891e5b2b9cf868365635301069fcb7": {
+    "describe": {
+      "columns": [
+        {
+          "name": "tx_hash",
+          "ordinal": 0,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "index_in_block",
+          "ordinal": 1,
+          "type_info": "Int4"
+        },
+        {
+          "name": "l1_batch_tx_index",
+          "ordinal": 2,
+          "type_info": "Int4"
+        },
+        {
+          "name": "block_number",
+          "ordinal": 3,
+          "type_info": "Int8"
+        },
+        {
+          "name": "error",
+          "ordinal": 4,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "effective_gas_price",
+          "ordinal": 5,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "initiator_address",
+          "ordinal": 6,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "transfer_to?",
+          "ordinal": 7,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "execute_contract_address?",
+          "ordinal": 8,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "tx_format?",
+          "ordinal": 9,
+          "type_info": "Int4"
+        },
+        {
+          "name": "refunded_gas",
+          "ordinal": 10,
+          "type_info": "Int8"
+        },
+        {
+          "name": "gas_limit",
+          "ordinal": 11,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "block_hash",
+          "ordinal": 12,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "l1_batch_number?",
+          "ordinal": 13,
+          "type_info": "Int8"
+        },
+        {
+          "name": "contract_address?",
+          "ordinal": 14,
+          "type_info": "Bytea"
+        }
+      ],
+      "nullable": [
+        false,
+        true,
+        true,
+        true,
+        true,
+        true,
+        false,
+        null,
+        null,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Bytea",
+          "Bytea"
+        ]
+      }
+    },
+    "query": "\n                WITH\n                    sl AS (\n                        SELECT\n                            *\n                        FROM\n                            storage_logs\n                        WHERE\n                            storage_logs.address = $1\n                            AND storage_logs.tx_hash = $2\n                        ORDER BY\n                            storage_logs.miniblock_number DESC,\n                            storage_logs.operation_number DESC\n                        LIMIT\n                            1\n                    )\n                SELECT\n                    transactions.hash AS tx_hash,\n                    transactions.index_in_block AS index_in_block,\n                    transactions.l1_batch_tx_index AS l1_batch_tx_index,\n                    transactions.miniblock_number AS block_number,\n                    transactions.error AS error,\n                    transactions.effective_gas_price AS effective_gas_price,\n                    transactions.initiator_address AS initiator_address,\n                    transactions.data -> 'to' AS \"transfer_to?\",\n                    transactions.data -> 'contractAddress' AS \"execute_contract_address?\",\n                    transactions.tx_format AS \"tx_format?\",\n                    transactions.refunded_gas AS refunded_gas,\n                    transactions.gas_limit AS gas_limit,\n                    miniblocks.hash AS \"block_hash\",\n                    miniblocks.l1_batch_number AS \"l1_batch_number?\",\n                    sl.key AS \"contract_address?\"\n                FROM\n                    transactions\n                    JOIN miniblocks ON miniblocks.number = transactions.miniblock_number\n                    LEFT JOIN sl ON sl.value != $3\n                WHERE\n                    transactions.hash = $2\n                "
   },
   "852aa5fe1c3b2dfe875cd4adf0d19a00c170cf7725d95dd6eb8b753fa5facec8": {
     "describe": {

--- a/core/lib/dal/src/transactions_web3_dal.rs
+++ b/core/lib/dal/src/transactions_web3_dal.rs
@@ -78,11 +78,7 @@ impl TransactionsWeb3Dal<'_, '_> {
             .fetch_optional(self.storage.conn())
             .await?
             .map(|db_row| {
-                let status = if db_row.error.is_none() {
-                    U64::from(0)
-                } else {
-                    U64::from(1)
-                };
+                let status = db_row.error.map(|_| U64::zero()).unwrap_or_else(U64::one);
 
                 let tx_type = db_row.tx_format.map(U64::from).unwrap_or_default();
                 let transaction_index = db_row.index_in_block.map(U64::from).unwrap_or_default();

--- a/core/lib/types/src/api/mod.rs
+++ b/core/lib/types/src/api/mod.rs
@@ -212,7 +212,7 @@ pub struct TransactionReceipt {
     pub block_hash: H256,
     /// Number of the miniblock this transaction was included within.
     #[serde(rename = "blockNumber")]
-    pub block_number: Option<U64>,
+    pub block_number: U64,
     /// Index of transaction in l1 batch
     #[serde(rename = "l1BatchTxIndex")]
     pub l1_batch_tx_index: Option<Index>,
@@ -246,7 +246,7 @@ pub struct TransactionReceipt {
     #[serde(rename = "l2ToL1Logs")]
     pub l2_to_l1_logs: Vec<L2ToL1Log>,
     /// Status: either 1 (success) or 0 (failure).
-    pub status: Option<U64>,
+    pub status: U64,
     /// State root.
     pub root: H256,
     /// Logs bloom

--- a/core/lib/types/src/api/mod.rs
+++ b/core/lib/types/src/api/mod.rs
@@ -209,7 +209,7 @@ pub struct TransactionReceipt {
     pub transaction_index: Index,
     /// Hash of the block this transaction was included within.
     #[serde(rename = "blockHash")]
-    pub block_hash: Option<H256>,
+    pub block_hash: H256,
     /// Number of the miniblock this transaction was included within.
     #[serde(rename = "blockNumber")]
     pub block_number: Option<U64>,
@@ -248,7 +248,7 @@ pub struct TransactionReceipt {
     /// Status: either 1 (success) or 0 (failure).
     pub status: Option<U64>,
     /// State root.
-    pub root: Option<H256>,
+    pub root: H256,
     /// Logs bloom
     #[serde(rename = "logsBloom")]
     pub logs_bloom: H2048,

--- a/core/lib/zksync_core/src/api_server/tx_sender/proxy.rs
+++ b/core/lib/zksync_core/src/api_server/tx_sender/proxy.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use tokio::sync::RwLock;
 use zksync_types::{
-    api::{BlockId, Transaction, TransactionDetails, TransactionId, TransactionReceipt},
+    api::{BlockId, Transaction, TransactionDetails, TransactionId},
     l2::L2Tx,
     H256,
 };
@@ -66,9 +66,5 @@ impl TxProxy {
 
     pub async fn request_tx_details(&self, hash: H256) -> RpcResult<Option<TransactionDetails>> {
         self.client.get_transaction_details(hash).await
-    }
-
-    pub async fn request_tx_receipt(&self, hash: H256) -> RpcResult<Option<TransactionReceipt>> {
-        self.client.get_transaction_receipt(hash).await
     }
 }

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/eth.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/eth.rs
@@ -508,29 +508,6 @@ impl<G: L1GasPriceProvider> EthNamespace<G> {
             .await
             .map_err(|err| internal_error(METHOD_NAME, err));
 
-        if let Some(proxy) = &self.state.tx_sender.0.proxy {
-            // We're running an external node
-            if matches!(receipt, Ok(None)) {
-                // If the transaction is not in the db, query main node.
-                // Because it might be the case that it got rejected in state keeper
-                // and won't be synced back to us, but we still want to return a receipt.
-                // We want to only forward these kinds of receipts because otherwise
-                // clients will assume that the transaction they got the receipt for
-                // was already processed on the EN (when it was not),
-                // and will think that the state has already been updated on the EN (when it was not).
-                if let Ok(Some(main_node_receipt)) = proxy
-                    .request_tx_receipt(hash)
-                    .await
-                    .map_err(|err| internal_error(METHOD_NAME, err))
-                {
-                    if main_node_receipt.status == 0.into() {
-                        // Transaction was rejected in state-keeper.
-                        receipt = Ok(Some(main_node_receipt));
-                    }
-                }
-            }
-        }
-
         method_latency.observe();
         receipt
     }

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/eth.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/eth.rs
@@ -497,7 +497,7 @@ impl<G: L1GasPriceProvider> EthNamespace<G> {
         const METHOD_NAME: &str = "get_transaction_receipt";
 
         let method_latency = API_METRICS.start_call(METHOD_NAME);
-        let mut receipt = self
+        let receipt = self
             .state
             .connection_pool
             .access_storage_tagged("api")

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/eth.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/eth.rs
@@ -523,9 +523,7 @@ impl<G: L1GasPriceProvider> EthNamespace<G> {
                     .await
                     .map_err(|err| internal_error(METHOD_NAME, err))
                 {
-                    if main_node_receipt.status == Some(0.into())
-                        && main_node_receipt.block_number.is_none()
-                    {
+                    if main_node_receipt.status == 0.into() {
                         // Transaction was rejected in state-keeper.
                         receipt = Ok(Some(main_node_receipt));
                     }

--- a/core/lib/zksync_core/src/sync_layer/tests.rs
+++ b/core/lib/zksync_core/src/sync_layer/tests.rs
@@ -174,7 +174,7 @@ async fn external_io_basics() {
         .await
         .unwrap()
         .expect("Transaction not persisted");
-    assert_eq!(tx_receipt.block_number, Some(1.into()));
+    assert_eq!(tx_receipt.block_number, 1.into());
     assert_eq!(tx_receipt.transaction_index, 0.into());
 }
 

--- a/core/tests/loadnext/src/account/mod.rs
+++ b/core/tests/loadnext/src/account/mod.rs
@@ -221,7 +221,7 @@ impl AccountLifespan {
         expected_outcome: &ExpectedOutcome,
     ) -> ReportLabel {
         match expected_outcome {
-            ExpectedOutcome::TxSucceed if transaction_receipt.status == Some(U64::one()) => {
+            ExpectedOutcome::TxSucceed if transaction_receipt.status == U64::one() => {
                 // If it was a successful `DeployContract` transaction, set the contract
                 // address for subsequent usage by `Execute`.
                 if let Some(address) = transaction_receipt.contract_address {
@@ -232,7 +232,7 @@ impl AccountLifespan {
                 // Transaction succeed and it should have.
                 ReportLabel::done()
             }
-            ExpectedOutcome::TxRejected if transaction_receipt.status == Some(U64::zero()) => {
+            ExpectedOutcome::TxRejected if transaction_receipt.status == U64::zero() => {
                 // Transaction failed and it should have.
                 ReportLabel::done()
             }

--- a/core/tests/loadnext/src/account/tx_command_executor.rs
+++ b/core/tests/loadnext/src/account/tx_command_executor.rs
@@ -445,13 +445,11 @@ impl AccountLifespan {
             .get_transaction_receipt(tx_hash)
             .await?;
 
-        let receipt = if response.as_ref().and_then(|r| r.block_number).is_some() {
-            response.unwrap()
-        } else {
+        let Some(receipt) = response else {
             return Ok(None);
         };
 
-        let block_number = receipt.block_number.unwrap();
+        let block_number = receipt.block_number;
 
         let response = self
             .wallet

--- a/core/tests/loadnext/src/executor.rs
+++ b/core/tests/loadnext/src/executor.rs
@@ -471,7 +471,7 @@ impl Executor {
                 .commit_timeout(COMMIT_TIMEOUT)
                 .wait_for_commit()
                 .await?;
-            if result.status == Some(U64::zero()) {
+            if result.status == U64::zero() {
                 return Err(anyhow::format_err!("Transfer failed"));
             }
         }

--- a/core/tests/revert-test/tests/revert-and-restart.test.ts
+++ b/core/tests/revert-test/tests/revert-and-restart.test.ts
@@ -184,7 +184,9 @@ describe('Block reverting test', function () {
             amount: depositAmount,
             to: alice.address
         });
+        console.log('here1');
         let receipt = await depositHandle.waitFinalize();
+        console.log('here2');
         expect(receipt.status).to.be.eql(1);
 
         const balanceAfter = await alice.getBalance();

--- a/core/tests/ts-integration/tests/api/web3.test.ts
+++ b/core/tests/ts-integration/tests/api/web3.test.ts
@@ -279,9 +279,9 @@ describe('web3 API compatibility tests', () => {
         let newTxHash: string | null = null;
         // We can't use `once` as there may be other pending txs sent together with our one.
         wsProvider.on('pending', async (txHash) => {
-            const receipt = await alice.provider.getTransactionReceipt(txHash);
+            const tx = await alice.provider.getTransaction(txHash);
             // We're waiting for the exact transaction to appear.
-            if (!receipt || receipt.to != uniqueRecipient) {
+            if (!tx || tx.to != uniqueRecipient) {
                 // Not the transaction we're looking for.
                 return;
             }

--- a/sdk/zksync-rs/src/operations/mod.rs
+++ b/sdk/zksync-rs/src/operations/mod.rs
@@ -111,8 +111,6 @@ where
         let mut timer = tokio::time::interval(self.polling_interval);
         let start = Instant::now();
 
-        let mut receipt = None;
-
         loop {
             timer.tick().await;
 
@@ -122,28 +120,24 @@ where
                 }
             }
 
-            // First, wait for the receipt with a block number.
-            if receipt.is_none() {
-                let response = self.provider.get_transaction_receipt(self.hash).await?;
-                if response.as_ref().and_then(|r| r.block_number).is_some() {
-                    receipt = response;
+            let receipt =
+                if let Some(receipt) = self.provider.get_transaction_receipt(self.hash).await? {
+                    receipt
                 } else {
                     continue;
-                }
-            }
+                };
 
             // Wait for transaction to be included into the committed
             // or finalized block:
             // Fetch the latest block with the given status and
             // check if it's greater than or equal to the one from receipt.
 
-            let receipt_ref = receipt.as_ref().unwrap();
-            let block_number = receipt_ref.block_number.unwrap();
+            let block_number = receipt.block_number;
 
             let response = self.provider.get_block_by_number(status, false).await?;
             if let Some(received_number) = response.map(|block| block.number) {
                 if block_number <= received_number {
-                    return Ok(receipt.take().unwrap());
+                    return Ok(receipt);
                 }
             }
         }


### PR DESCRIPTION
## What ❔

For compatibility with Ethereum, we have to return `Receipt` only if tx is included in the miniblock. Block hash is not null null. 

## Why ❔

For compatibility with Ethereum and for not breaking external clients, such as Metemask, they do not expect that block hash could be null

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
