### PR TITLE
DRAFT: multiVM to depend on the new geometry crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,21 +1296,7 @@ dependencies = [
  "serde",
  "snark_wrapper",
  "zk_evm 1.4.0",
- "zkevm_circuits 1.4.0",
-]
-
-[[package]]
-name = "circuit_definitions"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1#49028029f0a9a4b399ada3f0c5bdbc31cd368a3e"
-dependencies = [
- "crossbeam 0.8.2",
- "derivative",
- "seq-macro",
- "serde",
- "snark_wrapper",
- "zk_evm 1.4.1",
- "zkevm_circuits 1.4.1",
+ "zkevm_circuits",
 ]
 
 [[package]]
@@ -1883,36 +1869,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
 dependencies = [
  "nix",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "curl"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "socket2 0.4.10",
- "winapi",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.70+curl-8.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0333d8849afe78a4c8102a429a446bfdd055832af071945520e835ae2d841e"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
  "windows-sys 0.48.0",
 ]
 
@@ -2753,6 +2709,24 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "geometry_config"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_0124_140#34e472dee6a754514d6504ed2bc59fdbc05d2084"
+dependencies = [
+ "derivative",
+ "serde",
+]
+
+[[package]]
+name = "geometry_config"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_0124_141#3917dfe39c5d1b46a17566c07a67fccd5ab62401"
+dependencies = [
+ "derivative",
+ "serde",
 ]
 
 [[package]]
@@ -3797,7 +3771,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -4181,6 +4154,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ethabi",
+ "geometry_config 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_0124_140)",
+ "geometry_config 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_0124_141)",
  "hex",
  "itertools 0.10.5",
  "once_cell",
@@ -4192,8 +4167,6 @@ dependencies = [
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
  "zk_evm 1.4.0",
  "zk_evm 1.4.1",
- "zkevm_test_harness 1.4.0",
- "zkevm_test_harness 1.4.1",
  "zksync_contracts",
  "zksync_eth_signer",
  "zksync_state",
@@ -6318,12 +6291,6 @@ dependencies = [
  "url",
  "uuid",
 ]
-
-[[package]]
-name = "seq-macro"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
@@ -8507,25 +8474,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zkevm-assembly"
-version = "1.3.2"
-source = "git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.4.1#50282016d01bd2fd147021dd558209778db2268b"
-dependencies = [
- "env_logger 0.9.3",
- "hex",
- "lazy_static",
- "log",
- "nom",
- "num-bigint 0.4.4",
- "num-traits",
- "sha3 0.10.8",
- "smallvec",
- "structopt",
- "thiserror",
- "zkevm_opcode_defs 1.4.1",
-]
-
-[[package]]
 name = "zkevm_circuits"
 version = "1.4.0"
 source = "git+https://github.com/matter-labs/era-zkevm_circuits.git?branch=main#4fba537ccecc238e2da9c80844dc8c185e42466f"
@@ -8543,27 +8491,6 @@ dependencies = [
  "serde_json",
  "smallvec",
  "zkevm_opcode_defs 1.3.2",
-]
-
-[[package]]
-name = "zkevm_circuits"
-version = "1.4.1"
-source = "git+https://github.com/matter-labs/era-zkevm_circuits.git?branch=v1.4.1#70234e99c2492740226b9f40091e7fccc7ef28e9"
-dependencies = [
- "arrayvec 0.7.4",
- "bincode",
- "boojum",
- "cs_derive 0.1.0 (git+https://github.com/matter-labs/era-boojum.git?branch=main)",
- "derivative",
- "hex",
- "itertools 0.10.5",
- "rand 0.4.6",
- "rand 0.8.5",
- "seq-macro",
- "serde",
- "serde_json",
- "smallvec",
- "zkevm_opcode_defs 1.4.1",
 ]
 
 [[package]]
@@ -8629,7 +8556,7 @@ dependencies = [
  "test-log",
  "tracing",
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.3)",
- "zkevm-assembly 1.3.2 (git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.3.2)",
+ "zkevm-assembly",
 ]
 
 [[package]]
@@ -8638,7 +8565,7 @@ version = "1.4.0"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0#43aeb53d7d9c909508a98f9fc140edff0e9d2357"
 dependencies = [
  "bincode",
- "circuit_definitions 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0)",
+ "circuit_definitions",
  "codegen 0.2.0",
  "crossbeam 0.8.2",
  "derivative",
@@ -8652,36 +8579,7 @@ dependencies = [
  "structopt",
  "test-log",
  "tracing",
- "zkevm-assembly 1.3.2 (git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.3.2)",
-]
-
-[[package]]
-name = "zkevm_test_harness"
-version = "1.4.1"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1#49028029f0a9a4b399ada3f0c5bdbc31cd368a3e"
-dependencies = [
- "bincode",
- "circuit_definitions 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1)",
- "codegen 0.2.0",
- "crossbeam 0.8.2",
- "curl",
- "derivative",
- "env_logger 0.9.3",
- "hex",
- "lazy_static",
- "rand 0.4.6",
- "rayon",
- "reqwest",
- "rescue_poseidon 0.4.1 (git+https://github.com/matter-labs/rescue-poseidon.git?branch=poseidon2)",
- "serde",
- "serde_json",
- "smallvec",
- "snark_wrapper",
- "structopt",
- "test-log",
- "tracing",
- "walkdir",
- "zkevm-assembly 1.3.2 (git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.4.1)",
+ "zkevm-assembly",
 ]
 
 [[package]]

--- a/core/lib/multivm/Cargo.toml
+++ b/core/lib/multivm/Cargo.toml
@@ -15,8 +15,8 @@ zk_evm_1_4_0 = { package = "zk_evm", git = "https://github.com/matter-labs/era-z
 zk_evm_1_3_3 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", tag= "v1.3.3-rc2" }
 zk_evm_1_3_1 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", tag= "v1.3.1-rc2" }
 
-zkevm_test_harness_1_4_0 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.0", package = "zkevm_test_harness" }
-zkevm_test_harness_1_4_1 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.1", package = "zkevm_test_harness" }
+geometry_config_1_4_0 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_0124_140", package = "geometry_config" }
+geometry_config_1_4_1 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_0124_141", package = "geometry_config" }
 
 
 zksync_types = { path = "../types" }

--- a/core/lib/multivm/src/versions/vm_boojum_integration/tracers/circuits_capacity.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/tracers/circuits_capacity.rs
@@ -1,4 +1,4 @@
-use zkevm_test_harness_1_4_0::{geometry_config::get_geometry_config, toolset::GeometryConfig};
+use geometry_config_1_4_0::{get_geometry_config, GeometryConfig};
 
 const GEOMETRY_CONFIG: GeometryConfig = get_geometry_config();
 const OVERESTIMATE_PERCENT: f32 = 1.05;

--- a/core/lib/multivm/src/versions/vm_latest/tracers/circuits_capacity.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tracers/circuits_capacity.rs
@@ -1,4 +1,4 @@
-use zkevm_test_harness_1_4_1::{geometry_config::get_geometry_config, toolset::GeometryConfig};
+use geometry_config_1_4_1::{get_geometry_config, GeometryConfig};
 
 const GEOMETRY_CONFIG: GeometryConfig = get_geometry_config();
 const OVERESTIMATE_PERCENT: f32 = 1.05;


### PR DESCRIPTION
## What ❔

Changing multiVM to depend on the newly crated geometry_config crate.

## Why ❔

This crate is a lot smaller than the evm_test_harness one, and multiVM requires just the geometry information.
