### PR TITLE
feat(state-keeper): Reject transactions that fail to publish bytecodes

### DIFF
--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -74,6 +74,7 @@ async fn build_state_keeper(
             save_call_traces,
             false,
             config.optional.enum_index_migration_chunk_size,
+            true,
         ));
 
     let main_node_url = config.required.main_node_url().unwrap();

--- a/core/lib/multivm/src/interface/traits/vm.rs
+++ b/core/lib/multivm/src/interface/traits/vm.rs
@@ -104,7 +104,10 @@ pub trait VmInterface<S, H: HistoryMode> {
         &mut self,
         tx: Transaction,
         with_compression: bool,
-    ) -> Result<VmExecutionResultAndLogs, BytecodeCompressionError> {
+    ) -> (
+        Result<(), BytecodeCompressionError>,
+        VmExecutionResultAndLogs,
+    ) {
         self.inspect_transaction_with_bytecode_compression(
             Self::TracerDispatcher::default(),
             tx,
@@ -118,7 +121,10 @@ pub trait VmInterface<S, H: HistoryMode> {
         tracer: Self::TracerDispatcher,
         tx: Transaction,
         with_compression: bool,
-    ) -> Result<VmExecutionResultAndLogs, BytecodeCompressionError>;
+    ) -> (
+        Result<(), BytecodeCompressionError>,
+        VmExecutionResultAndLogs,
+    );
 
     /// Record VM memory metrics.
     fn record_vm_memory_metrics(&self) -> VmMemoryMetrics;

--- a/core/lib/multivm/src/interface/types/errors/halt.rs
+++ b/core/lib/multivm/src/interface/types/errors/halt.rs
@@ -41,6 +41,7 @@ pub enum Halt {
     FailedToAppendTransactionToL2Block(String),
     VMPanic,
     TracerCustom(String),
+    FailedToPublishCompressedBytecodes,
 }
 
 impl Display for Halt {
@@ -111,6 +112,9 @@ impl Display for Halt {
             }
             Halt::ValidationOutOfGas => {
                 write!(f, "Validation run out of gas")
+            }
+            Halt::FailedToPublishCompressedBytecodes => {
+                write!(f, "Failed to publish compressed bytecodes")
             }
         }
     }

--- a/core/lib/multivm/src/versions/vm_boojum_integration/vm.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/vm.rs
@@ -127,13 +127,19 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
         tracer: Self::TracerDispatcher,
         tx: Transaction,
         with_compression: bool,
-    ) -> Result<VmExecutionResultAndLogs, BytecodeCompressionError> {
+    ) -> (
+        Result<(), BytecodeCompressionError>,
+        VmExecutionResultAndLogs,
+    ) {
         self.push_transaction_with_compression(tx, with_compression);
         let result = self.inspect_inner(tracer, VmExecutionMode::OneTx);
         if self.has_unpublished_bytecodes() {
-            Err(BytecodeCompressionError::BytecodeCompressionFailed)
+            (
+                Err(BytecodeCompressionError::BytecodeCompressionFailed),
+                result,
+            )
         } else {
-            Ok(result)
+            (Ok(()), result)
         }
     }
 

--- a/core/lib/multivm/src/versions/vm_latest/vm.rs
+++ b/core/lib/multivm/src/versions/vm_latest/vm.rs
@@ -127,13 +127,19 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
         tracer: Self::TracerDispatcher,
         tx: Transaction,
         with_compression: bool,
-    ) -> Result<VmExecutionResultAndLogs, BytecodeCompressionError> {
+    ) -> (
+        Result<(), BytecodeCompressionError>,
+        VmExecutionResultAndLogs,
+    ) {
         self.push_transaction_with_compression(tx, with_compression);
         let result = self.inspect_inner(tracer, VmExecutionMode::OneTx);
         if self.has_unpublished_bytecodes() {
-            Err(BytecodeCompressionError::BytecodeCompressionFailed)
+            (
+                Err(BytecodeCompressionError::BytecodeCompressionFailed),
+                result,
+            )
         } else {
-            Ok(result)
+            (Ok(()), result)
         }
     }
 

--- a/core/lib/multivm/src/versions/vm_m5/vm.rs
+++ b/core/lib/multivm/src/versions/vm_m5/vm.rs
@@ -172,13 +172,16 @@ impl<S: Storage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
         _tracer: Self::TracerDispatcher,
         tx: Transaction,
         _with_compression: bool,
