### PR TITLE
chore(eth sender): Modify Default Gas Estimation Values

### DIFF
--- a/etc/env/base/eth_sender.toml
+++ b/etc/env/base/eth_sender.toml
@@ -38,7 +38,7 @@ aggregated_proof_sizes=[1,4]
 # for now (should be > 4kk which is max gas for one block commit/verify/execute)
 max_aggregated_tx_gas=4000000
 
-# Max gas that can used to include single block in aggregated operation
+# Max gas that can be used to include single block in aggregated operation
 max_single_tx_gas=6000000
 
 # Max acceptable fee for sending tx to L1
@@ -57,8 +57,8 @@ max_base_fee_samples=10_000
 # 2. base_fee_median * A * B ^ time_in_mempool
 # Currently the second is used.
 # To confirm, see core/bin/zksync_core/src/eth_sender/gas_adjuster/mod.rs
-pricing_formula_parameter_a=1.5
-pricing_formula_parameter_b=1.0005
+pricing_formula_parameter_a=2
+pricing_formula_parameter_b=1.001
 internal_l1_pricing_multiplier=0.8
 # Node polling period in seconds.
 poll_period=5


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

This PR changes the default values of the parameters responsible for gas estimations.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

During times of congestion, hyperchains operators have been running into `replacement transaction underpriced` errors. The new params will be less frugal in estimating gas which seems like the better choice for testnets.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
