### PR TITLE
ci: Logging in to Docker registries only when pushing Docker image

### DIFF
--- a/.github/workflows/build-core-template.yml
+++ b/.github/workflows/build-core-template.yml
@@ -74,7 +74,8 @@ jobs:
           ci_run yarn zk build
           ci_run curl -LO https://storage.googleapis.com/matterlabs-setup-keys-us/setup-keys/setup_2\^26.key
 
-      - name: login to Docker registries
+      - name: Login to Docker registries
+        if: ${{ inputs.action == 'push' }}
         run: |
           ci_run docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
           ci_run gcloud auth configure-docker us-docker.pkg.dev -q


### PR DESCRIPTION
## What ❔

This fixes the regression introduced in https://github.com/matter-labs/zksync-era/pull/848/files#diff-76efa69b014ead260f18ba8c40d184f93a2fe72673035d4b48bbaf2f852693a4L75, so Docker login happens only when we want to push image to Docker registry.

## Why ❔

This will allow CI to run against forks, where GHA secrets are not available.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
