### PR TITLE
fix: override file only needed in format_sql.ts

### DIFF
--- a/infrastructure/zk/src/format_sql.ts
+++ b/infrastructure/zk/src/format_sql.ts
@@ -144,12 +144,11 @@ async function formatFile(filePath: string, check: boolean) {
         }
     }
     modifiedFile = modifiedFile.slice(0, modifiedFile.length - 1);
-
-    if (!check) {
-        await fs.promises.writeFile(filePath, modifiedFile);
-    } else {
-        if (content !== modifiedFile) {
+    if (content !== modifiedFile) {
+        if (check) {
             console.warn(`Sqlx query format issues found in ${filePath}.`);
+        } else {
+            await fs.promises.writeFile(filePath, modifiedFile);
         }
     }
     return content === modifiedFile;


### PR DESCRIPTION
Change that makes format_sql.ts script only override file if there was some formatting to do. This change is needed to prevent rust build system from dropping build caches when files did not change