### PR TITLE
refactor: Improve error reporting

### DIFF
--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -515,7 +515,7 @@ async fn main() -> anyhow::Result<()> {
     let reorg_detector_last_correct_batch = reorg_detector_result.and_then(|result| match result {
         Ok(Ok(last_correct_batch)) => last_correct_batch,
         Ok(Err(err)) => {
-            tracing::error!("Reorg detector failed: {err}");
+            tracing::error!("Reorg detector failed: {err:#}");
             None
         }
         Err(err) => {

--- a/core/lib/utils/src/wait_for_tasks.rs
+++ b/core/lib/utils/src/wait_for_tasks.rs
@@ -25,7 +25,7 @@ pub async fn wait_for_tasks<Fut>(
             }
         }
         Ok(Err(err)) => {
-            let err = format!("One of the tokio actors unexpectedly finished with error: {err}");
+            let err = format!("One of the tokio actors unexpectedly finished with error: {err:#}");
             tracing::error!("{err}");
             vlog::capture_message(&err, vlog::AlertLevel::Warning);
             if let Some(graceful_shutdown) = graceful_shutdown {
@@ -36,9 +36,7 @@ pub async fn wait_for_tasks<Fut>(
             let is_panic = error.is_panic();
             let panic_message = try_extract_panic_message(error);
 
-            tracing::info!(
-                "One of the tokio actors unexpectedly finished with error: {panic_message}"
-            );
+            tracing::info!("One of the tokio actors panicked: {panic_message}");
 
             if is_panic {
                 if let Some(particular_alerts) = particular_crypto_alerts {

--- a/core/lib/zksync_core/src/state_keeper/keeper.rs
+++ b/core/lib/zksync_core/src/state_keeper/keeper.rs
@@ -319,9 +319,13 @@ impl ZkSyncStateKeeper {
                     ..
                 } = result
                 else {
-                    return Err(anyhow::anyhow!(
+                    tracing::error!(
                         "Re-executing stored tx failed. Tx: {tx:?}. Err: {:?}",
                         result.err()
+                    );
+                    return Err(anyhow::anyhow!(
+                        "Re-executing stored tx failed. It means that transaction was executed \
+                         successfully before, but failed after a restart."
                     )
                     .into());
                 };
@@ -358,6 +362,10 @@ impl ZkSyncStateKeeper {
                 );
             }
         }
+
+        tracing::debug!(
+            "All the transactions from the pending state were re-executed successfully"
+        );
 
         // We've processed all the miniblocks, and right now we're initializing the next *actual* miniblock.
         let new_miniblock_params = self


### PR DESCRIPTION
## What ❔

- Format anyhow errors on exit with `{:#}` [to preserve context ](https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations). Current behavior only shows the topmost context line, which is not helpful.
- Emit details about the failed tx from state keeper directly, do not rely on some outer code to provide critical context.
- Use different messages to distinguish an exited task from a panicked one.

## Why ❔

- Lack of these makes investigating problems harder.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