-    ) -> Result<VmExecutionResultAndLogs, BytecodeCompressionError> {
+    ) -> (
+        Result<(), BytecodeCompressionError>,
+        VmExecutionResultAndLogs,
+    ) {
         crate::vm_m5::vm_with_bootloader::push_transaction_to_bootloader_memory(
             &mut self.vm,
             &tx,
             self.system_env.execution_mode.glue_into(),
         );
-        Ok(self.execute(VmExecutionMode::OneTx))
+        (Ok(()), self.execute(VmExecutionMode::OneTx))
     }
 
     fn record_vm_memory_metrics(&self) -> VmMemoryMetrics {

--- a/core/lib/multivm/src/versions/vm_m6/vm.rs
+++ b/core/lib/multivm/src/versions/vm_m6/vm.rs
@@ -179,7 +179,10 @@ impl<S: Storage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
         _tracer: Self::TracerDispatcher,
         tx: Transaction,
         with_compression: bool,
-    ) -> Result<VmExecutionResultAndLogs, BytecodeCompressionError> {
+    ) -> (
+        Result<(), BytecodeCompressionError>,
+        VmExecutionResultAndLogs,
+    ) {
         self.last_tx_compressed_bytecodes = vec![];
         let bytecodes = if with_compression {
             let deps = tx.execute.factory_deps.as_deref().unwrap_or_default();
@@ -226,9 +229,12 @@ impl<S: Storage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
             .iter()
             .any(|info| !self.vm.is_bytecode_exists(info))
         {
-            Err(crate::interface::BytecodeCompressionError::BytecodeCompressionFailed)
+            (
+                Err(BytecodeCompressionError::BytecodeCompressionFailed),
+                result.glue_into(),
+            )
         } else {
-            Ok(result.glue_into())
+            (Ok(()), result.glue_into())
         }
     }
 

--- a/core/lib/multivm/src/versions/vm_refunds_enhancement/vm.rs
+++ b/core/lib/multivm/src/versions/vm_refunds_enhancement/vm.rs
@@ -118,13 +118,19 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
         dispatcher: Self::TracerDispatcher,
         tx: Transaction,
         with_compression: bool,
-    ) -> Result<VmExecutionResultAndLogs, BytecodeCompressionError> {
+    ) -> (
+        Result<(), BytecodeCompressionError>,
+        VmExecutionResultAndLogs,
+    ) {
         self.push_transaction_with_compression(tx, with_compression);
         let result = self.inspect(dispatcher, VmExecutionMode::OneTx);
         if self.has_unpublished_bytecodes() {
-            Err(BytecodeCompressionError::BytecodeCompressionFailed)
+            (
+                Err(BytecodeCompressionError::BytecodeCompressionFailed),
+                result,
+            )
         } else {
-            Ok(result)
+            (Ok(()), result)
         }
     }
 

--- a/core/lib/multivm/src/versions/vm_virtual_blocks/vm.rs
+++ b/core/lib/multivm/src/versions/vm_virtual_blocks/vm.rs
@@ -118,13 +118,19 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
         tracer: TracerDispatcher<S, H::VmVirtualBlocksMode>,
         tx: Transaction,
         with_compression: bool,
-    ) -> Result<VmExecutionResultAndLogs, BytecodeCompressionError> {
+    ) -> (
+        Result<(), BytecodeCompressionError>,
+        VmExecutionResultAndLogs,
+    ) {
         self.push_transaction_with_compression(tx, with_compression);
         let result = self.inspect_inner(tracer, VmExecutionMode::OneTx);
         if self.has_unpublished_bytecodes() {
-            Err(BytecodeCompressionError::BytecodeCompressionFailed)
+            (
+                Err(BytecodeCompressionError::BytecodeCompressionFailed),
+                result,
+            )
         } else {
-            Ok(result)
+            (Ok(()), result)
         }
     }
 

