### PR TITLE
feat(api): Consider State keeper fee model input in the API

### DIFF
--- a/core/lib/types/src/fee_model.rs
+++ b/core/lib/types/src/fee_model.rs
@@ -30,6 +30,18 @@ impl BatchFeeInput {
             fair_l2_gas_price,
         })
     }
+
+    pub fn pubdata_independent(
+        l1_gas_price: u64,
+        fair_l2_gas_price: u64,
+        fair_pubdata_price: u64,
+    ) -> Self {
+        Self::PubdataIndependent(PubdataIndependentBatchFeeModelInput {
+            l1_gas_price,
+            fair_l2_gas_price,
+            fair_pubdata_price,
+        })
+    }
 }
 
 impl Default for BatchFeeInput {
@@ -99,6 +111,27 @@ impl BatchFeeInput {
                 fair_l2_gas_price,
                 l1_gas_price,
             })
+        }
+    }
+
+    pub fn stricter(self, other: BatchFeeInput) -> Self {
+        match (self, other) {
+            (BatchFeeInput::L1Pegged(first), BatchFeeInput::L1Pegged(second)) => Self::l1_pegged(
+                first.l1_gas_price.max(second.l1_gas_price),
+                first.fair_l2_gas_price.max(second.fair_l2_gas_price),
+            ),
+            input @ (_, _) => {
+                let (first, second) = (
+                    input.0.into_pubdata_independent(),
+                    input.1.into_pubdata_independent(),
+                );
+
+                Self::pubdata_independent(
+                    first.l1_gas_price.max(second.l1_gas_price),
+                    first.fair_l2_gas_price.max(second.fair_l2_gas_price),
+                    first.fair_pubdata_price.max(second.fair_pubdata_price),
+                )
+            }
         }
     }
 }

--- a/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/zks.rs
@@ -142,7 +142,7 @@ impl ZksNamespaceServer for ZksNamespace {
     }
 
     async fn get_l1_gas_price(&self) -> RpcResult<U64> {
-        Ok(self.get_l1_gas_price_impl())
+        Ok(self.get_l1_gas_price_impl().await)
     }
 
     async fn get_fee_params(&self) -> RpcResult<FeeParams> {

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/debug.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/debug.rs
@@ -38,7 +38,8 @@ impl DebugNamespace {
                 .get_batch_fee_input_scaled(
                     state.api_config.estimate_gas_scale_factor,
                     state.api_config.estimate_gas_scale_factor,
-                ),
+                )
+                .await,
             state,
             api_contracts,
         }

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
@@ -542,7 +542,7 @@ impl ZksNamespace {
     }
 
     #[tracing::instrument(skip(self))]
