### PR TITLE
perf: use jemalloc in witness generator

### DIFF
--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -1617,7 +1617,11 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
 dependencies = [
+ "humantime",
+ "is-terminal",
  "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -2604,6 +2608,26 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
 
 [[package]]
 name = "jobserver"
@@ -6774,7 +6798,7 @@ dependencies = [
  "codegen",
  "crossbeam 0.8.4",
  "derivative",
- "env_logger 0.9.3",
+ "env_logger 0.10.1",
  "hex",
  "num-bigint 0.4.4",
  "num-integer",
@@ -6801,7 +6825,7 @@ dependencies = [
  "codegen",
  "crossbeam 0.8.4",
  "derivative",
- "env_logger 0.9.3",
+ "env_logger 0.10.1",
  "hex",
  "rand 0.4.6",
  "rayon",
@@ -6825,7 +6849,7 @@ dependencies = [
  "crossbeam 0.8.4",
  "curl",
  "derivative",
- "env_logger 0.9.3",
+ "env_logger 0.10.1",
  "hex",
  "lazy_static",
  "rand 0.4.6",
@@ -7330,6 +7354,7 @@ dependencies = [
  "ctrlc",
  "futures 0.3.30",
  "hex",
+ "jemallocator",
  "multivm",
  "prometheus_exporter",
  "rand 0.8.5",

--- a/prover/witness_generator/Cargo.toml
+++ b/prover/witness_generator/Cargo.toml
@@ -49,3 +49,6 @@ hex = "0.4"
 structopt = "0.3.26"
 ctrlc = { version = "3.1", features = ["termination"] }
 const-decoder = "0.3.0"
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+jemallocator = "0.5"

--- a/prover/witness_generator/src/main.rs
+++ b/prover/witness_generator/src/main.rs
@@ -34,6 +34,13 @@ mod scheduler;
 mod storage_oracle;
 mod utils;
 
+#[cfg(not(target_env = "msvc"))]
+use jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 #[derive(Debug, StructOpt)]
 #[structopt(
     name = "Run witness generator for different aggregation round",


### PR DESCRIPTION
jemalloc should free memory more aggressively than the system allocator and it was what I used in testing to measure memory use. Behaviour on stage did not correspond with my testing. I hope this will improve things.