### PR TITLE
chore(hyperchains): fix zk stack cli

### DIFF
--- a/infrastructure/zk/src/init.ts
+++ b/infrastructure/zk/src/init.ts
@@ -58,13 +58,7 @@ export async function init(initArgs: InitArgs = DEFAULT_ARGS) {
     if (deployerL2ContractInput.includeL2WETH) {
         await announced('Initializing L2 WETH token', contract.initializeWethToken(governorPrivateKeyArgs));
     }
-    await announced(
-        'Initializing governance',
-        contract.initializeGovernance([
-            ...governorPrivateKeyArgs,
-            !deployerL2ContractInput.includeL2WETH ? ['--skip-weth-bridge'] : []
-        ])
-    );
+    await announced('Initializing governance',contract.initializeGovernance(governorPrivateKeyArgs));
 }
 
 // A smaller version of `init` that "resets" the localhost environment, for which `init` was already called before.

--- a/infrastructure/zk/src/init.ts
+++ b/infrastructure/zk/src/init.ts
@@ -58,7 +58,7 @@ export async function init(initArgs: InitArgs = DEFAULT_ARGS) {
     if (deployerL2ContractInput.includeL2WETH) {
         await announced('Initializing L2 WETH token', contract.initializeWethToken(governorPrivateKeyArgs));
     }
-    await announced('Initializing governance',contract.initializeGovernance(governorPrivateKeyArgs));
+    await announced('Initializing governance', contract.initializeGovernance(governorPrivateKeyArgs));
 }
 
 // A smaller version of `init` that "resets" the localhost environment, for which `init` was already called before.


### PR DESCRIPTION
## What ❔

Fixes zk stack cli when spinning up a hyperchain without WETH bridge

## Why ❔

Because it was broken. Some changes over the last month removed a param that used to exist

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] Code has been formatted via `zk fmt` and `zk lint`.
- [X] Spellcheck has been run via `zk spellcheck`.
