### PR TITLE
feat(en): Make ENs detect reorgs earlier

### DIFF
--- a/core/lib/zksync_core/src/consistency_checker/mod.rs
+++ b/core/lib/zksync_core/src/consistency_checker/mod.rs
@@ -304,6 +304,7 @@ impl ConsistencyChecker {
                     }
                     L1DataMismatchBehavior::Log => {
                         tracing::warn!("L1 Batch #{batch_number} is inconsistent with L1");
+                        batch_number += 1; // We don't want to infinitely loop failing the check on the same batch
                     }
                 },
                 Err(CheckError::Web3(err)) => {

--- a/core/lib/zksync_core/src/reorg_detector/mod.rs
+++ b/core/lib/zksync_core/src/reorg_detector/mod.rs
@@ -85,10 +85,20 @@ impl UpdateCorrectBlock for () {
         last_correct_miniblock: MiniblockNumber,
         last_correct_l1_batch: L1BatchNumber,
     ) {
-        EN_METRICS.last_correct_batch[&CheckerComponent::ReorgDetector]
-            .set(last_correct_miniblock.0.into());
-        EN_METRICS.last_correct_miniblock[&CheckerComponent::ReorgDetector]
-            .set(last_correct_l1_batch.0.into());
+        let last_correct_miniblock = last_correct_miniblock.0.into();
+        let prev_checked_miniblock = EN_METRICS.last_correct_miniblock
+            [&CheckerComponent::ReorgDetector]
+            .set(last_correct_miniblock);
+        if prev_checked_miniblock != last_correct_miniblock {
+            tracing::debug!("No reorg at miniblock #{last_correct_miniblock}");
+        }
+
+        let last_correct_l1_batch = last_correct_l1_batch.0.into();
+        let prev_checked_l1_batch = EN_METRICS.last_correct_batch[&CheckerComponent::ReorgDetector]
+            .set(last_correct_l1_batch);
+        if prev_checked_l1_batch != last_correct_l1_batch {
+            tracing::debug!("No reorg at L1 batch #{last_correct_l1_batch}");
+        }
     }
 }
 

--- a/core/lib/zksync_core/src/reorg_detector/tests.rs
+++ b/core/lib/zksync_core/src/reorg_detector/tests.rs
@@ -58,8 +58,6 @@ async fn binary_search_with_simple_predicate() {
     }
 }
 
