### PR TITLE
chore: update flake.nix for the current release

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,16 +7,16 @@
     },
     "stable": {
       "locked": {
-        "lastModified": 1683478192,
-        "narHash": "sha256-7f7RR71w0jRABDgBwjq3vE1yY3nrVJyXk8hDzu5kl1E=",
+        "lastModified": 1705331948,
+        "narHash": "sha256-qjQXfvrAT1/RKDFAMdl8Hw3m4tLVvMCc8fMqzJv0pP4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c568239bcc990050b7aedadb7387832440ad8fb1",
+        "rev": "b8dd8be3c790215716e7c12b247f45ca525867e2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,40 +1,43 @@
 {
-    description = "zkSync development shell";
-    inputs = {
-        stable.url = "github:NixOS/nixpkgs/nixos-22.11";
-    };
-    outputs = {self, stable}: {
-        packages.x86_64-linux.default =
-        with import stable { system = "x86_64-linux"; };
-        pkgs.mkShell {
-            name = "zkSync";
-            src = ./.;
-            buildInputs = [
-                docker-compose
-                nodejs
-                yarn
-                axel
-                libclang
-                openssl
-                pkg-config
-                postgresql
-                python3
-                solc
-            ];
+  description = "zkSync development shell";
+  inputs = {
+    stable.url = "github:NixOS/nixpkgs/nixos-23.11";
+  };
+  outputs = { self, stable }: {
+    formatter.x86_64-linux = stable.legacyPackages.x86_64-linux.nixpkgs-fmt;
+    devShells.x86_64-linux.default =
+      with import stable { system = "x86_64-linux"; };
+      pkgs.mkShell.override { stdenv = pkgs.stdenvAdapters.useMoldLinker pkgs.gccStdenv; } {
+        name = "zkSync";
+        src = ./.;
+        buildInputs = [
+          docker-compose
+          nodejs
+          yarn
+          axel
+          libclang
+          openssl
+          pkg-config
+          postgresql
+          python3
+          solc
+          sqlx-cli
+          rustup
+        ];
 
-            # for RocksDB and other Rust bindgen libraries
-            LIBCLANG_PATH = lib.makeLibraryPath [ libclang.lib ];
-            BINDGEN_EXTRA_CLANG_ARGS = ''-I"${libclang.lib}/lib/clang/${libclang.version}/include"'';
+        # for RocksDB and other Rust bindgen libraries
+        LIBCLANG_PATH = lib.makeLibraryPath [ libclang.lib ];
+        BINDGEN_EXTRA_CLANG_ARGS = ''-I"${libclang.lib}/lib/clang/${builtins.elemAt (builtins.splitVersion libclang.version) 0}/include"'';
 
-            shellHook = ''
-                export ZKSYNC_HOME=$PWD
-                export PATH=$ZKSYNC_HOME/bin:$PATH
-            '';
+        shellHook = ''
+          export ZKSYNC_HOME=$PWD
+          export PATH=$ZKSYNC_HOME/bin:$PATH
+        '';
 
-            # hardhat solc requires ld-linux
-            # Nixos has to fake it with nix-ld
-            NIX_LD_LIBRARY_PATH = lib.makeLibraryPath [];
-            NIX_LD = builtins.readFile "${stdenv.cc}/nix-support/dynamic-linker";
-        };
-    };
+        # hardhat solc requires ld-linux
+        # Nixos has to fake it with nix-ld
+        NIX_LD_LIBRARY_PATH = lib.makeLibraryPath [];
+        NIX_LD = builtins.readFile "${stdenv.cc}/nix-support/dynamic-linker";
+      };
+  };
 }


### PR DESCRIPTION
## What ❔

- update flake.nix for the current release
- also modifiy the standard environment to use the `mold` linker
- add `rustup` and `sqlx-cli`
- reformat with `nixpkgs-fmt`
- add formatter to flake for `nix fmt`
- change flake output `packages` to `devShells`, because that is what this is
- tested the flake

## Why ❔

The old version was outdated and the environment with `nix develop --impure` didn't work anymore.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
