### PR TITLE
fix(vm): `inspect_transaction_with_bytecode_compression` for old VMs

### DIFF
--- a/core/lib/multivm/src/versions/vm_1_3_2/vm.rs
+++ b/core/lib/multivm/src/versions/vm_1_3_2/vm.rs
@@ -204,20 +204,31 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
         };
 
         // Even that call tracer is supported here, we don't use it.
-        let result = self.vm.execute_next_tx(
-            self.system_env.default_validation_computational_gas_limit,
-            false,
-        );
+        let result = match self.system_env.execution_mode {
+            TxExecutionMode::VerifyExecute => self
+                .vm
+                .execute_next_tx(
+                    self.system_env.default_validation_computational_gas_limit,
+                    false,
+                )
+                .glue_into(),
+            TxExecutionMode::EstimateFee | TxExecutionMode::EthCall => self
+                .vm
+                .execute_till_block_end(
+                    crate::vm_1_3_2::vm_with_bootloader::BootloaderJobType::TransactionExecution,
+                )
+                .glue_into(),
+        };
         if bytecodes
             .iter()
             .any(|info| !self.vm.is_bytecode_known(info))
         {
             (
                 Err(BytecodeCompressionError::BytecodeCompressionFailed),
-                result.glue_into(),
+                result,
             )
         } else {
-            (Ok(()), result.glue_into())
+            (Ok(()), result)
         }
     }
 

--- a/core/lib/multivm/src/versions/vm_m6/vm.rs
+++ b/core/lib/multivm/src/versions/vm_m6/vm.rs
@@ -221,20 +221,31 @@ impl<S: Storage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
         };
 
         // Even that call tracer is supported here, we don't use it.
-        let result = self.vm.execute_next_tx(
-            self.system_env.default_validation_computational_gas_limit,
-            false,
-        );
+        let result = match self.system_env.execution_mode {
+            TxExecutionMode::VerifyExecute => self
+                .vm
+                .execute_next_tx(
+                    self.system_env.default_validation_computational_gas_limit,
+                    false,
+                )
+                .glue_into(),
+            TxExecutionMode::EstimateFee | TxExecutionMode::EthCall => self
+                .vm
+                .execute_till_block_end(
+                    crate::vm_m6::vm_with_bootloader::BootloaderJobType::TransactionExecution,
+                )
+                .glue_into(),
+        };
         if bytecodes
             .iter()
             .any(|info| !self.vm.is_bytecode_exists(info))
         {
             (
                 Err(BytecodeCompressionError::BytecodeCompressionFailed),
-                result.glue_into(),
+                result,
             )
         } else {
-            (Ok(()), result.glue_into())
+            (Ok(()), result)
         }
     }
 


### PR DESCRIPTION
## What ❔

Fixes `inspect_transaction_with_bytecode_compression` for vm_1_3_2 and vm_m6 to work correctly with all tx execution modes

## Why ❔

Fix bug

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
