### PR TITLE
chore(zk): adds sql-formatter to zk dependencies

### DIFF
--- a/infrastructure/zk/package.json
+++ b/infrastructure/zk/package.json
@@ -32,6 +32,7 @@
         "@types/tabtab": "^3.0.1",
         "hardhat": "=2.16.0",
         "typescript": "^4.3.5",
-        "cspell": "*"
+        "cspell": "*",
+        "sql-formatter": "^13.1.0"
     }
 }


### PR DESCRIPTION
## What ❔

Bulding the newest image fails with


```
> [12/17] RUN cd /infrastructure/zk && yarn && yarn build && cd /:
26.23 [3/4] Linking dependencies...
26.23 warning " > zksync-web3@0.15.5" has incorrect peer dependency "ethers@~5.7.0".
32.77 [4/4] Building fresh packages...
38.07 success Saved lockfile.
38.08 Done in 37.55s.
38.39 yarn run v1.22.21
38.42 $ tsc
40.31 src/format_sql.ts(3,24): error TS2307: Cannot find module 'sql-formatter' or its corresponding type declarations.
40.34 error Command failed with exit code 1.
40.34 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
------
Dockerfile:50
--------------------
  48 |     
  49 |     # Build `zk` tool
  50 | >>> RUN cd /infrastructure/zk && yarn && yarn build && cd /
  51 |     # Build `local-setup-preparation` tool
  52 |     RUN cd /infrastructure/local-setup-preparation && yarn && cd /
  ```

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
