### PR TITLE
feat(api): Start API server after first L1 batch

### DIFF
--- a/core/lib/zksync_core/src/api_server/execution_sandbox/apply.rs
+++ b/core/lib/zksync_core/src/api_server/execution_sandbox/apply.rs
@@ -59,12 +59,10 @@ impl<'a> Sandbox<'a> {
         block_args: BlockArgs,
     ) -> anyhow::Result<Sandbox<'a>> {
         let resolve_started_at = Instant::now();
-        dbg!(&block_args);
         let resolved_block_info = block_args
             .resolve_block_info(&mut connection)
             .await
             .with_context(|| format!("cannot resolve block numbers for {block_args:?}"))?;
-        dbg!(&resolved_block_info);
         let resolve_time = resolve_started_at.elapsed();
         // We don't want to emit too many logs.
         if resolve_time > Duration::from_millis(10) {
@@ -99,7 +97,7 @@ impl<'a> Sandbox<'a> {
             shared_args,
             execution_args,
             &resolved_block_info,
-            dbg!(next_l2_block_info),
+            next_l2_block_info,
         );
 
         Ok(Self {
@@ -124,8 +122,6 @@ impl<'a> Sandbox<'a> {
         )
         .await
         .context("failed reading L2 block info")?;
-
-        dbg!(&current_l2_block_info);
 
         let next_l2_block_info = if is_pending_block {
             L2BlockEnv {
@@ -278,8 +274,8 @@ impl<'a> Sandbox<'a> {
 
         let storage_view = self.storage_view.to_rc_ptr();
         let vm = Box::new(VmInstance::new_with_specific_version(
-            dbg!(self.l1_batch_env),
-            dbg!(self.system_env),
+            self.l1_batch_env,
+            self.system_env,
             storage_view.clone(),
             protocol_version.into_api_vm_version(),
         ));

--- a/core/lib/zksync_core/src/api_server/execution_sandbox/apply.rs
+++ b/core/lib/zksync_core/src/api_server/execution_sandbox/apply.rs
@@ -38,8 +38,7 @@ use super::{
     BlockArgs, TxExecutionArgs, TxSharedArgs, VmPermit,
 };
 
-type SandboxStorageView<'a> = StorageView<PostgresStorage<'a>>;
-type BoxedVm<'a> = Box<VmInstance<SandboxStorageView<'a>, HistoryDisabled>>;
+type BoxedVm<'a> = Box<VmInstance<StorageView<PostgresStorage<'a>>, HistoryDisabled>>;
 
 #[derive(Debug)]
 struct Sandbox<'a> {
@@ -47,7 +46,7 @@ struct Sandbox<'a> {
     l1_batch_env: L1BatchEnv,
     execution_args: &'a TxExecutionArgs,
     l2_block_info_to_reset: Option<StoredL2BlockInfo>,
-    storage_view: SandboxStorageView<'a>,
+    storage_view: StorageView<PostgresStorage<'a>>,
 }
 
 impl<'a> Sandbox<'a> {
@@ -260,7 +259,7 @@ impl<'a> Sandbox<'a> {
         mut self,
         tx: &Transaction,
         adjust_pubdata_price: bool,
-    ) -> (BoxedVm<'a>, StoragePtr<SandboxStorageView<'a>>) {
+    ) -> (BoxedVm<'a>, StoragePtr<StorageView<PostgresStorage<'a>>>) {
         self.setup_storage_view(tx);
         let protocol_version = self.system_env.version;
         if adjust_pubdata_price {

--- a/core/lib/zksync_core/src/api_server/execution_sandbox/apply.rs
+++ b/core/lib/zksync_core/src/api_server/execution_sandbox/apply.rs
@@ -15,8 +15,9 @@ use multivm::{
     vm_latest::{constants::BLOCK_GAS_LIMIT, HistoryDisabled},
     VmInstance,
 };
+use tokio::runtime::Handle;
 use zksync_dal::{ConnectionPool, StorageProcessor};
-use zksync_state::{PostgresStorage, ReadStorage, StorageView, WriteStorage};
+use zksync_state::{PostgresStorage, ReadStorage, StoragePtr, StorageView, WriteStorage};
 use zksync_system_constants::{
     SYSTEM_CONTEXT_ADDRESS, SYSTEM_CONTEXT_CURRENT_L2_BLOCK_INFO_POSITION,
     SYSTEM_CONTEXT_CURRENT_TX_ROLLING_HASH_POSITION, ZKPORTER_IS_AVAILABLE,
@@ -37,6 +38,244 @@ use super::{
     BlockArgs, TxExecutionArgs, TxSharedArgs, VmPermit,
 };
 use crate::utils::projected_first_l1_batch;
+
+type SandboxStorageView<'a> = StorageView<PostgresStorage<'a>>;
+type BoxedVm<'a> = Box<VmInstance<SandboxStorageView<'a>, HistoryDisabled>>;
+
+#[derive(Debug)]
+struct Sandbox<'a> {
+    system_env: SystemEnv,
+    l1_batch_env: L1BatchEnv,
+    execution_args: &'a TxExecutionArgs,
+    l2_block_info_to_reset: Option<StoredL2BlockInfo>,
+    storage_view: SandboxStorageView<'a>,
+}
+
+impl<'a> Sandbox<'a> {
+    async fn new(
+        mut connection: StorageProcessor<'a>,
+        shared_args: TxSharedArgs,
+        execution_args: &'a TxExecutionArgs,
+        block_args: BlockArgs,
+    ) -> anyhow::Result<Sandbox<'a>> {
+        let resolve_started_at = Instant::now();
+        let resolved_block_info = block_args
+            .resolve_block_info(&mut connection)
+            .await
+            .with_context(|| format!("failed resolving block numbers for {block_args:?}"))?;
+        let resolve_time = resolve_started_at.elapsed();
+        // We don't want to emit too many logs.
+        if resolve_time > Duration::from_millis(10) {
+            tracing::debug!("Resolved block numbers (took {resolve_time:?})");
+        }
+
+        if block_args.resolves_to_latest_sealed_miniblock() {
+            shared_args
+                .caches
+                .schedule_values_update(resolved_block_info.state_l2_block_number);
+        }
+
+        let (next_l2_block_info, l2_block_info_to_reset) = Self::load_l2_block_info(
+            &mut connection,
+            block_args.is_pending_miniblock(),
+            &resolved_block_info,
+        )
+        .await?;
+
+        let storage = PostgresStorage::new_async(
+            Handle::current(),
+            connection,
+            resolved_block_info.state_l2_block_number,
+            false,
+        )
+        .await
+        .context("cannot create `PostgresStorage`")?
+        .with_caches(shared_args.caches.clone());
+
+        let storage_view = StorageView::new(storage);
+        let (system_env, l1_batch_env) = Self::prepare_env(
+            shared_args,
+            execution_args,
+            &resolved_block_info,
+            next_l2_block_info,
+        );
+
+        Ok(Self {
+            system_env,
+            l1_batch_env,
+            storage_view,
+            execution_args,
+            l2_block_info_to_reset,
+        })
+    }
+
+    async fn load_l2_block_info(
+        connection: &mut StorageProcessor<'_>,
+        is_pending_block: bool,
+        resolved_block_info: &ResolvedBlockInfo,
+    ) -> anyhow::Result<(L2BlockEnv, Option<StoredL2BlockInfo>)> {
+        let mut l2_block_info_to_reset = None;
+        let current_l2_block_info =
+            StoredL2BlockInfo::new(connection, resolved_block_info.state_l2_block_number)
+                .await
+                .context("failed reading L2 block info")?;
+
+        let next_l2_block_info = if is_pending_block {
+            L2BlockEnv {
+                number: current_l2_block_info.l2_block_number + 1,
+                timestamp: resolved_block_info.l1_batch_timestamp,
+                prev_block_hash: current_l2_block_info.l2_block_hash,
+                // For simplicity we assume each miniblock create one virtual block.
+                // This may be wrong only during transition period.
+                max_virtual_blocks_to_create: 1,
+            }
+        } else if current_l2_block_info.l2_block_number == 0 {
+            // Special case:
+            // - For environments, where genesis block was created before virtual block upgrade it doesn't matter what we put here.
+            // - Otherwise, we need to put actual values here. We cannot create next L2 block with block_number=0 and `max_virtual_blocks_to_create=0`
+            //   because of SystemContext requirements. But, due to intrinsics of SystemContext, block.number still will be resolved to 0.
+            L2BlockEnv {
+                number: 1,
+                timestamp: 0,
+                prev_block_hash: MiniblockHasher::legacy_hash(MiniblockNumber(0)),
+                max_virtual_blocks_to_create: 1,
+            }
+        } else {
+            // We need to reset L2 block info in storage to process transaction in the current block context.
+            // Actual resetting will be done after `storage_view` is created.
+            let prev_l2_block_info =
+                StoredL2BlockInfo::new(connection, resolved_block_info.state_l2_block_number - 1)
+                    .await
+                    .context("failed reading previous L2 block info")?;
+
+            l2_block_info_to_reset = Some(prev_l2_block_info);
+            L2BlockEnv {
+                number: current_l2_block_info.l2_block_number,
+                timestamp: current_l2_block_info.l2_block_timestamp,
+                prev_block_hash: prev_l2_block_info.l2_block_hash,
+                max_virtual_blocks_to_create: 1,
+            }
+        };
+
+        Ok((next_l2_block_info, l2_block_info_to_reset))
+    }
+
+    /// This method is blocking.
+    fn setup_storage_view(&mut self, tx: &Transaction) {
+        let storage_view_setup_started_at = Instant::now();
+        if let Some(nonce) = self.execution_args.enforced_nonce {
+            let nonce_key = get_nonce_key(&tx.initiator_account());
+            let full_nonce = self.storage_view.read_value(&nonce_key);
+            let (_, deployment_nonce) = decompose_full_nonce(h256_to_u256(full_nonce));
+            let enforced_full_nonce = nonces_to_full_nonce(U256::from(nonce.0), deployment_nonce);
+            self.storage_view
+                .set_value(nonce_key, u256_to_h256(enforced_full_nonce));
+        }
+
+        let payer = tx.payer();
+        let balance_key = storage_key_for_eth_balance(&payer);
+        let mut current_balance = h256_to_u256(self.storage_view.read_value(&balance_key));
+        current_balance += self.execution_args.added_balance;
+        self.storage_view
+            .set_value(balance_key, u256_to_h256(current_balance));
+
+        // Reset L2 block info if necessary.
+        if let Some(l2_block_info_to_reset) = self.l2_block_info_to_reset {
+            let l2_block_info_key = StorageKey::new(
+                AccountTreeId::new(SYSTEM_CONTEXT_ADDRESS),
+                SYSTEM_CONTEXT_CURRENT_L2_BLOCK_INFO_POSITION,
+            );
+            let l2_block_info = pack_block_info(
+                l2_block_info_to_reset.l2_block_number as u64,
+                l2_block_info_to_reset.l2_block_timestamp,
+            );
+            self.storage_view
+                .set_value(l2_block_info_key, u256_to_h256(l2_block_info));
+
+            let l2_block_txs_rolling_hash_key = StorageKey::new(
+                AccountTreeId::new(SYSTEM_CONTEXT_ADDRESS),
+                SYSTEM_CONTEXT_CURRENT_TX_ROLLING_HASH_POSITION,
+            );
+            self.storage_view.set_value(
+                l2_block_txs_rolling_hash_key,
+                l2_block_info_to_reset.txs_rolling_hash,
+            );
+        }
+
+        let storage_view_setup_time = storage_view_setup_started_at.elapsed();
+        // We don't want to emit too many logs.
+        if storage_view_setup_time > Duration::from_millis(10) {
+            tracing::debug!("Prepared the storage view (took {storage_view_setup_time:?})",);
+        }
+    }
+
+    fn prepare_env(
+        shared_args: TxSharedArgs,
+        execution_args: &TxExecutionArgs,
+        resolved_block_info: &ResolvedBlockInfo,
+        next_l2_block_info: L2BlockEnv,
+    ) -> (SystemEnv, L1BatchEnv) {
+        let TxSharedArgs {
+            operator_account,
+            fee_input,
+            base_system_contracts,
+            validation_computational_gas_limit,
+            chain_id,
+            ..
+        } = shared_args;
+
+        // In case we are executing in a past block, we'll use the historical fee data.
+        let fee_input = resolved_block_info
+            .historical_fee_input
+            .unwrap_or(fee_input);
+        let system_env = SystemEnv {
+            zk_porter_available: ZKPORTER_IS_AVAILABLE,
+            version: resolved_block_info.protocol_version,
+            base_system_smart_contracts: base_system_contracts
+                .get_by_protocol_version(resolved_block_info.protocol_version),
+            gas_limit: BLOCK_GAS_LIMIT,
+            execution_mode: execution_args.execution_mode,
+            default_validation_computational_gas_limit: validation_computational_gas_limit,
+            chain_id,
+        };
+        let l1_batch_env = L1BatchEnv {
+            previous_batch_hash: None,
+            number: resolved_block_info.vm_l1_batch_number,
+            timestamp: resolved_block_info.l1_batch_timestamp,
+            fee_input,
+            fee_account: *operator_account.address(),
+            enforced_base_fee: execution_args.enforced_base_fee,
+            first_l2_block: next_l2_block_info,
+        };
+        (system_env, l1_batch_env)
+    }
+
+    /// This method is blocking.
+    fn into_vm(
+        mut self,
+        tx: &Transaction,
+        adjust_pubdata_price: bool,
+    ) -> (BoxedVm<'a>, StoragePtr<SandboxStorageView<'a>>) {
+        self.setup_storage_view(tx);
+        let protocol_version = self.system_env.version;
+        if adjust_pubdata_price {
+            self.l1_batch_env.fee_input = adjust_pubdata_price_for_tx(
+                self.l1_batch_env.fee_input,
+                tx.gas_per_pubdata_byte_limit(),
+                protocol_version.into(),
+            );
+        };
+
+        let storage_view = self.storage_view.to_rc_ptr();
+        let vm = Box::new(VmInstance::new_with_specific_version(
+            self.l1_batch_env,
+            self.system_env,
+            storage_view.clone(),
+            protocol_version.into_api_vm_version(),
+        ));
+        (vm, storage_view)
+    }
+}
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn apply_vm_in_sandbox<T>(
@@ -59,185 +298,22 @@ pub(super) fn apply_vm_in_sandbox<T>(
     let span = tracing::debug_span!("initialization").entered();
 
     let rt_handle = vm_permit.rt_handle();
-    let mut connection = rt_handle
+    let connection = rt_handle
         .block_on(connection_pool.access_storage_tagged("api"))
         .context("failed acquiring DB connection")?;
     let connection_acquire_time = stage_started_at.elapsed();
     // We don't want to emit too many logs.
     if connection_acquire_time > Duration::from_millis(10) {
-        tracing::debug!(
-            "Obtained connection (took {:?})",
-            stage_started_at.elapsed()
-        );
+        tracing::debug!("Obtained connection (took {connection_acquire_time:?})");
     }
 
-    let resolve_started_at = Instant::now();
-    let ResolvedBlockInfo {
-        state_l2_block_number,
-        vm_l1_batch_number,
-        l1_batch_timestamp,
-        protocol_version,
-        historical_fee_input,
-    } = rt_handle
-        .block_on(block_args.resolve_block_info(&mut connection))
-        .with_context(|| format!("failed resolving block numbers for {block_args:?}"))?;
-    let resolve_time = resolve_started_at.elapsed();
-    // We don't want to emit too many logs.
-    if resolve_time > Duration::from_millis(10) {
-        tracing::debug!(
-            "Resolved block numbers (took {:?})",
-            resolve_started_at.elapsed()
-        );
-    }
-
-    if block_args.resolves_to_latest_sealed_miniblock() {
-        shared_args
-            .caches
-            .schedule_values_update(state_l2_block_number);
-    }
-
-    let mut l2_block_info_to_reset = None;
-    let current_l2_block_info = rt_handle
-        .block_on(StoredL2BlockInfo::new(
-            &mut connection,
-            state_l2_block_number,
-        ))
-        .context("failed reading L2 block info")?;
-    let next_l2_block_info = if block_args.is_pending_miniblock() {
-        L2BlockEnv {
-            number: current_l2_block_info.l2_block_number + 1,
-            timestamp: l1_batch_timestamp,
-            prev_block_hash: current_l2_block_info.l2_block_hash,
-            // For simplicity we assume each miniblock create one virtual block.
-            // This may be wrong only during transition period.
-            max_virtual_blocks_to_create: 1,
-        }
-    } else if current_l2_block_info.l2_block_number == 0 {
-        // Special case:
-        // - For environments, where genesis block was created before virtual block upgrade it doesn't matter what we put here.
-        // - Otherwise, we need to put actual values here. We cannot create next L2 block with block_number=0 and `max_virtual_blocks_to_create=0`
-        //   because of SystemContext requirements. But, due to intrinsics of SystemContext, block.number still will be resolved to 0.
-        L2BlockEnv {
-            number: 1,
-            timestamp: 0,
-            prev_block_hash: MiniblockHasher::legacy_hash(MiniblockNumber(0)),
-            max_virtual_blocks_to_create: 1,
-        }
-    } else {
-        // We need to reset L2 block info in storage to process transaction in the current block context.
-        // Actual resetting will be done after `storage_view` is created.
-        let prev_l2_block_info = rt_handle
-            .block_on(StoredL2BlockInfo::new(
-                &mut connection,
-                state_l2_block_number - 1,
-            ))
-            .context("failed reading previous L2 block info")?;
-
-        l2_block_info_to_reset = Some(prev_l2_block_info);
-        L2BlockEnv {
-            number: current_l2_block_info.l2_block_number,
-            timestamp: current_l2_block_info.l2_block_timestamp,
-            prev_block_hash: prev_l2_block_info.l2_block_hash,
-            max_virtual_blocks_to_create: 1,
-        }
-    };
-
-    let storage = PostgresStorage::new(rt_handle.clone(), connection, state_l2_block_number, false)
-        .with_caches(shared_args.caches);
-    let mut storage_view = StorageView::new(storage);
-
-    let storage_view_setup_started_at = Instant::now();
-    if let Some(nonce) = execution_args.enforced_nonce {
-        let nonce_key = get_nonce_key(&tx.initiator_account());
-        let full_nonce = storage_view.read_value(&nonce_key);
-        let (_, deployment_nonce) = decompose_full_nonce(h256_to_u256(full_nonce));
-        let enforced_full_nonce = nonces_to_full_nonce(U256::from(nonce.0), deployment_nonce);
-        storage_view.set_value(nonce_key, u256_to_h256(enforced_full_nonce));
-    }
-
-    let payer = tx.payer();
-    let balance_key = storage_key_for_eth_balance(&payer);
-    let mut current_balance = h256_to_u256(storage_view.read_value(&balance_key));
-    current_balance += execution_args.added_balance;
-    storage_view.set_value(balance_key, u256_to_h256(current_balance));
-
-    // Reset L2 block info.
-    if let Some(l2_block_info_to_reset) = l2_block_info_to_reset {
-        let l2_block_info_key = StorageKey::new(
-            AccountTreeId::new(SYSTEM_CONTEXT_ADDRESS),
-            SYSTEM_CONTEXT_CURRENT_L2_BLOCK_INFO_POSITION,
-        );
-        let l2_block_info = pack_block_info(
-            l2_block_info_to_reset.l2_block_number as u64,
-            l2_block_info_to_reset.l2_block_timestamp,
-        );
-        storage_view.set_value(l2_block_info_key, u256_to_h256(l2_block_info));
-
-        let l2_block_txs_rolling_hash_key = StorageKey::new(
-            AccountTreeId::new(SYSTEM_CONTEXT_ADDRESS),
-            SYSTEM_CONTEXT_CURRENT_TX_ROLLING_HASH_POSITION,
-        );
-        storage_view.set_value(
-            l2_block_txs_rolling_hash_key,
-            l2_block_info_to_reset.txs_rolling_hash,
-        );
-    }
-
-    let storage_view_setup_time = storage_view_setup_started_at.elapsed();
-    // We don't want to emit too many logs.
-    if storage_view_setup_time > Duration::from_millis(10) {
-        tracing::debug!("Prepared the storage view (took {storage_view_setup_time:?})",);
-    }
-
-    let TxSharedArgs {
-        operator_account,
-        fee_input,
-        base_system_contracts,
-        validation_computational_gas_limit,
-        chain_id,
-        ..
-    } = shared_args;
-
-    // In case we are executing in a past block, we'll
-    // use the historical fee data.
-    let fee_input = historical_fee_input.unwrap_or(fee_input);
-    let fee_input = if adjust_pubdata_price {
-        adjust_pubdata_price_for_tx(
-            fee_input,
-            tx.gas_per_pubdata_byte_limit(),
-            protocol_version.into(),
-        )
-    } else {
-        fee_input
-    };
-
-    let system_env = SystemEnv {
-        zk_porter_available: ZKPORTER_IS_AVAILABLE,
-        version: protocol_version,
-        base_system_smart_contracts: base_system_contracts
-            .get_by_protocol_version(protocol_version),
-        gas_limit: BLOCK_GAS_LIMIT,
-        execution_mode: execution_args.execution_mode,
-        default_validation_computational_gas_limit: validation_computational_gas_limit,
-        chain_id,
-    };
-    let l1_batch_env = L1BatchEnv {
-        previous_batch_hash: None,
-        number: vm_l1_batch_number,
-        timestamp: l1_batch_timestamp,
-        fee_input,
-        fee_account: *operator_account.address(),
-        enforced_base_fee: execution_args.enforced_base_fee,
-        first_l2_block: next_l2_block_info,
-    };
-
-    let storage_view = storage_view.to_rc_ptr();
-    let mut vm = Box::new(VmInstance::new_with_specific_version(
-        l1_batch_env,
-        system_env,
-        storage_view.clone(),
-        protocol_version.into_api_vm_version(),
-    ));
+    let sandbox = rt_handle.block_on(Sandbox::new(
+        connection,
+        shared_args,
+        execution_args,
+        block_args,
+    ))?;
+    let (mut vm, storage_view) = sandbox.into_vm(&tx, adjust_pubdata_price);
 
     SANDBOX_METRICS.sandbox[&SandboxStage::Initialization].observe(stage_started_at.elapsed());
     span.exit();
@@ -258,8 +334,6 @@ pub(super) fn apply_vm_in_sandbox<T>(
         vm_execution_took,
         storage_view.as_ref().borrow_mut().metrics(),
     );
-    drop(vm_permit); // Ensure that the permit lives until this point
-
     Ok(result)
 }
 

--- a/core/lib/zksync_core/src/api_server/execution_sandbox/apply.rs
+++ b/core/lib/zksync_core/src/api_server/execution_sandbox/apply.rs
@@ -339,7 +339,8 @@ impl BlockArgs {
         )
     }
 
-    pub(crate) async fn resolve_block_info(
+    // FIXME: needs to support snapshot recovery (otherwise, empty storage will lead to panics)
+    async fn resolve_block_info(
         &self,
         connection: &mut StorageProcessor<'_>,
     ) -> anyhow::Result<ResolvedBlockInfo> {

--- a/core/lib/zksync_core/src/api_server/execution_sandbox/execute.rs
+++ b/core/lib/zksync_core/src/api_server/execution_sandbox/execute.rs
@@ -115,7 +115,7 @@ impl TransactionExecutor {
     ) -> anyhow::Result<TransactionExecutionOutput> {
         #[cfg(test)]
         if let Self::Mock(mock_executor) = self {
-            return mock_executor.execute_tx(&tx);
+            return mock_executor.execute_tx(&tx, &block_args);
         }
 
         let total_factory_deps = tx

--- a/core/lib/zksync_core/src/api_server/execution_sandbox/mod.rs
+++ b/core/lib/zksync_core/src/api_server/execution_sandbox/mod.rs
@@ -219,6 +219,27 @@ pub(crate) struct TxSharedArgs {
     pub chain_id: L2ChainId,
 }
 
+impl TxSharedArgs {
+    #[cfg(test)]
+    pub fn mock(base_system_contracts: MultiVMBaseSystemContracts, pool: ConnectionPool) -> Self {
+        let mut caches = PostgresStorageCaches::new(1, 1);
+        tokio::task::spawn_blocking(caches.configure_storage_values_cache(
+            1,
+            pool,
+            Handle::current(),
+        ));
+
+        Self {
+            operator_account: AccountTreeId::default(),
+            fee_input: BatchFeeInput::l1_pegged(55, 555),
+            base_system_contracts,
+            caches,
+            validation_computational_gas_limit: u32::MAX,
+            chain_id: L2ChainId::default(),
+        }
+    }
+}
+
 /// Information about first L1 batch / miniblock in the node storage.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct BlockStartInfo {

--- a/core/lib/zksync_core/src/api_server/execution_sandbox/testonly.rs
+++ b/core/lib/zksync_core/src/api_server/execution_sandbox/testonly.rs
@@ -1,23 +1,76 @@
-use std::collections::HashMap;
+use std::fmt;
 
 use multivm::interface::{ExecutionResult, VmExecutionResultAndLogs};
 use zksync_types::{
-    fee::TransactionExecutionMetrics, l2::L2Tx, ExecuteTransactionCommon, Transaction, H256,
+    fee::TransactionExecutionMetrics, l2::L2Tx, ExecuteTransactionCommon, Transaction,
 };
 
 use super::{
     execute::{TransactionExecutionOutput, TransactionExecutor},
     validate::ValidationError,
+    BlockArgs,
 };
 
-#[derive(Debug, Default)]
+type CallResponseFn = dyn Fn(&[u8], &BlockArgs) -> ExecutionResult + Send + Sync;
+type TxResponseFn = dyn Fn(&Transaction, &BlockArgs) -> ExecutionResult + Send + Sync;
+
 pub(crate) struct MockTransactionExecutor {
-    call_responses: HashMap<Vec<u8>, TransactionExecutionOutput>,
-    tx_responses: HashMap<H256, TransactionExecutionOutput>,
+    call_responses: Box<CallResponseFn>,
+    tx_responses: Box<TxResponseFn>,
+}
+
+impl fmt::Debug for MockTransactionExecutor {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MockTransactionExecutor")
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for MockTransactionExecutor {
+    fn default() -> Self {
+        Self {
+            call_responses: Box::new(|calldata, _| {
+                panic!("Unexpected call with data {}", hex::encode(calldata));
+            }),
+            tx_responses: Box::new(|tx, _| {
+                panic!("Unexpect transaction call: {tx:?}");
+            }),
+        }
+    }
 }
 
 impl MockTransactionExecutor {
-    pub fn insert_call_response(&mut self, calldata: Vec<u8>, result: ExecutionResult) {
+    pub fn set_call_responses<F>(&mut self, responses: F)
+    where
+        F: Fn(&[u8], &BlockArgs) -> ExecutionResult + 'static + Send + Sync,
+    {
+        self.call_responses = Box::new(responses);
+    }
+
+    pub fn set_tx_responses<F>(&mut self, responses: F)
+    where
+        F: Fn(&Transaction, &BlockArgs) -> ExecutionResult + 'static + Send + Sync,
+    {
+        self.tx_responses = Box::new(responses);
+    }
+
+    pub fn validate_tx(&self, tx: L2Tx, block_args: &BlockArgs) -> Result<(), ValidationError> {
+        let result = (self.tx_responses)(&tx.into(), block_args);
+        match result {
+            ExecutionResult::Success { .. } => Ok(()),
+            other => Err(ValidationError::Internal(anyhow::anyhow!(
+                "transaction validation failed: {other:?}"
+            ))),
+        }
+    }
+
+    pub fn execute_tx(
+        &self,
+        tx: &Transaction,
+        block_args: &BlockArgs,
+    ) -> anyhow::Result<TransactionExecutionOutput> {
+        let result = self.get_execution_result(tx, block_args);
         let output = TransactionExecutionOutput {
             vm: VmExecutionResultAndLogs {
                 result,
@@ -28,47 +81,16 @@ impl MockTransactionExecutor {
             metrics: TransactionExecutionMetrics::default(),
             are_published_bytecodes_ok: true,
         };
-        self.call_responses.insert(calldata, output);
+        Ok(output)
     }
 
-    pub fn insert_tx_response(&mut self, tx_hash: H256, result: ExecutionResult) {
-        let output = TransactionExecutionOutput {
-            vm: VmExecutionResultAndLogs {
-                result,
-                logs: Default::default(),
-                statistics: Default::default(),
-                refunds: Default::default(),
-            },
-            metrics: TransactionExecutionMetrics::default(),
-            are_published_bytecodes_ok: true,
-        };
-        self.tx_responses.insert(tx_hash, output);
-    }
-
-    pub fn validate_tx(&self, tx: &L2Tx) -> Result<(), ValidationError> {
-        self.tx_responses
-            .get(&tx.hash())
-            .unwrap_or_else(|| panic!("Validating unexpected transaction: {tx:?}"));
-        Ok(())
-    }
-
-    pub fn execute_tx(&self, tx: &Transaction) -> anyhow::Result<TransactionExecutionOutput> {
+    fn get_execution_result(&self, tx: &Transaction, block_args: &BlockArgs) -> ExecutionResult {
         if let ExecuteTransactionCommon::L2(data) = &tx.common_data {
             if data.input.is_none() {
-                // `Transaction` was obtained from a `CallRequest`
-                return Ok(self
-                    .call_responses
-                    .get(tx.execute.calldata())
-                    .unwrap_or_else(|| panic!("Executing unexpected call: {tx:?}"))
-                    .clone());
+                return (self.call_responses)(tx.execute.calldata(), block_args);
             }
         }
-
-        Ok(self
-            .tx_responses
-            .get(&tx.hash())
-            .unwrap_or_else(|| panic!("Executing unexpected transaction: {tx:?}"))
-            .clone())
+        (self.tx_responses)(tx, block_args)
     }
 }
 

--- a/core/lib/zksync_core/src/api_server/execution_sandbox/tests.rs
+++ b/core/lib/zksync_core/src/api_server/execution_sandbox/tests.rs
@@ -1,12 +1,15 @@
 //! Tests for the VM execution sandbox.
 
 use assert_matches::assert_matches;
+use zksync_test_account::Account;
 
 use super::*;
 use crate::{
     api_server::{execution_sandbox::apply::apply_vm_in_sandbox, tx_sender::ApiContracts},
     genesis::{ensure_genesis_state, GenesisParams},
-    utils::testonly::{create_l2_transaction, create_miniblock, prepare_recovery_snapshot},
+    utils::testonly::{
+        create_l2_transaction, create_miniblock, prepare_recovery_snapshot, StorageSnapshot,
+    },
 };
 
 #[tokio::test]
@@ -197,13 +200,18 @@ async fn test_instantiating_vm(pool: ConnectionPool, block_args: BlockArgs) {
     .expect("VM instantiation errored");
 }
 
-#[ignore] // FIXME: `BlockArgs::resolve_block_info()` panics
 #[tokio::test]
 async fn instantiating_vm_after_snapshot_recovery() {
     let pool = ConnectionPool::test_pool().await;
-    let mut storage = pool.access_storage().await.unwrap();
-    prepare_recovery_snapshot(&mut storage, L1BatchNumber(23), MiniblockNumber(42), &[]).await;
+    // Since VM reads multiple bootloader storage slots, we want to recreate a real storage snapshot
+    // by executing a real VM with real transactions.
+    let snapshot = StorageSnapshot::new(&pool, &mut Account::random(), 10).await;
+    assert!(!snapshot.storage_logs.is_empty()); // sanity check
+    let expected_miniblock = snapshot.miniblock_number + 1;
+    snapshot.recover(&pool).await;
 
+    let mut storage = pool.access_storage().await.unwrap();
     let block_args = BlockArgs::pending(&mut storage).await.unwrap();
+    assert_eq!(block_args.resolved_block_number(), expected_miniblock);
     test_instantiating_vm(pool.clone(), block_args).await;
 }

--- a/core/lib/zksync_core/src/api_server/execution_sandbox/tests.rs
+++ b/core/lib/zksync_core/src/api_server/execution_sandbox/tests.rs
@@ -4,8 +4,9 @@ use assert_matches::assert_matches;
 
 use super::*;
 use crate::{
+    api_server::{execution_sandbox::apply::apply_vm_in_sandbox, tx_sender::ApiContracts},
     genesis::{ensure_genesis_state, GenesisParams},
-    utils::testonly::{create_miniblock, prepare_recovery_snapshot},
+    utils::testonly::{create_l2_transaction, create_miniblock, prepare_recovery_snapshot},
 };
 
 #[tokio::test]
@@ -153,4 +154,56 @@ async fn creating_block_args_after_snapshot_recovery() {
             .unwrap_err();
         assert_matches!(err, BlockArgsError::Missing);
     }
+}
+
+#[tokio::test]
+async fn instantiating_vm() {
+    let pool = ConnectionPool::test_pool().await;
+    let mut storage = pool.access_storage().await.unwrap();
+    ensure_genesis_state(&mut storage, L2ChainId::default(), &GenesisParams::mock())
+        .await
+        .unwrap();
+
+    let block_args = BlockArgs::pending(&mut storage).await.unwrap();
+    test_instantiating_vm(pool.clone(), block_args).await;
+    let start_info = BlockStartInfo::new(&mut storage).await.unwrap();
+    let block_args = BlockArgs::new(&mut storage, api::BlockId::Number(0.into()), start_info)
+        .await
+        .unwrap();
+    test_instantiating_vm(pool.clone(), block_args).await;
+}
+
+async fn test_instantiating_vm(pool: ConnectionPool, block_args: BlockArgs) {
+    let (vm_concurrency_limiter, _) = VmConcurrencyLimiter::new(1);
+    let vm_permit = vm_concurrency_limiter.acquire().await.unwrap();
+    let transaction = create_l2_transaction(10, 100).into();
+
+    tokio::task::spawn_blocking(move || {
+        apply_vm_in_sandbox(
+            vm_permit,
+            TxSharedArgs::mock(ApiContracts::load_from_disk().estimate_gas, pool.clone()),
+            true,
+            &TxExecutionArgs::for_gas_estimate(None, &transaction, 123),
+            &pool,
+            transaction.clone(),
+            block_args,
+            |_, received_tx| {
+                assert_eq!(received_tx, transaction);
+            },
+        )
+    })
+    .await
+    .expect("VM instantiation panicked")
+    .expect("VM instantiation errored");
+}
+
+#[ignore] // FIXME: `BlockArgs::resolve_block_info()` panics
+#[tokio::test]
+async fn instantiating_vm_after_snapshot_recovery() {
+    let pool = ConnectionPool::test_pool().await;
+    let mut storage = pool.access_storage().await.unwrap();
+    prepare_recovery_snapshot(&mut storage, L1BatchNumber(23), MiniblockNumber(42), &[]).await;
+
+    let block_args = BlockArgs::pending(&mut storage).await.unwrap();
+    test_instantiating_vm(pool.clone(), block_args).await;
 }

--- a/core/lib/zksync_core/src/api_server/execution_sandbox/validate.rs
+++ b/core/lib/zksync_core/src/api_server/execution_sandbox/validate.rs
@@ -42,7 +42,7 @@ impl TransactionExecutor {
     ) -> Result<(), ValidationError> {
         #[cfg(test)]
         if let Self::Mock(mock) = self {
-            return mock.validate_tx(&tx);
+            return mock.validate_tx(tx, &block_args);
         }
 
         let stage_latency = SANDBOX_METRICS.sandbox[&SandboxStage::ValidateInSandbox].start();

--- a/core/lib/zksync_core/src/api_server/tx_sender/mod.rs
+++ b/core/lib/zksync_core/src/api_server/tx_sender/mod.rs
@@ -39,6 +39,7 @@ use crate::{
     fee_model::BatchFeeModelInputProvider,
     metrics::{TxStage, APP_METRICS},
     state_keeper::seal_criteria::{ConditionalSealer, NoopSealer, SealData},
+    utils::pending_protocol_version,
 };
 
 mod proxy;
@@ -375,8 +376,7 @@ impl TxSender {
             .as_ref()
             .unwrap() // Checked above
             .access_storage_tagged("api")
-            .await
-            .unwrap()
+            .await?
             .transactions_dal()
             .insert_transaction_l2(tx, execution_output.metrics)
             .await;
@@ -664,11 +664,9 @@ impl TxSender {
 
         let mut connection = self.acquire_replica_connection().await?;
         let block_args = BlockArgs::pending(&mut connection).await?;
-        let protocol_version = block_args
-            .resolve_block_info(&mut connection)
+        let protocol_version = pending_protocol_version(&mut connection)
             .await
-            .with_context(|| format!("failed resolving block info for {block_args:?}"))?
-            .protocol_version;
+            .context("failed getting pending protocol version")?;
         drop(connection);
 
         let fee_input = {
@@ -917,12 +915,9 @@ impl TxSender {
 
     pub async fn gas_price(&self) -> anyhow::Result<u64> {
         let mut connection = self.acquire_replica_connection().await?;
-        let block_args = BlockArgs::pending(&mut connection).await?;
-        let protocol_version = block_args
-            .resolve_block_info(&mut connection)
+        let protocol_version = pending_protocol_version(&mut connection)
             .await
-            .with_context(|| format!("failed resolving block info for {block_args:?}"))?
-            .protocol_version;
+            .context("failed obtaining pending protocol version")?;
         drop(connection);
 
         let (base_fee, _) = derive_base_fee_and_gas_per_pubdata(

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/eth.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/eth.rs
@@ -579,12 +579,9 @@ impl EthNamespace {
             .blocks_dal()
             .get_sealed_miniblock_number()
             .await
-            .map_err(|err| internal_error(METHOD_NAME, err))?;
-        let next_block_number = match last_block_number {
-            Some(number) => number + 1,
-            // If we don't have miniblocks in the storage, use the first projected miniblock number as the cursor
-            None => self.state.start_info.first_miniblock,
-        };
+            .map_err(|err| internal_error(METHOD_NAME, err))?
+            .ok_or_else(|| internal_error(METHOD_NAME, "no miniblocks in storage"))?;
+        let next_block_number = last_block_number + 1;
         drop(storage);
 
         let idx = self

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/eth.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/eth.rs
@@ -109,7 +109,7 @@ impl EthNamespace {
             .set_nonce_for_call_request(&mut request_with_gas_per_pubdata_overridden)
             .await?;
 
-        if let Some(ref mut eip712_meta) = request_with_gas_per_pubdata_overridden.eip712_meta {
+        if let Some(eip712_meta) = &mut request_with_gas_per_pubdata_overridden.eip712_meta {
             if eip712_meta.gas_per_pubdata == U256::zero() {
                 eip712_meta.gas_per_pubdata = DEFAULT_L2_TX_GAS_PER_PUBDATA_BYTE.into();
             }
@@ -132,7 +132,6 @@ impl EthNamespace {
 
         // When we're estimating fee, we are trying to deduce values related to fee, so we should
         // not consider provided ones.
-
         let gas_price = self.state.tx_sender.gas_price().await;
         let gas_price = gas_price.map_err(|err| internal_error(METHOD_NAME, err))?;
         tx.common_data.fee.max_fee_per_gas = gas_price.into();

--- a/core/lib/zksync_core/src/api_server/web3/state.rs
+++ b/core/lib/zksync_core/src/api_server/web3/state.rs
@@ -352,13 +352,10 @@ impl RpcState {
             .await
             .map_err(|err| internal_error(METHOD_NAME, err))?;
 
-        // Since we might not have miniblocks in the storage, we resolve the pending block (which is guaranteed to succeed),
-        // and then subtract 1 to get (possibly projected) latest block number.
-        let pending_block_id = api::BlockId::Number(api::BlockNumber::Pending);
-        let pending_block_number = self
-            .resolve_block(&mut connection, pending_block_id, METHOD_NAME)
+        let latest_block_id = api::BlockId::Number(api::BlockNumber::Latest);
+        let latest_block_number = self
+            .resolve_block(&mut connection, latest_block_id, METHOD_NAME)
             .await?;
-        let latest_block_number = MiniblockNumber(pending_block_number.saturating_sub(1));
 
         let from = call_request.from.unwrap_or_default();
         let address_historical_nonce = connection

--- a/core/lib/zksync_core/src/api_server/web3/state.rs
+++ b/core/lib/zksync_core/src/api_server/web3/state.rs
@@ -343,24 +343,30 @@ impl RpcState {
     ) -> Result<(), Web3Error> {
         const METHOD_NAME: &str = "set_nonce_for_call_request";
 
-        if call_request.nonce.is_none() {
-            let from = call_request.from.unwrap_or_default();
-            let block_id = api::BlockId::Number(api::BlockNumber::Latest);
-            let mut connection = self
-                .connection_pool
-                .access_storage_tagged("api")
-                .await
-                .unwrap();
-            let block_number = self
-                .resolve_block(&mut connection, block_id, METHOD_NAME)
-                .await?;
-            let address_historical_nonce = connection
-                .storage_web3_dal()
-                .get_address_historical_nonce(from, block_number)
-                .await
-                .map_err(|err| internal_error(METHOD_NAME, err))?;
-            call_request.nonce = Some(address_historical_nonce);
+        if call_request.nonce.is_some() {
+            return Ok(());
         }
+        let mut connection = self
+            .connection_pool
+            .access_storage_tagged("api")
+            .await
+            .map_err(|err| internal_error(METHOD_NAME, err))?;
+
+        // Since we might not have miniblocks in the storage, we resolve the pending block (which is guaranteed to succeed),
+        // and then subtract 1 to get (possibly projected) latest block number.
+        let pending_block_id = api::BlockId::Number(api::BlockNumber::Pending);
+        let pending_block_number = self
+            .resolve_block(&mut connection, pending_block_id, METHOD_NAME)
+            .await?;
+        let latest_block_number = MiniblockNumber(pending_block_number.saturating_sub(1));
+
+        let from = call_request.from.unwrap_or_default();
+        let address_historical_nonce = connection
+            .storage_web3_dal()
+            .get_address_historical_nonce(from, latest_block_number)
+            .await
+            .map_err(|err| internal_error(METHOD_NAME, err))?;
+        call_request.nonce = Some(address_historical_nonce);
         Ok(())
     }
 }

--- a/core/lib/zksync_core/src/api_server/web3/tests/debug.rs
+++ b/core/lib/zksync_core/src/api_server/web3/tests/debug.rs
@@ -152,7 +152,7 @@ impl HttpTest for TraceBlockTestWithSnapshotRecovery {
             assert_pruned_block_error(&error, snapshot_miniblock_number + 1);
         }
 
-        TraceBlockTest(snapshot_miniblock_number + 1)
+        TraceBlockTest(snapshot_miniblock_number + 2)
             .test(client, pool)
             .await?;
         Ok(())

--- a/core/lib/zksync_core/src/api_server/web3/tests/filters.rs
+++ b/core/lib/zksync_core/src/api_server/web3/tests/filters.rs
@@ -31,7 +31,7 @@ impl HttpTest for BasicFilterChangesTest {
         let new_miniblock = store_miniblock(
             &mut pool.access_storage().await?,
             if self.snapshot_recovery {
-                StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 1
+                StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 2
             } else {
                 MiniblockNumber(1)
             },
@@ -115,12 +115,12 @@ impl HttpTest for LogFilterChangesTest {
         let topics_filter_id = client.new_filter(topics_filter).await?;
 
         let mut storage = pool.access_storage().await?;
-        let first_local_miniblock = if self.snapshot_recovery {
-            StorageInitialization::SNAPSHOT_RECOVERY_BLOCK.0 + 1
+        let next_local_miniblock = if self.snapshot_recovery {
+            StorageInitialization::SNAPSHOT_RECOVERY_BLOCK.0 + 2
         } else {
             1
         };
-        let (_, events) = store_events(&mut storage, first_local_miniblock, 0).await?;
+        let (_, events) = store_events(&mut storage, next_local_miniblock, 0).await?;
         drop(storage);
         let events: Vec<_> = events.iter().collect();
 

--- a/core/lib/zksync_core/src/api_server/web3/tests/mod.rs
+++ b/core/lib/zksync_core/src/api_server/web3/tests/mod.rs
@@ -14,7 +14,6 @@ use zksync_dal::{transactions_dal::L2TxSubmissionResult, ConnectionPool, Storage
 use zksync_health_check::CheckHealth;
 use zksync_types::{
     api,
-    api::BlockId,
     block::MiniblockHeader,
     fee::TransactionExecutionMetrics,
     get_nonce_key,
@@ -233,6 +232,10 @@ impl StorageInitialization {
                     .factory_deps_dal()
                     .insert_factory_deps(Self::SNAPSHOT_RECOVERY_BLOCK, factory_deps)
                     .await?;
+
+                // Insert the next L1 batch in the storage so that the API server doesn't hang up.
+                store_miniblock(storage, Self::SNAPSHOT_RECOVERY_BLOCK + 1, &[]).await?;
+                seal_l1_batch(storage, Self::SNAPSHOT_RECOVERY_BATCH + 1).await?;
             }
         }
         Ok(())
@@ -440,27 +443,12 @@ impl HttpTest for BlockMethodsWithSnapshotRecovery {
         StorageInitialization::empty_recovery()
     }
 
-    async fn test(&self, client: &HttpClient, pool: &ConnectionPool) -> anyhow::Result<()> {
-        let error = client.get_block_number().await.unwrap_err();
-        if let ClientError::Call(error) = error {
-            assert_eq!(error.code(), ErrorCode::InvalidParams.code());
-        } else {
-            panic!("Unexpected error: {error:?}");
-        }
-
-        let block = client
-            .get_block_by_number(api::BlockNumber::Latest, false)
-            .await?;
-        assert!(block.is_none());
+    async fn test(&self, client: &HttpClient, _pool: &ConnectionPool) -> anyhow::Result<()> {
         let block = client.get_block_by_number(1_000.into(), false).await?;
         assert!(block.is_none());
 
-        let mut storage = pool.access_storage().await?;
-        store_miniblock(&mut storage, MiniblockNumber(24), &[]).await?;
-        drop(storage);
-
-        let block_number = client.get_block_number().await?;
         let expected_block_number = StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 1;
+        let block_number = client.get_block_number().await?;
         assert_eq!(block_number, expected_block_number.0.into());
 
         for block_number in [api::BlockNumber::Latest, expected_block_number.0.into()] {
@@ -471,7 +459,7 @@ impl HttpTest for BlockMethodsWithSnapshotRecovery {
             assert_eq!(block.number, expected_block_number.0.into());
         }
 
-        for number in [0, 1, expected_block_number.0 - 1] {
+        for number in [0, 1, StorageInitialization::SNAPSHOT_RECOVERY_BLOCK.0] {
             let error = client
                 .get_block_details(MiniblockNumber(number))
                 .await
@@ -528,21 +516,9 @@ impl HttpTest for L1BatchMethodsWithSnapshotRecovery {
         StorageInitialization::empty_recovery()
     }
 
-    async fn test(&self, client: &HttpClient, pool: &ConnectionPool) -> anyhow::Result<()> {
-        let error = client.get_l1_batch_number().await.unwrap_err();
-        if let ClientError::Call(error) = error {
-            assert_eq!(error.code(), ErrorCode::InvalidParams.code());
-        } else {
-            panic!("Unexpected error: {error:?}");
-        }
-
-        let mut storage = pool.access_storage().await?;
+    async fn test(&self, client: &HttpClient, _pool: &ConnectionPool) -> anyhow::Result<()> {
         let miniblock_number = StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 1;
         let l1_batch_number = StorageInitialization::SNAPSHOT_RECOVERY_BATCH + 1;
-        store_miniblock(&mut storage, miniblock_number, &[]).await?;
-        seal_l1_batch(&mut storage, l1_batch_number).await?;
-        drop(storage);
-
         assert_eq!(
             client.get_l1_batch_number().await?,
             l1_batch_number.0.into()
@@ -631,9 +607,7 @@ impl HttpTest for StorageAccessWithSnapshotRecovery {
         StorageInitialization::Recovery { logs, factory_deps }
     }
 
-    async fn test(&self, client: &HttpClient, pool: &ConnectionPool) -> anyhow::Result<()> {
-        let mut storage = pool.access_storage().await?;
-
+    async fn test(&self, client: &HttpClient, _pool: &ConnectionPool) -> anyhow::Result<()> {
         let address = Address::repeat_byte(1);
         let first_local_miniblock = StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 1;
         for number in [0, 1, first_local_miniblock.0 - 1] {
@@ -648,9 +622,6 @@ impl HttpTest for StorageAccessWithSnapshotRecovery {
                 .unwrap_err();
             assert_pruned_block_error(&error, first_local_miniblock);
         }
-
-        store_miniblock(&mut storage, first_local_miniblock, &[]).await?;
-        drop(storage);
 
         for number in [api::BlockNumber::Latest, first_local_miniblock.0.into()] {
             let number = api::BlockIdVariant::BlockNumber(number);
@@ -806,8 +777,6 @@ impl HttpTest for TransactionCountAfterSnapshotRecoveryTest {
         }
 
         let latest_miniblock_number = StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 1;
-        store_miniblock(&mut storage, latest_miniblock_number, &[]).await?;
-
         let latest_block_numbers = [api::BlockNumber::Latest, latest_miniblock_number.0.into()];
         for number in latest_block_numbers {
             let number = api::BlockIdVariant::BlockNumber(number);
@@ -860,7 +829,7 @@ impl HttpTest for TransactionReceiptsTest {
         }
 
         let receipts = client
-            .get_block_receipts(BlockId::Number(miniblock_number.0.into()))
+            .get_block_receipts(api::BlockId::Number(miniblock_number.0.into()))
             .await?;
         assert_eq!(receipts.len(), 2);
         for (receipt, expected_receipt) in receipts.iter().zip(&expected_receipts) {

--- a/core/lib/zksync_core/src/api_server/web3/tests/vm.rs
+++ b/core/lib/zksync_core/src/api_server/web3/tests/vm.rs
@@ -447,8 +447,8 @@ impl HttpTest for EstimateGasTest {
             let storage_log = SendRawTransactionTest::balance_storage_log();
             let mut storage = pool.access_storage().await?;
             storage
-                .storage_dal()
-                .apply_storage_logs(&[(H256::zero(), vec![storage_log])])
+                .storage_logs_dal()
+                .append_storage_logs(MiniblockNumber(0), &[(H256::zero(), vec![storage_log])])
                 .await;
         }
         let mut call_request = CallRequest::from(l2_transaction);

--- a/core/lib/zksync_core/src/api_server/web3/tests/vm.rs
+++ b/core/lib/zksync_core/src/api_server/web3/tests/vm.rs
@@ -99,7 +99,7 @@ impl HttpTest for CallTestAfterSnapshotRecovery {
 
     fn transaction_executor(&self) -> MockTransactionExecutor {
         let first_local_miniblock = StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 1;
-        CallTest::create_executor(MiniblockNumber(first_local_miniblock))
+        CallTest::create_executor(first_local_miniblock)
     }
 
     async fn test(&self, client: &HttpClient, pool: &ConnectionPool) -> anyhow::Result<()> {
@@ -226,7 +226,7 @@ impl HttpTest for SendRawTransactionTest {
     fn transaction_executor(&self) -> MockTransactionExecutor {
         let mut tx_executor = MockTransactionExecutor::default();
         let pending_block = if self.snapshot_recovery {
-            MiniblockNumber(StorageInitialization::SNAPSHOT_RECOVERY_BLOCK) + 1
+            StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 1
         } else {
             MiniblockNumber(1)
         };
@@ -355,7 +355,7 @@ impl HttpTest for TraceCallTestAfterSnapshotRecovery {
 
     fn transaction_executor(&self) -> MockTransactionExecutor {
         let number = StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 1;
-        CallTest::create_executor(MiniblockNumber(number))
+        CallTest::create_executor(number)
     }
 
     async fn test(&self, client: &HttpClient, pool: &ConnectionPool) -> anyhow::Result<()> {
@@ -369,7 +369,7 @@ impl HttpTest for TraceCallTestAfterSnapshotRecovery {
         TraceCallTest::assert_debug_call(&call_request, &call_result);
 
         let first_local_miniblock = StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 1;
-        let first_miniblock_numbers = [api::BlockNumber::Latest, first_local_miniblock.into()];
+        let first_miniblock_numbers = [api::BlockNumber::Latest, first_local_miniblock.0.into()];
         for number in first_miniblock_numbers {
             let number = api::BlockId::Number(number);
             let error = client
@@ -383,7 +383,7 @@ impl HttpTest for TraceCallTestAfterSnapshotRecovery {
             }
         }
 
-        let pruned_block_numbers = [0, 1, StorageInitialization::SNAPSHOT_RECOVERY_BLOCK];
+        let pruned_block_numbers = [0, 1, StorageInitialization::SNAPSHOT_RECOVERY_BLOCK.0];
         for number in pruned_block_numbers {
             let number = api::BlockIdVariant::BlockNumber(number.into());
             let error = client
@@ -394,7 +394,7 @@ impl HttpTest for TraceCallTestAfterSnapshotRecovery {
         }
 
         let mut storage = pool.access_storage().await?;
-        store_miniblock(&mut storage, MiniblockNumber(first_local_miniblock), &[]).await?;
+        store_miniblock(&mut storage, first_local_miniblock, &[]).await?;
         drop(storage);
 
         let call_request = CallTest::call_request(b"pending");
@@ -445,7 +445,7 @@ impl HttpTest for EstimateGasTest {
     fn transaction_executor(&self) -> MockTransactionExecutor {
         let mut tx_executor = MockTransactionExecutor::default();
         let expected_block_number = if self.snapshot_recovery {
-            MiniblockNumber(StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 1)
+            StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 1
         } else {
             MiniblockNumber(1)
         };

--- a/core/lib/zksync_core/src/api_server/web3/tests/ws.rs
+++ b/core/lib/zksync_core/src/api_server/web3/tests/ws.rs
@@ -267,7 +267,7 @@ impl WsTest for BasicSubscriptionsTest {
         let tx_result = execute_l2_transaction(create_l2_transaction(1, 2));
         let new_tx_hash = tx_result.hash;
         let miniblock_number = if self.snapshot_recovery {
-            StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 1
+            StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 2
         } else {
             MiniblockNumber(1)
         };
@@ -389,12 +389,12 @@ impl WsTest for LogSubscriptionsTest {
         } = LogSubscriptions::new(client, &mut pub_sub_events).await?;
 
         let mut storage = pool.access_storage().await?;
-        let miniblock_number = if self.snapshot_recovery {
-            StorageInitialization::SNAPSHOT_RECOVERY_BLOCK.0 + 1
+        let next_miniblock_number = if self.snapshot_recovery {
+            StorageInitialization::SNAPSHOT_RECOVERY_BLOCK.0 + 2
         } else {
             1
         };
-        let (tx_location, events) = store_events(&mut storage, miniblock_number, 0).await?;
+        let (tx_location, events) = store_events(&mut storage, next_miniblock_number, 0).await?;
         drop(storage);
         let events: Vec<_> = events.iter().collect();
 
@@ -403,7 +403,7 @@ impl WsTest for LogSubscriptionsTest {
             assert_eq!(log.transaction_index, Some(0.into()));
             assert_eq!(log.log_index, Some(i.into()));
             assert_eq!(log.transaction_hash, Some(tx_location.tx_hash));
-            assert_eq!(log.block_number, Some(miniblock_number.into()));
+            assert_eq!(log.block_number, Some(next_miniblock_number.into()));
         }
         assert_logs_match(&all_logs, &events);
 

--- a/core/lib/zksync_core/src/api_server/web3/tests/ws.rs
+++ b/core/lib/zksync_core/src/api_server/web3/tests/ws.rs
@@ -172,17 +172,17 @@ async fn test_ws_server(test: impl WsTest) {
     drop(storage);
 
     let (stop_sender, stop_receiver) = watch::channel(false);
-    let (server_handles, pub_sub_events) = spawn_ws_server(
+    let (mut server_handles, pub_sub_events) = spawn_ws_server(
         &network_config,
         pool.clone(),
         stop_receiver,
         test.websocket_requests_per_minute_limit(),
     )
     .await;
-    server_handles.wait_until_ready().await;
 
+    let local_addr = server_handles.wait_until_ready().await;
     let client = WsClientBuilder::default()
-        .build(format!("ws://{}", server_handles.local_addr))
+        .build(format!("ws://{local_addr}"))
         .await
         .unwrap();
     test.test(&client, &pool, pub_sub_events).await.unwrap();

--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -415,8 +415,8 @@ pub async fn initialize_components(
             let elapsed = started_at.elapsed();
             APP_METRICS.init_latency[&InitStage::HttpApi].set(elapsed);
             tracing::info!(
-                "Initialized HTTP API on {:?} in {elapsed:?}",
-                server_handles.local_addr
+                "Initialized HTTP API on port {:?} in {elapsed:?}",
+                api_config.web3_json_rpc.http_port
             );
         }
 
@@ -453,8 +453,8 @@ pub async fn initialize_components(
             let elapsed = started_at.elapsed();
             APP_METRICS.init_latency[&InitStage::WsApi].set(elapsed);
             tracing::info!(
-                "initialized WS API on {:?} in {elapsed:?}",
-                server_handles.local_addr
+                "Initialized WS API on port {} in {elapsed:?}",
+                api_config.web3_json_rpc.ws_port
             );
         }
 

--- a/core/lib/zksync_core/src/sync_layer/tests.rs
+++ b/core/lib/zksync_core/src/sync_layer/tests.rs
@@ -658,15 +658,14 @@ async fn fetcher_with_real_server(snapshot_recovery: bool) {
     // Start the API server.
     let network_config = NetworkConfig::for_tests();
     let (stop_sender, stop_receiver) = watch::channel(false);
-    let server_handles = spawn_http_server(
+    let mut server_handles = spawn_http_server(
         &network_config,
         pool.clone(),
         Default::default(),
         stop_receiver.clone(),
     )
     .await;
-    server_handles.wait_until_ready().await;
-    let server_addr = &server_handles.local_addr;
+    let server_addr = &server_handles.wait_until_ready().await;
 
     // Start the fetcher connected to the API server.
     let sync_state = SyncState::default();

--- a/core/lib/zksync_core/src/utils/mod.rs
+++ b/core/lib/zksync_core/src/utils/mod.rs
@@ -142,14 +142,13 @@ pub(crate) async fn pending_protocol_version(
         });
     }
     // No miniblocks in the storage; use snapshot recovery information.
-    let _snapshot_recovery = storage
+    let snapshot_recovery = storage
         .snapshot_recovery_dal()
         .get_applied_snapshot_status()
         .await
         .context("failed getting snapshot recovery status")?
         .context("storage contains neither miniblocks, nor snapshot recovery info")?;
-    // FIXME: actually get version from snapshot recovery
-    Ok(ProtocolVersionId::latest())
+    Ok(snapshot_recovery.protocol_version)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What ❔

- Delays the API server start until there's at least one L1 batch present in the node DB.
- Refactors the VM sandbox so that it's more modular / maintainable.
- Tests VM-related API server methods.

## Why ❔

Fixes API server operation when working on the DB after snapshot recovery.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.