### PR TITLE
fix(test): Provide higher min allowance in estimation

### DIFF
--- a/core/tests/loadnext/src/account/tx_command_executor.rs
+++ b/core/tests/loadnext/src/account/tx_command_executor.rs
@@ -20,7 +20,9 @@ use zksync_types::{
 use crate::{
     account::{AccountLifespan, ExecutionType},
     command::{IncorrectnessModifier, TxCommand, TxType},
-    constants::{ETH_CONFIRMATION_TIMEOUT, ETH_POLLING_INTERVAL},
+    constants::{
+        ETH_CONFIRMATION_TIMEOUT, ETH_POLLING_INTERVAL, MIN_ALLOWANCE_FOR_PAYMASTER_ESTIMATE,
+    },
     corrupted_tx::Corrupted,
     report::ReportLabel,
     utils::format_gwei,
@@ -228,6 +230,7 @@ impl AccountLifespan {
             .estimate_fee(Some(get_approval_based_paymaster_input_for_estimation(
                 self.paymaster_address,
                 self.main_l2_token,
+                MIN_ALLOWANCE_FOR_PAYMASTER_ESTIMATE.into(),
             )))
             .await?;
         builder = builder.fee(fee.clone());
@@ -276,6 +279,7 @@ impl AccountLifespan {
             .estimate_fee(Some(get_approval_based_paymaster_input_for_estimation(
                 self.paymaster_address,
                 self.main_l2_token,
+                MIN_ALLOWANCE_FOR_PAYMASTER_ESTIMATE.into(),
             )))
             .await?;
         builder = builder.fee(fee.clone());
@@ -403,6 +407,7 @@ impl AccountLifespan {
             .estimate_fee(Some(get_approval_based_paymaster_input_for_estimation(
                 self.paymaster_address,
                 self.main_l2_token,
+                MIN_ALLOWANCE_FOR_PAYMASTER_ESTIMATE.into(),
             )))
             .await?;
         tracing::trace!(

--- a/core/tests/loadnext/src/constants.rs
+++ b/core/tests/loadnext/src/constants.rs
@@ -36,3 +36,8 @@ pub const MIN_PAYMASTER_BALANCE: u128 = 10u128.pow(18) * 50;
 /// If the paymaster balance is lower than MIN_PAYMASTER_BALANCE,
 /// loadtest will deposit funds to the paymaster account so that its balance reaches this value
 pub const TARGET_PAYMASTER_BALANCE: u128 = 10u128.pow(18) * 60;
+
+/// Min allowance for estimating the price for the paymaster transaction.
+/// It should be roughly equal (or maybe a bit higher) than the actual used tokens in the transaction for the most precise
+/// estimations. Note, however that is must not be higher than the ERC20 balance of the account.
+pub const MIN_ALLOWANCE_FOR_PAYMASTER_ESTIMATE: u128 = 10u128.pow(18);

--- a/core/tests/loadnext/src/executor.rs
+++ b/core/tests/loadnext/src/executor.rs
@@ -442,6 +442,7 @@ impl Executor {
             let paymaster_params = get_approval_based_paymaster_input_for_estimation(
                 paymaster_address,
                 self.l2_main_token,
+                MIN_ALLOWANCE_FOR_PAYMASTER_ESTIMATE.into(),
             );
 
             let fee = builder.estimate_fee(Some(paymaster_params)).await?;

--- a/sdk/zksync-rs/src/utils.rs
+++ b/sdk/zksync-rs/src/utils.rs
@@ -55,16 +55,19 @@ pub fn get_approval_based_paymaster_input(
     }
 }
 
+/// Returns the approval based paymaster input to be used for estimation of transactions.
+/// Note, that the `min_allowance` will be approved to paymaster contract during estimation and so for
+/// instance "low" values like zero could lead to underestimation of the transaction (because the cost per
+/// write depends on the size of the value).
+///
+/// This is a chicken-and-egg problem, because we need to know the cost of the transaction to estimate it, so in order to provide
+/// the most correct estimate possible it is recommended to set as realistic `min_allowance` as possible.
 pub fn get_approval_based_paymaster_input_for_estimation(
     paymaster: Address,
     token_address: Address,
+    min_allowance: U256,
 ) -> PaymasterParams {
-    get_approval_based_paymaster_input(
-        paymaster,
-        token_address,
-        Default::default(),
-        Default::default(),
-    )
+    get_approval_based_paymaster_input(paymaster, token_address, min_allowance, Default::default())
 }
 
 pub fn get_general_paymaster_input(paymaster: Address, inner_input: Vec<u8>) -> PaymasterParams {


### PR DESCRIPTION
## What ❔

During the estimation of transaction, the `minAllowance` is set by the user to the paymaster (and then it is fully transferred to the paymaster). Note, however, that the amount of funds to be paid for this operation depends on the size of `minAllowance` (and may also endure additional costs if the write to the slot is an initial one). 

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
