### PR TITLE
fix(local-node): deploy erc20 tokens to fix the deployment

### DIFF
--- a/infrastructure/zk/src/init.ts
+++ b/infrastructure/zk/src/init.ts
@@ -95,6 +95,7 @@ export async function lightweightInit() {
     await announced('Deploying L1 verifier', contract.deployVerifier([]));
     await announced('Reloading env', env.reload());
     await announced('Running server genesis setup', server.genesisFromBinary());
+    await announced('Deploying localhost ERC20 tokens', run.deployERC20('dev', '', '', '', []));
     await announced('Deploying L1 contracts', contract.redeployL1([]));
     await announced('Initializing validator', contract.initializeValidator());
     await announced('Deploying L2 contracts', contract.deployL2([], true, false));


### PR DESCRIPTION
## What ❔
Currently the run of [local-node](https://github.com/matter-labs/local-node) fails in the logs with:

```
2024-01-15 07:36:06 Deploying TransparentUpgradeableProxy
2024-01-15 07:36:09 TransparentUpgradeableProxy deployed, gasUsed: 678557
2024-01-15 07:36:09 CONTRACTS_L1_ERC20_BRIDGE_PROXY_ADDR=0x1242f30c5c146ed47194BF6D56013A70D9B7C1A0
2024-01-15 07:36:09 Error: TypeError: Cannot read properties of undefined (reading 'address')
2024-01-15 07:36:09     at Deployer.<anonymous> (/contracts/ethereum/src.ts/deploy.ts:318:92)
2024-01-15 07:36:09     at step (/contracts/ethereum/src.ts/deploy.ts:33:23)
2024-01-15 07:36:09     at Object.next (/contracts/ethereum/src.ts/deploy.ts:14:53)
2024-01-15 07:36:09     at /contracts/ethereum/src.ts/deploy.ts:8:71
2024-01-15 07:36:09     at new Promise (<anonymous>)
2024-01-15 07:36:09     at __awaiter (/contracts/ethereum/src.ts/deploy.ts:4:12)
2024-01-15 07:36:09     at Deployer.deployWethBridgeImplementation (/contracts/ethereum/src.ts/deploy.ts:390:16)
2024-01-15 07:36:09     at Deployer.<anonymous> (/contracts/ethereum/src.ts/deploy.ts:439:16)
2024-01-15 07:36:09     at step (/contracts/ethereum/src.ts/deploy.ts:33:23)
2024-01-15 07:36:09     at Object.next (/contracts/ethereum/src.ts/deploy.ts:14:53)
error Command failed with exit code 1.
2024-01-15 07:36:09 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
2024-01-15 07:36:09 Skip contract verification on localhost
```

However the overall run of the setup doesn't fail weirdly after this. What this failure does is that prevents the further steps in the L1 contract deployment and important stuff such as `VERIFIER_TIMELOCK` does not get deployed.

Further down the road the environment variables get populated from the two files:

https://github.com/matter-labs/zksync-era/blob/3af4644f428af0328cdea0fbae8a8f965489c6c4/docker/local-node/entrypoint.sh#L44-L45

However the `.init.dev` file does not contain the `CONTRACT_VERIFIER_TIMELOCK_ADDR` variable so it gets populated with `0xFC073319977e314F251EAE6ae6bE76B0B3BAeeCF` address from `/etc/env/dev.env` and all transactions such as `commitBlocks` go to this address which breaks block commit/verify/execution. The reason of the failure above is that the WETH bridge deployment needs to search for WETH token in `/etc/env/localhost.json` and because the ERC20 deployment step has been empty this file is also empty. So this fix adds a step of ERC20 deployment to fix this.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
