### PR TITLE
fix(core): do not unwrap unexisting calldata in commitment and regenerate it

### DIFF
--- a/core/lib/types/src/commitment.rs
+++ b/core/lib/types/src/commitment.rs
@@ -209,13 +209,50 @@ impl L1BatchWithMetadata {
                         .to_vec(),
                 ),
                 Token::Bytes(self.metadata.l2_l1_messages_compressed.clone()),
-                Token::Bytes(self.header.pubdata_input.clone().unwrap()),
+                Token::Bytes(
+                    self.header
+                        .pubdata_input
+                        .clone()
+                        .unwrap_or(self.construct_pubdata()),
+                ),
             ])
         }
     }
 
     pub fn l1_commit_data_size(&self) -> usize {
         crate::ethabi::encode(&[Token::Array(vec![self.l1_commit_data()])]).len()
+    }
+
+    /// Packs all pubdata needed for batch commitment in boojum into one bytes array. The packing contains the
+    /// following: logs, messages, bytecodes, and compressed state diffs.
+    /// This data is currently part of calldata but will be submitted as part of the blob section post EIP-4844.
+    pub fn construct_pubdata(&self) -> Vec<u8> {
+        let mut res: Vec<u8> = vec![];
+
+        // Process and Pack Logs
+        res.extend((self.header.l2_to_l1_logs.len() as u32).to_be_bytes());
+        for l2_to_l1_log in &self.header.l2_to_l1_logs {
+            res.extend(l2_to_l1_log.0.to_bytes());
+        }
+
+        // Process and Pack Msgs
+        res.extend((self.header.l2_to_l1_messages.len() as u32).to_be_bytes());
+        for msg in &self.header.l2_to_l1_messages {
+            res.extend((msg.len() as u32).to_be_bytes());
+            res.extend(msg);
+        }
+
+        // Process and Pack Bytecodes
+        res.extend((self.factory_deps.len() as u32).to_be_bytes());
+        for bytecode in &self.factory_deps {
+            res.extend((bytecode.len() as u32).to_be_bytes());
+            res.extend(bytecode);
+        }
+
+        // Extend with Compressed StateDiffs
+        res.extend(&self.metadata.state_diffs_compressed);
+
+        res
     }
 }
 


### PR DESCRIPTION
## What ❔

Solve panics on nonexistent calldata.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
