### PR TITLE
fix: silence cat errors on Show Logs step

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Show logs
         if: always()
         run: |
-          ci_run cat server.log
+          ci_run cat server.log || true
           ci_run sccache --show-stats
           ci_run cat /tmp/sccache_log.txt
   integration:
@@ -203,10 +203,10 @@ jobs:
       - name: Show logs
         if: always()
         run: |
-          ci_run cat server.log
-          ci_run cat contract_verifier.log
-          ci_run cat core/tests/revert-test/revert.log
-          ci_run cat core/tests/upgrade-test/upgrade.log
+          ci_run cat server.log || true
+          ci_run cat contract_verifier.log || true
+          ci_run cat core/tests/revert-test/revert.log || true
+          ci_run cat core/tests/upgrade-test/upgrade.log || true
           ci_run sccache --show-stats
           ci_run cat /tmp/sccache_log.txt
 
@@ -310,9 +310,9 @@ jobs:
       - name: Show logs
         if: always()
         run: |
-          ci_run cat server.log
-          ci_run cat ext-node.log
-          ci_run cat core/tests/revert-test/revert.log
-          ci_run cat core/tests/upgrade-test/upgrade.log
+          ci_run cat server.log || true
+          ci_run cat ext-node.log || true
+          ci_run cat core/tests/revert-test/revert.log || true
+          ci_run cat core/tests/upgrade-test/upgrade.log || true
           ci_run sccache --show-stats
           ci_run cat /tmp/sccache_log.txt

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -207,10 +207,10 @@ jobs:
       - name: Show contract_verifier.log logs
         run: ci_run cat contract_verifier.log || true
 
-      - name: Show core/tests/revert-test/revert.log logs
+      - name: Show revert.log logs
         run: ci_run cat core/tests/revert-test/revert.log || true
 
-      - name: Show core/tests/upgrade-test/upgrade.log logs
+      - name: Show upgrade.log logs
         run: ci_run cat core/tests/upgrade-test/upgrade.log || true
 
       - name: Show sccache logs
@@ -321,10 +321,10 @@ jobs:
       - name: Show contract_verifier.log logs
         run: ci_run cat ext-node.log || true
 
-      - name: Show core/tests/revert-test/revert.log logs
+      - name: Show revert.log logs
         run: ci_run cat core/tests/revert-test/revert.log || true
 
-      - name: Show core/tests/upgrade-test/upgrade.log logs
+      - name: Show upgrade.log logs
         run: ci_run cat core/tests/upgrade-test/upgrade.log || true
 
       - name: Show sccache logs

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -108,10 +108,11 @@ jobs:
       - name: Perform loadtest
         run: ci_run zk run loadtest
 
-      - name: Show logs
-        if: always()
+      - name: Show server.log logs
+        run: ci_run cat server.log || true
+
+      - name: Show sccache logs
         run: |
-          ci_run cat server.log || true
           ci_run sccache --show-stats
           ci_run cat /tmp/sccache_log.txt
   integration:
@@ -200,13 +201,20 @@ jobs:
           ci_run sleep 10
           ci_run zk test i upgrade
 
-      - name: Show logs
-        if: always()
+      - name: Show server.log logs
+        run: ci_run cat server.log || true
+
+      - name: Show contract_verifier.log logs
+        run: ci_run cat contract_verifier.log || true
+
+      - name: Show core/tests/revert-test/revert.log logs
+        run: ci_run cat core/tests/revert-test/revert.log || true
+
+      - name: Show core/tests/upgrade-test/upgrade.log logs
+        run: ci_run cat core/tests/upgrade-test/upgrade.log || true
+
+      - name: Show sccache logs
         run: |
-          ci_run cat server.log || true
-          ci_run cat contract_verifier.log || true
-          ci_run cat core/tests/revert-test/revert.log || true
-          ci_run cat core/tests/upgrade-test/upgrade.log || true
           ci_run sccache --show-stats
           ci_run cat /tmp/sccache_log.txt
 
@@ -307,12 +315,19 @@ jobs:
           ci_run zk env docker
           CHECK_EN_URL="http://0.0.0.0:3060" ci_run zk test i upgrade
 
-      - name: Show logs
-        if: always()
+      - name: Show server.log logs
+        run: ci_run cat server.log || true
+
+      - name: Show contract_verifier.log logs
+        run: ci_run cat ext-node.log || true
+
+      - name: Show core/tests/revert-test/revert.log logs
+        run: ci_run cat core/tests/revert-test/revert.log || true
+
+      - name: Show core/tests/upgrade-test/upgrade.log logs
+        run: ci_run cat core/tests/upgrade-test/upgrade.log || true
+
+      - name: Show sccache logs
         run: |
-          ci_run cat server.log || true
-          ci_run cat ext-node.log || true
-          ci_run cat core/tests/revert-test/revert.log || true
-          ci_run cat core/tests/upgrade-test/upgrade.log || true
           ci_run sccache --show-stats
           ci_run cat /tmp/sccache_log.txt


### PR DESCRIPTION
## What ❔

Silencing errors like:
```
Run ci_run cat server.log
cat: server.log: No such file or directory
Error: Process completed with exit code 1.
```
That imo are just an additional needless noise that decrease the UX of development.