### PR TITLE
fix(docker): Fix zk stack start

### DIFF
--- a/docker-compose-zkstack-common.yml
+++ b/docker-compose-zkstack-common.yml
@@ -17,7 +17,6 @@ services:
     container_name: geth
   postgres:
     image: "postgres:14"
-    command: postgres -c 'max_connections=200'
     container_name: postgres
     ports:
       - "127.0.0.1:5432:5432"


### PR DESCRIPTION
## What ❔
Remove redundant postgres command from zk stack docker-compose
<img width="1706" alt="image" src="https://github.com/matter-labs/zksync-era/assets/8031374/dcaba1b8-a8e1-4a57-83bd-2a54c175d62a">

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
