### PR TITLE
fix(error & syntax): Optimize error handling

### DIFF
--- a/core/bin/contract-verifier/src/main.rs
+++ b/core/bin/contract-verifier/src/main.rs
@@ -28,9 +28,9 @@ async fn update_compiler_versions(connection_pool: &ConnectionPool) {
         .unwrap()
         .filter_map(|file| {
             let file = file.unwrap();
-            let Ok(file_type) = file.file_type() else {
+            let file_type = file.file_type().unwrap_or_else(|_| {
                 return None;
-            };
+            });
             if file_type.is_dir() {
                 file.file_name().into_string().ok()
             } else {

--- a/core/lib/circuit_breaker/src/lib.rs
+++ b/core/lib/circuit_breaker/src/lib.rs
@@ -16,6 +16,10 @@ pub enum CircuitBreakerError {
     FailedL1Transaction,
     #[error("Replication lag ({0:?}) is above the threshold ({1:?})")]
     ReplicationLag(u32, u32),
+    #[error("Failed to access storage")]
+    StorageAccessFailed,
+    #[error("Failed to check transactions")]
+    FailedTransactionCheck,
 }
 
 /// Checks circuit breakers


### PR DESCRIPTION
## What ❔
1. Before the if statement, the else keyword is used, which is incorrect. The unwrap_or_else method should be used before the if statement to handle possible errors.

2. Unwrap() is used to handle possible errors, which may cause the program to crash when an error is encountered. A better approach is to use the ? operator to propagate errors so that the function can return an error when it encounters it, rather than crashing.

I added two new error types StorageAccessFailed and FailedTransactionCheck to the CircuitBreakerError enumeration



## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
