### PR TITLE
test(api): Fix flaky API server tests

### DIFF
--- a/core/lib/zksync_core/src/api_server/web3/pubsub.rs
+++ b/core/lib/zksync_core/src/api_server/web3/pubsub.rs
@@ -44,6 +44,7 @@ impl IdProvider for EthSubscriptionIdProvider {
 pub(super) enum PubSubEvent {
     Subscribed(SubscriptionType),
     NotifyIterationFinished(SubscriptionType),
+    MiniblockAdvanced(SubscriptionType, MiniblockNumber),
 }
 
 /// Manager of notifications for a certain type of subscriptions.
@@ -103,6 +104,10 @@ impl PubSubNotifier {
                 last_block_number = MiniblockNumber(last_block.number.unwrap().as_u32());
                 let new_blocks = new_blocks.into_iter().map(PubSubResult::Header).collect();
                 self.send_pub_sub_results(new_blocks, SubscriptionType::Blocks);
+                self.emit_event(PubSubEvent::MiniblockAdvanced(
+                    SubscriptionType::Blocks,
+                    last_block_number,
+                ));
             }
             self.emit_event(PubSubEvent::NotifyIterationFinished(
                 SubscriptionType::Blocks,
@@ -188,6 +193,10 @@ impl PubSubNotifier {
                 last_block_number = MiniblockNumber(last_log.block_number.unwrap().as_u32());
                 let new_logs = new_logs.into_iter().map(PubSubResult::Log).collect();
                 self.send_pub_sub_results(new_logs, SubscriptionType::Logs);
+                self.emit_event(PubSubEvent::MiniblockAdvanced(
+                    SubscriptionType::Logs,
+                    last_block_number,
+                ));
             }
             self.emit_event(PubSubEvent::NotifyIterationFinished(SubscriptionType::Logs));
         }

--- a/core/lib/zksync_core/src/api_server/web3/tests/filters.rs
+++ b/core/lib/zksync_core/src/api_server/web3/tests/filters.rs
@@ -22,6 +22,10 @@ impl HttpTest for BasicFilterChangesTest {
     async fn test(&self, client: &HttpClient, pool: &ConnectionPool) -> anyhow::Result<()> {
         let block_filter_id = client.new_block_filter().await?;
         let tx_filter_id = client.new_pending_transaction_filter().await?;
+
+        // Sleep a little so that the filter timestamp is strictly lesser than the transaction "received at" timestamp.
+        tokio::time::sleep(POLL_INTERVAL).await;
+
         let tx_result = execute_l2_transaction(create_l2_transaction(1, 2));
         let new_tx_hash = tx_result.hash;
         let new_miniblock = store_miniblock(

--- a/core/lib/zksync_core/src/api_server/web3/tests/mod.rs
+++ b/core/lib/zksync_core/src/api_server/web3/tests/mod.rs
@@ -264,11 +264,24 @@ async fn test_http_server(test: impl HttpTest) {
 }
 
 fn assert_logs_match(actual_logs: &[api::Log], expected_logs: &[&VmEvent]) {
-    assert_eq!(actual_logs.len(), expected_logs.len());
+    assert_eq!(
+        actual_logs.len(),
+        expected_logs.len(),
+        "expected: {expected_logs:?}, actual: {actual_logs:?}"
+    );
     for (actual_log, &expected_log) in actual_logs.iter().zip(expected_logs) {
-        assert_eq!(actual_log.address, expected_log.address);
-        assert_eq!(actual_log.topics, expected_log.indexed_topics);
-        assert_eq!(actual_log.data.0, expected_log.value);
+        assert_eq!(
+            actual_log.address, expected_log.address,
+            "expected: {expected_logs:?}, actual: {actual_logs:?}"
+        );
+        assert_eq!(
+            actual_log.topics, expected_log.indexed_topics,
+            "expected: {expected_logs:?}, actual: {actual_logs:?}"
+        );
+        assert_eq!(
+            actual_log.data.0, expected_log.value,
+            "expected: {expected_logs:?}, actual: {actual_logs:?}"
+        );
     }
 }
 


### PR DESCRIPTION
## What ❔

Fixes flaky API server tests:

- `filters::basic_filter_changes` tests (fail when comparing `tx_filter_changes`)
- `ws::log_subscriptions_with_delay` (fails at one of `assert_logs_match` calls).

## Why ❔

Flaky tests are obviously bad.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.