### PR TITLE
add eth_getBlockReceipts

### DIFF
--- a/core/lib/types/src/api/mod.rs
+++ b/core/lib/types/src/api/mod.rs
@@ -177,6 +177,12 @@ impl From<H256> for TransactionId {
     }
 }
 
+impl From<(BlockId, Index)> for TransactionId {
+    fn from((block_id, index): (BlockId, Index)) -> Self {
+        TransactionId::Block(block_id, index)
+    }
+}
+
 /// A struct with the proof for the L2->L1 log in a specific block.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/core/lib/web3_decl/src/error.rs
+++ b/core/lib/web3_decl/src/error.rs
@@ -7,6 +7,8 @@ use zksync_types::api::SerializationTransactionError;
 pub enum Web3Error {
     #[error("Block with such an ID doesn't exist yet")]
     NoBlock,
+    #[error("Transaction with such an ID doesn't exist yet")]
+    NoTransaction,
     #[error("Request timeout")]
     RequestTimeout,
     #[error("Internal error")]

--- a/core/lib/web3_decl/src/namespaces/eth.rs
+++ b/core/lib/web3_decl/src/namespaces/eth.rs
@@ -3,7 +3,7 @@ use jsonrpsee::{
     proc_macros::rpc,
 };
 use zksync_types::{
-    api::{BlockIdVariant, BlockNumber, Transaction, TransactionVariant},
+    api::{BlockId, BlockIdVariant, BlockNumber, Transaction, TransactionVariant},
     transaction_request::CallRequest,
     Address, H256,
 };
@@ -85,6 +85,9 @@ pub trait EthNamespace {
         &self,
         block_number: BlockNumber,
     ) -> RpcResult<Option<U256>>;
+
+    #[method(name = "getBlockReceipts")]
+    async fn get_block_receipts(&self, block_id: BlockId) -> RpcResult<Vec<TransactionReceipt>>;
 
     #[method(name = "getBlockTransactionCountByHash")]
     async fn get_block_transaction_count_by_hash(

--- a/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/mod.rs
+++ b/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/mod.rs
@@ -23,6 +23,7 @@ pub fn into_jsrpc_error(err: Web3Error) -> ErrorObjectOwned {
         match err {
             Web3Error::InternalError | Web3Error::NotImplemented => ErrorCode::InternalError.code(),
             Web3Error::NoBlock
+            | Web3Error::NoTransaction
             | Web3Error::NoSuchFunction
             | Web3Error::RLPError(_)
             | Web3Error::InvalidTransactionData(_)

--- a/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/eth.rs
+++ b/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/eth.rs
@@ -112,6 +112,12 @@ impl EthNamespaceServer for EthNamespace {
             .map_err(into_jsrpc_error)
     }
 
+    async fn get_block_receipts(&self, block_id: BlockId) -> RpcResult<Vec<TransactionReceipt>> {
+        self.get_block_receipts_impl(block_id.into())
+            .await
+            .map_err(into_jsrpc_error)
+    }
+
     async fn get_block_transaction_count_by_hash(
         &self,
         block_hash: H256,

--- a/core/tests/ts-integration/tests/api/web3.test.ts
+++ b/core/tests/ts-integration/tests/api/web3.test.ts
@@ -39,11 +39,22 @@ describe('web3 API compatibility tests', () => {
         const blockWithTxsByNumber = await alice.provider.getBlockWithTransactions(blockNumber);
         expect(blockWithTxsByNumber.gasLimit).bnToBeGt(0);
         let sumTxGasUsed = ethers.BigNumber.from(0);
+
         for (const tx of blockWithTxsByNumber.transactions) {
             const receipt = await alice.provider.getTransactionReceipt(tx.hash);
             sumTxGasUsed = sumTxGasUsed.add(receipt.gasUsed);
         }
         expect(blockWithTxsByNumber.gasUsed).bnToBeGte(sumTxGasUsed);
+
+        let expectedReceipts = [];
+
+        for (const tx of blockWithTxsByNumber.transactions) {
+            const receipt = await alice.provider.send('eth_getTransactionReceipt', [tx.hash]);
+            expectedReceipts.push(receipt);
+        }
+
+        let receipts = await alice.provider.send('eth_getBlockReceipts', [blockNumberHex]);
+        expect(receipts).toEqual(expectedReceipts);
 
         // eth_getBlockByHash
         await alice.provider.getBlock(blockHash);


### PR DESCRIPTION
## What ❔

Add `eth_getBlockReceipts` to API server

## Why ❔

For better Ethereum API compatibility.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
