### PR TITLE
fix: reorg check was performed on a too high block

### DIFF
--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -525,7 +525,7 @@ pub async fn initialize_components(
                     // For now in case of error we just log it and allow the server
                     // to continue running.
                     if let Err(err) = cfg.run(ctx, pool).await {
-                        tracing::error!(%err, "Consensus actor failed");
+                        tracing::error!("Consensus actor failed: {err:#}");
                     } else {
                         tracing::info!("Consensus actor stopped");
                     }

--- a/core/lib/zksync_core/src/reorg_detector/tests.rs
+++ b/core/lib/zksync_core/src/reorg_detector/tests.rs
@@ -1,7 +1,7 @@
 //! Tests for the reorg detector component.
 
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     sync::{Arc, Mutex},
 };
 
@@ -58,7 +58,7 @@ async fn binary_search_with_simple_predicate() {
     }
 }
 
-type ResponsesMap<K> = HashMap<K, H256>;
+type ResponsesMap<K> = BTreeMap<K, H256>;
 
 #[derive(Debug, Clone, Copy)]
 enum RpcErrorKind {
@@ -106,6 +106,13 @@ impl MainNodeClient for MockMainNodeClient {
         } else {
             Ok(None)
         }
+    }
+
+    async fn last_miniblock(&self) -> Result<MiniblockNumber, RpcError> {
+        if let &Some(error_kind) = &*self.error_kind.lock().unwrap() {
+            return Err(error_kind.into());
+        }
+        Ok(*self.miniblock_hash_responses.last_key_value().unwrap().0)
     }
 }
 


### PR DESCRIPTION
## What ❔

reorg check at min(local head, remote head)

## Why ❔

So that divergence is determined as soon as it occurs, rather than waiting for the main node to produce enough miniblocks.