### PR TITLE
feat: Remove generic bounds on L1GasPriceProvider

### DIFF
--- a/core/lib/eth_client/src/clients/mock.rs
+++ b/core/lib/eth_client/src/clients/mock.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, HashMap},
+    fmt,
     sync::{
         atomic::{AtomicU64, Ordering},
         RwLock,
@@ -415,7 +416,7 @@ impl BoundEthInterface for MockEthereum {
 }
 
 #[async_trait]
-impl<T: AsRef<MockEthereum> + Send + Sync> EthInterface for T {
+impl<T: 'static + AsRef<MockEthereum> + Send + Sync + fmt::Debug> EthInterface for T {
     async fn nonce_at_for_account(
         &self,
         account: Address,
@@ -535,7 +536,7 @@ impl<T: AsRef<MockEthereum> + Send + Sync> EthInterface for T {
 }
 
 #[async_trait::async_trait]
-impl<T: AsRef<MockEthereum> + Send + Sync> BoundEthInterface for T {
+impl<T: 'static + AsRef<MockEthereum> + Send + Sync + fmt::Debug> BoundEthInterface for T {
     fn contract(&self) -> &ethabi::Contract {
         self.as_ref().contract()
     }

--- a/core/lib/eth_client/src/lib.rs
+++ b/core/lib/eth_client/src/lib.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::upper_case_acronyms, clippy::derive_partial_eq_without_eq)]
 
+use std::fmt;
+
 use async_trait::async_trait;
 use zksync_types::{
     web3::{
@@ -38,7 +40,7 @@ pub mod types;
 /// unnecessary high amount of Web3 calls. Implementations are advice to count invocations
 /// per component and expose them to Prometheus.
 #[async_trait]
-pub trait EthInterface: Sync + Send {
+pub trait EthInterface: 'static + Sync + Send + fmt::Debug {
     /// Returns the nonce of the provided account at the specified block.
     async fn nonce_at_for_account(
         &self,

--- a/core/lib/eth_signer/src/lib.rs
+++ b/core/lib/eth_signer/src/lib.rs
@@ -14,7 +14,7 @@ pub mod pk_signer;
 pub mod raw_ethereum_tx;
 
 #[async_trait]
-pub trait EthereumSigner: Send + Sync + Clone {
+pub trait EthereumSigner: 'static + Send + Sync + Clone {
     async fn sign_message(&self, message: &[u8]) -> Result<PackedEthSignature, SignerError>;
     async fn sign_typed_data<S: EIP712TypedStructure + Sync>(
         &self,

--- a/core/lib/zksync_core/src/api_server/tx_sender/mod.rs
+++ b/core/lib/zksync_core/src/api_server/tx_sender/mod.rs
@@ -187,13 +187,13 @@ impl TxSenderBuilder {
         self
     }
 
-    pub async fn build<G: L1GasPriceProvider>(
+    pub async fn build(
         self,
-        l1_gas_price_source: Arc<G>,
+        l1_gas_price_source: Arc<dyn L1GasPriceProvider>,
         vm_concurrency_limiter: Arc<VmConcurrencyLimiter>,
         api_contracts: ApiContracts,
         storage_caches: PostgresStorageCaches,
-    ) -> TxSender<G> {
+    ) -> TxSender {
         assert!(
             self.master_connection_pool.is_some() || self.proxy.is_some(),
             "Either master connection pool or proxy must be set"
@@ -250,12 +250,12 @@ impl TxSenderConfig {
     }
 }
 
-pub struct TxSenderInner<G> {
+pub struct TxSenderInner {
     pub(super) sender_config: TxSenderConfig,
     pub master_connection_pool: Option<ConnectionPool>,
     pub replica_connection_pool: ConnectionPool,
     // Used to keep track of gas prices for the fee ticker.
-    pub l1_gas_price_source: Arc<G>,
+    pub l1_gas_price_source: Arc<dyn L1GasPriceProvider>,
     pub(super) api_contracts: ApiContracts,
     /// Optional rate limiter that will limit the amount of transactions per second sent from a single entity.
     rate_limiter: Option<TxSenderRateLimiter>,
@@ -271,24 +271,16 @@ pub struct TxSenderInner<G> {
     storage_caches: PostgresStorageCaches,
 }
 
-pub struct TxSender<G>(pub(super) Arc<TxSenderInner<G>>);
+#[derive(Clone)]
+pub struct TxSender(pub(super) Arc<TxSenderInner>);
 
-// Custom implementation is required due to generic param:
-// Even though it's under `Arc`, compiler doesn't generate the `Clone` implementation unless
-// an unnecessary bound is added.
-impl<G> Clone for TxSender<G> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-
-impl<G> std::fmt::Debug for TxSender<G> {
+impl std::fmt::Debug for TxSender {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TxSender").finish()
     }
 }
 
-impl<G: L1GasPriceProvider> TxSender<G> {
+impl TxSender {
     pub(crate) fn vm_concurrency_limiter(&self) -> Arc<VmConcurrencyLimiter> {
         Arc::clone(&self.0.vm_concurrency_limiter)
     }

--- a/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/en.rs
+++ b/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/en.rs
@@ -4,13 +4,10 @@ use zksync_web3_decl::{
     namespaces::en::EnNamespaceServer,
 };
 
-use crate::{
-    api_server::web3::{backend_jsonrpsee::into_jsrpc_error, namespaces::EnNamespace},
-    l1_gas_price::L1GasPriceProvider,
-};
+use crate::api_server::web3::{backend_jsonrpsee::into_jsrpc_error, namespaces::EnNamespace};
 
 #[async_trait]
-impl<G: L1GasPriceProvider + Send + Sync + 'static> EnNamespaceServer for EnNamespace<G> {
+impl EnNamespaceServer for EnNamespace {
     async fn sync_l2_block(
         &self,
         block_number: MiniblockNumber,

--- a/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/eth.rs
+++ b/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/eth.rs
@@ -13,13 +13,10 @@ use zksync_web3_decl::{
     types::{Filter, FilterChanges},
 };
 
-use crate::{
-    api_server::web3::{backend_jsonrpsee::into_jsrpc_error, EthNamespace},
-    l1_gas_price::L1GasPriceProvider,
-};
+use crate::api_server::web3::{backend_jsonrpsee::into_jsrpc_error, EthNamespace};
 
 #[async_trait]
-impl<G: L1GasPriceProvider + Send + Sync + 'static> EthNamespaceServer for EthNamespace<G> {
+impl EthNamespaceServer for EthNamespace {
     async fn get_block_number(&self) -> RpcResult<U64> {
         self.get_block_number_impl().await.map_err(into_jsrpc_error)
     }

--- a/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/snapshots.rs
+++ b/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/snapshots.rs
@@ -5,15 +5,12 @@ use zksync_types::{
 };
 use zksync_web3_decl::{jsonrpsee::core::RpcResult, namespaces::SnapshotsNamespaceServer};
 
-use crate::{
-    api_server::web3::{backend_jsonrpsee::into_jsrpc_error, namespaces::SnapshotsNamespace},
-    l1_gas_price::L1GasPriceProvider,
+use crate::api_server::web3::{
+    backend_jsonrpsee::into_jsrpc_error, namespaces::SnapshotsNamespace,
 };
 
 #[async_trait]
-impl<G: L1GasPriceProvider + Send + Sync + 'static> SnapshotsNamespaceServer
-    for SnapshotsNamespace<G>
-{
+impl SnapshotsNamespaceServer for SnapshotsNamespace {
     async fn get_all_snapshots(&self) -> RpcResult<AllSnapshots> {
         self.get_all_snapshots_impl()
             .await

--- a/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/zks.rs
@@ -16,13 +16,10 @@ use zksync_web3_decl::{
     types::Token,
 };
 
-use crate::{
-    api_server::web3::{backend_jsonrpsee::into_jsrpc_error, ZksNamespace},
-    l1_gas_price::L1GasPriceProvider,
-};
+use crate::api_server::web3::{backend_jsonrpsee::into_jsrpc_error, ZksNamespace};
 
 #[async_trait]
-impl<G: L1GasPriceProvider + Send + Sync + 'static> ZksNamespaceServer for ZksNamespace<G> {
+impl ZksNamespaceServer for ZksNamespace {
     async fn estimate_fee(&self, req: CallRequest) -> RpcResult<Fee> {
         self.estimate_fee_impl(req).await.map_err(into_jsrpc_error)
     }

--- a/core/lib/zksync_core/src/api_server/web3/mod.rs
+++ b/core/lib/zksync_core/src/api_server/web3/mod.rs
@@ -40,7 +40,6 @@ use crate::{
         execution_sandbox::VmConcurrencyBarrier, tree::TreeApiHttpClient, tx_sender::TxSender,
         web3::backend_jsonrpsee::batch_limiter_middleware::LimitMiddleware,
     },
-    l1_gas_price::L1GasPriceProvider,
     sync_layer::SyncState,
 };
 
@@ -119,12 +118,12 @@ struct OptionalApiParams {
 
 /// Full API server parameters.
 #[derive(Debug)]
-struct FullApiParams<G> {
+struct FullApiParams {
     pool: ConnectionPool,
     last_miniblock_pool: ConnectionPool,
     config: InternalApiConfig,
     transport: ApiTransport,
-    tx_sender: TxSender<G>,
+    tx_sender: TxSender,
     vm_barrier: VmConcurrencyBarrier,
     threads: usize,
     polling_interval: Duration,
@@ -133,14 +132,14 @@ struct FullApiParams<G> {
 }
 
 #[derive(Debug)]
-pub struct ApiBuilder<G> {
+pub struct ApiBuilder {
     pool: ConnectionPool,
     last_miniblock_pool: ConnectionPool,
     config: InternalApiConfig,
     polling_interval: Duration,
     // Mandatory params that must be set using builder methods.
     transport: Option<ApiTransport>,
-    tx_sender: Option<TxSender<G>>,
+    tx_sender: Option<TxSender>,
     vm_barrier: Option<VmConcurrencyBarrier>,
     threads: Option<usize>,
     // Optional params that may or may not be set using builder methods. We treat `namespaces`
@@ -149,7 +148,7 @@ pub struct ApiBuilder<G> {
     optional: OptionalApiParams,
 }
 
-impl<G> ApiBuilder<G> {
+impl ApiBuilder {
     const DEFAULT_POLLING_INTERVAL: Duration = Duration::from_millis(200);
 
     pub fn jsonrpsee_backend(config: InternalApiConfig, pool: ConnectionPool) -> Self {
@@ -185,11 +184,7 @@ impl<G> ApiBuilder<G> {
         self
     }
 
-    pub fn with_tx_sender(
-        mut self,
-        tx_sender: TxSender<G>,
-        vm_barrier: VmConcurrencyBarrier,
-    ) -> Self {
+    pub fn with_tx_sender(mut self, tx_sender: TxSender, vm_barrier: VmConcurrencyBarrier) -> Self {
         self.tx_sender = Some(tx_sender);
         self.vm_barrier = Some(vm_barrier);
         self
@@ -255,7 +250,7 @@ impl<G> ApiBuilder<G> {
         self
     }
 
-    fn into_full_params(self) -> anyhow::Result<FullApiParams<G>> {
+    fn into_full_params(self) -> anyhow::Result<FullApiParams> {
         Ok(FullApiParams {
             pool: self.pool,
             last_miniblock_pool: self.last_miniblock_pool,
@@ -276,7 +271,7 @@ impl<G> ApiBuilder<G> {
     }
 }
 
-impl<G: 'static + Send + Sync + L1GasPriceProvider> ApiBuilder<G> {
+impl ApiBuilder {
     pub async fn build(
         self,
         stop_receiver: watch::Receiver<bool>,
@@ -285,8 +280,8 @@ impl<G: 'static + Send + Sync + L1GasPriceProvider> ApiBuilder<G> {
     }
 }
 
-impl<G: 'static + Send + Sync + L1GasPriceProvider> FullApiParams<G> {
-    fn build_rpc_state(self) -> RpcState<G> {
+impl FullApiParams {
+    fn build_rpc_state(self) -> RpcState {
         // Chosen to be significantly smaller than the interval between miniblocks, but larger than
         // the latency of getting the latest sealed miniblock number from Postgres. If the API server
         // processes enough requests, information about the latest sealed miniblock will be updated

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/debug.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/debug.rs
@@ -13,20 +13,17 @@ use zksync_types::{
 };
 use zksync_web3_decl::error::Web3Error;
 
-use crate::{
-    api_server::{
-        execution_sandbox::{
-            execute_tx_eth_call, ApiTracer, BlockArgs, TxSharedArgs, VmConcurrencyLimiter,
-        },
-        tx_sender::ApiContracts,
-        web3::{
-            backend_jsonrpsee::internal_error,
-            metrics::API_METRICS,
-            resolve_block,
-            state::{RpcState, SealedMiniblockNumber},
-        },
+use crate::api_server::{
+    execution_sandbox::{
+        execute_tx_eth_call, ApiTracer, BlockArgs, TxSharedArgs, VmConcurrencyLimiter,
     },
-    l1_gas_price::L1GasPriceProvider,
+    tx_sender::ApiContracts,
+    web3::{
+        backend_jsonrpsee::internal_error,
+        metrics::API_METRICS,
+        resolve_block,
+        state::{RpcState, SealedMiniblockNumber},
+    },
 };
 
 #[derive(Debug, Clone)]
@@ -42,7 +39,7 @@ pub struct DebugNamespace {
 }
 
 impl DebugNamespace {
-    pub async fn new<G: L1GasPriceProvider>(state: RpcState<G>) -> Self {
+    pub async fn new(state: RpcState) -> Self {
         let sender_config = &state.tx_sender.0.sender_config;
 
         let api_contracts = ApiContracts::load_from_disk();

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/en.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/en.rs
@@ -1,28 +1,17 @@
 use zksync_types::{api::en::SyncBlock, MiniblockNumber};
 use zksync_web3_decl::error::Web3Error;
 
-use crate::{
-    api_server::web3::{backend_jsonrpsee::internal_error, state::RpcState},
-    l1_gas_price::L1GasPriceProvider,
-};
+use crate::api_server::web3::{backend_jsonrpsee::internal_error, state::RpcState};
 
 /// Namespace for External Node unique methods.
 /// Main use case for it is the EN synchronization.
 #[derive(Debug)]
-pub struct EnNamespace<G> {
-    pub state: RpcState<G>,
+pub struct EnNamespace {
+    pub state: RpcState,
 }
 
-impl<G> Clone for EnNamespace<G> {
-    fn clone(&self) -> Self {
-        Self {
-            state: self.state.clone(),
-        }
-    }
-}
-
-impl<G: L1GasPriceProvider> EnNamespace<G> {
-    pub fn new(state: RpcState<G>) -> Self {
+impl EnNamespace {
+    pub fn new(state: RpcState) -> Self {
         Self { state }
     }
 

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/eth.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/eth.rs
@@ -17,38 +17,27 @@ use zksync_web3_decl::{
     types::{Address, Block, Filter, FilterChanges, Log, U64},
 };
 
-use crate::{
-    api_server::{
-        execution_sandbox::BlockArgs,
-        web3::{
-            backend_jsonrpsee::internal_error,
-            metrics::{BlockCallObserver, API_METRICS},
-            resolve_block,
-            state::RpcState,
-            TypedFilter,
-        },
+use crate::api_server::{
+    execution_sandbox::BlockArgs,
+    web3::{
+        backend_jsonrpsee::internal_error,
+        metrics::{BlockCallObserver, API_METRICS},
+        resolve_block,
+        state::RpcState,
+        TypedFilter,
     },
-    l1_gas_price::L1GasPriceProvider,
 };
 
 pub const EVENT_TOPIC_NUMBER_LIMIT: usize = 4;
 pub const PROTOCOL_VERSION: &str = "zks/1";
 
 #[derive(Debug)]
-pub struct EthNamespace<G> {
-    state: RpcState<G>,
+pub struct EthNamespace {
+    state: RpcState,
 }
 
-impl<G> Clone for EthNamespace<G> {
-    fn clone(&self) -> Self {
-        Self {
-            state: self.state.clone(),
-        }
-    }
-}
-
-impl<G: L1GasPriceProvider> EthNamespace<G> {
-    pub fn new(state: RpcState<G>) -> Self {
+impl EthNamespace {
+    pub fn new(state: RpcState) -> Self {
         Self { state }
     }
 
@@ -860,7 +849,7 @@ impl<G: L1GasPriceProvider> EthNamespace<G> {
 // They are moved into a separate `impl` block so they don't make the actual implementation noisy.
 // This `impl` block contains methods that we *have* to implement for compliance, but don't really
 // make sense in terms of L2.
-impl<E> EthNamespace<E> {
+impl EthNamespace {
     pub fn coinbase_impl(&self) -> Address {
         // There is no coinbase account.
         Address::default()

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/snapshots.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/snapshots.rs
@@ -4,25 +4,17 @@ use zksync_types::{
 };
 use zksync_web3_decl::error::Web3Error;
 
-use crate::{
-    api_server::web3::{backend_jsonrpsee::internal_error, metrics::API_METRICS, state::RpcState},
-    l1_gas_price::L1GasPriceProvider,
+use crate::api_server::web3::{
+    backend_jsonrpsee::internal_error, metrics::API_METRICS, state::RpcState,
 };
 
-#[derive(Debug)]
-pub struct SnapshotsNamespace<G> {
-    state: RpcState<G>,
+#[derive(Debug, Clone)]
+pub struct SnapshotsNamespace {
+    state: RpcState,
 }
 
-impl<G> Clone for SnapshotsNamespace<G> {
-    fn clone(&self) -> Self {
-        Self {
-            state: self.state.clone(),
-        }
-    }
-}
-impl<G: L1GasPriceProvider> SnapshotsNamespace<G> {
-    pub fn new(state: RpcState<G>) -> Self {
+impl SnapshotsNamespace {
+    pub fn new(state: RpcState) -> Self {
         Self { state }
     }
 

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
@@ -24,29 +24,18 @@ use zksync_web3_decl::{
     types::{Address, Token, H256},
 };
 
-use crate::{
-    api_server::{
-        tree::TreeApiClient,
-        web3::{backend_jsonrpsee::internal_error, metrics::API_METRICS, RpcState},
-    },
-    l1_gas_price::L1GasPriceProvider,
+use crate::api_server::{
+    tree::TreeApiClient,
+    web3::{backend_jsonrpsee::internal_error, metrics::API_METRICS, RpcState},
 };
 
 #[derive(Debug)]
-pub struct ZksNamespace<G> {
-    pub state: RpcState<G>,
+pub struct ZksNamespace {
+    pub state: RpcState,
 }
 
-impl<G> Clone for ZksNamespace<G> {
-    fn clone(&self) -> Self {
-        Self {
-            state: self.state.clone(),
-        }
-    }
-}
-
-impl<G: L1GasPriceProvider> ZksNamespace<G> {
-    pub fn new(state: RpcState<G>) -> Self {
+impl ZksNamespace {
+    pub fn new(state: RpcState) -> Self {
         Self { state }
     }
 

--- a/core/lib/zksync_core/src/api_server/web3/state.rs
+++ b/core/lib/zksync_core/src/api_server/web3/state.rs
@@ -152,35 +152,18 @@ impl SealedMiniblockNumber {
 }
 
 /// Holder for the data required for the API to be functional.
-#[derive(Debug)]
-pub struct RpcState<E> {
+#[derive(Debug, Clone)]
+pub struct RpcState {
     pub(crate) installed_filters: Arc<Mutex<Filters>>,
     pub connection_pool: ConnectionPool,
     pub tree_api: Option<TreeApiHttpClient>,
-    pub tx_sender: TxSender<E>,
+    pub tx_sender: TxSender,
     pub sync_state: Option<SyncState>,
     pub(super) api_config: InternalApiConfig,
     pub(super) last_sealed_miniblock: SealedMiniblockNumber,
 }
 
-// Custom implementation is required due to generic param:
-// Even though it's under `Arc`, compiler doesn't generate the `Clone` implementation unless
-// an unnecessary bound is added.
-impl<E> Clone for RpcState<E> {
-    fn clone(&self) -> Self {
-        Self {
-            installed_filters: self.installed_filters.clone(),
-            connection_pool: self.connection_pool.clone(),
-            tx_sender: self.tx_sender.clone(),
-            tree_api: self.tree_api.clone(),
-            sync_state: self.sync_state.clone(),
-            api_config: self.api_config.clone(),
-            last_sealed_miniblock: self.last_sealed_miniblock.clone(),
-        }
-    }
-}
-
-impl<E> RpcState<E> {
+impl RpcState {
     pub fn parse_transaction_bytes(&self, bytes: &[u8]) -> Result<(L2Tx, H256), Web3Error> {
         let chain_id = self.api_config.l2_chain_id;
         let (tx_request, hash) = api::TransactionRequest::from_bytes(bytes, chain_id)?;

--- a/core/lib/zksync_core/src/api_server/web3/tests/mod.rs
+++ b/core/lib/zksync_core/src/api_server/web3/tests/mod.rs
@@ -26,6 +26,7 @@ use super::{metrics::ApiTransportLabel, *};
 use crate::{
     api_server::tx_sender::TxSenderConfig,
     genesis::{ensure_genesis_state, GenesisParams},
+    l1_gas_price::L1GasPriceProvider,
     state_keeper::tests::create_l2_transaction,
 };
 
@@ -35,6 +36,7 @@ const TEST_TIMEOUT: Duration = Duration::from_secs(10);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 /// Mock [`L1GasPriceProvider`] that returns a constant value.
+#[derive(Debug)]
 struct MockL1GasPriceProvider(u64);
 
 impl L1GasPriceProvider for MockL1GasPriceProvider {

--- a/core/lib/zksync_core/src/l1_gas_price/mod.rs
+++ b/core/lib/zksync_core/src/l1_gas_price/mod.rs
@@ -1,5 +1,7 @@
 //! This module determines the fees to pay in txs containing blocks submitted to the L1.
 
+use std::fmt;
+
 pub use gas_adjuster::GasAdjuster;
 pub use main_node_fetcher::MainNodeGasPriceFetcher;
 pub use singleton::GasAdjusterSingleton;
@@ -10,7 +12,7 @@ pub mod singleton;
 
 /// Abstraction that provides information about the L1 gas price currently
 /// observed by the application.
-pub trait L1GasPriceProvider {
+pub trait L1GasPriceProvider: fmt::Debug + 'static + Send + Sync {
     /// Returns a best guess of a realistic value for the L1 gas price.
     /// Return value is in wei.
     fn estimate_effective_gas_price(&self) -> u64;

--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -1024,15 +1024,15 @@ fn build_storage_caches(
     Ok(storage_caches)
 }
 
-async fn build_tx_sender<G: L1GasPriceProvider>(
+async fn build_tx_sender(
     tx_sender_config: &TxSenderConfig,
     web3_json_config: &Web3JsonRpcConfig,
     state_keeper_config: &StateKeeperConfig,
     replica_pool: ConnectionPool,
     master_pool: ConnectionPool,
-    l1_gas_price_provider: Arc<G>,
+    l1_gas_price_provider: Arc<dyn L1GasPriceProvider>,
     storage_caches: PostgresStorageCaches,
-) -> (TxSender<G>, VmConcurrencyBarrier) {
+) -> (TxSender, VmConcurrencyBarrier) {
     let mut tx_sender_builder = TxSenderBuilder::new(tx_sender_config.clone(), replica_pool)
         .with_main_connection_pool(master_pool)
         .with_state_keeper_config(state_keeper_config.clone());

--- a/core/lib/zksync_core/src/state_keeper/io/mempool.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/mempool.rs
@@ -43,7 +43,7 @@ use crate::{
 /// Decides which batch parameters should be used for the new batch.
 /// This is an IO for the main server application.
 #[derive(Debug)]
-pub(crate) struct MempoolIO<G> {
+pub(crate) struct MempoolIO {
     mempool: MempoolGuard,
     pool: ConnectionPool,
     object_store: Box<dyn ObjectStore>,
@@ -57,7 +57,7 @@ pub(crate) struct MempoolIO<G> {
     validation_computational_gas_limit: u32,
     delay_interval: Duration,
     // Used to keep track of gas prices to set accepted price per pubdata byte in blocks.
-    l1_gas_price_provider: Arc<G>,
+    l1_gas_price_provider: Arc<dyn L1GasPriceProvider>,
     l2_erc20_bridge_addr: Address,
     chain_id: L2ChainId,
 
@@ -65,10 +65,7 @@ pub(crate) struct MempoolIO<G> {
     virtual_blocks_per_miniblock: u32,
 }
 
-impl<G> IoSealCriteria for MempoolIO<G>
-where
-    G: L1GasPriceProvider + 'static + Send + Sync,
-{
+impl IoSealCriteria for MempoolIO {
     fn should_seal_l1_batch_unconditionally(&mut self, manager: &UpdatesManager) -> bool {
         self.timeout_sealer
             .should_seal_l1_batch_unconditionally(manager)
@@ -80,10 +77,7 @@ where
 }
 
 #[async_trait]
-impl<G> StateKeeperIO for MempoolIO<G>
-where
-    G: L1GasPriceProvider + 'static + Send + Sync,
-{
+impl StateKeeperIO for MempoolIO {
     fn current_l1_batch_number(&self) -> L1BatchNumber {
         self.current_l1_batch_number
     }
@@ -401,13 +395,13 @@ async fn sleep_past(timestamp: u64, miniblock: MiniblockNumber) -> u64 {
     }
 }
 
-impl<G: L1GasPriceProvider> MempoolIO<G> {
+impl MempoolIO {
     #[allow(clippy::too_many_arguments)]
     pub(in crate::state_keeper) async fn new(
         mempool: MempoolGuard,
         object_store: Box<dyn ObjectStore>,
         miniblock_sealer_handle: MiniblockSealerHandle,
-        l1_gas_price_provider: Arc<G>,
+        l1_gas_price_provider: Arc<dyn L1GasPriceProvider>,
         pool: ConnectionPool,
         config: &StateKeeperConfig,
         delay_interval: Duration,
@@ -517,7 +511,7 @@ impl<G: L1GasPriceProvider> MempoolIO<G> {
 
 /// Getters required for testing the MempoolIO.
 #[cfg(test)]
-impl<G: L1GasPriceProvider> MempoolIO<G> {
+impl MempoolIO {
     pub(super) fn filter(&self) -> &L2TxFilter {
         &self.filter
     }

--- a/core/lib/zksync_core/src/state_keeper/io/tests/tester.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/tests/tester.rs
@@ -65,7 +65,7 @@ impl Tester {
         &self,
         pool: ConnectionPool,
         miniblock_sealer_capacity: usize,
-    ) -> (MempoolIO<GasAdjuster<MockEthereum>>, MempoolGuard) {
+    ) -> (MempoolIO, MempoolGuard) {
         let gas_adjuster = Arc::new(self.create_gas_adjuster().await);
         let mempool = MempoolGuard::new(PriorityOpId(0), 100);
         let (miniblock_sealer, miniblock_sealer_handle) =

--- a/core/lib/zksync_core/src/state_keeper/mempool_actor.rs
+++ b/core/lib/zksync_core/src/state_keeper/mempool_actor.rs
@@ -12,8 +12,8 @@ use crate::l1_gas_price::L1GasPriceProvider;
 /// Creates a mempool filter for L2 transactions based on the current L1 gas price.
 /// The filter is used to filter out transactions from the mempool that do not cover expenses
 /// to process them.
-pub fn l2_tx_filter<G: L1GasPriceProvider>(
-    gas_price_provider: &G,
+pub fn l2_tx_filter(
+    gas_price_provider: &dyn L1GasPriceProvider,
     fair_l2_gas_price: u64,
 ) -> L2TxFilter {
     let effective_gas_price = gas_price_provider.estimate_effective_gas_price();

--- a/core/lib/zksync_core/src/state_keeper/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/mod.rs
@@ -33,7 +33,7 @@ pub(crate) mod types;
 pub(crate) mod updates;
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn create_state_keeper<G>(
+pub(crate) async fn create_state_keeper(
     contracts_config: &ContractsConfig,
     state_keeper_config: StateKeeperConfig,
     db_config: &DBConfig,
@@ -41,14 +41,11 @@ pub(crate) async fn create_state_keeper<G>(
     mempool_config: &MempoolConfig,
     pool: ConnectionPool,
     mempool: MempoolGuard,
-    l1_gas_price_provider: Arc<G>,
+    l1_gas_price_provider: Arc<dyn L1GasPriceProvider>,
     miniblock_sealer_handle: MiniblockSealerHandle,
     object_store: Box<dyn ObjectStore>,
     stop_receiver: watch::Receiver<bool>,
-) -> ZkSyncStateKeeper
-where
-    G: L1GasPriceProvider + 'static + Send + Sync,
-{
+) -> ZkSyncStateKeeper {
     assert!(
         state_keeper_config.transaction_slots <= MAX_TXS_IN_BLOCK,
         "Configured transaction_slots ({}) must be lower than the bootloader constant MAX_TXS_IN_BLOCK={}",


### PR DESCRIPTION
## What ❔

- Replaces uses of `G: L1GasPriceProvider` with `dyn L1GasPriceProvider`.
- ...as a result, `StateKeeper` and `TxSender` (and thus all the API structures) are now generic-free.

## Why ❔

- Prerequisite for modular system (generic types are hard for dynamically-configured setup).
- Invoking `L1GasPriceProvider` is not related to any hot loops where dynamic dispatch would be noticeable, so having it as a generic is kinda meaningless anyways.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
