### PR TITLE
refactor: Remove generics in eth_watch and eth_sender

### DIFF
--- a/core/lib/eth_client/src/lib.rs
+++ b/core/lib/eth_client/src/lib.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use async_trait::async_trait;
 use zksync_types::{
     web3::{
-        contract::{tokens::Tokenize, Options},
+        contract::Options,
         ethabi,
         types::{
             Address, Block, BlockId, BlockNumber, Filter, Log, Transaction, TransactionReceipt,
@@ -224,13 +224,18 @@ pub trait BoundEthInterface: EthInterface {
     }
 
     /// Encodes a function using the `Self::contract()` ABI.
-    fn encode_tx_data<P: Tokenize>(&self, func: &str, params: P) -> Vec<u8> {
+    ///
+    /// `params` are tokenized parameters of the function. Most of the time, you can use
+    /// [`Tokenize`][tokenize] trait to convert the parameters into tokens.
+    ///
+    /// [tokenize]: https://docs.rs/web3/latest/web3/contract/tokens/trait.Tokenize.html
+    fn encode_tx_data(&self, func: &str, params: Vec<ethabi::Token>) -> Vec<u8> {
         let f = self
             .contract()
             .function(func)
             .expect("failed to get function parameters");
 
-        f.encode_input(&params.into_tokens())
+        f.encode_input(&params)
             .expect("failed to encode parameters")
     }
 }

--- a/core/lib/zksync_core/src/eth_sender/eth_tx_aggregator.rs
+++ b/core/lib/zksync_core/src/eth_sender/eth_tx_aggregator.rs
@@ -1,4 +1,4 @@
-use std::convert::TryInto;
+use std::{convert::TryInto, sync::Arc};
 
 use tokio::sync::watch;
 use zksync_config::configs::eth_sender::SenderConfig;
@@ -42,9 +42,9 @@ pub struct MulticallData {
 /// Such as CommitBlocks, PublishProofBlocksOnchain and ExecuteBlock
 /// These eth_txs will be used as a queue for generating signed txs and send them later
 #[derive(Debug)]
-pub struct EthTxAggregator<E> {
+pub struct EthTxAggregator {
     aggregator: Aggregator,
-    eth_client: E,
+    eth_client: Arc<dyn BoundEthInterface>,
     config: SenderConfig,
     timelock_contract_address: Address,
     l1_multicall3_address: Address,
@@ -53,11 +53,11 @@ pub struct EthTxAggregator<E> {
     base_nonce: u64,
 }
 
-impl<E: BoundEthInterface> EthTxAggregator<E> {
+impl EthTxAggregator {
     pub fn new(
         config: SenderConfig,
         aggregator: Aggregator,
-        eth_client: E,
+        eth_client: Arc<dyn BoundEthInterface>,
         timelock_contract_address: Address,
         l1_multicall3_address: Address,
         main_zksync_contract_address: Address,

--- a/core/lib/zksync_core/src/eth_sender/eth_tx_manager.rs
+++ b/core/lib/zksync_core/src/eth_sender/eth_tx_manager.rs
@@ -47,20 +47,17 @@ pub(super) struct L1BlockNumbers {
 /// Based on eth_tx_history queue the component can mark txs as stuck and create the new attempt
 /// with higher gas price
 #[derive(Debug)]
-pub struct EthTxManager<E> {
-    ethereum_gateway: E,
+pub struct EthTxManager {
+    ethereum_gateway: Arc<dyn BoundEthInterface>,
     config: SenderConfig,
     gas_adjuster: Arc<dyn L1TxParamsProvider>,
 }
 
-impl<E> EthTxManager<E>
-where
-    E: BoundEthInterface + Sync,
-{
+impl EthTxManager {
     pub fn new(
         config: SenderConfig,
         gas_adjuster: Arc<dyn L1TxParamsProvider>,
-        ethereum_gateway: E,
+        ethereum_gateway: Arc<dyn BoundEthInterface>,
     ) -> Self {
         Self {
             ethereum_gateway,

--- a/core/lib/zksync_core/src/eth_sender/tests.rs
+++ b/core/lib/zksync_core/src/eth_sender/tests.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 
 // Alias to conveniently call static methods of ETHSender.
-type MockEthTxManager = EthTxManager<Arc<MockEthereum>>;
+type MockEthTxManager = EthTxManager;
 
 static DUMMY_OPERATION: Lazy<AggregatedOperation> = Lazy::new(|| {
     AggregatedOperation::Execute(L1BatchExecuteOperation {
@@ -53,7 +53,7 @@ struct EthSenderTester {
     conn: ConnectionPool,
     gateway: Arc<MockEthereum>,
     manager: MockEthTxManager,
-    aggregator: EthTxAggregator<Arc<MockEthereum>>,
+    aggregator: EthTxAggregator,
     gas_adjuster: Arc<GasAdjuster<Arc<MockEthereum>>>,
 }
 

--- a/core/lib/zksync_core/src/eth_watch/event_processors/governance_upgrades.rs
+++ b/core/lib/zksync_core/src/eth_watch/event_processors/governance_upgrades.rs
@@ -38,11 +38,11 @@ impl GovernanceUpgradesEventProcessor {
 }
 
 #[async_trait::async_trait]
-impl<W: EthClient + Sync> EventProcessor<W> for GovernanceUpgradesEventProcessor {
+impl EventProcessor for GovernanceUpgradesEventProcessor {
     async fn process_events(
         &mut self,
         storage: &mut StorageProcessor<'_>,
-        client: &W,
+        client: &dyn EthClient,
         events: Vec<Log>,
     ) -> Result<(), Error> {
         let mut upgrades = Vec::new();

--- a/core/lib/zksync_core/src/eth_watch/event_processors/mod.rs
+++ b/core/lib/zksync_core/src/eth_watch/event_processors/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use zksync_dal::StorageProcessor;
 use zksync_types::{web3::types::Log, H256};
 
@@ -8,12 +10,12 @@ pub mod priority_ops;
 pub mod upgrades;
 
 #[async_trait::async_trait]
-pub trait EventProcessor<W: EthClient + Sync>: Send + std::fmt::Debug {
+pub trait EventProcessor: 'static + fmt::Debug + Send + Sync {
     /// Processes given events
     async fn process_events(
         &mut self,
         storage: &mut StorageProcessor<'_>,
-        client: &W,
+        client: &dyn EthClient,
         events: Vec<Log>,
     ) -> Result<(), Error>;
 

--- a/core/lib/zksync_core/src/eth_watch/event_processors/priority_ops.rs
+++ b/core/lib/zksync_core/src/eth_watch/event_processors/priority_ops.rs
@@ -33,11 +33,11 @@ impl PriorityOpsEventProcessor {
 }
 
 #[async_trait::async_trait]
-impl<W: EthClient + Sync> EventProcessor<W> for PriorityOpsEventProcessor {
+impl EventProcessor for PriorityOpsEventProcessor {
     async fn process_events(
         &mut self,
         storage: &mut StorageProcessor<'_>,
-        _client: &W,
+        _client: &dyn EthClient,
         events: Vec<Log>,
     ) -> Result<(), Error> {
         let mut priority_ops = Vec::new();

--- a/core/lib/zksync_core/src/eth_watch/event_processors/upgrades.rs
+++ b/core/lib/zksync_core/src/eth_watch/event_processors/upgrades.rs
@@ -29,11 +29,11 @@ impl UpgradesEventProcessor {
 }
 
 #[async_trait::async_trait]
-impl<W: EthClient + Sync> EventProcessor<W> for UpgradesEventProcessor {
+impl EventProcessor for UpgradesEventProcessor {
     async fn process_events(
         &mut self,
         storage: &mut StorageProcessor<'_>,
-        client: &W,
+        client: &dyn EthClient,
         events: Vec<Log>,
     ) -> Result<(), Error> {
         let mut upgrades = Vec::new();

--- a/core/lib/zksync_core/src/eth_watch/tests.rs
+++ b/core/lib/zksync_core/src/eth_watch/tests.rs
@@ -17,6 +17,7 @@ use crate::eth_watch::{
     client::EthClient, event_processors::upgrades::UPGRADE_PROPOSAL_SIGNATURE, EthWatch,
 };
 
+#[derive(Debug)]
 struct FakeEthClientData {
     transactions: HashMap<u64, Vec<Log>>,
     diamond_upgrades: HashMap<u64, Vec<Log>>,
@@ -67,7 +68,7 @@ impl FakeEthClientData {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 struct FakeEthClient {
     inner: Arc<RwLock<FakeEthClientData>>,
 }
@@ -208,7 +209,7 @@ async fn test_normal_operation_l1_txs() {
     let mut watcher = EthWatch::new(
         Address::default(),
         None,
-        client.clone(),
+        Box::new(client.clone()),
         &connection_pool,
         std::time::Duration::from_nanos(1),
     )
@@ -256,7 +257,7 @@ async fn test_normal_operation_upgrades() {
     let mut watcher = EthWatch::new(
         Address::default(),
         None,
-        client.clone(),
+        Box::new(client.clone()),
         &connection_pool,
         std::time::Duration::from_nanos(1),
     )
@@ -317,7 +318,7 @@ async fn test_gap_in_upgrades() {
     let mut watcher = EthWatch::new(
         Address::default(),
         None,
-        client.clone(),
+        Box::new(client.clone()),
         &connection_pool,
         std::time::Duration::from_nanos(1),
     )
@@ -356,7 +357,7 @@ async fn test_normal_operation_governance_upgrades() {
     let mut watcher = EthWatch::new(
         Address::default(),
         Some(governance_contract()),
-        client.clone(),
+        Box::new(client.clone()),
         &connection_pool,
         std::time::Duration::from_nanos(1),
     )
@@ -418,7 +419,7 @@ async fn test_gap_in_single_batch() {
     let mut watcher = EthWatch::new(
         Address::default(),
         None,
-        client.clone(),
+        Box::new(client.clone()),
         &connection_pool,
         std::time::Duration::from_nanos(1),
     )
@@ -448,7 +449,7 @@ async fn test_gap_between_batches() {
     let mut watcher = EthWatch::new(
         Address::default(),
         None,
-        client.clone(),
+        Box::new(client.clone()),
         &connection_pool,
         std::time::Duration::from_nanos(1),
     )
@@ -483,7 +484,7 @@ async fn test_overlapping_batches() {
     let mut watcher = EthWatch::new(
         Address::default(),
         None,
-        client.clone(),
+        Box::new(client.clone()),
         &connection_pool,
         std::time::Duration::from_nanos(1),
     )

--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -521,7 +521,7 @@ pub async fn initialize_components(
             start_eth_watch(
                 eth_watch_config,
                 eth_watch_pool,
-                query_client.clone(),
+                Box::new(query_client.clone()),
                 main_zksync_contract_address,
                 governance,
                 stop_receiver.clone(),

--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -555,7 +555,7 @@ pub async fn initialize_components(
                 eth_sender.sender.clone(),
                 store_factory.create_store().await,
             ),
-            eth_client,
+            Arc::new(eth_client),
             contracts_config.validator_timelock_addr,
             contracts_config.l1_multicall3_addr,
             main_zksync_contract_address,
@@ -588,7 +588,7 @@ pub async fn initialize_components(
                 .get_or_init()
                 .await
                 .context("gas_adjuster.get_or_init()")?,
-            eth_client,
+            Arc::new(eth_client),
         );
         task_futures.extend([tokio::spawn(
             eth_tx_manager_actor.run(eth_manager_pool, stop_receiver.clone()),

--- a/sdk/zksync-rs/src/ethereum/mod.rs
+++ b/sdk/zksync-rs/src/ethereum/mod.rs
@@ -408,7 +408,8 @@ impl<S: EthereumSigner> EthereumProvider<S> {
                 L1_TO_L2_GAS_PER_PUBDATA,
                 factory_deps,
                 refund_recipient,
-            ),
+            )
+                .into_tokens(),
         );
 
         let tx = self


### PR DESCRIPTION
## What ❔

Replaces generic parameters in `eth_watch` and `eth_sender` with `Arc<dyn ..>` or `Box<dyn ...>`.

## Why ❔

- Prerequisite for ZK Stack framework.
 

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
