### PR TITLE
fix: all Docker configs no longer expose PostgreSQL externally

### DIFF
--- a/docker-compose-cpu-runner.yml
+++ b/docker-compose-cpu-runner.yml
@@ -33,6 +33,6 @@ services:
   postgres:
     image: "postgres:14"
     ports:
-      - "5432:5432"
+      - 127.0.0.1:5432:5432
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust

--- a/docker-compose-gpu-runner-cuda-12-0.yml
+++ b/docker-compose-gpu-runner-cuda-12-0.yml
@@ -47,6 +47,6 @@ services:
   postgres:
     image: "postgres:14"
     ports:
-      - "5432:5432"
+      - 127.0.0.1:5432:5432
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust

--- a/docker-compose-gpu-runner.yml
+++ b/docker-compose-gpu-runner.yml
@@ -38,6 +38,6 @@ services:
   postgres:
     image: "postgres:14"
     ports:
-      - "5432:5432"
+      - 127.0.0.1:5432:5432
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust


### PR DESCRIPTION
PostgreSQL should only be accessible from the localhost interface, otherwise malicious actors can change or delete the database.

Per discussion with Shahar, fixing all the remaining configs.
Related: https://github.com/matter-labs/zksync-era/pull/741