-    pub fn get_l1_gas_price_impl(&self) -> U64 {
+    pub async fn get_l1_gas_price_impl(&self) -> U64 {
         const METHOD_NAME: &str = "get_l1_gas_price";
 
         let method_latency = API_METRICS.start_call(METHOD_NAME);
@@ -552,6 +552,7 @@ impl ZksNamespace {
             .0
             .batch_fee_input_provider
             .get_batch_fee_input()
+            .await
             .l1_gas_price();
 
         method_latency.observe();

--- a/core/lib/zksync_core/src/fee_model.rs
+++ b/core/lib/zksync_core/src/fee_model.rs
@@ -12,10 +12,11 @@ use zksync_utils::ceil_div_u256;
 use crate::l1_gas_price::L1GasPriceProvider;
 
 /// Trait responsible for providing fee info for a batch
+#[async_trait::async_trait]
 pub trait BatchFeeModelInputProvider: fmt::Debug + 'static + Send + Sync {
     /// Returns the batch fee with scaling applied. This may be used to account for the fact that the L1 gas and pubdata prices may fluctuate, esp.
     /// in API methods that should return values that are valid for some period of time after the estimation was done.
-    fn get_batch_fee_input_scaled(
+    async fn get_batch_fee_input_scaled(
         &self,
         l1_gas_price_scale_factor: f64,
         l1_pubdata_price_scale_factor: f64,
@@ -38,8 +39,8 @@ pub trait BatchFeeModelInputProvider: fmt::Debug + 'static + Send + Sync {
     }
 
     /// Returns the batch fee input as-is, i.e. without any scaling for the L1 gas and pubdata prices.
-    fn get_batch_fee_input(&self) -> BatchFeeInput {
-        self.get_batch_fee_input_scaled(1.0, 1.0)
+    async fn get_batch_fee_input(&self) -> BatchFeeInput {
+        self.get_batch_fee_input_scaled(1.0, 1.0).await
     }
 
     /// Returns the fee model parameters.
@@ -76,6 +77,15 @@ impl MainNodeFeeInputProvider {
         Self { provider, config }
     }
 }
+
+pub(crate) struct ApiFeeInputProvider {
+    l1_gas_price_provider: Arc<dyn L1GasPriceProvider>,
+    config: FeeModelConfig,
+}
+
+// impl BatchFeeModelInputProvider for ApiFeeInputProvider {
+
+// }
 
 /// Calculates the batch fee input based on the main node parameters.
 /// This function uses the `V1` fee model, i.e. where the pubdata price does not include the proving costs.

--- a/core/lib/zksync_core/src/state_keeper/io/mempool.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/mempool.rs
@@ -163,7 +163,8 @@ impl StateKeeperIO for MempoolIO {
             self.filter = l2_tx_filter(
                 self.batch_fee_input_provider.as_ref(),
                 protocol_version.into(),
-            );
+            )
+            .await;
             // We only need to get the root hash when we're certain that we have a new transaction.
             if !self.mempool.has_next(&self.filter) {
                 tokio::time::sleep(self.delay_interval).await;

--- a/core/lib/zksync_core/src/state_keeper/io/tests/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/tests/mod.rs
@@ -106,7 +106,8 @@ async fn test_filter_with_no_pending_batch() {
     let want_filter = l2_tx_filter(
         &tester.create_batch_fee_input_provider().await,
         ProtocolVersionId::latest().into(),
-    );
+    )
+    .await;
 
     // Create a mempool without pending batch and ensure that filter is not initialized just yet.
     let (mut mempool, mut guard) = tester.create_test_mempool_io(connection_pool, 1).await;
@@ -150,7 +151,8 @@ async fn test_timestamps_are_distinct(
     let tx_filter = l2_tx_filter(
         &tester.create_batch_fee_input_provider().await,
         ProtocolVersionId::latest().into(),
-    );
+    )
+    .await;
     tester.insert_tx(&mut guard, tx_filter.fee_per_gas, tx_filter.gas_per_pubdata);
 
     let batch_params = mempool

--- a/core/lib/zksync_core/src/state_keeper/mempool_actor.rs
+++ b/core/lib/zksync_core/src/state_keeper/mempool_actor.rs
@@ -13,11 +13,11 @@ use crate::{api_server::execution_sandbox::BlockArgs, fee_model::BatchFeeModelIn
 /// Creates a mempool filter for L2 transactions based on the current L1 gas price.
 /// The filter is used to filter out transactions from the mempool that do not cover expenses
 /// to process them.
-pub fn l2_tx_filter(
+pub async fn l2_tx_filter(
     batch_fee_input_provider: &dyn BatchFeeModelInputProvider,
     vm_version: VmVersion,
 ) -> L2TxFilter {
-    let fee_input = batch_fee_input_provider.get_batch_fee_input();
+    let fee_input = batch_fee_input_provider.get_batch_fee_input().await;
 
     let (base_fee, gas_per_pubdata) = derive_base_fee_and_gas_per_pubdata(fee_input, vm_version);
     L2TxFilter {
@@ -87,7 +87,8 @@ impl<G: BatchFeeModelInputProvider> MempoolFetcher<G> {
             let l2_tx_filter = l2_tx_filter(
                 self.batch_fee_input_provider.as_ref(),
                 protocol_version.into(),
-            );
+            )
+            .await;
 
             let (transactions, nonces) = storage
                 .transactions_dal()


### PR DESCRIPTION
## What ❔

Before, under big spikes in L1 gas price, it was possible that the state keeper retained the inflated gas price, while the API got the smaller one. In this PR we ensure that the API takes into account the fee params of the latest sealed miniblock

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
