### PR TITLE
fix: added consensus column back

### DIFF
--- a/core/lib/dal/migrations/20240131123456_add_consensus_fields_for_miniblocks.down.sql
+++ b/core/lib/dal/migrations/20240131123456_add_consensus_fields_for_miniblocks.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE miniblocks
+    DROP COLUMN IF EXISTS consensus;

--- a/core/lib/dal/migrations/20240131123456_add_consensus_fields_for_miniblocks.up.sql
+++ b/core/lib/dal/migrations/20240131123456_add_consensus_fields_for_miniblocks.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE miniblocks
+    ADD COLUMN consensus JSONB NULL;


### PR DESCRIPTION
## What ❔

Added back consensus column to miniblocks table.

## Why ❔

There are still binaries deployed which use the column.