### PR TITLE
fix(db): Make `snapshot_recovery` migration backward-compatible

### DIFF
--- a/core/lib/dal/migrations/20240129133815_revert_removing_snapshot_recovery_columns.down.sql
+++ b/core/lib/dal/migrations/20240129133815_revert_removing_snapshot_recovery_columns.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE snapshot_recovery
+    DROP COLUMN IF EXISTS last_finished_chunk_id,
+    DROP COLUMN IF EXISTS total_chunk_count;

--- a/core/lib/dal/migrations/20240129133815_revert_removing_snapshot_recovery_columns.up.sql
+++ b/core/lib/dal/migrations/20240129133815_revert_removing_snapshot_recovery_columns.up.sql
@@ -1,0 +1,5 @@
+-- Temporary revert of the previous `snapshot_recovery` so that the migration is backward-compatible.
+-- Do not use these columns in code.
+ALTER TABLE snapshot_recovery
+    ADD COLUMN IF NOT EXISTS last_finished_chunk_id INT,
+    ADD COLUMN IF NOT EXISTS total_chunk_count INT NOT NULL DEFAULT 0;


### PR DESCRIPTION
## What ❔

Creates a new DB migration that restores removed snapshot_recovery columns.

## Why ❔

Having non-backward-compatible change leads to potential breaks on various environments.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).