### PR TITLE
refactor: Remove zk_evm deps from zksync_types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8261,6 +8261,8 @@ name = "zksync_commitment_utils"
 version = "0.1.0"
 dependencies = [
  "multivm",
+ "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
+ "zk_evm 1.4.1",
  "zkevm_test_harness 1.4.0",
  "zkevm_test_harness 1.4.1",
  "zksync_types",
@@ -8923,8 +8925,6 @@ dependencies = [
  "strum",
  "thiserror",
  "tokio",
- "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
- "zk_evm 1.4.1",
  "zkevm_test_harness 1.3.3",
  "zksync_basic_types",
  "zksync_config",

--- a/core/lib/commitment_utils/Cargo.toml
+++ b/core/lib/commitment_utils/Cargo.toml
@@ -14,4 +14,6 @@ zksync_types = { path = "../../lib/types" }
 zksync_utils = { path = "../../lib/utils" }
 zkevm_test_harness_1_4_0 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.0", package = "zkevm_test_harness" }
 zkevm_test_harness_1_4_1 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.1", package = "zkevm_test_harness" }
+zk_evm_1_4_1 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.4.1" }
+zk_evm_1_3_3 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.3-rc2" }
 multivm = { path = "../../lib/multivm" }

--- a/core/lib/commitment_utils/src/lib.rs
+++ b/core/lib/commitment_utils/src/lib.rs
@@ -1,5 +1,13 @@
 //! Utils for commitment calculation.
 use multivm::utils::get_used_bootloader_memory_bytes;
+use zk_evm_1_3_3::{
+    aux_structures::Timestamp as Timestamp_1_3_3,
+    zk_evm_abstractions::queries::LogQuery as LogQuery_1_3_3,
+};
+use zk_evm_1_4_1::{
+    aux_structures::Timestamp as Timestamp_1_4_1,
+    zk_evm_abstractions::queries::LogQuery as LogQuery_1_4_1,
+};
 use zksync_types::{zk_evm_types::LogQuery, ProtocolVersionId, VmVersion, H256, U256};
 use zksync_utils::expand_memory_contents;
 
@@ -10,12 +18,18 @@ pub fn events_queue_commitment(
     match VmVersion::from(protocol_version) {
         VmVersion::VmBoojumIntegration => Some(H256(
             zkevm_test_harness_1_4_0::witness::utils::events_queue_commitment_fixed(
-                &events_queue.iter().map(|x| (*x).into()).collect(),
+                &events_queue
+                    .iter()
+                    .map(|x| to_log_query_1_3_3(*x))
+                    .collect(),
             ),
         )),
         VmVersion::Vm1_4_1 => Some(H256(
             zkevm_test_harness_1_4_1::witness::utils::events_queue_commitment_fixed(
-                &events_queue.iter().map(|x| (*x).into()).collect(),
+                &events_queue
+                    .iter()
+                    .map(|x| to_log_query_1_4_1(*x))
+                    .collect(),
             ),
         )),
         _ => None,
@@ -47,5 +61,37 @@ pub fn bootloader_initial_content_commitment(
             ),
         )),
         _ => unreachable!(),
+    }
+}
+
+fn to_log_query_1_3_3(log_query: LogQuery) -> LogQuery_1_3_3 {
+    LogQuery_1_3_3 {
+        timestamp: Timestamp_1_3_3(log_query.timestamp.0),
+        tx_number_in_block: log_query.tx_number_in_block,
+        aux_byte: log_query.aux_byte,
+        shard_id: log_query.shard_id,
+        address: log_query.address,
+        key: log_query.key,
+        read_value: log_query.read_value,
+        written_value: log_query.written_value,
+        rw_flag: log_query.rw_flag,
+        rollback: log_query.rollback,
+        is_service: log_query.is_service,
+    }
+}
+
+fn to_log_query_1_4_1(log_query: LogQuery) -> LogQuery_1_4_1 {
+    LogQuery_1_4_1 {
+        timestamp: Timestamp_1_4_1(log_query.timestamp.0),
+        tx_number_in_block: log_query.tx_number_in_block,
+        aux_byte: log_query.aux_byte,
+        shard_id: log_query.shard_id,
+        address: log_query.address,
+        key: log_query.key,
+        read_value: log_query.read_value,
+        written_value: log_query.written_value,
+        rw_flag: log_query.rw_flag,
+        rollback: log_query.rollback,
+        is_service: log_query.is_service,
     }
 }

--- a/core/lib/types/Cargo.toml
+++ b/core/lib/types/Cargo.toml
@@ -20,8 +20,6 @@ zksync_config = { path = "../config" }
 # We need this import because we wanat DAL to be responsible for (de)serialization
 codegen = { git = "https://github.com/matter-labs/solidity_plonk_verifier.git", branch = "dev" }
 zkevm_test_harness = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3" }
-zk_evm_1_4_1 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.4.1" }
-zk_evm_1_3_3 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.3-rc2" }
 zksync_protobuf = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5727a3e0b22470bb90092388f9125bcb366df613" }
 
 anyhow = "1.0.75"