--- a/core/lib/multivm/src/vm_instance.rs
+++ b/core/lib/multivm/src/vm_instance.rs
@@ -5,8 +5,8 @@ use zksync_utils::bytecode::CompressedBytecodeInfo;
 use crate::{
     glue::history_mode::HistoryMode,
     interface::{
-        BootloaderMemory, CurrentExecutionState, FinishedL1Batch, L1BatchEnv, L2BlockEnv,
-        SystemEnv, VmExecutionMode, VmExecutionResultAndLogs, VmInterface,
+        BootloaderMemory, BytecodeCompressionError, CurrentExecutionState, FinishedL1Batch,
+        L1BatchEnv, L2BlockEnv, SystemEnv, VmExecutionMode, VmExecutionResultAndLogs, VmInterface,
         VmInterfaceHistoryEnabled, VmMemoryMetrics,
     },
     tracers::TracerDispatcher,
@@ -86,7 +86,10 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for VmInstance<S, H> {
         &mut self,
         tx: zksync_types::Transaction,
         with_compression: bool,
-    ) -> Result<VmExecutionResultAndLogs, crate::interface::BytecodeCompressionError> {
+    ) -> (
+        Result<(), BytecodeCompressionError>,
+        VmExecutionResultAndLogs,
+    ) {
         dispatch_vm!(self.execute_transaction_with_bytecode_compression(tx, with_compression))
     }
 
@@ -96,7 +99,10 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for VmInstance<S, H> {
         dispatcher: Self::TracerDispatcher,
         tx: zksync_types::Transaction,
         with_compression: bool,
-    ) -> Result<VmExecutionResultAndLogs, crate::interface::BytecodeCompressionError> {
+    ) -> (
+        Result<(), BytecodeCompressionError>,
+        VmExecutionResultAndLogs,
+    ) {
         dispatch_vm!(self.inspect_transaction_with_bytecode_compression(
             dispatcher.into(),
             tx,

--- a/core/lib/zksync_core/src/api_server/execution_sandbox/error.rs
+++ b/core/lib/zksync_core/src/api_server/execution_sandbox/error.rs
@@ -64,6 +64,9 @@ impl From<Halt> for SandboxExecutionError {
             Halt::ValidationOutOfGas => Self::AccountValidationFailed(
                 "The validation of the transaction ran out of gas".to_string(),
             ),
+            Halt::FailedToPublishCompressedBytecodes => {
+                Self::UnexpectedVMBehavior("Failed to publish compressed bytecodes".to_string())
+            }
         }
     }
 }

--- a/core/lib/zksync_core/src/api_server/tx_sender/mod.rs
+++ b/core/lib/zksync_core/src/api_server/tx_sender/mod.rs
@@ -283,7 +283,7 @@ impl TxSender {
         let block_args = BlockArgs::pending(&mut connection).await;
         drop(connection);
 
-        let (_, tx_metrics) = execute_tx_in_sandbox(
+        let (_, tx_metrics, published_bytecodes) = execute_tx_in_sandbox(
             vm_permit.clone(),
             shared_args.clone(),
             true,
@@ -317,6 +317,10 @@ impl TxSender {
 
         if let Err(err) = validation_result {
             return Err(err.into());
+        }
+
+        if !published_bytecodes {
+            return Err(SubmitTxError::FailedToPublishCompressedBytecodes);
         }
 
         let stage_started_at = Instant::now();
@@ -588,7 +592,7 @@ impl TxSender {
         let vm_execution_cache_misses_limit = self.0.sender_config.vm_execution_cache_misses_limit;
         let execution_args =
             TxExecutionArgs::for_gas_estimate(vm_execution_cache_misses_limit, &tx, base_fee);
-        let (exec_result, tx_metrics) = execute_tx_in_sandbox(
+        let (exec_result, tx_metrics, _) = execute_tx_in_sandbox(
             vm_permit,
             shared_args,
             true,

--- a/core/lib/zksync_core/src/api_server/tx_sender/result.rs
+++ b/core/lib/zksync_core/src/api_server/tx_sender/result.rs
@@ -69,6 +69,8 @@ pub enum SubmitTxError {
     /// Error returned from main node
     #[error("{0}")]
     ProxyError(#[from] zksync_web3_decl::jsonrpsee::core::ClientError),
+    #[error("not enough gas to publish compressed bytecodes")]
+    FailedToPublishCompressedBytecodes,
 }
 
 impl SubmitTxError {
@@ -99,6 +101,7 @@ impl SubmitTxError {
             Self::InsufficientFundsForTransfer => "insufficient-funds-for-transfer",
             Self::IntrinsicGas => "intrinsic-gas",
             Self::ProxyError(_) => "proxy-error",
+            Self::FailedToPublishCompressedBytecodes => "failed-to-publish-compressed-bytecodes",
         }
     }
 

--- a/core/lib/zksync_core/src/basic_witness_input_producer/vm_interactions.rs
+++ b/core/lib/zksync_core/src/basic_witness_input_producer/vm_interactions.rs
@@ -74,6 +74,7 @@ pub(super) fn execute_tx<S: WriteStorage>(
     vm.make_snapshot();
     if vm
         .execute_transaction_with_bytecode_compression(tx.clone(), true)
+        .0
         .is_ok()
     {
         vm.pop_snapshot_no_rollback();
@@ -84,6 +85,7 @@ pub(super) fn execute_tx<S: WriteStorage>(
     vm.rollback_to_the_latest_snapshot();
     if vm
         .execute_transaction_with_bytecode_compression(tx.clone(), false)
+        .0
         .is_err()
     {
         return Err(anyhow!("compression can't fail if we don't apply it"));

--- a/core/lib/zksync_core/src/state_keeper/batch_executor/tests/tester.rs
+++ b/core/lib/zksync_core/src/state_keeper/batch_executor/tests/tester.rs
@@ -112,6 +112,7 @@ impl Tester {
             l1_batch,
             system_env,
             self.config.upload_witness_inputs_to_gcs,
+            false,
         )
     }
 

--- a/core/lib/zksync_core/src/state_keeper/io/mempool.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/mempool.rs
@@ -151,7 +151,7 @@ impl StateKeeperIO for MempoolIO {
             );
             let current_timestamp = current_timestamp.await.ok()?;
 
-            tracing::info!(
+            tracing::trace!(
                 "(l1_gas_price, fair_l2_gas_price) for L1 batch #{} is ({}, {})",
                 self.current_l1_batch_number.0,
                 self.filter.l1_gas_price,

--- a/core/lib/zksync_core/src/state_keeper/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/mod.rs
@@ -52,6 +52,7 @@ pub(crate) async fn create_state_keeper(
         state_keeper_config.save_call_traces,
         state_keeper_config.upload_witness_inputs_to_gcs,
         state_keeper_config.enum_index_migration_chunk_size(),
+        false,
     );
 
     let io = MempoolIO::new(

--- a/core/tests/ts-integration/tests/contracts.test.ts
+++ b/core/tests/ts-integration/tests/contracts.test.ts
@@ -306,7 +306,7 @@ describe('Smart contract behavior checks', () => {
         ).toBeAccepted([]);
     });
 
-    test.only('Should reject tx with not enough gas for publishing bytecode', async () => {
+    test('Should reject tx with not enough gas for publishing bytecode', async () => {
         // Send a transaction with big unique factory dep and provide gas enough for validation but not for bytecode publishing.
         // Transaction should be rejected by API.
 

--- a/core/tests/ts-integration/tests/contracts.test.ts
+++ b/core/tests/ts-integration/tests/contracts.test.ts
@@ -306,6 +306,37 @@ describe('Smart contract behavior checks', () => {
         ).toBeAccepted([]);
     });
 
+    test('Should reject tx with not enough gas for publishing bytecode', async () => {
+        // Send a transaction with big unique factory dep and provide gas enough for validation but not for bytecode publishing.
+        // Transaction should be rejected by state keeper.
+
+        const BYTECODE_LEN = 50016;
+        const bytecode = ethers.utils.hexlify(ethers.utils.randomBytes(BYTECODE_LEN));
+
+        // Estimate gas for "no-op". It's a good estimate for validation gas.
+        const gasLimit = await alice.estimateGas({
+            to: alice.address,
+            data: '0x'
+        });
+
+        const tx = await alice.sendTransaction({
+            to: alice.address,
+            gasLimit,
+            customData: {
+                factoryDeps: [bytecode]
+            }
+        });
+
+        // We don't have a good check that tx was indeed rejected.
+        // Most that we can do is to ensure that tx wasn't mined for some time.
+        const attempts = 5;
+        for (let i = 0; i < attempts; ++i) {
+            const receipt = await alice.provider.getTransactionReceipt(tx.hash);
+            expect(receipt).toBeNull();
+            await zksync.utils.sleep(1000);
+        }
+    });
+
     afterAll(async () => {
         await testMaster.deinitialize();
     });

--- a/core/tests/ts-integration/tests/contracts.test.ts
+++ b/core/tests/ts-integration/tests/contracts.test.ts
@@ -306,9 +306,9 @@ describe('Smart contract behavior checks', () => {
         ).toBeAccepted([]);
     });
 
-    test('Should reject tx with not enough gas for publishing bytecode', async () => {
+    test.only('Should reject tx with not enough gas for publishing bytecode', async () => {
         // Send a transaction with big unique factory dep and provide gas enough for validation but not for bytecode publishing.
-        // Transaction should be rejected by state keeper.
+        // Transaction should be rejected by API.
 
         const BYTECODE_LEN = 50016;
         const bytecode = ethers.utils.hexlify(ethers.utils.randomBytes(BYTECODE_LEN));
@@ -319,22 +319,15 @@ describe('Smart contract behavior checks', () => {
             data: '0x'
         });
 
-        const tx = await alice.sendTransaction({
-            to: alice.address,
-            gasLimit,
-            customData: {
-                factoryDeps: [bytecode]
-            }
-        });
-
-        // We don't have a good check that tx was indeed rejected.
-        // Most that we can do is to ensure that tx wasn't mined for some time.
-        const attempts = 5;
-        for (let i = 0; i < attempts; ++i) {
-            const receipt = await alice.provider.getTransactionReceipt(tx.hash);
-            expect(receipt).toBeNull();
-            await zksync.utils.sleep(1000);
-        }
+        await expect(
+            alice.sendTransaction({
+                to: alice.address,
+                gasLimit,
+                customData: {
+                    factoryDeps: [bytecode]
+                }
+            })
+        ).toBeRejected('not enough gas to publish compressed bytecodes');
     });
 
     afterAll(async () => {


### PR DESCRIPTION
## What ❔

State keeper and API reject transactions that fail to publish bytecodes

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `cargo spellcheck --cfg=./spellcheck/era.cfg --code 1`.
