### PR TITLE
fix: make `zk status prover` use the new prover table

### DIFF
--- a/infrastructure/zk/src/status.ts
+++ b/infrastructure/zk/src/status.ts
@@ -102,7 +102,7 @@ async function compareVerificationKeys() {
         return;
     }
 
-    let protocol_version = await query('select recursion_scheduler_level_vk_hash from prover_protocol_versions');
+    let protocol_version = await query('select recursion_scheduler_level_vk_hash from prover_fri_protocol_versions');
     if (protocol_version.rowCount != 1) {
         console.log(`${redStart}Got ${protocol_version.rowCount} rows with protocol versions, expected 1${resetColor}`);
         return;

--- a/prover/vk_setup_data_generator_server_fri/src/commitment_utils.rs
+++ b/prover/vk_setup_data_generator_server_fri/src/commitment_utils.rs
@@ -45,7 +45,7 @@ fn circuit_commitments() -> anyhow::Result<L1VerifierConfig> {
         // we load the SNARK-wrapper verification key.
         // This is due to the fact that these keys are used only for picking the
         // prover jobs / witgen jobs from the DB. The keys are matched with the ones in
-        // `prover_protocol_versions` table, which has the SNARK-wrapper verification key.
+        // `prover_fri_protocol_versions` table, which has the SNARK-wrapper verification key.
         // This is OK because if the FRI VK changes, the SNARK-wrapper VK will change as well.
         // You can actually compute the SNARK-wrapper VK from the FRI VK, but this is not yet
         // implemented in the `zkevm_test_harness`, so instead we're loading it from the env.


### PR DESCRIPTION
## What ❔

Changed all usages of `prover_protocol_versions` to `prover_fri_protocol_versions`, since the table got renamed

## Why ❔

`zk status prover` is broken:

```
$ zk status prover                                                                                                                                                                   19:04:27
==== FRI Prover Status ====
State keeper: First batch: 0, recent batch: 1
L1 state: block verified: 0, block committed: 1
Verification key hash on contract is 0x8574e152c41dc39a2ecab984545e1cf21cb3ec250b919018a8053f2fa270784f
Error: relation "prover_protocol_versions" does not exist
```

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
