### PR TITLE
chore(ci): Enable custom-erc20-bridge tests for EN

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -258,34 +258,6 @@ jobs:
           echo RUN_CONTRACT_VERIFICATION_TEST=true >> .env
           echo ZKSYNC_DEBUG_LOGS=true >> .env
 
-      - name: Download zksolc/solc and zkvyper/vyper
-        run: |
-          sudo apt update && sudo apt install wget -y
-
-          mkdir -p $(pwd)/etc/solc-bin/0.8.23
-          wget https://github.com/ethereum/solc-bin/raw/gh-pages/linux-amd64/solc-linux-amd64-v0.8.23%2Bcommit.f704f362
-          mv solc-linux-amd64-v0.8.23+commit.f704f362 $(pwd)/etc/solc-bin/0.8.23/solc
-          chmod +x $(pwd)/etc/solc-bin/0.8.23/solc
-          
-          mkdir -p $(pwd)/etc/solc-bin/zkVM-0.8.23-1.0.0
-          wget https://github.com/matter-labs/era-solidity/releases/download/0.8.23-1.0.0/solc-linux-amd64-0.8.23-1.0.0 -O $(pwd)/etc/solc-bin/zkVM-0.8.23-1.0.0/solc
-          chmod +x $(pwd)/etc/solc-bin/zkVM-0.8.23-1.0.0/solc
-
-          mkdir -p $(pwd)/etc/zksolc-bin/v1.3.21
-          wget https://github.com/matter-labs/zksolc-bin/raw/main/linux-amd64/zksolc-linux-amd64-musl-v1.3.21
-          mv zksolc-linux-amd64-musl-v1.3.21 $(pwd)/etc/zksolc-bin/v1.3.21/zksolc
-          chmod +x $(pwd)/etc/zksolc-bin/v1.3.21/zksolc
-
-          mkdir -p $(pwd)/etc/vyper-bin/0.3.10
-          wget -O vyper0.3.10 https://github.com/vyperlang/vyper/releases/download/v0.3.10/vyper.0.3.10%2Bcommit.91361694.linux
-          mv vyper0.3.10 $(pwd)/etc/vyper-bin/0.3.10/vyper
-          chmod +x $(pwd)/etc/vyper-bin/0.3.10/vyper
-
-          mkdir -p $(pwd)/etc/zkvyper-bin/v1.3.11
-          wget https://github.com/matter-labs/zkvyper-bin/raw/main/linux-amd64/zkvyper-linux-amd64-musl-v1.3.11
-          mv zkvyper-linux-amd64-musl-v1.3.11 $(pwd)/etc/zkvyper-bin/v1.3.11/zkvyper
-          chmod +x $(pwd)/etc/zkvyper-bin/v1.3.11/zkvyper
-
       - name: Start services
         run: |
           ci_localnet_up

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -313,9 +313,8 @@ jobs:
           ci_run zk external-node $EXT_NODE_FLAGS &>ext-node.log &
           ci_run sleep 30
 
-      # TODO(PLA-653): Restore bridge tests for EN.
       - name: Integration tests
-        run: ci_run zk test i server --testPathIgnorePatterns 'contract-verification|custom-erc20-bridge|snapshots-creator'
+        run: ci_run zk test i server --testPathIgnorePatterns 'contract-verification|snapshots-creator'
 
       - name: Run revert test
         run: |


### PR DESCRIPTION
## What ❔

- Enable custom-erc20-bridge tests for EN
- Remove `Download zksolc/solc and zkvyper/vyper` step as it's needed only for contract verifier which is not running in EN integration tests job

## Why ❔

Test was fixed some time ago and now should be stable

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
