### PR TITLE
chore: Forbid unstable features for the core workspace

### DIFF
--- a/infrastructure/zk/src/lint.ts
+++ b/infrastructure/zk/src/lint.ts
@@ -30,7 +30,7 @@ async function lintContracts(check: boolean = false) {
 
 async function clippy() {
     process.chdir(process.env.ZKSYNC_HOME!);
-    await utils.spawn('cargo clippy --tests --locked -- -D warnings');
+    await utils.spawn('cargo clippy --tests --locked -- -D warnings -D unstable_features');
 }
 
 async function proverClippy() {


### PR DESCRIPTION
## What ❔

Adds a flag to clippy in `zk lint` to check for unstable features in the core workspace.

## Why ❔

We're only using nightly in core workspace temporary, and unstable features would make it harder to migrate back to stable later.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
