### PR TITLE
refactor(constants): Remove dead code from zksync_constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8963,8 +8963,6 @@ dependencies = [
 name = "zksync_system_constants"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "num 0.3.1",
  "once_cell",
  "zksync_basic_types",
  "zksync_utils",

--- a/core/lib/constants/Cargo.toml
+++ b/core/lib/constants/Cargo.toml
@@ -13,6 +13,4 @@ categories = ["cryptography"]
 zksync_basic_types = { path = "../../lib/basic_types" }
 zksync_utils = { path = "../../lib/utils" }
 
-anyhow = "1.0"
-num = "0.3.1"
 once_cell = "1.13.0"

--- a/core/lib/constants/src/crypto.rs
+++ b/core/lib/constants/src/crypto.rs
@@ -1,27 +1,9 @@
-use num::BigUint;
-use once_cell::sync::Lazy;
-
 pub const ZKPORTER_IS_AVAILABLE: bool = false;
 
 /// Depth of the account tree.
 pub const ROOT_TREE_DEPTH: usize = 256;
-/// Cost of 1 byte of calldata in bytes.
-// TODO (SMA-1609): Double check this value.
-// TODO: possibly remove this value.
-pub const GAS_PER_PUBDATA_BYTE: u32 = 16;
-
-/// Maximum amount of bytes in one packed write storage slot.
-/// Calculated as `(len(hash) + 1) + len(u256)`
-// TODO (SMA-1609): Double check this value.
-pub const MAX_BYTES_PER_PACKED_SLOT: u64 = 65;
-
-/// Amount of gas required to publish one slot in pubdata.
-pub static GAS_PER_SLOT: Lazy<BigUint> =
-    Lazy::new(|| BigUint::from(MAX_BYTES_PER_PACKED_SLOT) * BigUint::from(GAS_PER_PUBDATA_BYTE));
 
 pub const MAX_NEW_FACTORY_DEPS: usize = 32;
-
-pub const PAD_MSG_BEFORE_HASH_BITS_LEN: usize = 736;
 
 /// To avoid DDoS we limit the size of the transactions size.
 /// TODO(X): remove this as a constant and introduce a config.

--- a/core/lib/constants/src/ethereum.rs
+++ b/core/lib/constants/src/ethereum.rs
@@ -3,7 +3,7 @@ use zksync_basic_types::Address;
 /// Priority op should be executed for this number of eth blocks.
 pub const PRIORITY_EXPIRATION: u64 = 50000;
 pub const MAX_L1_TRANSACTION_GAS_LIMIT: u64 = 300000;
-pub static ETHEREUM_ADDRESS: Address = Address::zero();
+pub const ETHEREUM_ADDRESS: Address = Address::zero();
 
 /// The maximum number of pubdata per L1 batch. This limit is due to the fact that the Ethereum
 /// nodes do not accept transactions that have more than 128kb of pubdata.

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -3150,29 +3150,15 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
-dependencies = [
- "num-bigint 0.3.3",
- "num-complex 0.3.1",
- "num-integer",
- "num-iter",
- "num-rational 0.3.2",
- "num-traits",
-]
-
-[[package]]
-name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
  "num-bigint 0.4.4",
- "num-complex 0.4.4",
+ "num-complex",
  "num-integer",
  "num-iter",
- "num-rational 0.4.1",
+ "num-rational",
  "num-traits",
 ]
 
@@ -3214,15 +3200,6 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "zeroize",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -3284,18 +3261,6 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64a5fe11d4135c3bcdf3a95b18b194afa9608a5f6ff034f5d857bc9a27fb0119"
 dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
-dependencies = [
- "autocfg",
- "num-bigint 0.3.3",
  "num-integer",
  "num-traits",
 ]
@@ -6587,7 +6552,7 @@ dependencies = [
  "blake2 0.10.6 (git+https://github.com/RustCrypto/hashes.git?rev=1f727ce37ff40fa0cce84eb8543a45bdd3ca4a4e)",
  "k256 0.11.6",
  "lazy_static",
- "num 0.4.1",
+ "num",
  "serde",
  "serde_json",
  "sha2 0.10.6",
@@ -6603,7 +6568,7 @@ source = "git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2#fbee2
 dependencies = [
  "anyhow",
  "lazy_static",
- "num 0.4.1",
+ "num",
  "serde",
  "serde_json",
  "static_assertions",
@@ -6618,7 +6583,7 @@ source = "git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.3#fbee20
 dependencies = [
  "anyhow",
  "lazy_static",
- "num 0.4.1",
+ "num",
  "serde",
  "serde_json",
  "static_assertions",
@@ -6633,7 +6598,7 @@ source = "git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.4.0#dd76fc
 dependencies = [
  "anyhow",
  "lazy_static",
- "num 0.4.1",
+ "num",
  "serde",
  "serde_json",
  "static_assertions",
@@ -6648,7 +6613,7 @@ source = "git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.4.1#6250db
 dependencies = [
  "anyhow",
  "lazy_static",
- "num 0.4.1",
+ "num",
  "serde",
  "serde_json",
  "static_assertions",
@@ -7016,7 +6981,7 @@ dependencies = [
  "chrono",
  "hex",
  "itertools 0.10.5",
- "num 0.4.1",
+ "num",
  "once_cell",
  "prost",
  "rand 0.8.5",
@@ -7298,8 +7263,6 @@ dependencies = [
 name = "zksync_system_constants"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "num 0.3.1",
  "once_cell",
  "zksync_basic_types",
  "zksync_utils",
@@ -7313,7 +7276,7 @@ dependencies = [
  "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono",
  "hex",
- "num 0.4.1",
+ "num",
  "num_enum",
  "once_cell",
  "prost",
@@ -7344,7 +7307,7 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "metrics",
- "num 0.4.1",
+ "num",
  "reqwest",
  "serde",
  "thiserror",


### PR DESCRIPTION
## What ❔

Removes some dead code (and 2 dependencies!) from `zksync_constants`

## Why ❔

Dead code bad

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
