### PR TITLE
fix(local env): don't expose some ports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
               - 'Cargo.lock'
               - '!**/*.md'
               - '!**/*.MD'
+              - 'docker-compose.yml'
             docs:
               - '**/*.md'
               - '**/*.MD'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,10 +80,8 @@ services:
       - --enable-debug-rpc-endpoints
     ports:
       - 4000:4000
-      - 3500:3500
       - 8080:8080
       - 6060:6060
-      - 9090:9090
     volumes:
       - ./volumes/prysm:/consensus
       - ./volumes/geth:/execution

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       - --enable-debug-rpc-endpoints
     ports:
       - 4000:4000
-      - 8080:8080
+      - 3500:3500
       - 6060:6060
     volumes:
       - ./volumes/prysm:/consensus


### PR DESCRIPTION
port 9090 is used for prometheus, and it's likely that the host machine runs prometheus as well. I don't think we need to export it from docker.

Same applies to 8080