### PR TITLE
feat(en): Make snapshots applier resilient and process storage log chunks in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8913,7 +8913,9 @@ name = "zksync_snapshots_applier"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-trait",
+ "test-casing",
  "thiserror",
  "tokio",
  "tracing",

--- a/core/lib/snapshots_applier/Cargo.toml
+++ b/core/lib/snapshots_applier/Cargo.toml
@@ -23,3 +23,7 @@ async-trait = "0.1"
 tokio = { version = "1", features = ["time"] }
 tracing = "0.1"
 thiserror = "1.0"
+
+[dev-dependencies]
+assert_matches = "1.5.0"
+test-casing = "0.1.2"

--- a/core/lib/snapshots_applier/src/lib.rs
+++ b/core/lib/snapshots_applier/src/lib.rs
@@ -1,21 +1,19 @@
 //! Logic for applying application-level snapshots to Postgres storage.
 
-use std::ops::Mul;
-use std::time::Duration;
-use std::{collections::HashMap, fmt};
+use std::{collections::HashMap, fmt, ops::Mul, time::Duration};
 
 use anyhow::Context as _;
 use async_trait::async_trait;
 use tokio::sync::{AcquireError, Semaphore};
 use zksync_dal::{ConnectionPool, SqlxError, StorageProcessor};
 use zksync_object_store::{ObjectStore, ObjectStoreError};
-use zksync_types::web3::futures;
 use zksync_types::{
     api::en::SyncBlock,
     snapshots::{
         SnapshotFactoryDependencies, SnapshotHeader, SnapshotRecoveryStatus, SnapshotStorageLog,
         SnapshotStorageLogsChunk, SnapshotStorageLogsStorageKey,
     },
+    web3::futures,
     MiniblockNumber, H256,
 };
 use zksync_utils::bytecode::hash_bytecode;

