### PR TITLE
chore: Increase number of connections for local postgres

### DIFF
--- a/docker-compose-cpu-runner.yml
+++ b/docker-compose-cpu-runner.yml
@@ -32,6 +32,7 @@ services:
       - ./.env
   postgres:
     image: "postgres:14"
+    command: postgres -c 'max_connections=200'
     ports:
       - 127.0.0.1:5432:5432
     environment:

--- a/docker-compose-gpu-runner-cuda-12-0.yml
+++ b/docker-compose-gpu-runner-cuda-12-0.yml
@@ -46,6 +46,7 @@ services:
             - capabilities: [gpu]
   postgres:
     image: "postgres:14"
+    command: postgres -c 'max_connections=200'
     ports:
       - 127.0.0.1:5432:5432
     environment:

--- a/docker-compose-gpu-runner.yml
+++ b/docker-compose-gpu-runner.yml
@@ -37,6 +37,7 @@ services:
             - capabilities: [gpu]
   postgres:
     image: "postgres:14"
+    command: postgres -c 'max_connections=200'
     ports:
       - 127.0.0.1:5432:5432
     environment:

--- a/docker-compose-zkstack-common.yml
+++ b/docker-compose-zkstack-common.yml
@@ -17,6 +17,7 @@ services:
     container_name: geth
   postgres:
     image: "postgres:14"
+    command: postgres -c 'max_connections=200'
     container_name: postgres
     ports:
       - "127.0.0.1:5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,7 @@ services:
       - ./volumes/prysm:/consensus
   postgres:
     image: "postgres:14"
+    command: postgres -c 'max_connections=200'
     ports:
       - 127.0.0.1:5432:5432
     volumes:


### PR DESCRIPTION
## What ❔

- Increases `max_connections` in postgres (locally) from 100 to 200.
- Hopefully, it'll reduce the problems with integration tests in CI.

## Why ❔

- A single server (main node or EN) instance by default uses a connection pool size of 50, and it spawns several additional unique connections, making the total slightly higher than 50.
- In integration tests, we run the server and the EN simultaneously, resulting in more than 100 connections being utilized.
- We recently bumped SQLx to 0.7, which [seems to have problems with that](https://github.com/launchbadge/sqlx/issues/2848).
- ...with 200 connections supported, we will be below the threshold again, so it might help.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
