### PR TITLE
fix(docs): Set expectations for typo PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,9 @@ Be polite and respectful.
 
 **Q**: I have a small contribution that's not getting traction/being merged?
 
-**A**: Due to capacity, contributions that are simple renames of variables or stylistic/minor text improvements,
-one-off typo fix will not be merged. If you do find any typos or grammar errors, the preferred avenue is to improve the
-existing spellchecker. Given you have no technical prowess to do so, please create an issue. Please note that issues
-will be resolved on a best effort basis.
+**A**: Due to capacity, contributions that are simple renames of variables or stylistic/minor text improvements, one-off
+typo fix will not be merged. If you do find any typos or grammar errors, the preferred avenue is to improve the existing
+spellchecker. Given you have no technical prowess to do so, please create an issue. Please note that issues will be
+resolved on a best effort basis.
 
 ### Thank you


### PR DESCRIPTION
This change is in place to set the expectation for what will happen with
small typo fixes, synonym replacements, etc.

This policy is being added as there are too many PRs opened that either
rename small fragments, rephrase synonyms or fix typos. The goal is to
limit those and focus the energy/ attention on improving the
spellchecker.

This policy eases the "review PR" procedure. It's much easier to say
"no, here's a link why" and close the PR, rather than filtering through
the subjective opinion of the reviewer and figure out if removing some
spaces or replacing "enhance" with "empowers" better fits the
description.
