### PR TITLE
feat(eth_sender): Remove generic bounds on L1TxParamsProvider in EthSender

### DIFF
--- a/core/lib/zksync_core/src/eth_sender/eth_tx_aggregator.rs
+++ b/core/lib/zksync_core/src/eth_sender/eth_tx_aggregator.rs
@@ -295,7 +295,6 @@ impl<E: BoundEthInterface> EthTxAggregator<E> {
     /// Loads current verifier config on L1
     async fn get_recursion_scheduler_level_vk_hash(
         &mut self,
-
         verifier_address: Address,
         contracts_are_pre_boojum: bool,
     ) -> Result<H256, ETHSenderError> {

--- a/core/lib/zksync_core/src/eth_sender/eth_tx_manager.rs
+++ b/core/lib/zksync_core/src/eth_sender/eth_tx_manager.rs
@@ -48,18 +48,21 @@ pub(super) struct L1BlockNumbers {
 /// Based on eth_tx_history queue the component can mark txs as stuck and create the new attempt
 /// with higher gas price
 #[derive(Debug)]
-pub struct EthTxManager<E, G> {
+pub struct EthTxManager<E> {
     ethereum_gateway: E,
     config: SenderConfig,
-    gas_adjuster: Arc<G>,
+    gas_adjuster: Arc<dyn L1TxParamsProvider>,
 }
 
-impl<E, G> EthTxManager<E, G>
+impl<E> EthTxManager<E>
 where
     E: BoundEthInterface + Sync,
-    G: L1TxParamsProvider,
 {
-    pub fn new(config: SenderConfig, gas_adjuster: Arc<G>, ethereum_gateway: E) -> Self {
+    pub fn new(
+        config: SenderConfig,
+        gas_adjuster: Arc<dyn L1TxParamsProvider>,
+        ethereum_gateway: E,
+    ) -> Self {
         Self {
             ethereum_gateway,
             config,

--- a/core/lib/zksync_core/src/eth_sender/tests.rs
+++ b/core/lib/zksync_core/src/eth_sender/tests.rs
@@ -53,7 +53,7 @@ struct EthSenderTester {
     conn: ConnectionPool,
     gateway: Arc<MockEthereum>,
     manager: MockEthTxManager,
-    aggregator: EthTxAggregator,
+    aggregator: EthTxAggregator<Arc<MockEthereum>>,
     gas_adjuster: Arc<GasAdjuster<Arc<MockEthereum>>>,
 }
 
@@ -113,6 +113,7 @@ impl EthSenderTester {
                 aggregator_config.clone(),
                 store_factory.create_store().await,
             ),
+            gateway.clone(),
             // zkSync contract address
             Address::random(),
             contracts_config.l1_multicall3_addr,
@@ -859,7 +860,7 @@ async fn test_parse_multicall_data() {
 async fn get_multicall_data() {
     let connection_pool = ConnectionPool::test_pool().await;
     let mut tester = EthSenderTester::new(connection_pool, vec![100; 100], false).await;
-    let multicall_data = tester.aggregator.get_multicall_data(&tester.gateway).await;
+    let multicall_data = tester.aggregator.get_multicall_data().await;
     assert!(multicall_data.is_ok());
 }
 

--- a/core/lib/zksync_core/src/eth_sender/tests.rs
+++ b/core/lib/zksync_core/src/eth_sender/tests.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 
 // Alias to conveniently call static methods of ETHSender.
-type MockEthTxManager = EthTxManager<Arc<MockEthereum>, GasAdjuster<Arc<MockEthereum>>>;
+type MockEthTxManager = EthTxManager<Arc<MockEthereum>>;
 
 static DUMMY_OPERATION: Lazy<AggregatedOperation> = Lazy::new(|| {
     AggregatedOperation::Execute(L1BatchExecuteOperation {

--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -558,16 +558,15 @@ pub async fn initialize_components(
                 eth_sender.sender.clone(),
                 store_factory.create_store().await,
             ),
+            eth_client,
             contracts_config.validator_timelock_addr,
             contracts_config.l1_multicall3_addr,
             main_zksync_contract_address,
             nonce.as_u64(),
         );
-        task_futures.push(tokio::spawn(eth_tx_aggregator_actor.run(
-            eth_sender_pool,
-            eth_client,
-            stop_receiver.clone(),
-        )));
+        task_futures.push(tokio::spawn(
+            eth_tx_aggregator_actor.run(eth_sender_pool, stop_receiver.clone()),
+        ));
         let elapsed = started_at.elapsed();
         APP_METRICS.init_latency[&InitStage::EthTxAggregator].set(elapsed);
         tracing::info!("initialized ETH-TxAggregator in {elapsed:?}");


### PR DESCRIPTION
## What ❔

Follow-up to https://github.com/matter-labs/zksync-era/pull/792 

## Why ❔

Same reasons

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
