### PR TITLE
fix(db): miniblocks index

### DIFF
--- a/core/lib/dal/migrations/20240204153050_add-miniblocks-l1-batch-index.down.sql
+++ b/core/lib/dal/migrations/20240204153050_add-miniblocks-l1-batch-index.down.sql
@@ -1,0 +1,1 @@
+drop index ix_miniblocks_t2;

--- a/core/lib/dal/migrations/20240204153050_add-miniblocks-l1-batch-index.up.sql
+++ b/core/lib/dal/migrations/20240204153050_add-miniblocks-l1-batch-index.up.sql
@@ -1,0 +1,2 @@
+create index if not exists ix_miniblocks_t2
+    on miniblocks (l1_batch_number, number);


### PR DESCRIPTION
We added this index to the DB manually, need to have it in the migrations