### PR TITLE
refactor(state_keeper): Abstract ConditionalSealer

### DIFF
--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -23,8 +23,8 @@ use zksync_core::{
     reorg_detector::ReorgDetector,
     setup_sigint_handler,
     state_keeper::{
-        L1BatchExecutorBuilder, MainBatchExecutorBuilder, MiniblockSealer, MiniblockSealerHandle,
-        ZkSyncStateKeeper,
+        seal_criteria::NoopSealer, L1BatchExecutorBuilder, MainBatchExecutorBuilder,
+        MiniblockSealer, MiniblockSealerHandle, ZkSyncStateKeeper,
     },
     sync_layer::{
         batch_status_updater::BatchStatusUpdater, external_io::ExternalIO, fetcher::FetcherCursor,
@@ -92,7 +92,12 @@ async fn build_state_keeper(
     )
     .await;
 
-    ZkSyncStateKeeper::without_sealer(stop_receiver, Box::new(io), batch_executor_base)
+    ZkSyncStateKeeper::new(
+        stop_receiver,
+        Box::new(io),
+        batch_executor_base,
+        Box::new(NoopSealer),
+    )
 }
 
 async fn init_tasks(

--- a/core/lib/zksync_core/src/consensus/testonly.rs
+++ b/core/lib/zksync_core/src/consensus/testonly.rs
@@ -12,6 +12,7 @@ use zksync_types::{
 use crate::{
     genesis::{ensure_genesis_state, GenesisParams},
     state_keeper::{
+        seal_criteria::NoopSealer,
         tests::{create_l1_batch_metadata, create_l2_transaction, MockBatchExecutorBuilder},
         MiniblockSealer, ZkSyncStateKeeper,
     },
@@ -354,10 +355,11 @@ impl StateKeeperRunner {
             s.spawn_bg(miniblock_sealer.run());
             s.spawn_bg(run_mock_metadata_calculator(ctx, pool.clone()));
             s.spawn_bg(
-                ZkSyncStateKeeper::without_sealer(
+                ZkSyncStateKeeper::new(
                     stop_receiver,
                     Box::new(io),
                     Box::new(MockBatchExecutorBuilder),
+                    Box::new(NoopSealer),
                 )
                 .run(),
             );

--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -70,7 +70,9 @@ use crate::{
         MetadataCalculator, MetadataCalculatorConfig, MetadataCalculatorModeConfig,
     },
     metrics::{InitStage, APP_METRICS},
-    state_keeper::{create_state_keeper, MempoolFetcher, MempoolGuard, MiniblockSealer},
+    state_keeper::{
+        create_state_keeper, MempoolFetcher, MempoolGuard, MiniblockSealer, SequencerSealer,
+    },
 };
 
 pub mod api_server;
@@ -1033,9 +1035,10 @@ async fn build_tx_sender(
     l1_gas_price_provider: Arc<dyn L1GasPriceProvider>,
     storage_caches: PostgresStorageCaches,
 ) -> (TxSender, VmConcurrencyBarrier) {
+    let sequencer_sealer = SequencerSealer::new(state_keeper_config.clone());
     let tx_sender_builder = TxSenderBuilder::new(tx_sender_config.clone(), replica_pool)
         .with_main_connection_pool(master_pool)
-        .with_state_keeper_config(state_keeper_config.clone());
+        .with_sealer(Arc::new(sequencer_sealer));
 
     let max_concurrency = web3_json_config.vm_concurrency_limit();
     let (vm_concurrency_limiter, vm_barrier) = VmConcurrencyLimiter::new(max_concurrency);

--- a/core/lib/zksync_core/src/state_keeper/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/mod.rs
@@ -16,7 +16,7 @@ pub use self::{
     keeper::ZkSyncStateKeeper,
 };
 pub(crate) use self::{
-    mempool_actor::MempoolFetcher, seal_criteria::ConditionalSealer, types::MempoolGuard,
+    mempool_actor::MempoolFetcher, seal_criteria::SequencerSealer, types::MempoolGuard,
 };
 use crate::l1_gas_price::L1GasPriceProvider;
 
@@ -26,7 +26,7 @@ pub(crate) mod io;
 mod keeper;
 mod mempool_actor;
 pub(crate) mod metrics;
-pub(crate) mod seal_criteria;
+pub mod seal_criteria;
 #[cfg(test)]
 pub(crate) mod tests;
 pub(crate) mod types;
@@ -76,11 +76,11 @@ pub(crate) async fn create_state_keeper(
     )
     .await;
 
-    let sealer = ConditionalSealer::new(state_keeper_config);
+    let sealer = SequencerSealer::new(state_keeper_config);
     ZkSyncStateKeeper::new(
         stop_receiver,
         Box::new(io),
         Box::new(batch_executor_base),
-        sealer,
+        Box::new(sealer),
     )
 }

--- a/core/lib/zksync_core/src/state_keeper/seal_criteria/conditional_sealer.rs
+++ b/core/lib/zksync_core/src/state_keeper/seal_criteria/conditional_sealer.rs
@@ -1,7 +1,10 @@
 //! This module represents the conditional sealer, which can decide whether the batch
 //! should be sealed after executing a particular transaction.
-//! It is used on the main node to decide when the batch should be sealed (as opposed to the external node,
-//! which unconditionally follows the instructions from the main node).
+//!
+//! The conditional sealer abstraction allows to implement different sealing strategies, e.g. the actual
+//! sealing strategy for the main node or noop sealer for the external node.
+
+use std::fmt;
 
 use zksync_config::configs::chain::StateKeeperConfig;
 use zksync_types::ProtocolVersionId;
@@ -9,28 +12,51 @@ use zksync_types::ProtocolVersionId;
 use super::{criteria, SealCriterion, SealData, SealResolution, AGGREGATION_METRICS};
 
 /// Checks if an L1 batch should be sealed after executing a transaction.
+pub trait ConditionalSealer: 'static + fmt::Debug + Send + Sync {
+    /// Finds a reason why a transaction with the specified `data` is unexecutable.
+    ///
+    /// Can be used to determine whether the transaction can be executed by the sequencer.
+    fn find_unexecutable_reason(
+        &self,
+        data: &SealData,
+        protocol_version: ProtocolVersionId,
+    ) -> Option<&'static str>;
+
+    /// Returns the action that should be taken by the state keeper after executing a transaction.
+    fn should_seal_l1_batch(
+        &self,
+        l1_batch_number: u32,
+        block_open_timestamp_ms: u128,
+        tx_count: usize,
+        block_data: &SealData,
+        tx_data: &SealData,
+        protocol_version: ProtocolVersionId,
+    ) -> SealResolution;
+}
+
+/// Implementation of [`ConditionalSealer`] used by the main node.
+/// Internally uses a set of [`SealCriterion`]s to determine whether the batch should be sealed.
 ///
 /// The checks are deterministic, i.e., should depend solely on execution metrics and [`StateKeeperConfig`].
 /// Non-deterministic seal criteria are expressed using [`IoSealCriteria`](super::IoSealCriteria).
 #[derive(Debug)]
-pub struct ConditionalSealer {
+pub struct SequencerSealer {
     config: StateKeeperConfig,
     sealers: Vec<Box<dyn SealCriterion>>,
 }
 
-impl ConditionalSealer {
-    /// Finds a reason why a transaction with the specified `data` is unexecutable.
-    pub(crate) fn find_unexecutable_reason(
-        config: &StateKeeperConfig,
+impl ConditionalSealer for SequencerSealer {
+    fn find_unexecutable_reason(
+        &self,
         data: &SealData,
         protocol_version: ProtocolVersionId,
     ) -> Option<&'static str> {
-        for sealer in &Self::default_sealers() {
+        for sealer in &self.sealers {
             const MOCK_BLOCK_TIMESTAMP: u128 = 0;
             const TX_COUNT: usize = 1;
 
             let resolution = sealer.should_seal(
-                config,
+                &self.config,
                 MOCK_BLOCK_TIMESTAMP,
                 TX_COUNT,
                 data,
@@ -44,20 +70,7 @@ impl ConditionalSealer {
         None
     }
 
-    pub(crate) fn new(config: StateKeeperConfig) -> Self {
-        let sealers = Self::default_sealers();
-        Self { config, sealers }
-    }
-
-    #[cfg(test)]
-    pub(in crate::state_keeper) fn with_sealers(
-        config: StateKeeperConfig,
-        sealers: Vec<Box<dyn SealCriterion>>,
-    ) -> Self {
-        Self { config, sealers }
-    }
-
-    pub fn should_seal_l1_batch(
+    fn should_seal_l1_batch(
         &self,
         l1_batch_number: u32,
         block_open_timestamp_ms: u128,
@@ -99,6 +112,21 @@ impl ConditionalSealer {
         }
         final_seal_resolution
     }
+}
+
+impl SequencerSealer {
+    pub(crate) fn new(config: StateKeeperConfig) -> Self {
+        let sealers = Self::default_sealers();
+        Self { config, sealers }
+    }
+
+    #[cfg(test)]
+    pub(in crate::state_keeper) fn with_sealers(
+        config: StateKeeperConfig,
+        sealers: Vec<Box<dyn SealCriterion>>,
+    ) -> Self {
+        Self { config, sealers }
+    }
 
     fn default_sealers() -> Vec<Box<dyn SealCriterion>> {
         vec![
@@ -112,5 +140,33 @@ impl ConditionalSealer {
             Box::new(criteria::TxEncodingSizeCriterion),
             Box::new(criteria::L2ToL1LogsCriterion),
         ]
+    }
+}
+
+/// Implementation of [`ConditionalSealer`] that never seals the batch.
+/// Can be used in contexts where, for example, state keeper configuration is not available,
+/// or the decision to seal batch is taken by some other component.
+#[derive(Debug)]
+pub struct NoopSealer;
+
+impl ConditionalSealer for NoopSealer {
+    fn find_unexecutable_reason(
+        &self,
+        _data: &SealData,
+        _protocol_version: ProtocolVersionId,
+    ) -> Option<&'static str> {
+        None
+    }
+
+    fn should_seal_l1_batch(
+        &self,
+        _l1_batch_number: u32,
+        _block_open_timestamp_ms: u128,
+        _tx_count: usize,
+        _block_data: &SealData,
+        _tx_data: &SealData,
+        _protocol_version: ProtocolVersionId,
+    ) -> SealResolution {
+        SealResolution::NoSeal
     }
 }

--- a/core/lib/zksync_core/src/state_keeper/seal_criteria/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/seal_criteria/mod.rs
@@ -25,7 +25,7 @@ use zksync_utils::time::millis_since;
 mod conditional_sealer;
 pub(super) mod criteria;
 
-pub(crate) use self::conditional_sealer::ConditionalSealer;
+pub use self::conditional_sealer::{ConditionalSealer, NoopSealer, SequencerSealer};
 use super::{extractors, metrics::AGGREGATION_METRICS, updates::UpdatesManager};
 use crate::gas_tracker::{gas_count_from_tx_and_metrics, gas_count_from_writes};
 
@@ -104,7 +104,7 @@ impl SealData {
     }
 }
 
-pub(super) trait SealCriterion: fmt::Debug + Send + 'static {
+pub(super) trait SealCriterion: fmt::Debug + Send + Sync + 'static {
     fn should_seal(
         &self,
         config: &StateKeeperConfig,

--- a/core/lib/zksync_core/src/state_keeper/tests/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/tests/mod.rs
@@ -42,7 +42,7 @@ use crate::{
         keeper::POLL_WAIT_DURATION,
         seal_criteria::{
             criteria::{GasCriterion, SlotsCriterion},
-            ConditionalSealer,
+            SequencerSealer,
         },
         types::ExecutionMetricsForCriteria,
         updates::UpdatesManager,
@@ -250,7 +250,7 @@ async fn sealed_by_number_of_txs() {
         transaction_slots: 2,
         ..StateKeeperConfig::default()
     };
-    let sealer = ConditionalSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
+    let sealer = SequencerSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
 
     TestScenario::new()
         .seal_miniblock_when(|updates| updates.miniblock.executed_transactions.len() == 1)
@@ -271,7 +271,7 @@ async fn sealed_by_gas() {
         close_block_at_gas_percentage: 0.5,
         ..StateKeeperConfig::default()
     };
-    let sealer = ConditionalSealer::with_sealers(config, vec![Box::new(GasCriterion)]);
+    let sealer = SequencerSealer::with_sealers(config, vec![Box::new(GasCriterion)]);
 
     let l1_gas_per_tx = BlockGasCount {
         commit: 1, // Both txs together with block_base_cost would bring it over the block 31_001 commit bound.
@@ -320,7 +320,7 @@ async fn sealed_by_gas_then_by_num_tx() {
         transaction_slots: 3,
         ..StateKeeperConfig::default()
     };
-    let sealer = ConditionalSealer::with_sealers(
+    let sealer = SequencerSealer::with_sealers(
         config,
         vec![Box::new(GasCriterion), Box::new(SlotsCriterion)],
     );
@@ -357,7 +357,7 @@ async fn batch_sealed_before_miniblock_does() {
         transaction_slots: 2,
         ..StateKeeperConfig::default()
     };
-    let sealer = ConditionalSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
+    let sealer = SequencerSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
 
     // Miniblock sealer will not return true before the batch is sealed because the batch only has 2 txs.
     TestScenario::new()
@@ -382,7 +382,7 @@ async fn rejected_tx() {
         transaction_slots: 2,
         ..StateKeeperConfig::default()
     };
-    let sealer = ConditionalSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
+    let sealer = SequencerSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
 
     let rejected_tx = random_tx(1);
     TestScenario::new()
@@ -404,7 +404,7 @@ async fn bootloader_tip_out_of_gas_flow() {
         transaction_slots: 2,
         ..StateKeeperConfig::default()
     };
-    let sealer = ConditionalSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
+    let sealer = SequencerSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
 
     let first_tx = random_tx(1);
     let bootloader_out_of_gas_tx = random_tx(2);
@@ -442,7 +442,7 @@ async fn pending_batch_is_applied() {
         transaction_slots: 3,
         ..StateKeeperConfig::default()
     };
-    let sealer = ConditionalSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
+    let sealer = SequencerSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
 
     let pending_batch = pending_batch_data(vec![
         MiniblockExecutionData {
@@ -500,7 +500,7 @@ async fn unconditional_sealing() {
         transaction_slots: 2,
         ..StateKeeperConfig::default()
     };
-    let sealer = ConditionalSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
+    let sealer = SequencerSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
 
     TestScenario::new()
         .seal_l1_batch_when(move |_| batch_seal_trigger_checker.load(Ordering::Relaxed))
@@ -530,7 +530,7 @@ async fn miniblock_timestamp_after_pending_batch() {
         transaction_slots: 2,
         ..StateKeeperConfig::default()
     };
-    let sealer = ConditionalSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
+    let sealer = SequencerSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
 
     let pending_batch = pending_batch_data(vec![MiniblockExecutionData {
         number: MiniblockNumber(1),
@@ -574,7 +574,7 @@ async fn time_is_monotonic() {
         transaction_slots: 2,
         ..StateKeeperConfig::default()
     };
-    let sealer = ConditionalSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
+    let sealer = SequencerSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
 
     TestScenario::new()
         .seal_miniblock_when(|updates| updates.miniblock.executed_transactions.len() == 1)
@@ -625,7 +625,7 @@ async fn protocol_upgrade() {
         transaction_slots: 2,
         ..StateKeeperConfig::default()
     };
-    let sealer = ConditionalSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
+    let sealer = SequencerSealer::with_sealers(config, vec![Box::new(SlotsCriterion)]);
 
     TestScenario::new()
         .seal_miniblock_when(|updates| updates.miniblock.executed_transactions.len() == 1)

--- a/core/lib/zksync_core/src/state_keeper/tests/tester.rs
+++ b/core/lib/zksync_core/src/state_keeper/tests/tester.rs
@@ -23,7 +23,7 @@ use zksync_types::{
 use crate::state_keeper::{
     batch_executor::{BatchExecutorHandle, Command, L1BatchExecutorBuilder, TxExecutionResult},
     io::{MiniblockParams, PendingBatchData, StateKeeperIO},
-    seal_criteria::{ConditionalSealer, IoSealCriteria},
+    seal_criteria::{IoSealCriteria, SequencerSealer},
     tests::{
         create_l2_transaction, default_l1_batch_env, default_vm_block_result, BASE_SYSTEM_CONTRACTS,
     },
@@ -189,7 +189,7 @@ impl TestScenario {
 
     /// Launches the test.
     /// Provided `SealManager` is expected to be externally configured to adhere the written scenario logic.
-    pub(crate) async fn run(self, sealer: ConditionalSealer) {
+    pub(crate) async fn run(self, sealer: SequencerSealer) {
         assert!(!self.actions.is_empty(), "Test scenario can't be empty");
 
         let batch_executor_base = TestBatchExecutorBuilder::new(&self);
@@ -199,7 +199,7 @@ impl TestScenario {
             stop_receiver,
             Box::new(io),
             Box::new(batch_executor_base),
-            sealer,
+            Box::new(sealer),
         );
         let sk_thread = tokio::spawn(sk.run());
 

--- a/core/lib/zksync_core/src/sync_layer/tests.rs
+++ b/core/lib/zksync_core/src/sync_layer/tests.rs
@@ -19,6 +19,7 @@ use crate::{
     consensus::testonly::MockMainNodeClient,
     genesis::{ensure_genesis_state, GenesisParams},
     state_keeper::{
+        seal_criteria::NoopSealer,
         tests::{create_l1_batch_metadata, create_l2_transaction, TestBatchExecutorBuilder},
         MiniblockSealer, ZkSyncStateKeeper,
     },
@@ -77,10 +78,11 @@ impl StateKeeperHandles {
             batch_executor_base.push_successful_transactions(tx_hashes_in_l1_batch);
         }
 
-        let state_keeper = ZkSyncStateKeeper::without_sealer(
+        let state_keeper = ZkSyncStateKeeper::new(
             stop_receiver,
             Box::new(io),
             Box::new(batch_executor_base),
+            Box::new(NoopSealer),
         );
         Self {
             stop_sender,

--- a/spellcheck/era.dic
+++ b/spellcheck/era.dic
@@ -608,3 +608,4 @@ codebase
 compactions
 M6
 compiler_common
+noop


### PR DESCRIPTION
## What ❔

Defines a new trait: `ConditionalSealer` and provides two implementations: `SequencerSealer` and `NoopSealer`.

## Why ❔

- Prerequisite for ZK Stack configuration system.
- Leaves a single constructor for the state keeper.
- Removes `StateKeeperConfig` use from `TxSender`.
- Potentially makes it possible to create `ConditionalSealer` that contains some kind of sealing logic but does not rely on `StateKeeperConfig`.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
