### PR TITLE
fix: close Docker PostgreSQL to external connections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,7 @@ services:
   postgres:
     image: "postgres:14"
     ports:
-      - 5432:5432
+      - 127.0.0.1:5432:5432
     volumes:
       - type: bind
         source: ./volumes/postgres


### PR DESCRIPTION
PostgreSQL should only be accessible from the localhost interface, otherwise malicious actors can change or delete the database.

Bringing the `zk init` settings in line with `zk stack init` settings: https://github.com/matter-labs/zksync-era/blob/main/docker-compose-zkstack-common.yml#L28