--- a/core/lib/types/src/zk_evm_types.rs
+++ b/core/lib/types/src/zk_evm_types.rs
@@ -1,11 +1,3 @@
-use zk_evm_1_3_3::{
-    aux_structures::Timestamp as Timestamp_1_3_3,
-    zk_evm_abstractions::queries::LogQuery as LogQuery_1_3_3,
-};
-use zk_evm_1_4_1::{
-    aux_structures::Timestamp as Timestamp_1_4_1,
-    zk_evm_abstractions::queries::LogQuery as LogQuery_1_4_1,
-};
 use zksync_basic_types::{Address, U256};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -35,76 +27,4 @@ pub struct LogQuery {
     pub rw_flag: bool,
     pub rollback: bool,
     pub is_service: bool,
-}
-
-impl From<LogQuery> for LogQuery_1_3_3 {
-    fn from(log_query: LogQuery) -> Self {
-        Self {
-            timestamp: Timestamp_1_3_3(log_query.timestamp.0),
-            tx_number_in_block: log_query.tx_number_in_block,
-            aux_byte: log_query.aux_byte,
-            shard_id: log_query.shard_id,
-            address: log_query.address,
-            key: log_query.key,
-            read_value: log_query.read_value,
-            written_value: log_query.written_value,
-            rw_flag: log_query.rw_flag,
-            rollback: log_query.rollback,
-            is_service: log_query.is_service,
-        }
-    }
-}
-
-impl From<LogQuery_1_3_3> for LogQuery {
-    fn from(log_query: LogQuery_1_3_3) -> Self {
-        Self {
-            timestamp: Timestamp(log_query.timestamp.0),
-            tx_number_in_block: log_query.tx_number_in_block,
-            aux_byte: log_query.aux_byte,
-            shard_id: log_query.shard_id,
-            address: log_query.address,
-            key: log_query.key,
-            read_value: log_query.read_value,
-            written_value: log_query.written_value,
-            rw_flag: log_query.rw_flag,
-            rollback: log_query.rollback,
-            is_service: log_query.is_service,
-        }
-    }
-}
-
-impl From<LogQuery> for LogQuery_1_4_1 {
-    fn from(log_query: LogQuery) -> Self {
-        Self {
-            timestamp: Timestamp_1_4_1(log_query.timestamp.0),
-            tx_number_in_block: log_query.tx_number_in_block,
-            aux_byte: log_query.aux_byte,
-            shard_id: log_query.shard_id,
-            address: log_query.address,
-            key: log_query.key,
-            read_value: log_query.read_value,
-            written_value: log_query.written_value,
-            rw_flag: log_query.rw_flag,
-            rollback: log_query.rollback,
-            is_service: log_query.is_service,
-        }
-    }
-}
-
-impl From<LogQuery_1_4_1> for LogQuery {
-    fn from(log_query: LogQuery_1_4_1) -> Self {
-        Self {
-            timestamp: Timestamp(log_query.timestamp.0),
-            tx_number_in_block: log_query.tx_number_in_block,
-            aux_byte: log_query.aux_byte,
-            shard_id: log_query.shard_id,
-            address: log_query.address,
-            key: log_query.key,
-            read_value: log_query.read_value,
-            written_value: log_query.written_value,
-            rw_flag: log_query.rw_flag,
-            rollback: log_query.rollback,
-            is_service: log_query.is_service,
-        }
-    }
 }

--- a/core/lib/zksync_core/src/genesis.rs
+++ b/core/lib/zksync_core/src/genesis.rs
@@ -18,7 +18,7 @@ use zksync_types::{
     get_code_key, get_system_context_init_logs,
     protocol_version::{L1VerifierConfig, ProtocolVersion},
     tokens::{TokenInfo, TokenMetadata, ETHEREUM_ADDRESS},
-    zk_evm_types::LogQuery,
+    zk_evm_types::{LogQuery, Timestamp},
     AccountTreeId, Address, L1BatchNumber, L2ChainId, MiniblockNumber, ProtocolVersionId,
     StorageKey, StorageLog, StorageLogKind, H256,
 };
@@ -231,7 +231,19 @@ async fn insert_system_contracts(
     let deduped_log_queries: Vec<LogQuery> = sort_storage_access_queries(&log_queries)
         .1
         .into_iter()
-        .map(Into::into)
+        .map(|log_query| LogQuery {
+            timestamp: Timestamp(log_query.timestamp.0),
+            tx_number_in_block: log_query.tx_number_in_block,
+            aux_byte: log_query.aux_byte,
+            shard_id: log_query.shard_id,
+            address: log_query.address,
+            key: log_query.key,
+            read_value: log_query.read_value,
+            written_value: log_query.written_value,
+            rw_flag: log_query.rw_flag,
+            rollback: log_query.rollback,
+            is_service: log_query.is_service,
+        })
         .collect();
 
     let (deduplicated_writes, protective_reads): (Vec<_>, Vec<_>) = deduped_log_queries


### PR DESCRIPTION
## What ❔

- Remove `zk_evm_xxx` deps from `zksync_types`

## Why ❔

- These deps only needed for a few use cases, so these use cases are implemented elsewhere. Part of initiative of moving heavyweight stuff from `zksync_types`.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
