### PR TITLE
Fix typo

### DIFF
--- a/docs/guides/advanced/how_transaction_works.md
+++ b/docs/guides/advanced/how_transaction_works.md
@@ -74,7 +74,7 @@ The transaction can have three different results in state keeper:
 - Success
 - Failure (but still included in the block, and gas was charged)
 - Rejection - when it fails validation, and cannot be included in the block. This last case should (in theory) never
-  happen - as we cannot charge the fee in such scenario, and it opens the possiblity for the DDoS attack.
+  happen - as we cannot charge the fee in such scenario, and it opens the possibility for the DDoS attack.
 
 [transaction_request_from_bytes]:
   https://github.com/matter-labs/zksync-era/blob/main/core/lib/types/src/transaction_request.rs#L196

--- a/docs/specs/l1_l2_communication/l1_to_l2.md
+++ b/docs/specs/l1_l2_communication/l1_to_l2.md
@@ -87,7 +87,7 @@ been complete.
 The upgrade transactions are processed just like with priority transactions, with only the following differences:
 
 - We can have only one upgrade transaction per batch & this transaction must be the first transaction in the batch.
-- The system contracts upgrade transaction is not appended to `priorityOperationsRollingHash` and doesn’t increment
+- The system contracts upgrade transaction is not appended to `priorityOperationsRollingHash` and doesn't increment
   `numberOfPriorityTransactions`. Instead, its hash is calculated via a system L2→L1 log _before_ it gets executed.
   Note, that it is an important property. More on it [below](#security-considerations).
 


### PR DESCRIPTION
## What ❔
fix some minor typo in readme.md and overview.md files

## Why ❔
I think it’s important to let users read the most accurate documentation
