### PR TITLE
fix(zk-stack): Remove remapping docker containers

### DIFF
--- a/infrastructure/zk/src/hyperchain_wizard.ts
+++ b/infrastructure/zk/src/hyperchain_wizard.ts
@@ -43,9 +43,6 @@ export interface BasePromptOptions {
     skip?: ((state: object) => boolean | Promise<boolean>) | boolean;
 }
 
-// PLA:681
-let isLocalhost = false;
-
 // An init command that allows configuring and spinning up a new hyperchain network.
 async function initHyperchain() {
     await announced('Initializing hyperchain creation', setupConfiguration());
@@ -71,15 +68,6 @@ async function initHyperchain() {
     };
 
     await init(initArgs);
-
-    // if we used matterlabs/geth network, we need custom ENV file for hyperchain compose parts
-    // This breaks `zk status prover` command, but neccessary for working in isolated docker-network
-    // TODO: Think about better implementation
-    // PLA:681
-    if (isLocalhost) {
-        wrapEnvModify('ETH_CLIENT_WEB3_URL', 'http://geth:8545');
-        wrapEnvModify('DATABASE_URL', 'postgres://postgres:notsecurepassword@postgres:5432/zksync_local');
-    }
 
     env.mergeInitToEnv();
 
@@ -262,8 +250,6 @@ async function setHyperchainMetadata() {
             feeReceiverAddress = keyResults.feeReceiver;
         }
     } else {
-        // PLA:681
-        isLocalhost = true;
         l1Rpc = 'http://localhost:8545';
         l1Id = 9;
         databaseUrl = 'postgres://postgres:notsecurepassword@localhost:5432/zksync_local';


### PR DESCRIPTION
## What ❔

Remove remapping urls for zk stack initialization

## Why ❔

Meanwhile it's good to not expose ports, especially on linux machine. It's hardly complicated to work with it from localhost environment. And we hope, that users won't use our docker-composes for production environment

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
