### PR TITLE
refactor: Remove zk_evm deps from zksync_types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8906,8 +8906,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
- "zk_evm 1.4.0",
- "zk_evm 1.4.1",
  "zkevm_test_harness 1.3.3",
  "zksync_basic_types",
  "zksync_config",

--- a/core/lib/multivm/src/glue/types/mod.rs
+++ b/core/lib/multivm/src/glue/types/mod.rs
@@ -7,4 +7,5 @@
 
 mod vm;
 mod zk_evm_1_3_1;
+mod zk_evm_1_4_0;
 mod zk_evm_1_4_1;

--- a/core/lib/multivm/src/glue/types/zk_evm_1_4_0.rs
+++ b/core/lib/multivm/src/glue/types/zk_evm_1_4_0.rs
@@ -1,0 +1,17 @@
+use zk_evm_1_4_0::reference_impls::event_sink::EventMessage as EventMessage_1_4_0;
+use zksync_types::l2_to_l1_log::L2ToL1Log;
+
+use crate::glue::GlueFrom;
+
+impl GlueFrom<EventMessage_1_4_0> for L2ToL1Log {
+    fn glue_from(m: EventMessage_1_4_0) -> Self {
+        Self {
+            shard_id: m.shard_id,
+            is_service: m.is_first,
+            tx_number_in_block: m.tx_number_in_block,
+            sender: m.address,
+            key: zksync_utils::u256_to_h256(m.key),
+            value: zksync_utils::u256_to_h256(m.value),
+        }
+    }
+}

--- a/core/lib/multivm/src/glue/types/zk_evm_1_4_1.rs
+++ b/core/lib/multivm/src/glue/types/zk_evm_1_4_1.rs
@@ -1,8 +1,9 @@
 use zk_evm_1_4_1::{
     aux_structures::{LogQuery as LogQuery_1_4_1, Timestamp as Timestamp_1_4_1},
+    reference_impls::event_sink::EventMessage as EventMessage_1_4_1,
     zkevm_opcode_defs::FarCallOpcode as FarCallOpcode_1_4_1,
 };
-use zksync_types::{FarCallOpcode, LogQuery, Timestamp};
+use zksync_types::{l2_to_l1_log::L2ToL1Log, FarCallOpcode, LogQuery, Timestamp};
 
 use crate::glue::{GlueFrom, GlueInto};
 
@@ -60,6 +61,19 @@ impl GlueFrom<LogQuery> for LogQuery_1_4_1 {
             rw_flag: value.rw_flag,
             rollback: value.rollback,
             is_service: value.is_service,
+        }
+    }
+}
+
+impl GlueFrom<EventMessage_1_4_1> for L2ToL1Log {
+    fn glue_from(m: EventMessage_1_4_1) -> Self {
+        Self {
+            shard_id: m.shard_id,
+            is_service: m.is_first,
+            tx_number_in_block: m.tx_number_in_block,
+            sender: m.address,
+            key: zksync_utils::u256_to_h256(m.key),
+            value: zksync_utils::u256_to_h256(m.value),
         }
     }
 }