-type ResponsesMap<K> = HashMap<K, H256>;
-
 #[derive(Debug, Clone, Copy)]
 enum RpcErrorKind {
     Transient,
@@ -77,13 +75,33 @@ impl From<RpcErrorKind> for RpcError {
 
 #[derive(Debug, Default)]
 struct MockMainNodeClient {
-    miniblock_hash_responses: ResponsesMap<MiniblockNumber>,
-    l1_batch_root_hash_responses: ResponsesMap<L1BatchNumber>,
+    latest_miniblock_response: Option<MiniblockNumber>,
+    latest_l1_batch_response: Option<L1BatchNumber>,
+    miniblock_hash_responses: HashMap<MiniblockNumber, H256>,
+    l1_batch_root_hash_responses: HashMap<L1BatchNumber, H256>,
     error_kind: Arc<Mutex<Option<RpcErrorKind>>>,
 }
 
 #[async_trait]
 impl MainNodeClient for MockMainNodeClient {
+    async fn sealed_miniblock_number(&self) -> Result<MiniblockNumber, RpcError> {
+        if let &Some(error_kind) = &*self.error_kind.lock().unwrap() {
+            return Err(error_kind.into());
+        }
+        Ok(self
+            .latest_miniblock_response
+            .expect("unexpected `sealed_miniblock_number` request"))
+    }
+
+    async fn sealed_l1_batch_number(&self) -> Result<L1BatchNumber, RpcError> {
+        if let &Some(error_kind) = &*self.error_kind.lock().unwrap() {
+            return Err(error_kind.into());
+        }
+        Ok(self
+            .latest_l1_batch_response
+            .expect("unexpected `sealed_l1_batch_number` request"))
+    }
+
     async fn miniblock_hash(&self, number: MiniblockNumber) -> Result<Option<H256>, RpcError> {
         if let &Some(error_kind) = &*self.error_kind.lock().unwrap() {
             return Err(error_kind.into());
@@ -125,18 +143,22 @@ impl UpdateCorrectBlock for mpsc::UnboundedSender<(MiniblockNumber, L1BatchNumbe
 async fn normal_reorg_function(snapshot_recovery: bool, with_transient_errors: bool) {
     let pool = ConnectionPool::test_pool().await;
     let mut storage = pool.access_storage().await.unwrap();
+    let mut client = MockMainNodeClient::default();
     if snapshot_recovery {
         storage
             .protocol_versions_dal()
             .save_protocol_version_with_tx(ProtocolVersion::default())
             .await;
     } else {
-        ensure_genesis_state(&mut storage, L2ChainId::default(), &GenesisParams::mock())
-            .await
-            .unwrap();
+        let genesis_root_hash =
+            ensure_genesis_state(&mut storage, L2ChainId::default(), &GenesisParams::mock())
+                .await
+                .unwrap();
+        client
+            .l1_batch_root_hash_responses
+            .insert(L1BatchNumber(0), genesis_root_hash);
     }
 
-    let mut client = MockMainNodeClient::default();
     let l1_batch_numbers = if snapshot_recovery {
         11_u32..=20
     } else {
@@ -227,12 +249,16 @@ async fn detector_stops_on_fatal_rpc_error() {
 async fn reorg_is_detected_on_batch_hash_mismatch() {
     let pool = ConnectionPool::test_pool().await;
     let mut storage = pool.access_storage().await.unwrap();
-    ensure_genesis_state(&mut storage, L2ChainId::default(), &GenesisParams::mock())
-        .await
-        .unwrap();
+    let genesis_root_hash =
+        ensure_genesis_state(&mut storage, L2ChainId::default(), &GenesisParams::mock())
+            .await
+            .unwrap();
+    let mut client = MockMainNodeClient::default();
+    client
+        .l1_batch_root_hash_responses
+        .insert(L1BatchNumber(0), genesis_root_hash);
 
     let (_stop_sender, stop_receiver) = watch::channel(false);
-    let mut client = MockMainNodeClient::default();
     let miniblock_hash = H256::from_low_u64_be(23);
     client
         .miniblock_hash_responses
@@ -271,12 +297,16 @@ async fn reorg_is_detected_on_batch_hash_mismatch() {
 async fn reorg_is_detected_on_miniblock_hash_mismatch() {
     let pool = ConnectionPool::test_pool().await;
     let mut storage = pool.access_storage().await.unwrap();
-    ensure_genesis_state(&mut storage, L2ChainId::default(), &GenesisParams::mock())
-        .await
-        .unwrap();
+    let mut client = MockMainNodeClient::default();
+    let genesis_root_hash =
+        ensure_genesis_state(&mut storage, L2ChainId::default(), &GenesisParams::mock())
+            .await
+            .unwrap();
+    client
+        .l1_batch_root_hash_responses
+        .insert(L1BatchNumber(0), genesis_root_hash);
 
     let (_stop_sender, stop_receiver) = watch::channel(false);
-    let mut client = MockMainNodeClient::default();
     let miniblock_hash = H256::from_low_u64_be(23);
     client
         .miniblock_hash_responses
@@ -349,6 +379,13 @@ async fn reorg_is_detected_on_historic_batch_hash_mismatch(
     seal_l1_batch(&mut storage, earliest_l1_batch_number, H256::zero()).await;
 
     let mut client = MockMainNodeClient::default();
+    client
+        .miniblock_hash_responses
+        .insert(MiniblockNumber(earliest_l1_batch_number), H256::zero());
+    client
+        .l1_batch_root_hash_responses
+        .insert(L1BatchNumber(earliest_l1_batch_number), H256::zero());
+
     let miniblock_and_l1_batch_hashes = l1_batch_numbers.clone().map(|number| {
         let mut miniblock_hash = H256::from_low_u64_be(number.into());
         client
@@ -491,3 +528,5 @@ async fn detector_errors_on_earliest_batch_hash_mismatch_with_snapshot_recovery(
     let err = detector.run_inner().await.unwrap_err();
     assert_matches!(err, HashMatchError::EarliestHashMismatch(L1BatchNumber(3)));
 }
+
+// FIXME: test reorg


### PR DESCRIPTION
## What ❔

Currently, the reorg detector only detects divergence based on the latest local miniblock / L1 batch. This means that if a reorg actually happens, it will only be detected be an EN once the main node catches up to it.

This PR changes this logic as follows. If the main node doesn't contain local node data, it makes sense to check correspondence of the latest L1 batch / miniblock on the main node.

## Why ❔

Late reorg detection is less efficient and it may be the reason (or one of the reasons?) EN integration tests in CI frequently fail when gossip-based syncing is enabled.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.