### PR TITLE
feat: address remaining spelling issues in dev comments and turns on dev_comments in cfg

### DIFF
--- a/core/bin/block_reverter/src/main.rs
+++ b/core/bin/block_reverter/src/main.rs
@@ -32,7 +32,7 @@ enum Command {
         #[arg(long)]
         l1_batch_number: u32,
         /// Priority fee used for rollback Ethereum transaction.
-        // We operate only by priority fee because we want to use base fee from ethereum
+        // We operate only by priority fee because we want to use base fee from Ethereum
         // and send transaction as soon as possible without any resend logic
         #[arg(long)]
         priority_fee_per_gas: Option<u64>,

--- a/core/bin/contract-verifier/src/main.rs
+++ b/core/bin/contract-verifier/src/main.rs
@@ -178,7 +178,7 @@ async fn main() -> anyhow::Result<()> {
 
     let contract_verifier = ContractVerifier::new(verifier_config, pool);
     let tasks = vec![
-        // todo PLA-335: Leftovers after the prover DB split.
+        // TODO PLA-335: Leftovers after the prover DB split.
         // The prover connection pool is not used by the contract verifier, but we need to pass it
         // since `JobProcessor` trait requires it.
         tokio::spawn(contract_verifier.run(stop_receiver.clone(), opt.jobs_number)),

--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -437,7 +437,7 @@ impl ExternalNodeConfig {
             .context("Unable to fetch required config values from the main node")?;
 
         // We can query them from main node, but it's better to set them explicitly
-        // as well to avoid connecting to wrong envs unintentionally.
+        // as well to avoid connecting to wrong environment variables unintentionally.
         let eth_chain_id = HttpClientBuilder::default()
             .build(required.eth_client_url()?)
             .expect("Unable to build HTTP client for L1 client")

--- a/core/bin/system-constants-generator/src/intrinsic_costs.rs
+++ b/core/bin/system-constants-generator/src/intrinsic_costs.rs
@@ -81,7 +81,7 @@ pub(crate) fn l2_gas_constants() -> IntrinsicSystemGasConstants {
         true,
     );
 
-    // This price does not include the overhead for the transaction itself, but rather auxilary parts
+    // This price does not include the overhead for the transaction itself, but rather auxiliary parts
     // that must be done by the transaction and it can not be enforced by the operator to not to accept
     // the transaction if it does not cover the minimal costs.
     let min_l1_tx_price = empty_l1_tx_result.gas_consumed - bootloader_intrinsic_gas;
@@ -107,7 +107,7 @@ pub(crate) fn l2_gas_constants() -> IntrinsicSystemGasConstants {
 
     let delta_from_544_bytes = lengthier_tx_result.gas_consumed - empty_l1_tx_result.gas_consumed;
 
-    // The number of public data per factory dep should not depend on the size/structure of the factory
+    // The number of public data per factory dependencies should not depend on the size/structure of the factory
     // dependency, since the dependency has already been published on L1.
     let tx_with_more_factory_deps_result = execute_user_txs_in_test_gas_vm(
         vec![get_l1_tx(
@@ -180,7 +180,7 @@ fn get_intrinsic_overheads_for_tx_type(tx_generator: &TransactionGenerator) -> I
     let bootloader_intrinsic_pubdata = result_0.pubdata_published;
 
     // For various small reasons the overhead for the first transaction and for all the subsequent ones
-    // might differ a bit, so we will calculate both and will use the maximum one as the result for l2 txs.
+    // might differ a bit, so we will calculate both and will use the maximum one as the result for L2 txs.
 
     let (tx1_intrinsic_gas, tx1_intrinsic_pubdata) = get_intrinsic_price(result_0, result_1);
     let (tx2_intrinsic_gas, tx2_intrinsic_pubdata) = get_intrinsic_price(result_1, result_2);

--- a/core/lib/multivm/src/tracers/call_tracer/vm_boojum_integration/mod.rs
+++ b/core/lib/multivm/src/tracers/call_tracer/vm_boojum_integration/mod.rs
@@ -143,7 +143,7 @@ impl CallTracer {
         let fat_data_pointer =
             state.vm_local_state.registers[RET_IMPLICIT_RETURNDATA_PARAMS_REGISTER as usize];
 
-        // if fat_data_pointer is not a pointer then there is no output
+        // if `fat_data_pointer` is not a pointer then there is no output
         let output = if fat_data_pointer.is_pointer {
             let fat_data_pointer = FatPointer::from_u256(fat_data_pointer.value);
             if !fat_data_pointer.is_trivial() {

--- a/core/lib/multivm/src/versions/vm_boojum_integration/bootloader_state/l2_block.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/bootloader_state/l2_block.rs
@@ -19,7 +19,7 @@ pub(crate) struct BootloaderL2Block {
     pub(crate) timestamp: u64,
     pub(crate) txs_rolling_hash: H256, // The rolling hash of all the transactions in the miniblock
     pub(crate) prev_block_hash: H256,
-    // Number of the first l2 block tx in l1 batch
+    // Number of the first L2 block tx in L1 batch
     pub(crate) first_tx_index: usize,
     pub(crate) max_virtual_blocks_to_create: u32,
     pub(super) txs: Vec<BootloaderTx>,

--- a/core/lib/multivm/src/versions/vm_boojum_integration/bootloader_state/state.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/bootloader_state/state.rs
@@ -68,7 +68,7 @@ impl BootloaderState {
 
     pub(crate) fn set_refund_for_current_tx(&mut self, refund: u32) {
         let current_tx = self.current_tx();
-        // We can't set the refund for the latest tx or using the latest l2_block for fining tx
+        // We can't set the refund for the latest tx or using the latest `l2_block` for fining tx
         // Because we can fill the whole batch first and then execute txs one by one
         let tx = self.find_tx_mut(current_tx);
         tx.refund = refund;

--- a/core/lib/multivm/src/versions/vm_boojum_integration/bootloader_state/utils.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/bootloader_state/utils.rs
@@ -74,7 +74,7 @@ pub(super) fn apply_tx_to_memory(
     };
     apply_l2_block(memory, &bootloader_l2_block, tx_index);
 
-    // Note, +1 is moving for pointer
+    // Note, `+1` is moving for pointer
     let compressed_bytecodes_offset = COMPRESSED_BYTECODES_OFFSET + 1 + compressed_bytecodes_size;
 
     let encoded_compressed_bytecodes =
@@ -94,8 +94,8 @@ pub(crate) fn apply_l2_block(
     bootloader_l2_block: &BootloaderL2Block,
     txs_index: usize,
 ) {
-    // Since L2 block infos start from the TX_OPERATOR_L2_BLOCK_INFO_OFFSET and each
-    // L2 block info takes TX_OPERATOR_SLOTS_PER_L2_BLOCK_INFO slots, the position where the L2 block info
+    // Since L2 block information starts from the `TX_OPERATOR_L2_BLOCK_INFO_OFFSET` and each
+    // L2 block info takes `TX_OPERATOR_SLOTS_PER_L2_BLOCK_INFO slots`, the position where the L2 block info
     // for this transaction needs to be written is:
 
     let block_position =
@@ -120,12 +120,12 @@ pub(crate) fn apply_pubdata_to_memory(
     pubdata_information: PubdataInput,
 ) {
     // Skipping two slots as they will be filled by the bootloader itself:
-    // - One slot is for the selector of the call to the L1Messenger.
+    // - One slot is for the selector of the call to the `L1Messenger`.
     // - The other slot is for the 0x20 offset for the calldata.
     let l1_messenger_pubdata_start_slot = OPERATOR_PROVIDED_L1_MESSENGER_PUBDATA_OFFSET + 2;
 
     // Need to skip first word as it represents array offset
-    // while bootloader expects only [len || data]
+    // while bootloader expects only `[len || data]`
     let pubdata = ethabi::encode(&[ethabi::Token::Bytes(
         pubdata_information.build_pubdata(true),
     )])[32..]
@@ -156,8 +156,8 @@ pub(crate) fn apply_pubdata_to_memory(
 ///     For example, when checking validity, we don't want to actually execute transaction and have side effects.
 ///
 ///     Possible values:
-///     - 0x00: validate & execute (normal mode)
-///     - 0x02: execute but DO NOT validate
+///     - `0x00`: validate & execute (normal mode)
+///     - `0x02`: execute but DO NOT validate
 ///
 /// - 31 byte (LSB): whether to execute transaction or not (at all).
 pub(super) fn assemble_tx_meta(execution_mode: TxExecutionMode, execute_tx: bool) -> U256 {

--- a/core/lib/multivm/src/versions/vm_boojum_integration/implementation/snapshots.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/implementation/snapshots.rs
@@ -34,8 +34,8 @@ impl<S: WriteStorage> Vm<S, crate::vm_latest::HistoryEnabled> {
     pub(crate) fn make_snapshot_inner(&mut self) {
         self.snapshots.push(VmSnapshot {
             // Vm local state contains O(1) various parameters (registers/etc).
-            // The only "expensive" copying here is copying of the callstack.
-            // It will take O(callstack_depth) to copy it.
+            // The only "expensive" copying here is copying of the call stack.
+            // It will take `O(callstack_depth)` to copy it.
             // So it is generally recommended to get snapshots of the bootloader frame,
             // where the depth is 1.
             local_state: self.state.local_state.clone(),

--- a/core/lib/multivm/src/versions/vm_boojum_integration/old_vm/event_sink.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/old_vm/event_sink.rs
@@ -54,7 +54,7 @@ impl<H: HistoryMode> InMemoryEventSink<H> {
     pub fn log_queries_after_timestamp(&self, from_timestamp: Timestamp) -> &[Box<LogQuery>] {
         let events = self.frames_stack.forward().current_frame();
 
-        // Select all of the last elements where e.timestamp >= from_timestamp.
+        // Select all of the last elements where `e.timestamp >= from_timestamp`.
         // Note, that using binary search here is dangerous, because the logs are not sorted by timestamp.
         events
             .rsplit(|e| e.timestamp < from_timestamp)

--- a/core/lib/multivm/src/versions/vm_boojum_integration/old_vm/history_recorder.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/old_vm/history_recorder.rs
@@ -12,14 +12,14 @@ use zksync_utils::{h256_to_u256, u256_to_h256};
 pub(crate) type MemoryWithHistory<H> = HistoryRecorder<MemoryWrapper, H>;
 pub(crate) type IntFrameManagerWithHistory<T, H> = HistoryRecorder<FramedStack<T>, H>;
 
-// Within the same cycle, timestamps in range timestamp..timestamp+TIME_DELTA_PER_CYCLE-1
+// Within the same cycle, timestamps in range `timestamp..timestamp+TIME_DELTA_PER_CYCLE-1`
 // can be used. This can sometimes violate monotonicity of the timestamp within the
 // same cycle, so it should be normalized.
 #[inline]
 fn normalize_timestamp(timestamp: Timestamp) -> Timestamp {
     let timestamp = timestamp.0;
 
-    // Making sure it is divisible by TIME_DELTA_PER_CYCLE
+    // Making sure it is divisible by `TIME_DELTA_PER_CYCLE`
     Timestamp(timestamp - timestamp % zkevm_opcode_defs::TIME_DELTA_PER_CYCLE)
 }
 

--- a/core/lib/multivm/src/versions/vm_boojum_integration/old_vm/memory.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/old_vm/memory.rs
@@ -282,7 +282,7 @@ impl<H: HistoryMode> Memory for SimpleMemory<H> {
         let returndata_page = returndata_fat_pointer.memory_page;
 
         for &page in current_observable_pages {
-            // If the page's number is greater than or equal to the base_page,
+            // If the page's number is greater than or equal to the `base_page`,
             // it means that it was created by the internal calls of this contract.
             // We need to add this check as the calldata pointer is also part of the
             // observable pages.
@@ -299,7 +299,7 @@ impl<H: HistoryMode> Memory for SimpleMemory<H> {
     }
 }
 
-// It is expected that there is some intersection between [word_number*32..word_number*32+31] and [start, end]
+// It is expected that there is some intersection between `[word_number*32..word_number*32+31]` and `[start, end]`
 fn extract_needed_bytes_from_word(
     word_value: Vec<u8>,
     word_number: usize,
@@ -307,7 +307,7 @@ fn extract_needed_bytes_from_word(
     end: usize,
 ) -> Vec<u8> {
     let word_start = word_number * 32;
-    let word_end = word_start + 31; // Note, that at word_start + 32 a new word already starts
+    let word_end = word_start + 31; // Note, that at `word_start + 32` a new word already starts
 
     let intersection_left = std::cmp::max(word_start, start);
     let intersection_right = std::cmp::min(word_end, end);

--- a/core/lib/multivm/src/versions/vm_boojum_integration/old_vm/oracles/precompile.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/old_vm/oracles/precompile.rs
@@ -109,6 +109,6 @@ impl<H: HistoryMode> PrecompilesProcessor for PrecompilesProcessorWithHistory<H>
     }
 
     fn finish_frame(&mut self, _panicked: bool) {
-        // there are no revertable precompile yes, so we are ok
+        // there are no revertible precompile yes, so we are ok
     }
 }

--- a/core/lib/multivm/src/versions/vm_boojum_integration/old_vm/utils.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/old_vm/utils.rs
@@ -122,7 +122,7 @@ pub(crate) fn vm_may_have_ended_inner<S: WriteStorage, H: HistoryMode>(
         }
         (false, _) => None,
         (true, l) if l == outer_eh_location => {
-            // check r1,r2,r3
+            // check `r1,r2,r3`
             if vm.local_state.flags.overflow_or_less_than_flag {
                 Some(VmExecutionResult::Panic)
             } else {

--- a/core/lib/multivm/src/versions/vm_boojum_integration/oracles/storage.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/oracles/storage.rs
@@ -53,7 +53,7 @@ pub struct StorageOracle<S: WriteStorage, H: HistoryMode> {
     pub(crate) paid_changes: HistoryRecorder<HashMap<StorageKey, u32>, H>,
 
     // The map that contains all the first values read from storage for each slot.
-    // While formally it does not have to be rollbackable, we still do it to avoid memory bloat
+    // While formally it does not have to be rolled back, we still do it to avoid memory bloat
     // for unused slots.
     pub(crate) initial_values: HistoryRecorder<HashMap<StorageKey, U256>, H>,
 
@@ -212,7 +212,7 @@ impl<S: WriteStorage, H: HistoryMode> StorageOracle<S, H> {
             let required_pubdata =
                 self.base_price_for_write(&key, first_slot_value, current_slot_value);
 
-            // We assume that "prepaid_for_slot" represents both the number of pubdata published and the number of bytes paid by the previous transactions
+            // We assume that `prepaid_for_slot` represents both the number of pubdata published and the number of bytes paid by the previous transactions
             // as they should be identical.
             let prepaid_for_slot = self
                 .pre_paid_changes
@@ -292,7 +292,7 @@ impl<S: WriteStorage, H: HistoryMode> StorageOracle<S, H> {
     ) -> &[Box<StorageLogQuery>] {
         let logs = self.frames_stack.forward().current_frame();
 
-        // Select all of the last elements where l.log_query.timestamp >= from_timestamp.
+        // Select all of the last elements where `l.log_query.timestamp >= from_timestamp`.
         // Note, that using binary search here is dangerous, because the logs are not sorted by timestamp.
         logs.rsplit(|l| l.log_query.timestamp < from_timestamp)
             .next()
@@ -340,6 +340,7 @@ impl<S: WriteStorage, H: HistoryMode> VmStorageOracle for StorageOracle<S, H> {
         _monotonic_cycle_counter: u32,
         mut query: LogQuery,
     ) -> LogQuery {
+        //```
         // tracing::trace!(
         //     "execute partial query cyc {:?} addr {:?} key {:?}, rw {:?}, wr {:?}, tx {:?}",
         //     _monotonic_cycle_counter,
@@ -349,6 +350,7 @@ impl<S: WriteStorage, H: HistoryMode> VmStorageOracle for StorageOracle<S, H> {
         //     query.written_value,
         //     query.tx_number_in_block
         // );
+        //```
         assert!(!query.rollback);
         if query.rw_flag {
             // The number of bytes that have been compensated by the user to perform this write
@@ -443,7 +445,7 @@ impl<S: WriteStorage, H: HistoryMode> VmStorageOracle for StorageOracle<S, H> {
                 );
 
                 // Additional validation that the current value was correct
-                // Unwrap is safe because the return value from write_inner is the previous value in this leaf.
+                // Unwrap is safe because the return value from `write_inner` is the previous value in this leaf.
                 // It is impossible to set leaf value to `None`
                 assert_eq!(current_value, written_value);
             }
@@ -457,7 +459,7 @@ impl<S: WriteStorage, H: HistoryMode> VmStorageOracle for StorageOracle<S, H> {
 
 /// Returns the number of bytes needed to publish a slot.
 // Since we need to publish the state diffs onchain, for each of the updated storage slot
-// we basically need to publish the following pair: (<storage_key, compressed_new_value>).
+// we basically need to publish the following pair: `(<storage_key, compressed_new_value>)`.
 // For key we use the following optimization:
 //   - The first time we publish it, we use 32 bytes.
 //         Then, we remember a 8-byte id for this slot and assign it to it. We call this initial write.

--- a/core/lib/multivm/src/versions/vm_boojum_integration/tracers/circuits_capacity.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/tracers/circuits_capacity.rs
@@ -47,7 +47,7 @@ pub(crate) const AVERAGE_OPCODE_FRACTION: f32 =
     MAIN_VM_CYCLE_FRACTION + RAM_PERMUTATION_CYCLE_FRACTION;
 
 // Here "base" fraction is a fraction that will be used unconditionally.
-// Usage of StorageApplication is being tracked separately as it depends on whether slot was read before or not.
+// Usage of `StorageApplication` is being tracked separately as it depends on whether slot was read before or not.
 pub(crate) const STORAGE_READ_BASE_FRACTION: f32 = MAIN_VM_CYCLE_FRACTION
     + RAM_PERMUTATION_CYCLE_FRACTION
     + LOG_DEMUXER_CYCLE_FRACTION
@@ -59,7 +59,7 @@ pub(crate) const EVENT_OR_L1_MESSAGE_FRACTION: f32 = MAIN_VM_CYCLE_FRACTION
     + 2.0 * EVENTS_OR_L1_MESSAGES_SORTER_CYCLE_FRACTION;
 
 // Here "base" fraction is a fraction that will be used unconditionally.
-// Usage of StorageApplication is being tracked separately as it depends on whether slot was written before or not.
+// Usage of `StorageApplication` is being tracked separately as it depends on whether slot was written before or not.
 pub(crate) const STORAGE_WRITE_BASE_FRACTION: f32 = MAIN_VM_CYCLE_FRACTION
     + RAM_PERMUTATION_CYCLE_FRACTION
     + 2.0 * LOG_DEMUXER_CYCLE_FRACTION

--- a/core/lib/multivm/src/versions/vm_boojum_integration/tracers/default_tracers.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/tracers/default_tracers.rs
@@ -54,7 +54,7 @@ pub(crate) struct DefaultExecutionTracer<S: WriteStorage, H: HistoryMode> {
     pub(crate) result_tracer: ResultTracer<S>,
     // This tracer is designed specifically for calculating refunds. Its separation from the custom tracer
     // ensures static dispatch, enhancing performance by avoiding dynamic dispatch overhead.
-    // Additionally, being an internal tracer, it saves the results directly to VmResultAndLogs.
+    // Additionally, being an internal tracer, it saves the results directly to `VmResultAndLogs`.
     pub(crate) refund_tracer: Option<RefundsTracer<S>>,
     // The pubdata tracer is responsible for inserting the pubdata packing information into the bootloader
     // memory at the end of the batch. Its separation from the custom tracer
@@ -298,7 +298,7 @@ impl<S: WriteStorage, H: HistoryMode> DefaultExecutionTracer<S, H> {
 }
 
 fn current_frame_is_bootloader(local_state: &VmLocalState) -> bool {
-    // The current frame is bootloader if the callstack depth is 1.
+    // The current frame is bootloader if the call stack depth is 1.
     // Some of the near calls inside the bootloader can be out of gas, which is totally normal behavior
     // and it shouldn't result in `is_bootloader_out_of_gas` becoming true.
     local_state.callstack.inner.len() == 1

--- a/core/lib/multivm/src/versions/vm_boojum_integration/tracers/pubdata_tracer.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/tracers/pubdata_tracer.rs
@@ -56,7 +56,7 @@ impl<S: WriteStorage> PubdataTracer<S> {
 
 impl<S: WriteStorage> PubdataTracer<S> {
     // Packs part of L1 Messenger total pubdata that corresponds to
-    // L2toL1Logs sent in the block
+    // `L2toL1Logs` sent in the block
     fn get_total_user_logs<H: HistoryMode>(
         &self,
         state: &ZkSyncVmState<S, H>,

--- a/core/lib/multivm/src/versions/vm_boojum_integration/tracers/refunds.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/tracers/refunds.rs
@@ -214,8 +214,8 @@ impl<S: WriteStorage, H: HistoryMode> VmTracer<S, H> for RefundsTracer<S> {
         #[vise::register]
         static METRICS: vise::Global<RefundMetrics> = vise::Global::new();
 
-        // This means that the bootloader has informed the system (usually via VMHooks) - that some gas
-        // should be refunded back (see askOperatorForRefund in bootloader.yul for details).
+        // This means that the bootloader has informed the system (usually via `VMHooks`) - that some gas
+        // should be refunded back (see `askOperatorForRefund` in `bootloader.yul` for details).
         if let Some(bootloader_refund) = self.requested_refund() {
             assert!(
                 self.operator_refund.is_none(),

--- a/core/lib/multivm/src/versions/vm_boojum_integration/tracers/result_tracer.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/tracers/result_tracer.rs
@@ -54,7 +54,7 @@ impl<S> ResultTracer<S> {
 }
 
 fn current_frame_is_bootloader(local_state: &VmLocalState) -> bool {
-    // The current frame is bootloader if the callstack depth is 1.
+    // The current frame is bootloader if the call stack depth is 1.
     // Some of the near calls inside the bootloader can be out of gas, which is totally normal behavior
     // and it shouldn't result in `is_bootloader_out_of_gas` becoming true.
     local_state.callstack.inner.len() == 1
@@ -150,7 +150,7 @@ impl<S: WriteStorage> ResultTracer<S> {
                 });
             }
             VmExecutionResult::Revert(output) => {
-                // Unlike VmHook::ExecutionResult,  vm has completely finished and returned not only the revert reason,
+                // Unlike `VmHook::ExecutionResult`,  vm has completely finished and returned not only the revert reason,
                 // but with bytecode, which represents the type of error from the bootloader side
                 let revert_reason = TxRevertReason::parse_error(&output);
 

--- a/core/lib/multivm/src/versions/vm_boojum_integration/tracers/utils.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/tracers/utils.rs
@@ -57,7 +57,7 @@ impl VmHook {
 
         let value = data.src1_value.value;
 
-        // Only UMA opcodes in the bootloader serve for vm hooks
+        // Only `UMA` opcodes in the bootloader serve for vm hooks
         if !matches!(opcode_variant.opcode, Opcode::UMA(UMAOpcode::HeapWrite))
             || heap_page != BOOTLOADER_HEAP_PAGE
             || fat_ptr.offset != VM_HOOK_POSITION * 32

--- a/core/lib/multivm/src/versions/vm_boojum_integration/types/internals/pubdata.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/types/internals/pubdata.rs
@@ -24,14 +24,14 @@ impl PubdataInput {
         } = self;
 
         // Encoding user L2->L1 logs.
-        // Format: [(numberOfL2ToL1Logs as u32) || l2tol1logs[1] || ... || l2tol1logs[n]]
+        // Format: `[(numberOfL2ToL1Logs as u32) || l2tol1logs[1] || ... || l2tol1logs[n]]`
         l1_messenger_pubdata.extend((user_logs.len() as u32).to_be_bytes());
         for l2tol1log in user_logs {
             l1_messenger_pubdata.extend(l2tol1log.packed_encoding());
         }
 
         // Encoding L2->L1 messages
-        // Format: [(numberOfMessages as u32) || (messages[1].len() as u32) || messages[1] || ... || (messages[n].len() as u32) || messages[n]]
+        // Format: `[(numberOfMessages as u32) || (messages[1].len() as u32) || messages[1] || ... || (messages[n].len() as u32) || messages[n]]`
         l1_messenger_pubdata.extend((l2_to_l1_messages.len() as u32).to_be_bytes());
         for message in l2_to_l1_messages {
             l1_messenger_pubdata.extend((message.len() as u32).to_be_bytes());
@@ -39,7 +39,7 @@ impl PubdataInput {
         }
 
         // Encoding bytecodes
-        // Format: [(numberOfBytecodes as u32) || (bytecodes[1].len() as u32) || bytecodes[1] || ... || (bytecodes[n].len() as u32) || bytecodes[n]]
+        // Format: `[(numberOfBytecodes as u32) || (bytecodes[1].len() as u32) || bytecodes[1] || ... || (bytecodes[n].len() as u32) || bytecodes[n]]`
         l1_messenger_pubdata.extend((published_bytecodes.len() as u32).to_be_bytes());
         for bytecode in published_bytecodes {
             l1_messenger_pubdata.extend((bytecode.len() as u32).to_be_bytes());
@@ -47,7 +47,7 @@ impl PubdataInput {
         }
 
         // Encoding state diffs
-        // Format: [size of compressed state diffs u32 || compressed state diffs || (# state diffs: intial + repeated) as u32 || sorted state diffs by <index, address, key>]
+        // Format: `[size of compressed state diffs u32 || compressed state diffs || (# state diffs: initial + repeated) as u32 || sorted state diffs by <index, address, key>]`
         let state_diffs_compressed = compress_state_diffs(state_diffs.clone());
         l1_messenger_pubdata.extend(state_diffs_compressed);
 

--- a/core/lib/multivm/src/versions/vm_boojum_integration/types/internals/transaction_data.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/types/internals/transaction_data.rs
@@ -234,7 +234,7 @@ impl TransactionData {
         let l2_tx: L2Tx = self.clone().try_into().unwrap();
         let transaction_request: TransactionRequest = l2_tx.into();
 
-        // It is assumed that the TransactionData always has all the necessary components to recover the hash.
+        // It is assumed that the `TransactionData` always has all the necessary components to recover the hash.
         transaction_request
             .get_tx_hash(chain_id)
             .expect("Could not recover L2 transaction hash")

--- a/core/lib/multivm/src/versions/vm_boojum_integration/utils/fee.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/utils/fee.rs
@@ -18,7 +18,7 @@ pub(crate) fn derive_base_fee_and_gas_per_pubdata(
 ) -> (u64, u64) {
     let eth_price_per_pubdata_byte = eth_price_per_pubdata_byte(l1_gas_price);
 
-    // The baseFee is set in such a way that it is always possible for a transaction to
+    // The `baseFee` is set in such a way that it is always possible for a transaction to
     // publish enough public data while compensating us for it.
     let base_fee = std::cmp::max(
         fair_gas_price,

--- a/core/lib/multivm/src/versions/vm_boojum_integration/utils/l2_blocks.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/utils/l2_blocks.rs
@@ -68,7 +68,7 @@ pub fn load_last_l2_block<S: ReadStorage>(storage: StoragePtr<S>) -> Option<L2Bl
         return None;
     }
 
-    // Get prev block hash
+    // Get previous block hash
     let position = get_l2_block_hash_key(block_number - 1);
     let prev_block_hash = storage_ptr.read_value(&position);
 

--- a/core/lib/multivm/src/versions/vm_boojum_integration/utils/overhead.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/utils/overhead.rs
@@ -14,17 +14,17 @@ pub(crate) fn derive_overhead(
     encoded_len: usize,
     coefficients: OverheadCoefficients,
 ) -> u32 {
-    // Even if the gas limit is greater than the MAX_TX_ERGS_LIMIT, we assume that everything beyond MAX_TX_ERGS_LIMIT
+    // Even if the gas limit is greater than the `MAX_TX_ERGS_LIMIT`, we assume that everything beyond `MAX_TX_ERGS_LIMIT`
     // will be spent entirely on publishing bytecodes and so we derive the overhead solely based on the capped value
     let gas_limit = std::cmp::min(MAX_TX_ERGS_LIMIT, gas_limit);
 
-    // Using large U256 type to avoid overflow
+    // Using large `U256` type to avoid overflow
     let max_block_overhead = U256::from(block_overhead_gas(gas_price_per_pubdata));
     let gas_limit = U256::from(gas_limit);
     let encoded_len = U256::from(encoded_len);
 
-    // The MAX_TX_ERGS_LIMIT is formed in a way that may fulfills a single-instance circuits
-    // if used in full. That is, within MAX_TX_ERGS_LIMIT it is possible to fully saturate all the single-instance
+    // The `MAX_TX_ERGS_LIMIT` is formed in a way that may fulfills a single-instance circuits
+    // if used in full. That is, within `MAX_TX_ERGS_LIMIT` it is possible to fully saturate all the single-instance
     // circuits.
     let overhead_for_single_instance_circuits =
         ceil_div_u256(gas_limit * max_block_overhead, MAX_TX_ERGS_LIMIT.into());
@@ -38,15 +38,17 @@ pub(crate) fn derive_overhead(
     // The overhead for occupying a single tx slot
     let tx_slot_overhead = ceil_div_u256(max_block_overhead, MAX_TXS_IN_BLOCK.into());
 
-    // We use "ceil" here for formal reasons to allow easier approach for calculating the overhead in O(1)
-    // let max_pubdata_in_tx = ceil_div_u256(gas_limit, gas_price_per_pubdata);
+    // We use `ceil` here for formal reasons to allow easier approach for calculating the overhead in `O(1)`
+    // `let max_pubdata_in_tx = ceil_div_u256(gas_limit, gas_price_per_pubdata);`
 
     // The maximal potential overhead from pubdata
     // TODO (EVM-67): possibly use overhead for pubdata
+    // ```
     // let pubdata_overhead = ceil_div_u256(
     //     max_pubdata_in_tx * max_block_overhead,
     //     MAX_PUBDATA_PER_BLOCK.into(),
     // );
+    //```
 
     vec![
         (coefficients.ergs_limit_overhead_coeficient
@@ -102,8 +104,8 @@ impl OverheadCoefficients {
         OverheadCoefficients::new_checked(
             1.0, 1.0,
             // For L2 transactions we allow a certain default discount with regard to the number of ergs.
-            // Multiinstance circuits can in theory be spawned infinite times, while projected future limitations
-            // on gas per pubdata allow for roughly 800kk gas per L1 batch, so the rough trust "discount" on the proof's part
+            // Multi-instance circuits can in theory be spawned infinite times, while projected future limitations
+            // on gas per pubdata allow for roughly 800k gas per L1 batch, so the rough trust "discount" on the proof's part
             // to be paid by the users is 0.1.
             0.1,
         )
@@ -132,28 +134,28 @@ pub(crate) fn get_amortized_overhead(
     let encoded_len = U256::from(encoded_len);
 
     // Derivation of overhead consists of 4 parts:
-    // 1. The overhead for taking up a transaction's slot. (O1): O1 = 1 / MAX_TXS_IN_BLOCK
-    // 2. The overhead for taking up the bootloader's memory (O2): O2 = encoded_len / BOOTLOADER_TX_ENCODING_SPACE
-    // 3. The overhead for possible usage of pubdata. (O3): O3 = max_pubdata_in_tx / MAX_PUBDATA_PER_BLOCK
-    // 4. The overhead for possible usage of all the single-instance circuits. (O4): O4 = gas_limit / MAX_TX_ERGS_LIMIT
+    // 1. The overhead for taking up a transaction's slot. `(O1): O1 = 1 / MAX_TXS_IN_BLOCK`
+    // 2. The overhead for taking up the bootloader's memory `(O2): O2 = encoded_len / BOOTLOADER_TX_ENCODING_SPACE`
+    // 3. The overhead for possible usage of pubdata. `(O3): O3 = max_pubdata_in_tx / MAX_PUBDATA_PER_BLOCK`
+    // 4. The overhead for possible usage of all the single-instance circuits. `(O4): O4 = gas_limit / MAX_TX_ERGS_LIMIT`
     //
     // The maximum of these is taken to derive the part of the block's overhead to be paid by the users:
     //
-    // max_overhead = max(O1, O2, O3, O4)
-    // overhead_gas = ceil(max_overhead * overhead_for_block_gas). Thus, overhead_gas is a function of
-    // tx_gas_limit, gas_per_pubdata_byte_limit and encoded_len.
+    // `max_overhead = max(O1, O2, O3, O4)`
+    // `overhead_gas = ceil(max_overhead * overhead_for_block_gas)`. Thus, `overhead_gas` is a function of
+    // `tx_gas_limit`, `gas_per_pubdata_byte_limit` and `encoded_len`.
     //
-    // While it is possible to derive the overhead with binary search in O(log n), it is too expensive to be done
-    // on L1, so here is a reference implementation of finding the overhead for transaction in O(1):
+    // While it is possible to derive the overhead with binary search in `O(log n)`, it is too expensive to be done
+    // on L1, so here is a reference implementation of finding the overhead for transaction in `O(1)`:
     //
-    // Given total_gas_limit = tx_gas_limit + overhead_gas, we need to find overhead_gas and tx_gas_limit, such that:
-    // 1. overhead_gas is maximal possible (the operator is paid fairly)
-    // 2. overhead_gas(tx_gas_limit, gas_per_pubdata_byte_limit, encoded_len) >= overhead_gas (the user does not overpay)
+    // Given `total_gas_limit = tx_gas_limit + overhead_gas`, we need to find `overhead_gas` and `tx_gas_limit`, such that:
+    // 1. `overhead_gas` is maximal possible (the operator is paid fairly)
+    // 2. `overhead_gas(tx_gas_limit, gas_per_pubdata_byte_limit, encoded_len) >= overhead_gas` (the user does not overpay)
     // The third part boils to the following 4 inequalities (at least one of these must hold):
-    // ceil(O1 * overhead_for_block_gas) >= overhead_gas
-    // ceil(O2 * overhead_for_block_gas) >= overhead_gas
-    // ceil(O3 * overhead_for_block_gas) >= overhead_gas
-    // ceil(O4 * overhead_for_block_gas) >= overhead_gas
+    // `ceil(O1 * overhead_for_block_gas) >= overhead_gas`
+    // `ceil(O2 * overhead_for_block_gas) >= overhead_gas`
+    // `ceil(O3 * overhead_for_block_gas) >= overhead_gas`
+    // `ceil(O4 * overhead_for_block_gas) >= overhead_gas`
     //
     // Now, we need to solve each of these separately:
 
@@ -164,7 +166,7 @@ pub(crate) fn get_amortized_overhead(
         (coefficients.slot_overhead_coeficient * tx_slot_overhead as f64).floor() as u32
     };
 
-    // 2. The overhead for occupying the bootloader memory can be derived from encoded_len
+    // 2. The overhead for occupying the bootloader memory can be derived from `encoded_len`
     let overhead_for_length = {
         let overhead_for_length = ceil_div_u256(
             encoded_len * overhead_for_block_gas,
@@ -175,7 +177,7 @@ pub(crate) fn get_amortized_overhead(
         (coefficients.bootloader_memory_overhead_coeficient * overhead_for_length as f64).floor()
             as u32
     };
-
+    //```
     // TODO (EVM-67): possibly include the overhead for pubdata. The formula below has not been properly maintained,
     // since the pubdat is not published. If decided to use the pubdata overhead, it needs to be updated.
     // 3. ceil(O3 * overhead_for_block_gas) >= overhead_gas
@@ -196,7 +198,7 @@ pub(crate) fn get_amortized_overhead(
     //         + gas_per_pubdata_byte_limit * U256::from(MAX_PUBDATA_PER_BLOCK);
     //     let denominator =
     //         gas_per_pubdata_byte_limit * U256::from(MAX_PUBDATA_PER_BLOCK) + overhead_for_block_gas;
-
+    //
     //     // Corner case: if `total_gas_limit` = `gas_per_pubdata_byte_limit` = 0
     //     // then the numerator will be 0 and subtracting 1 will cause a panic, so we just return a zero.
     //     if numerator.is_zero() {
@@ -205,15 +207,15 @@ pub(crate) fn get_amortized_overhead(
     //         (numerator - 1) / denominator
     //     }
     // };
-
-    // 4. K * ceil(O4 * overhead_for_block_gas) >= overhead_gas, where K is the discount
-    // O4 = gas_limit / MAX_TX_ERGS_LIMIT. Using the notation from the previous equation:
-    // ceil(OB * GL / MAX_TX_ERGS_LIMIT) >= (OE / K)
-    // ceil(OB * (TL - OE) / MAX_TX_ERGS_LIMIT) >= (OE/K)
-    // OB * (TL - OE) / MAX_TX_ERGS_LIMIT > (OE/K) - 1
-    // OB * (TL - OE) > (OE/K) * MAX_TX_ERGS_LIMIT - MAX_TX_ERGS_LIMIT
-    // OB * TL + MAX_TX_ERGS_LIMIT > OE * ( MAX_TX_ERGS_LIMIT/K + OB)
-    // OE = floor(OB * TL + MAX_TX_ERGS_LIMIT / (MAX_TX_ERGS_LIMIT/K + OB)), with possible -1 if the division is without remainder
+    //```
+    // 4. `K * ceil(O4 * overhead_for_block_gas) >= overhead_gas`, where K is the discount
+    // `O4 = gas_limit / MAX_TX_ERGS_LIMIT`. Using the notation from the previous equation:
+    // `ceil(OB * GL / MAX_TX_ERGS_LIMIT) >= (OE / K)`
+    // `ceil(OB * (TL - OE) / MAX_TX_ERGS_LIMIT) >= (OE/K)`
+    // `OB * (TL - OE) / MAX_TX_ERGS_LIMIT > (OE/K) - 1`
+    // `OB * (TL - OE) > (OE/K) * MAX_TX_ERGS_LIMIT - MAX_TX_ERGS_LIMIT`
+    // `OB * TL + MAX_TX_ERGS_LIMIT > OE * ( MAX_TX_ERGS_LIMIT/K + OB)`
+    // `OE = floor(OB * TL + MAX_TX_ERGS_LIMIT / (MAX_TX_ERGS_LIMIT/K + OB))`, with possible -1 if the division is without remainder
     let overhead_for_gas = {
         let numerator = overhead_for_block_gas * total_gas_limit + U256::from(MAX_TX_ERGS_LIMIT);
         let denominator: U256 = U256::from(

--- a/core/lib/multivm/src/versions/vm_latest/old_vm/oracles/precompile.rs
+++ b/core/lib/multivm/src/versions/vm_latest/old_vm/oracles/precompile.rs
@@ -107,6 +107,6 @@ impl<H: HistoryMode> PrecompilesProcessor for PrecompilesProcessorWithHistory<H>
     }
 
     fn finish_frame(&mut self, _panicked: bool) {
-        // there are no revertable precompile yes, so we are ok
+        // there are no revertible precompile yes, so we are ok
     }
 }

--- a/core/lib/multivm/src/versions/vm_latest/tests/precompiles.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/precompiles.rs
@@ -56,7 +56,7 @@ fn test_keccak() {
 
 #[test]
 fn test_sha256() {
-    // Execute special transaction and check that at least 1000 sha256 calls were made.
+    // Execute special transaction and check that at least 1000 `sha256` calls were made.
     let contract = read_precompiles_contract();
     let address = Address::random();
     let mut vm = VmTesterBuilder::new(HistoryEnabled)
@@ -100,7 +100,7 @@ fn test_sha256() {
 
 #[test]
 fn test_ecrecover() {
-    // Execute simple transfer and check that exactly 1 ecrecover call was made (it's done during tx validation).
+    // Execute simple transfer and check that exactly 1 `ecrecover` call was made (it's done during tx validation).
     let mut vm = VmTesterBuilder::new(HistoryEnabled)
         .with_empty_in_memory_storage()
         .with_random_rich_accounts(1)

--- a/core/lib/multivm/src/versions/vm_latest/tracers/circuits_capacity.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tracers/circuits_capacity.rs
@@ -47,7 +47,7 @@ pub(crate) const AVERAGE_OPCODE_FRACTION: f32 =
     MAIN_VM_CYCLE_FRACTION + RAM_PERMUTATION_CYCLE_FRACTION;
 
 // Here "base" fraction is a fraction that will be used unconditionally.
-// Usage of StorageApplication is being tracked separately as it depends on whether slot was read before or not.
+// Usage of `StorageApplication` is being tracked separately as it depends on whether slot was read before or not.
 pub(crate) const STORAGE_READ_BASE_FRACTION: f32 = MAIN_VM_CYCLE_FRACTION
     + RAM_PERMUTATION_CYCLE_FRACTION
     + LOG_DEMUXER_CYCLE_FRACTION
@@ -59,7 +59,7 @@ pub(crate) const EVENT_OR_L1_MESSAGE_FRACTION: f32 = MAIN_VM_CYCLE_FRACTION
     + 2.0 * EVENTS_OR_L1_MESSAGES_SORTER_CYCLE_FRACTION;
 
 // Here "base" fraction is a fraction that will be used unconditionally.
-// Usage of StorageApplication is being tracked separately as it depends on whether slot was written before or not.
+// Usage of `StorageApplication` is being tracked separately as it depends on whether slot was written before or not.
 pub(crate) const STORAGE_WRITE_BASE_FRACTION: f32 = MAIN_VM_CYCLE_FRACTION
     + RAM_PERMUTATION_CYCLE_FRACTION
     + 2.0 * LOG_DEMUXER_CYCLE_FRACTION

--- a/core/lib/multivm/src/versions/vm_latest/utils/fee.rs
+++ b/core/lib/multivm/src/versions/vm_latest/utils/fee.rs
@@ -38,9 +38,11 @@ pub(crate) fn adjust_l1_gas_price_for_tx(
     fair_l2_gas_price: u64,
     tx_gas_per_pubdata_limit: U256,
 ) -> u64 {
+    //```
     // gasPerPubdata = ceil(17 * l1gasprice / fair_l2_gas_price)
     // gasPerPubdata <= 17 * l1gasprice / fair_l2_gas_price + 1
     // fair_l2_gas_price(gasPerPubdata - 1) / 17 <= l1gasprice
+    //```
     let l1_gas_price = U256::from(fair_l2_gas_price)
         * (tx_gas_per_pubdata_limit - U256::from(1u32))
         / U256::from(17);

--- a/core/lib/types/src/commitment.rs
+++ b/core/lib/types/src/commitment.rs
@@ -131,25 +131,25 @@ impl L1BatchWithMetadata {
         })
     }
 
-    /// Encodes L1Batch into StorageBatchInfo (see IExecutor.sol)
+    /// Encodes L1Batch into `StorageBatchInfo` (see `IExecutor.sol`)
     pub fn l1_header_data(&self) -> Token {
         Token::Tuple(vec![
-            // batchNumber
+            // `batchNumber`
             Token::Uint(U256::from(self.header.number.0)),
-            // batchHash
+            // `batchHash`
             Token::FixedBytes(self.metadata.root_hash.as_bytes().to_vec()),
-            // indexRepeatedStorageChanges
+            // `indexRepeatedStorageChanges`
             Token::Uint(U256::from(self.metadata.rollup_last_leaf_index)),
-            // numberOfLayer1Txs
+            // `numberOfLayer1Txs`
             Token::Uint(U256::from(self.header.l1_tx_count)),
-            // priorityOperationsHash
+            // `priorityOperationsHash`
             Token::FixedBytes(
                 self.header
                     .priority_ops_onchain_data_hash()
                     .as_bytes()
                     .to_vec(),
             ),
-            // l2LogsTreeRoot
+            // `l2LogsTreeRoot`
             Token::FixedBytes(self.metadata.l2_l1_merkle_root.as_bytes().to_vec()),
             // timestamp
             Token::Uint(U256::from(self.header.timestamp)),
@@ -193,24 +193,24 @@ impl L1BatchWithMetadata {
             ])
         } else {
             Token::Tuple(vec![
-                // batchNumber
+                // `batchNumber`
                 Token::Uint(U256::from(self.header.number.0)),
-                // timestamp
+                // `timestamp`
                 Token::Uint(U256::from(self.header.timestamp)),
-                // indexRepeatedStorageChanges
+                // `indexRepeatedStorageChanges`
                 Token::Uint(U256::from(self.metadata.rollup_last_leaf_index)),
-                // newStateRoot
+                // `newStateRoot`
                 Token::FixedBytes(self.metadata.merkle_root_hash.as_bytes().to_vec()),
-                // numberOfLayer1Txs
+                // `numberOfLayer1Txs`
                 Token::Uint(U256::from(self.header.l1_tx_count)),
-                // priorityOperationsHash
+                // `priorityOperationsHash`
                 Token::FixedBytes(
                     self.header
                         .priority_ops_onchain_data_hash()
                         .as_bytes()
                         .to_vec(),
                 ),
-                // bootloaderHeapInitialContentsHash
+                // `bootloaderHeapInitialContentsHash`
                 Token::FixedBytes(
                     self.metadata
                         .bootloader_initial_content_commitment
@@ -218,7 +218,7 @@ impl L1BatchWithMetadata {
                         .as_bytes()
                         .to_vec(),
                 ),
-                // eventsQueueStateHash
+                // `eventsQueueStateHash`
                 Token::FixedBytes(
                     self.metadata
                         .events_queue_commitment
@@ -226,9 +226,9 @@ impl L1BatchWithMetadata {
                         .as_bytes()
                         .to_vec(),
                 ),
-                // systemLogs
+                // `systemLogs`
                 Token::Bytes(self.metadata.l2_l1_messages_compressed.clone()),
-                // totalL2ToL1Pubdata
+                // `totalL2ToL1Pubdata`
                 Token::Bytes(
                     self.header
                         .pubdata_input

--- a/core/lib/zksync_core/src/consistency_checker/tests/mod.rs
+++ b/core/lib/zksync_core/src/consistency_checker/tests/mod.rs
@@ -49,9 +49,9 @@ fn build_commit_tx_input_data(batches: &[L1BatchWithMetadata]) -> Vec<u8> {
     let mut encoded = vec![];
     // Fake Solidity function selector (not checked for now)
     encoded.extend_from_slice(b"fake");
-    // Mock an additional arg used in real `commitBlocks` / `commitBatches`. In real transactions,
-    // it's taken from the L1 batch previous to batches[0], but since this arg is not checked,
-    // it's OK to use batches[0].
+    // Mock an additional argument used in real `commitBlocks` / `commitBatches`. In real transactions,
+    // it's taken from the L1 batch previous to `batches[0]`, but since this argument is not checked,
+    // it's OK to use `batches[0]`.
     let prev_header_tokens = batches[0].l1_header_data();
     encoded.extend_from_slice(&ethabi::encode(&[prev_header_tokens, commit_tokens]));
     encoded
@@ -101,8 +101,8 @@ fn build_commit_tx_input_data_is_correct() {
 fn extracting_commit_data_for_boojum_batch() {
     let contract = zksync_contracts::zksync_contract();
     let commit_function = contract.function("commitBatches").unwrap();
-    // Calldata taken from the commit transaction for https://sepolia.explorer.zksync.io/batch/4470;
-    // https://sepolia.etherscan.io/tx/0x300b9115037028b1f8aa2177abf98148c3df95c9b04f95a4e25baf4dfee7711f
+    // Calldata taken from the commit transaction for `https://sepolia.explorer.zksync.io/batch/4470`;
+    // `https://sepolia.etherscan.io/tx/0x300b9115037028b1f8aa2177abf98148c3df95c9b04f95a4e25baf4dfee7711f`
     let commit_tx_input_data = include_bytes!("commit_l1_batch_4470_testnet_sepolia.calldata");
 
     let commit_data = ConsistencyChecker::extract_commit_data(
@@ -131,8 +131,8 @@ fn extracting_commit_data_for_boojum_batch() {
 fn extracting_commit_data_for_multiple_batches() {
     let contract = zksync_contracts::zksync_contract();
     let commit_function = contract.function("commitBatches").unwrap();
-    // Calldata taken from the commit transaction for https://explorer.zksync.io/batch/351000;
-    // https://etherscan.io/tx/0xbd8dfe0812df0da534eb95a2d2a4382d65a8172c0b648a147d60c1c2921227fd
+    // Calldata taken from the commit transaction for `https://explorer.zksync.io/batch/351000`;
+    // `https://etherscan.io/tx/0xbd8dfe0812df0da534eb95a2d2a4382d65a8172c0b648a147d60c1c2921227fd`
     let commit_tx_input_data = include_bytes!("commit_l1_batch_351000-351004_mainnet.calldata");
 
     for l1_batch in 351_000..=351_004 {
@@ -161,8 +161,8 @@ fn extracting_commit_data_for_multiple_batches() {
 
 #[test]
 fn extracting_commit_data_for_pre_boojum_batch() {
-    // Calldata taken from the commit transaction for https://goerli.explorer.zksync.io/batch/200000;
-    // https://goerli.etherscan.io/tx/0xfd2ef4ccd1223f502cc4a4e0f76c6905feafabc32ba616e5f70257eb968f20a3
+    // Calldata taken from the commit transaction for `https://goerli.explorer.zksync.io/batch/200000`;
+    // `https://goerli.etherscan.io/tx/0xfd2ef4ccd1223f502cc4a4e0f76c6905feafabc32ba616e5f70257eb968f20a3`
     let commit_tx_input_data = include_bytes!("commit_l1_batch_200000_testnet_goerli.calldata");
 
     let commit_data = ConsistencyChecker::extract_commit_data(

--- a/core/lib/zksync_core/src/eth_sender/tests.rs
+++ b/core/lib/zksync_core/src/eth_sender/tests.rs
@@ -29,7 +29,7 @@ use crate::{
     utils::testonly::create_l1_batch,
 };
 
-// Alias to conveniently call static methods of ETHSender.
+// Alias to conveniently call static methods of `ETHSender`.
 type MockEthTxManager = EthTxManager;
 
 static DUMMY_OPERATION: Lazy<AggregatedOperation> = Lazy::new(|| {
@@ -268,7 +268,7 @@ async fn resend_each_block() -> anyhow::Result<()> {
     assert_eq!(sent_tx.nonce, 0.into());
     assert_eq!(
         sent_tx.max_fee_per_gas.unwrap() - sent_tx.max_priority_fee_per_gas.unwrap(),
-        18.into() // 6 * 3 * 2^0
+        18.into() // `6 * 3 * 2^0`
     );
 
     // now, median is 5
@@ -318,7 +318,7 @@ async fn resend_each_block() -> anyhow::Result<()> {
     assert_eq!(resent_tx.nonce, 0.into());
     assert_eq!(
         resent_tx.max_fee_per_gas.unwrap() - resent_tx.max_priority_fee_per_gas.unwrap(),
-        30.into() // 5 * 3 * 2^1
+        30.into() // `5 * 3 * 2^1`
     );
 
     Ok(())

--- a/core/tests/cross_external_nodes_checker/src/checker.rs
+++ b/core/tests/cross_external_nodes_checker/src/checker.rs
@@ -367,7 +367,7 @@ impl Checker {
         tracing::debug!("Maybe checking batch {}", miniblock_batch_number);
 
         // We should check batches only the first time we encounter them per instance
-        // (i.e., next_instance_batch_to_check == miniblock_batch_number)
+        // (i.e., `next_instance_batch_to_check == miniblock_batch_number`)
         match instance_batch_to_check.cmp(&miniblock_batch_number) {
             Greater => return Ok(()), // This batch has already been checked.
             Less => {

--- a/core/tests/loadnext/src/account/mod.rs
+++ b/core/tests/loadnext/src/account/mod.rs
@@ -136,7 +136,7 @@ impl AccountLifespan {
             let is_l1_transaction =
                 matches!(command.command_type, TxType::L1Execute | TxType::Deposit);
             if is_l1_transaction && l1_tx_count >= MAX_L1_TRANSACTIONS {
-                continue; // Skip command to not run out of ethereum on L1
+                continue; // Skip command to not run out of Ethereum on L1
             }
 
             // The new transaction should be sent only if mempool is not full

--- a/core/tests/loadnext/src/account/tx_command_executor.rs
+++ b/core/tests/loadnext/src/account/tx_command_executor.rs
@@ -201,7 +201,7 @@ impl AccountLifespan {
         }?;
 
         // Update current nonce for future txs
-        // If the transaction has a tx_hash and is small enough to be included in a block, this tx will change the nonce.
+        // If the transaction has a `tx_hash` and is small enough to be included in a block, this tx will change the nonce.
         // We can be sure that the nonce will be changed based on this assumption.
         if let SubmitResult::TxHash(_) = &result {
             self.current_nonce = Some(nonce + 1)

--- a/core/tests/loadnext/src/account_pool.rs
+++ b/core/tests/loadnext/src/account_pool.rs
@@ -90,7 +90,7 @@ impl AccountPool {
     /// Generates all the required test accounts and prepares `Wallet` objects.
     pub async fn new(config: &LoadtestConfig) -> anyhow::Result<Self> {
         let l2_chain_id = L2ChainId::try_from(config.l2_chain_id).unwrap();
-        // Create a client for pinging the rpc.
+        // Create a client for pinging the RPC.
         let client = HttpClientBuilder::default()
             .build(&config.l2_rpc_address)
             .unwrap();

--- a/core/tests/loadnext/src/command/api.rs
+++ b/core/tests/loadnext/src/command/api.rs
@@ -73,7 +73,7 @@ async fn random_block_number(wallet: &SyncWallet, rng: &mut LoadtestRng) -> api:
     match block_number {
         BlockNumber::Committed => api::BlockNumber::Committed,
         BlockNumber::Number => {
-            // Choose a random block in the range [0, latest_committed_block_number).
+            // Choose a random block in the range `[0, latest_committed_block_number)`.
             match wallet
                 .provider
                 .get_block_by_number(api::BlockNumber::Committed, false)

--- a/core/tests/loadnext/src/config.rs
+++ b/core/tests/loadnext/src/config.rs
@@ -152,8 +152,8 @@ fn default_l1_rpc_address() -> String {
 
 fn default_master_wallet_pk() -> String {
     // Use this key only for localhost because it is compromised!
-    // Using this key for rinkeby will result in losing rinkeby ETH.
-    // Corresponding wallet is 0x36615Cf349d7F6344891B1e7CA7C72883F5dc049
+    // Using this key for Rinkeby will result in losing Rinkeby ETH.
+    // Corresponding wallet is `0x36615Cf349d7F6344891B1e7CA7C72883F5dc049`
     let result = "7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110".to_string();
     tracing::info!("Using default MASTER_WALLET_PK: {result}");
     result
@@ -181,7 +181,7 @@ fn default_main_token() -> H160 {
     // Read token addresses from `etc/tokens/localhost.json`. Use the first one
     // as a main token since all of them are suitable.
 
-    // 0xeb8f08a975Ab53E34D8a0330E0D34de942C95926 for rinkeby
+    // `0xeb8f08a975Ab53E34D8a0330E0D34de942C95926` for Rinkeby
     let tokens = read_tokens(Network::Localhost).expect("Failed to parse tokens file");
     let main_token = tokens.first().expect("Loaded tokens list is empty");
     tracing::info!("Main token: {main_token:?}");
@@ -225,7 +225,7 @@ fn default_seed() -> Option<String> {
 }
 
 fn default_l2_chain_id() -> u64 {
-    // 270 for rinkeby
+    // 270 for Rinkeby
     let result = L2ChainId::default().as_u64();
     tracing::info!("Using default L2_CHAIN_ID: {result}");
     result
@@ -236,14 +236,14 @@ pub fn get_default_l2_rpc_address() -> String {
 }
 
 fn default_l2_rpc_address() -> String {
-    // https://z2-dev-api.zksync.dev:443 for stage2
+    // `https://z2-dev-api.zksync.dev:443` for stage2
     let result = get_default_l2_rpc_address();
     tracing::info!("Using default L2_RPC_ADDRESS: {result}");
     result
 }
 
 fn default_l2_ws_rpc_address() -> String {
-    // ws://z2-dev-api.zksync.dev:80/ws for stage2
+    // `ws://z2-dev-api.zksync.dev:80/ws` for stage2
     let result = "ws://127.0.0.1:3051".to_string();
     tracing::info!("Using default L2_WS_RPC_ADDRESS: {result}");
     result

--- a/core/tests/loadnext/src/executor.rs
+++ b/core/tests/loadnext/src/executor.rs
@@ -54,7 +54,7 @@ impl Executor {
     ) -> anyhow::Result<Self> {
         let pool = AccountPool::new(&config).await?;
 
-        // derive l2 main token address
+        // derive L2 main token address
         let l2_main_token = pool
             .master_wallet
             .ethereum(&config.l1_rpc_address)

--- a/core/tests/loadnext/src/report_collector/metrics_collector.rs
+++ b/core/tests/loadnext/src/report_collector/metrics_collector.rs
@@ -151,7 +151,7 @@ mod tests {
 
     #[test]
     fn histogram_window_size() {
-        // Vector of ((window_idx, window_size), expected_range)).
+        // Vector of `((window_idx, window_size), expected_range))`.
         let test_vector = [
             ((0, 100), (0, 99)),
             ((1, 100), (100, 199)),

--- a/core/tests/loadnext/src/rng.rs
+++ b/core/tests/loadnext/src/rng.rs
@@ -45,7 +45,7 @@ impl LoadtestRng {
         // We chain the current seed bytes and the Ethereum private key together,
         // and then calculate the hash of this data.
         // This way we obtain a derived seed, unique for each wallet, which will result in
-        // an uniques set of operations for each account.
+        // an unique set of operations for each account.
         let input_bytes: Vec<u8> = self
             .seed
             .iter()

--- a/core/tests/vm-benchmark/harness/src/lib.rs
+++ b/core/tests/vm-benchmark/harness/src/lib.rs
@@ -39,7 +39,7 @@ pub fn cut_to_allowed_bytecode_size(bytes: &[u8]) -> Option<&[u8]> {
 static STORAGE: Lazy<InMemoryStorage> = Lazy::new(|| {
     let mut storage = InMemoryStorage::with_system_contracts(hash_bytecode);
 
-    // give PRIVATE_KEY some money
+    // give `PRIVATE_KEY` some money
     let my_addr = PackedEthSignature::address_from_private_key(&PRIVATE_KEY).unwrap();
     let key = storage_key_for_eth_balance(&my_addr);
     storage.set_value(key, zksync_utils::u256_to_h256(U256([0, 0, 1, 0])));

--- a/sdk/zksync-rs/src/ethereum/mod.rs
+++ b/sdk/zksync-rs/src/ethereum/mod.rs
@@ -39,7 +39,7 @@ const ZKSYNC_INTERFACE: &str = include_str!("../abi/IZkSync.json");
 const L1_DEFAULT_BRIDGE_INTERFACE: &str = include_str!("../abi/IL1Bridge.json");
 const RAW_ERC20_DEPOSIT_GAS_LIMIT: &str = include_str!("DepositERC20GasLimit.json");
 
-// The gasPerPubdata to be used in L1->L2 requests. It may be almost any number, but here we 800
+// The `gasPerPubdata` to be used in L1->L2 requests. It may be almost any number, but here we 800
 // as an optimal one. In the future, it will be estimated.
 const L1_TO_L2_GAS_PER_PUBDATA: u32 = 800;
 
@@ -72,7 +72,7 @@ pub struct EthereumProvider<S: EthereumSigner> {
     polling_interval: Duration,
 }
 
-// TODO (SMA-1623): create a way to pass `Options` (e.g. nonce, gas_limit, priority_fee_per_gas)
+// TODO (SMA-1623): create a way to pass `Options` (e.g. `nonce`, `gas_limit, priority_fee_per_gas`)
 // into methods that perform L1 transactions. The unit is wei.
 pub const DEFAULT_PRIORITY_FEE: u64 = 2_000_000_000;
 
@@ -472,7 +472,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
 
         let mut options = eth_options.unwrap_or_default();
 
-        // If the user has already provided max_fee_per_gas or gas_price, we will use
+        // If the user has already provided `max_fee_per_gas` or `gas_price`, we will use
         // it to calculate the base cost for the transaction
         let gas_price = if let Some(max_fee_per_gas) = options.max_fee_per_gas {
             max_fee_per_gas

--- a/sdk/zksync-rs/src/ethereum/mod.rs
+++ b/sdk/zksync-rs/src/ethereum/mod.rs
@@ -72,7 +72,7 @@ pub struct EthereumProvider<S: EthereumSigner> {
     polling_interval: Duration,
 }
 
-// TODO (SMA-1623): create a way to pass `Options` (e.g. `nonce`, `gas_limit, priority_fee_per_gas`)
+// TODO (SMA-1623): create a way to pass `Options` (e.g. `nonce`, `gas_limit`, `priority_fee_per_gas`)
 // into methods that perform L1 transactions. The unit is wei.
 pub const DEFAULT_PRIORITY_FEE: u64 = 2_000_000_000;
 

--- a/spellcheck/era.cfg
+++ b/spellcheck/era.cfg
@@ -2,7 +2,7 @@
 # ${CARGO_MANIFEST_DIR}/.config/spellcheck.toml
 
 # Also take into account developer comments
-dev_comments = false
+dev_comments = true
 
 # Skip the README.md file as defined in the cargo manifest
 skip_readme = false

--- a/spellcheck/era.dic
+++ b/spellcheck/era.dic
@@ -863,3 +863,4 @@ tokenized
 Aggregator
 DecommittmentProcessor
 decommitment
+hardcoded


### PR DESCRIPTION
Related to: https://github.com/matter-labs/zksync-era/pull/681

## What ❔
- Sets dev_comments to true
- Addresses new / remaining spelling issues in dev comments
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔
- Dev comments should be checked for spelling issues for improved readability
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