--- a/core/lib/multivm/src/versions/vm_boojum_integration/utils/logs.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/utils/logs.rs
@@ -2,6 +2,7 @@ use zksync_state::WriteStorage;
 use zksync_types::{l2_to_l1_log::L2ToL1Log, Timestamp, VmEvent};
 
 use crate::{
+    glue::GlueInto,
     interface::L1BatchEnv,
     vm_boojum_integration::{
         old_vm::{events::merge_events, history_recorder::HistoryMode},
@@ -21,5 +22,8 @@ pub(crate) fn collect_events_and_l1_system_logs_after_timestamp<S: WriteStorage,
         .into_iter()
         .map(|e| e.into_vm_event(batch_env.number))
         .collect();
-    (events, l1_messages.into_iter().map(Into::into).collect())
+    (
+        events,
+        l1_messages.into_iter().map(GlueInto::glue_into).collect(),
+    )
 }

--- a/core/lib/multivm/src/versions/vm_boojum_integration/vm.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/vm.rs
@@ -7,6 +7,7 @@ use zksync_types::{
 use zksync_utils::bytecode::CompressedBytecodeInfo;
 
 use crate::{
+    glue::GlueInto,
     interface::{
         BootloaderMemory, BytecodeCompressionError, CurrentExecutionState, FinishedL1Batch,
         L1BatchEnv, L2BlockEnv, SystemEnv, VmExecutionMode, VmExecutionResultAndLogs, VmInterface,
@@ -93,7 +94,7 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
         let user_l2_to_l1_logs = extract_l2tol1logs_from_l1_messenger(&events);
         let system_logs = l1_messages
             .into_iter()
-            .map(|log| SystemL2ToL1Log(log.into()))
+            .map(|log| SystemL2ToL1Log(log.glue_into()))
             .collect();
         let total_log_queries = self.state.event_sink.get_log_queries()
             + self

--- a/core/lib/multivm/src/versions/vm_latest/utils/logs.rs
+++ b/core/lib/multivm/src/versions/vm_latest/utils/logs.rs
@@ -3,6 +3,7 @@ use zksync_state::WriteStorage;
 use zksync_types::{l2_to_l1_log::L2ToL1Log, VmEvent};
 
 use crate::{
+    glue::GlueInto,
     interface::L1BatchEnv,
     vm_latest::{
         old_vm::{events::merge_events, history_recorder::HistoryMode},
@@ -22,5 +23,8 @@ pub(crate) fn collect_events_and_l1_system_logs_after_timestamp<S: WriteStorage,
         .into_iter()
         .map(|e| e.into_vm_event(batch_env.number))
         .collect();
-    (events, l1_messages.into_iter().map(Into::into).collect())
+    (
+        events,
+        l1_messages.into_iter().map(GlueInto::glue_into).collect(),
+    )
 }

--- a/core/lib/multivm/src/versions/vm_latest/vm.rs
+++ b/core/lib/multivm/src/versions/vm_latest/vm.rs
@@ -94,7 +94,7 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
         let user_l2_to_l1_logs = extract_l2tol1logs_from_l1_messenger(&events);
         let system_logs = l1_messages
             .into_iter()
-            .map(|log| SystemL2ToL1Log(log.into()))
+            .map(|log| SystemL2ToL1Log(log.glue_into()))
             .collect();
         let total_log_queries = self.state.event_sink.get_log_queries()
             + self

--- a/core/lib/types/Cargo.toml
+++ b/core/lib/types/Cargo.toml
@@ -20,8 +20,6 @@ zksync_config = { path = "../config" }
 # We need this import because we wanat DAL to be responsible for (de)serialization
 codegen = { git = "https://github.com/matter-labs/solidity_plonk_verifier.git", branch = "dev" }
 zkevm_test_harness = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3" }
-zk_evm_1_4_1 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.4.1" }
-zk_evm_1_4_0 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.4.0" }
 zk_evm = { git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.3-rc2" }
 zksync_protobuf = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5727a3e0b22470bb90092388f9125bcb366df613" }
 

--- a/core/lib/types/src/l2_to_l1_log.rs
+++ b/core/lib/types/src/l2_to_l1_log.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
 use zk_evm::reference_impls::event_sink::EventMessage;
-use zk_evm_1_4_0::reference_impls::event_sink::EventMessage as EventMessage_1_4_0;
-use zk_evm_1_4_1::reference_impls::event_sink::EventMessage as EventMessage_1_4_1;
 use zksync_utils::u256_to_h256;
 
 use crate::{commitment::SerializeCommitment, Address, H256};
@@ -69,32 +67,6 @@ impl L2ToL1Log {
 
 impl From<EventMessage> for L2ToL1Log {
     fn from(m: EventMessage) -> Self {
-        Self {
-            shard_id: m.shard_id,
-            is_service: m.is_first,
-            tx_number_in_block: m.tx_number_in_block,
-            sender: m.address,
-            key: u256_to_h256(m.key),
-            value: u256_to_h256(m.value),
-        }
-    }
-}
-
-impl From<EventMessage_1_4_0> for L2ToL1Log {
-    fn from(m: EventMessage_1_4_0) -> Self {
-        Self {
-            shard_id: m.shard_id,
-            is_service: m.is_first,
-            tx_number_in_block: m.tx_number_in_block,
-            sender: m.address,
-            key: u256_to_h256(m.key),
-            value: u256_to_h256(m.value),
-        }
-    }
-}
-
-impl From<EventMessage_1_4_1> for L2ToL1Log {
-    fn from(m: EventMessage_1_4_1) -> Self {
         Self {
             shard_id: m.shard_id,
             is_service: m.is_first,

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -7884,8 +7884,6 @@ dependencies = [
  "strum",
  "thiserror",
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
- "zk_evm 1.4.0",
- "zk_evm 1.4.1",
  "zkevm_test_harness 1.3.3",
  "zksync_basic_types",
  "zksync_config",


### PR DESCRIPTION
## What ❔

- Moves zkevm glue from zksync_types to multivm

## Why ❔

- Glue is used by the multivm
- Multivm already has these deps
- zksync_types doesn't need these deps
- A lot of crates depend on zksync_types but also don't need these deps
- We need to think about our dependency graphs more.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