--- a/core/lib/snapshots_applier/src/lib.rs
+++ b/core/lib/snapshots_applier/src/lib.rs
@@ -390,7 +390,7 @@ impl<'a> SnapshotsApplier<'a> {
             .storage_logs_chunks_processed
             .iter()
             .enumerate()
-            .filter(|(chunk_id, is_processed)| !**is_processed)
+            .filter(|(_chunk_id, is_processed)| !**is_processed)
             .map(|(chunk_id, _)| {
                 self.recover_storage_logs_single_chunk(&semaphore, chunk_id as u64)
             });

--- a/core/lib/snapshots_applier/src/lib.rs
+++ b/core/lib/snapshots_applier/src/lib.rs
@@ -137,12 +137,9 @@ impl SnapshotsApplierConfig {
         let mut backoff = self.initial_retry_backoff;
         let mut last_error = None;
         for retry_id in 0..self.retry_count {
-            let result = SnapshotsApplier::load_snapshot_inner(
-                connection_pool,
-                main_node_client,
-                blob_store,
-            )
-            .await;
+            let result =
+                SnapshotsApplier::load_snapshot(connection_pool, main_node_client, blob_store)
+                    .await;
 
             match result {
                 Ok(()) => return Ok(SnapshotsApplierOutcome::Ok),
@@ -232,7 +229,7 @@ impl<'a> SnapshotsApplier<'a> {
         }
     }
 
-    async fn load_snapshot_inner(
+    async fn load_snapshot(
         connection_pool: &'a ConnectionPool,
         main_node_client: &dyn SnapshotsApplierMainNodeClient,
         blob_store: &'a dyn ObjectStore,

--- a/core/lib/snapshots_applier/src/tests/mod.rs
+++ b/core/lib/snapshots_applier/src/tests/mod.rs
@@ -86,7 +86,7 @@ async fn snapshots_creator_can_successfully_recover_db(
     }
 
     // Try recovering again; it should return early.
-    let err = SnapshotsApplier::load_snapshot_inner(&pool, &client, object_store)
+    let err = SnapshotsApplier::load_snapshot(&pool, &client, object_store)
         .await
         .unwrap_err();
     assert_matches!(

--- a/core/lib/snapshots_applier/src/tests/mod.rs
+++ b/core/lib/snapshots_applier/src/tests/mod.rs
@@ -1,109 +1,59 @@
 //! Snapshot applier tests.
 
-use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use assert_matches::assert_matches;
 use test_casing::test_casing;
 use zksync_object_store::ObjectStoreFactory;
 use zksync_types::{
     block::{L1BatchHeader, MiniblockHeader},
-    snapshots::{SnapshotFactoryDependency, SnapshotStorageLogsChunkMetadata},
-    Address, Bytes, L1BatchNumber, ProtocolVersion, ProtocolVersionId,
+    Address, L1BatchNumber, ProtocolVersion, ProtocolVersionId,
 };
 
-use self::utils::{l1_block_metadata, miniblock_metadata, random_storage_logs, MockMainNodeClient};
+use self::utils::{
+    mock_recovery_status, prepare_clients, MockMainNodeClient, ObjectStoreWithErrors,
+};
 use super::*;
 
 mod utils;
 
-#[test_casing(2, [None, Some(2)])]
+#[test_casing(3, [(None, false), (Some(2), false), (None, true)])]
 #[tokio::test]
-async fn snapshots_creator_can_successfully_recover_db(pool_size: Option<u32>) {
+async fn snapshots_creator_can_successfully_recover_db(
+    pool_size: Option<u32>,
+    with_object_store_errors: bool,
+) {
     let pool = if let Some(pool_size) = pool_size {
         ConnectionPool::constrained_test_pool(pool_size).await
     } else {
         ConnectionPool::test_pool().await
     };
-    let object_store_factory = ObjectStoreFactory::mock();
-    let object_store = object_store_factory.create_store().await;
-    let mut client = MockMainNodeClient::default();
-    let miniblock_number = MiniblockNumber(1234);
-    let l1_batch_number = L1BatchNumber(123);
-    let l1_batch_root_hash = H256::random();
-    let miniblock_hash = H256::random();
-    let factory_dep_bytes: Vec<u8> = (0..32).collect();
-    let factory_deps = SnapshotFactoryDependencies {
-        factory_deps: vec![SnapshotFactoryDependency {
-            bytecode: Bytes::from(factory_dep_bytes),
-        }],
+    let expected_status = mock_recovery_status();
+    let (object_store, client, all_snapshot_storage_logs) = prepare_clients(&expected_status).await;
+
+    let object_store_with_errors;
+    let object_store: &dyn ObjectStore = if with_object_store_errors {
+        let error_counter = AtomicUsize::new(0);
+        object_store_with_errors = ObjectStoreWithErrors::new(object_store, move |_| {
+            if error_counter.fetch_add(1, Ordering::SeqCst) >= 3 {
+                Ok(()) // "recover" after 3 retries
+            } else {
+                Err(ObjectStoreError::Other("transient error".into()))
+            }
+        });
+        &object_store_with_errors
+    } else {
+        &object_store
     };
-    object_store
-        .put(l1_batch_number, &factory_deps)
-        .await
-        .unwrap();
 
-    let mut all_snapshot_storage_logs = HashMap::<H256, SnapshotStorageLog>::new();
-    for chunk_id in 0..2 {
-        let chunk_storage_logs = SnapshotStorageLogsChunk {
-            storage_logs: random_storage_logs(l1_batch_number, chunk_id, 10),
-        };
-        let chunk_key = SnapshotStorageLogsStorageKey {
-            l1_batch_number,
-            chunk_id,
-        };
-        object_store
-            .put(chunk_key, &chunk_storage_logs)
-            .await
-            .unwrap();
-
-        all_snapshot_storage_logs.extend(
-            chunk_storage_logs
-                .storage_logs
-                .into_iter()
-                .map(|log| (log.key.hashed_key(), log)),
-        );
-    }
-
-    let snapshot_header = SnapshotHeader {
-        l1_batch_number,
-        miniblock_number,
-        last_l1_batch_with_metadata: l1_block_metadata(l1_batch_number, l1_batch_root_hash),
-        storage_logs_chunks: vec![
-            SnapshotStorageLogsChunkMetadata {
-                chunk_id: 0,
-                filepath: "file0".to_string(),
-            },
-            SnapshotStorageLogsChunkMetadata {
-                chunk_id: 1,
-                filepath: "file1".to_string(),
-            },
-        ],
-        factory_deps_filepath: "some_filepath".to_string(),
-    };
-    client.fetch_newest_snapshot_response = Some(snapshot_header);
-    client.fetch_l2_block_responses.insert(
-        miniblock_number,
-        miniblock_metadata(miniblock_number, l1_batch_number, miniblock_hash),
-    );
-
-    let outcome = SnapshotsApplier::load_snapshot(&pool, &client, &object_store)
+    let outcome = SnapshotsApplierConfig::for_tests()
+        .run(&pool, &client, object_store)
         .await
         .unwrap();
     assert_matches!(outcome, SnapshotsApplierOutcome::Ok);
 
     let mut storage = pool.access_storage().await.unwrap();
     let mut recovery_dal = storage.snapshot_recovery_dal();
-
-    let expected_status = SnapshotRecoveryStatus {
-        l1_batch_number,
-        l1_batch_root_hash,
-        l1_batch_timestamp: 0,
-        miniblock_number,
-        miniblock_hash,
-        miniblock_timestamp: 0,
-        protocol_version: ProtocolVersionId::default(),
-        storage_logs_chunks_processed: vec![true, true],
-    };
 
     let current_db_status = recovery_dal.get_applied_snapshot_status().await.unwrap();
     assert_eq!(current_db_status.unwrap(), expected_status);
@@ -132,11 +82,11 @@ async fn snapshots_creator_can_successfully_recover_db(pool_size: Option<u32>) {
         assert_eq!(db_log.address, *expected_log.key.address());
         assert_eq!(db_log.key, *expected_log.key.key());
         assert_eq!(db_log.value, expected_log.value);
-        assert_eq!(db_log.miniblock_number, miniblock_number);
+        assert_eq!(db_log.miniblock_number, expected_status.miniblock_number);
     }
 
     // Try recovering again; it should return early.
-    let err = SnapshotsApplier::load_snapshot_inner(&pool, &client, &object_store)
+    let err = SnapshotsApplier::load_snapshot_inner(&pool, &client, object_store)
         .await
         .unwrap_err();
     assert_matches!(
@@ -195,7 +145,8 @@ async fn applier_returns_early_after_genesis() {
     let object_store = object_store_factory.create_store().await;
     let client = MockMainNodeClient::default();
 
-    let outcome = SnapshotsApplier::load_snapshot(&pool, &client, &object_store)
+    let outcome = SnapshotsApplierConfig::for_tests()
+        .run(&pool, &client, &object_store)
         .await
         .unwrap();
     assert_matches!(outcome, SnapshotsApplierOutcome::InitializedWithoutSnapshot);
@@ -208,8 +159,51 @@ async fn applier_returns_early_without_snapshots() {
     let object_store = object_store_factory.create_store().await;
     let client = MockMainNodeClient::default();
 
-    let outcome = SnapshotsApplier::load_snapshot(&pool, &client, &object_store)
+    let outcome = SnapshotsApplierConfig::for_tests()
+        .run(&pool, &client, &object_store)
         .await
         .unwrap();
     assert_matches!(outcome, SnapshotsApplierOutcome::NoSnapshotsOnMainNode);
+}
+
+#[tokio::test]
+async fn applier_returns_error_on_fatal_object_store_error() {
+    let pool = ConnectionPool::test_pool().await;
+    let expected_status = mock_recovery_status();
+    let (object_store, client, _) = prepare_clients(&expected_status).await;
+    let object_store = ObjectStoreWithErrors::new(object_store, |_| {
+        Err(ObjectStoreError::KeyNotFound("not found".into()))
+    });
+
+    let err = SnapshotsApplierConfig::for_tests()
+        .run(&pool, &client, &object_store)
+        .await
+        .unwrap_err();
+    assert!(err.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<ObjectStoreError>(),
+            Some(ObjectStoreError::KeyNotFound(_))
+        )
+    }));
+}
+
+#[tokio::test]
+async fn applier_returns_error_after_too_many_object_store_retries() {
+    let pool = ConnectionPool::test_pool().await;
+    let expected_status = mock_recovery_status();
+    let (object_store, client, _) = prepare_clients(&expected_status).await;
+    let object_store = ObjectStoreWithErrors::new(object_store, |_| {
+        Err(ObjectStoreError::Other("service not available".into()))
+    });
+
+    let err = SnapshotsApplierConfig::for_tests()
+        .run(&pool, &client, &object_store)
+        .await
+        .unwrap_err();
+    assert!(err.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<ObjectStoreError>(),
+            Some(ObjectStoreError::Other(_))
+        )
+    }));
 }

--- a/core/lib/snapshots_applier/src/tests/utils.rs
+++ b/core/lib/snapshots_applier/src/tests/utils.rs
@@ -1,15 +1,20 @@
 //! Test utils.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt, sync::Arc};
 
 use async_trait::async_trait;
+use zksync_object_store::{Bucket, ObjectStore, ObjectStoreError, ObjectStoreFactory};
 use zksync_types::{
     api::en::SyncBlock,
     block::L1BatchHeader,
     commitment::{L1BatchMetaParameters, L1BatchMetadata, L1BatchWithMetadata},
-    snapshots::{SnapshotHeader, SnapshotStorageLog},
-    AccountTreeId, L1BatchNumber, MiniblockNumber, ProtocolVersionId, StorageKey, StorageValue,
-    H160, H256,
+    snapshots::{
+        SnapshotFactoryDependencies, SnapshotFactoryDependency, SnapshotHeader,
+        SnapshotRecoveryStatus, SnapshotStorageLog, SnapshotStorageLogsChunk,
+        SnapshotStorageLogsChunkMetadata, SnapshotStorageLogsStorageKey,
+    },
+    AccountTreeId, Bytes, L1BatchNumber, MiniblockNumber, ProtocolVersionId, StorageKey,
+    StorageValue, H160, H256,
 };
 use zksync_web3_decl::jsonrpsee::core::ClientError as RpcError;
 
@@ -32,7 +37,57 @@ impl SnapshotsApplierMainNodeClient for MockMainNodeClient {
     }
 }
 
-pub(crate) fn miniblock_metadata(
+type ValidateFn = dyn Fn(&str) -> Result<(), ObjectStoreError> + Send + Sync;
+
+pub(super) struct ObjectStoreWithErrors {
+    inner: Arc<dyn ObjectStore>,
+    validate_fn: Box<ValidateFn>,
+}
+
+impl fmt::Debug for ObjectStoreWithErrors {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.as_ref().fmt(formatter)
+    }
+}
+
+impl ObjectStoreWithErrors {
+    pub fn new(
+        inner: Arc<dyn ObjectStore>,
+        validate_fn: impl Fn(&str) -> Result<(), ObjectStoreError> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            inner,
+            validate_fn: Box::new(validate_fn),
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectStore for ObjectStoreWithErrors {
+    async fn get_raw(&self, bucket: Bucket, key: &str) -> Result<Vec<u8>, ObjectStoreError> {
+        (self.validate_fn)(key)?;
+        self.inner.get_raw(bucket, key).await
+    }
+
+    async fn put_raw(
+        &self,
+        _bucket: Bucket,
+        _key: &str,
+        _value: Vec<u8>,
+    ) -> Result<(), ObjectStoreError> {
+        unreachable!("Should not be used in snapshot applier")
+    }
+
+    async fn remove_raw(&self, _bucket: Bucket, _key: &str) -> Result<(), ObjectStoreError> {
+        unreachable!("Should not be used in snapshot applier")
+    }
+
+    fn storage_prefix_raw(&self, bucket: Bucket) -> String {
+        self.inner.storage_prefix_raw(bucket)
+    }
+}
+
+fn miniblock_metadata(
     number: MiniblockNumber,
     l1_batch_number: L1BatchNumber,
     hash: H256,
@@ -54,10 +109,7 @@ pub(crate) fn miniblock_metadata(
     }
 }
 
-pub(crate) fn l1_block_metadata(
-    l1_batch_number: L1BatchNumber,
-    root_hash: H256,
-) -> L1BatchWithMetadata {
+fn l1_block_metadata(l1_batch_number: L1BatchNumber, root_hash: H256) -> L1BatchWithMetadata {
     L1BatchWithMetadata {
         header: L1BatchHeader::new(
             l1_batch_number,
@@ -90,7 +142,7 @@ pub(crate) fn l1_block_metadata(
     }
 }
 
-pub(super) fn random_storage_logs(
+fn random_storage_logs(
     l1_batch_number: L1BatchNumber,
     chunk_id: u64,
     logs_per_chunk: u64,
@@ -106,4 +158,91 @@ pub(super) fn random_storage_logs(
             enumeration_index: x + chunk_id * logs_per_chunk,
         })
         .collect()
+}
+
+pub(super) fn mock_recovery_status() -> SnapshotRecoveryStatus {
+    SnapshotRecoveryStatus {
+        l1_batch_number: L1BatchNumber(123),
+        l1_batch_root_hash: H256::random(),
+        l1_batch_timestamp: 0,
+        miniblock_number: MiniblockNumber(321),
+        miniblock_hash: H256::random(),
+        miniblock_timestamp: 0,
+        protocol_version: ProtocolVersionId::default(),
+        storage_logs_chunks_processed: vec![true, true],
+    }
+}
+
+pub(super) async fn prepare_clients(
+    status: &SnapshotRecoveryStatus,
+) -> (
+    Arc<dyn ObjectStore>,
+    MockMainNodeClient,
+    HashMap<H256, SnapshotStorageLog>,
+) {
+    let object_store_factory = ObjectStoreFactory::mock();
+    let object_store = object_store_factory.create_store().await;
+    let mut client = MockMainNodeClient::default();
+    let factory_dep_bytes: Vec<u8> = (0..32).collect();
+    let factory_deps = SnapshotFactoryDependencies {
+        factory_deps: vec![SnapshotFactoryDependency {
+            bytecode: Bytes::from(factory_dep_bytes),
+        }],
+    };
+    object_store
+        .put(status.l1_batch_number, &factory_deps)
+        .await
+        .unwrap();
+
+    let mut all_snapshot_storage_logs = HashMap::<H256, SnapshotStorageLog>::new();
+    for chunk_id in 0..status.storage_logs_chunks_processed.len() as u64 {
+        let chunk_storage_logs = SnapshotStorageLogsChunk {
+            storage_logs: random_storage_logs(status.l1_batch_number, chunk_id, 10),
+        };
+        let chunk_key = SnapshotStorageLogsStorageKey {
+            l1_batch_number: status.l1_batch_number,
+            chunk_id,
+        };
+        object_store
+            .put(chunk_key, &chunk_storage_logs)
+            .await
+            .unwrap();
+
+        all_snapshot_storage_logs.extend(
+            chunk_storage_logs
+                .storage_logs
+                .into_iter()
+                .map(|log| (log.key.hashed_key(), log)),
+        );
+    }
+
+    let snapshot_header = SnapshotHeader {
+        l1_batch_number: status.l1_batch_number,
+        miniblock_number: status.miniblock_number,
+        last_l1_batch_with_metadata: l1_block_metadata(
+            status.l1_batch_number,
+            status.l1_batch_root_hash,
+        ),
+        storage_logs_chunks: vec![
+            SnapshotStorageLogsChunkMetadata {
+                chunk_id: 0,
+                filepath: "file0".to_string(),
+            },
+            SnapshotStorageLogsChunkMetadata {
+                chunk_id: 1,
+                filepath: "file1".to_string(),
+            },
+        ],
+        factory_deps_filepath: "some_filepath".to_string(),
+    };
+    client.fetch_newest_snapshot_response = Some(snapshot_header);
+    client.fetch_l2_block_responses.insert(
+        status.miniblock_number,
+        miniblock_metadata(
+            status.miniblock_number,
+            status.l1_batch_number,
+            status.miniblock_hash,
+        ),
+    );
+    (object_store, client, all_snapshot_storage_logs)
 }


### PR DESCRIPTION
## What ❔

- Modifies DB recovery logic so that it retries on failures.
- Parallelizes DB recovery using a semaphore (i.e., similarly to snapshot recovery in some components).

## Why ❔

- Retries on transient errors reduce the chance of the recovery getting stuck.
- Parallelizing DB recovery can speed it up.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.