### PR TITLE
refactor(metadata_calculator): Make config owned

### DIFF
--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -181,11 +181,9 @@ async fn init_tasks(
         stop_receiver.clone(),
     );
 
-    let metadata_calculator = MetadataCalculator::new(&MetadataCalculatorConfig {
-        db_path: &config.required.merkle_tree_path,
-        mode: MetadataCalculatorModeConfig::Full {
-            store_factory: None,
-        },
+    let metadata_calculator = MetadataCalculator::new(MetadataCalculatorConfig {
+        db_path: config.required.merkle_tree_path.clone(),
+        mode: MetadataCalculatorModeConfig::Full { object_store: None },
         delay_interval: config.optional.metadata_calculator_delay(),
         max_l1_batches_per_iter: config.optional.max_l1_batches_per_tree_iter,
         multi_get_chunk_size: config.optional.merkle_tree_multi_get_chunk_size,

--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -774,7 +774,7 @@ async fn add_trees_to_task_futures(
     let mode = match db_config.merkle_tree.mode {
         MerkleTreeMode::Lightweight => MetadataCalculatorModeConfig::Lightweight,
         MerkleTreeMode::Full => MetadataCalculatorModeConfig::Full {
-            store_factory: Some(store_factory),
+            object_store: Some(store_factory.create_store().await),
         },
     };
 
@@ -800,7 +800,7 @@ async fn run_tree(
     db_config: &DBConfig,
     api_config: Option<&MerkleTreeApiConfig>,
     operation_manager: &OperationsManagerConfig,
-    mode: MetadataCalculatorModeConfig<'_>,
+    mode: MetadataCalculatorModeConfig,
     stop_receiver: watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
     let started_at = Instant::now();
@@ -813,7 +813,7 @@ async fn run_tree(
 
     let config =
         MetadataCalculatorConfig::for_main_node(&db_config.merkle_tree, operation_manager, mode);
-    let metadata_calculator = MetadataCalculator::new(&config).await;
+    let metadata_calculator = MetadataCalculator::new(config).await;
     if let Some(api_config) = api_config {
         let address = (Ipv4Addr::UNSPECIFIED, api_config.port).into();
         let tree_reader = metadata_calculator.tree_reader();

--- a/core/lib/zksync_core/src/metadata_calculator/mod.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/mod.rs
@@ -14,7 +14,7 @@ use zksync_config::configs::{
 use zksync_dal::{ConnectionPool, StorageProcessor};
 use zksync_health_check::{HealthUpdater, ReactiveHealthCheck};
 use zksync_merkle_tree::domain::TreeMetadata;
-use zksync_object_store::{ObjectStore, ObjectStoreFactory};
+use zksync_object_store::ObjectStore;
 use zksync_types::{
     block::L1BatchHeader,
     commitment::{L1BatchCommitment, L1BatchMetadata},
@@ -37,20 +37,20 @@ pub(crate) mod tests;
 mod updater;
 
 /// Part of [`MetadataCalculator`] related to the operation mode of the Merkle tree.
-#[derive(Debug, Clone, Copy)]
-pub enum MetadataCalculatorModeConfig<'a> {
+#[derive(Debug)]
+pub enum MetadataCalculatorModeConfig {
     /// In this mode, `MetadataCalculator` computes Merkle tree root hashes and some auxiliary information
     /// for L1 batches, but not witness inputs.
     Lightweight,
     /// In this mode, `MetadataCalculator` will compute commitments and witness inputs for all storage operations
-    /// and optionally put witness inputs into the object store as provided by `store_factory` (e.g., GCS).
+    /// and optionally put witness inputs into the object store (e.g., GCS).
     Full {
-        store_factory: Option<&'a ObjectStoreFactory>,
+        object_store: Option<Box<dyn ObjectStore>>,
     },
 }
 
-impl MetadataCalculatorModeConfig<'_> {
-    fn to_mode(self) -> MerkleTreeMode {
+impl MetadataCalculatorModeConfig {
+    fn to_mode(&self) -> MerkleTreeMode {
         if matches!(self, Self::Full { .. }) {
             MerkleTreeMode::Full
         } else {
@@ -61,11 +61,11 @@ impl MetadataCalculatorModeConfig<'_> {
 
 /// Configuration of [`MetadataCalculator`].
 #[derive(Debug)]
-pub struct MetadataCalculatorConfig<'a> {
+pub struct MetadataCalculatorConfig {
     /// Filesystem path to the RocksDB instance that stores the tree.
-    pub db_path: &'a str,
+    pub db_path: String,
     /// Configuration of the Merkle tree mode.
-    pub mode: MetadataCalculatorModeConfig<'a>,
+    pub mode: MetadataCalculatorModeConfig,
     /// Interval between polling Postgres for updates if no progress was made by the tree.
     pub delay_interval: Duration,
     /// Maximum number of L1 batches to get from Postgres on a single update iteration.
@@ -82,14 +82,14 @@ pub struct MetadataCalculatorConfig<'a> {
     pub stalled_writes_timeout: Duration,
 }
 
-impl<'a> MetadataCalculatorConfig<'a> {
+impl MetadataCalculatorConfig {
     pub(crate) fn for_main_node(
-        merkle_tree_config: &'a MerkleTreeConfig,
-        operation_config: &'a OperationsManagerConfig,
-        mode: MetadataCalculatorModeConfig<'a>,
+        merkle_tree_config: &MerkleTreeConfig,
+        operation_config: &OperationsManagerConfig,
+        mode: MetadataCalculatorModeConfig,
     ) -> Self {
         Self {
-            db_path: &merkle_tree_config.path,
+            db_path: merkle_tree_config.path.clone(),
             mode,
             delay_interval: operation_config.delay_interval(),
             max_l1_batches_per_iter: merkle_tree_config.max_l1_batches_per_iter,
@@ -113,7 +113,7 @@ pub struct MetadataCalculator {
 
 impl MetadataCalculator {
     /// Creates a calculator with the specified `config`.
-    pub async fn new(config: &MetadataCalculatorConfig<'_>) -> Self {
+    pub async fn new(config: MetadataCalculatorConfig) -> Self {
         assert!(
             config.max_l1_batches_per_iter > 0,
             "Maximum L1 batches per iteration is misconfigured to be 0; please update it to positive value"
@@ -121,15 +121,12 @@ impl MetadataCalculator {
 
         let mode = config.mode.to_mode();
         let object_store = match config.mode {
-            MetadataCalculatorModeConfig::Full { store_factory } => match store_factory {
-                Some(f) => Some(f.create_store().await),
-                None => None,
-            },
+            MetadataCalculatorModeConfig::Full { object_store } => object_store,
             MetadataCalculatorModeConfig::Lightweight => None,
         };
 
         let db = create_db(
-            config.db_path.into(),
+            config.db_path.clone().into(),
             config.block_cache_capacity,
             config.memtable_capacity,
             config.stalled_writes_timeout,

--- a/core/lib/zksync_core/src/metadata_calculator/recovery/tests.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/recovery/tests.rs
@@ -294,7 +294,7 @@ async fn entire_recovery_workflow(case: RecoveryWorkflowCase) {
         &OperationsManagerConfig { delay_interval: 50 },
         MetadataCalculatorModeConfig::Lightweight,
     );
-    let mut calculator = MetadataCalculator::new(&calculator_config).await;
+    let mut calculator = MetadataCalculator::new(calculator_config).await;
     let (delay_sx, mut delay_rx) = mpsc::unbounded_channel();
     calculator.delayer.delay_notifier = delay_sx;
 

--- a/core/lib/zksync_core/src/metadata_calculator/tests.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/tests.rs
@@ -363,10 +363,11 @@ pub(crate) async fn setup_calculator(
     db_path: &Path,
     pool: &ConnectionPool,
 ) -> (MetadataCalculator, Box<dyn ObjectStore>) {
-    let store_factory = &ObjectStoreFactory::mock();
+    let store_factory = ObjectStoreFactory::mock();
+    let store = store_factory.create_store().await;
     let (merkle_tree_config, operation_manager) = create_config(db_path);
     let mode = MetadataCalculatorModeConfig::Full {
-        store_factory: Some(store_factory),
+        object_store: Some(store),
     };
     let calculator =
         setup_calculator_with_options(&merkle_tree_config, &operation_manager, pool, mode).await;
@@ -395,11 +396,11 @@ async fn setup_calculator_with_options(
     merkle_tree_config: &MerkleTreeConfig,
     operation_config: &OperationsManagerConfig,
     pool: &ConnectionPool,
-    mode: MetadataCalculatorModeConfig<'_>,
+    mode: MetadataCalculatorModeConfig,
 ) -> MetadataCalculator {
     let calculator_config =
         MetadataCalculatorConfig::for_main_node(merkle_tree_config, operation_config, mode);
-    let metadata_calculator = MetadataCalculator::new(&calculator_config).await;
+    let metadata_calculator = MetadataCalculator::new(calculator_config).await;
 
     let mut storage = pool.access_storage().await.unwrap();
     if storage.blocks_dal().is_genesis_needed().await.unwrap() {


### PR DESCRIPTION
## What ❔

Makes metadata calculator config owned + makes it use `Box<dyn ObjectStore>` instead of `ObjectStoreFactory`.

## Why ❔

- Prerequisite for ZK Stack modular thingy.
- Makes it easy to store the config object in a dynamic context.
- Makes it more abstract w.r.t. resources required for instantiation.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
