### PR TITLE
refactor: Get rid of L1GasPriceProvider trait

### DIFF
--- a/core/lib/zksync_core/src/api_server/tx_sender/tests.rs
+++ b/core/lib/zksync_core/src/api_server/tx_sender/tests.rs
@@ -6,7 +6,7 @@ use super::*;
 use crate::{
     api_server::execution_sandbox::{testonly::MockTransactionExecutor, VmConcurrencyBarrier},
     genesis::{ensure_genesis_state, GenesisParams},
-    utils::testonly::{create_miniblock, prepare_recovery_snapshot, MockL1GasPriceProvider},
+    utils::testonly::{create_miniblock, prepare_recovery_snapshot, MockBatchFeeParamsProvider},
 };
 
 pub(crate) async fn create_test_tx_sender(
@@ -26,14 +26,14 @@ pub(crate) async fn create_test_tx_sender(
     );
     tokio::task::spawn_blocking(cache_update_task);
 
-    let gas_adjuster = Arc::new(MockL1GasPriceProvider(1));
+    let batch_fee_model_input_provider = Arc::new(MockBatchFeeParamsProvider::default());
     let (mut tx_sender, vm_barrier) = crate::build_tx_sender(
         &tx_sender_config,
         &web3_config,
         &state_keeper_config,
         pool.clone(),
         pool,
-        gas_adjuster,
+        batch_fee_model_input_provider,
         storage_caches,
     )
     .await;

--- a/core/lib/zksync_core/src/eth_sender/tests.rs
+++ b/core/lib/zksync_core/src/eth_sender/tests.rs
@@ -49,7 +49,7 @@ struct EthSenderTester {
     gateway: Arc<MockEthereum>,
     manager: MockEthTxManager,
     aggregator: EthTxAggregator,
-    gas_adjuster: Arc<GasAdjuster<Arc<MockEthereum>>>,
+    gas_adjuster: Arc<GasAdjuster>,
 }
 
 impl EthSenderTester {

--- a/core/lib/zksync_core/src/l1_gas_price/gas_adjuster/mod.rs
+++ b/core/lib/zksync_core/src/l1_gas_price/gas_adjuster/mod.rs
@@ -11,7 +11,7 @@ use zksync_eth_client::{Error, EthInterface};
 use zksync_system_constants::L1_GAS_PER_PUBDATA_BYTE;
 
 use self::metrics::METRICS;
-use super::{L1GasPriceProvider, L1TxParamsProvider};
+use super::L1TxParamsProvider;
 use crate::state_keeper::metrics::KEEPER_METRICS;
 
 mod metrics;
@@ -112,12 +112,10 @@ impl GasAdjuster {
         }
         Ok(())
     }
-}
 
-impl L1GasPriceProvider for GasAdjuster {
     /// Returns the sum of base and priority fee, in wei, not considering time in mempool.
     /// Can be used to get an estimate of current gas price.
-    fn estimate_effective_gas_price(&self) -> u64 {
+    pub(crate) fn estimate_effective_gas_price(&self) -> u64 {
         if let Some(price) = self.config.internal_enforced_l1_gas_price {
             return price;
         }
@@ -131,7 +129,7 @@ impl L1GasPriceProvider for GasAdjuster {
         self.bound_gas_price(calculated_price)
     }
 
-    fn estimate_effective_pubdata_price(&self) -> u64 {
+    pub(crate) fn estimate_effective_pubdata_price(&self) -> u64 {
         // For now, pubdata is only sent via calldata, so its price is pegged to the L1 gas price.
         self.estimate_effective_gas_price() * L1_GAS_PER_PUBDATA_BYTE as u64
     }

--- a/core/lib/zksync_core/src/l1_gas_price/gas_adjuster/tests.rs
+++ b/core/lib/zksync_core/src/l1_gas_price/gas_adjuster/tests.rs
@@ -34,7 +34,7 @@ async fn kept_updated() {
     eth_client.advance_block_number(5);
 
     let adjuster = GasAdjuster::new(
-        Arc::clone(&eth_client),
+        eth_client.clone(),
         GasAdjusterConfig {
             default_priority_fee_per_gas: 5,
             max_base_fee_samples: 5,

--- a/core/lib/zksync_core/src/l1_gas_price/mod.rs
+++ b/core/lib/zksync_core/src/l1_gas_price/mod.rs
@@ -23,11 +23,11 @@ pub trait L1GasPriceProvider: fmt::Debug + 'static + Send + Sync {
     fn estimate_effective_pubdata_price(&self) -> u64;
 }
 
-/// Extended version of `L1GasPriceProvider` that can provide parameters
-/// to set the fee for an L1 transaction, taking the desired mining time into account.
+/// Abstraction that provides parameters to set the fee for an L1 transaction, taking the desired
+/// mining time into account.
 ///
 /// This trait, as a bound, should only be used in components that actually sign and send transactions.
-pub trait L1TxParamsProvider: L1GasPriceProvider {
+pub trait L1TxParamsProvider: fmt::Debug + 'static + Send + Sync {
     /// Returns the recommended `max_fee_per_gas` value (EIP1559).
     fn get_base_fee(&self, time_in_mempool: u32) -> u64;
 

--- a/core/lib/zksync_core/src/l1_gas_price/mod.rs
+++ b/core/lib/zksync_core/src/l1_gas_price/mod.rs
@@ -10,19 +10,6 @@ mod gas_adjuster;
 mod main_node_fetcher;
 pub mod singleton;
 
-/// Abstraction that provides information about the L1 gas price currently
-/// observed by the application.
-pub trait L1GasPriceProvider: fmt::Debug + 'static + Send + Sync {
-    /// Returns a best guess of a realistic value for the L1 gas price.
-    /// Return value is in wei.
-    fn estimate_effective_gas_price(&self) -> u64;
-
-    /// Returns a best guess of a realistic value for the L1 pubdata price.
-    /// Note that starting with EIP4844 it will become independent from the gas price.
-    /// Return value is in wei.
-    fn estimate_effective_pubdata_price(&self) -> u64;
-}
-
 /// Abstraction that provides parameters to set the fee for an L1 transaction, taking the desired
 /// mining time into account.
 ///

--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -3,7 +3,7 @@
 use std::{net::Ipv4Addr, str::FromStr, sync::Arc, time::Instant};
 
 use anyhow::Context as _;
-use fee_model::{ApiFeeInputProvider, MainNodeFeeInputProvider};
+use fee_model::{ApiFeeInputProvider, BatchFeeModelInputProvider, MainNodeFeeInputProvider};
 use futures::channel::oneshot;
 use prometheus_exporter::PrometheusExporterConfig;
 use temp_config_store::TempConfigStore;
@@ -67,7 +67,7 @@ use crate::{
         periodic_job::PeriodicJob,
         waiting_to_queued_fri_witness_job_mover::WaitingToQueuedFriWitnessJobMover,
     },
-    l1_gas_price::{GasAdjusterSingleton, L1GasPriceProvider},
+    l1_gas_price::GasAdjusterSingleton,
     metadata_calculator::{MetadataCalculator, MetadataCalculatorConfig},
     metrics::{InitStage, APP_METRICS},
     state_keeper::{
@@ -402,6 +402,10 @@ pub async fn initialize_components(
                 .get_or_init()
                 .await
                 .context("gas_adjuster.get_or_init()")?;
+            let batch_fee_input_provider = Arc::new(MainNodeFeeInputProvider::new(
+                bounded_gas_adjuster,
+                FeeModelConfig::from_state_keeper_config(&state_keeper_config),
+            ));
             let server_handles = run_http_api(
                 &postgres_config,
                 &tx_sender_config,
@@ -411,7 +415,7 @@ pub async fn initialize_components(
                 connection_pool.clone(),
                 replica_connection_pool.clone(),
                 stop_receiver.clone(),
-                bounded_gas_adjuster.clone(),
+                batch_fee_input_provider,
                 state_keeper_config.save_call_traces,
                 storage_caches.clone().unwrap(),
             )
@@ -441,13 +445,17 @@ pub async fn initialize_components(
                 .get_or_init()
                 .await
                 .context("gas_adjuster.get_or_init()")?;
+            let batch_fee_input_provider = Arc::new(MainNodeFeeInputProvider::new(
+                bounded_gas_adjuster,
+                FeeModelConfig::from_state_keeper_config(&state_keeper_config),
+            ));
             let server_handles = run_ws_api(
                 &postgres_config,
                 &tx_sender_config,
                 &state_keeper_config,
                 &internal_api_config,
                 &api_config,
-                bounded_gas_adjuster.clone(),
+                batch_fee_input_provider,
                 connection_pool.clone(),
                 replica_connection_pool.clone(),
                 stop_receiver.clone(),
@@ -494,18 +502,23 @@ pub async fn initialize_components(
             .get_or_init()
             .await
             .context("gas_adjuster.get_or_init()")?;
+        let state_keeper_config = configs
+            .state_keeper_config
+            .clone()
+            .context("state_keeper_config")?;
+        let batch_fee_input_provider = Arc::new(MainNodeFeeInputProvider::new(
+            bounded_gas_adjuster,
+            FeeModelConfig::from_state_keeper_config(&state_keeper_config),
+        ));
         add_state_keeper_to_task_futures(
             &mut task_futures,
             &postgres_config,
             &contracts_config,
-            configs
-                .state_keeper_config
-                .clone()
-                .context("state_keeper_config")?,
+            state_keeper_config,
             &configs.network_config.clone().context("network_config")?,
             &db_config,
             &configs.mempool_config.clone().context("mempool_config")?,
-            bounded_gas_adjuster,
+            batch_fee_input_provider,
             store_factory.create_store().await,
             stop_receiver.clone(),
         )
@@ -713,7 +726,7 @@ pub async fn initialize_components(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn add_state_keeper_to_task_futures<E: L1GasPriceProvider + Send + Sync + 'static>(
+async fn add_state_keeper_to_task_futures(
     task_futures: &mut Vec<JoinHandle<anyhow::Result<()>>>,
     postgres_config: &PostgresConfig,
     contracts_config: &ContractsConfig,
@@ -721,7 +734,7 @@ async fn add_state_keeper_to_task_futures<E: L1GasPriceProvider + Send + Sync + 
     network_config: &NetworkConfig,
     db_config: &DBConfig,
     mempool_config: &MempoolConfig,
-    gas_adjuster: Arc<E>,
+    batch_fee_input_provider: Arc<dyn BatchFeeModelInputProvider>,
     object_store: Arc<dyn ObjectStore>,
     stop_receiver: watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
@@ -739,11 +752,6 @@ async fn add_state_keeper_to_task_futures<E: L1GasPriceProvider + Send + Sync + 
         .await;
     let mempool = MempoolGuard::new(next_priority_id, mempool_config.capacity);
     mempool.register_metrics();
-
-    let batch_fee_input_provider = Arc::new(MainNodeFeeInputProvider::new(
-        gas_adjuster,
-        FeeModelConfig::from_state_keeper_config(&state_keeper_config),
-    ));
 
     let miniblock_sealer_pool = pool_builder
         .build()
@@ -1049,7 +1057,7 @@ async fn build_tx_sender(
     state_keeper_config: &StateKeeperConfig,
     replica_pool: ConnectionPool,
     master_pool: ConnectionPool,
-    l1_gas_price_provider: Arc<dyn L1GasPriceProvider>,
+    batch_fee_model_input_provider: Arc<dyn BatchFeeModelInputProvider>,
     storage_caches: PostgresStorageCaches,
 ) -> (TxSender, VmConcurrencyBarrier) {
     let sequencer_sealer = SequencerSealer::new(state_keeper_config.clone());
@@ -1060,11 +1068,8 @@ async fn build_tx_sender(
     let max_concurrency = web3_json_config.vm_concurrency_limit();
     let (vm_concurrency_limiter, vm_barrier) = VmConcurrencyLimiter::new(max_concurrency);
 
-    let batch_fee_input_provider = ApiFeeInputProvider::new(
-        l1_gas_price_provider,
-        FeeModelConfig::from_state_keeper_config(state_keeper_config),
-        replica_pool,
-    );
+    let batch_fee_input_provider =
+        ApiFeeInputProvider::new(batch_fee_model_input_provider, replica_pool);
 
     let tx_sender = tx_sender_builder
         .build(
@@ -1078,7 +1083,7 @@ async fn build_tx_sender(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn run_http_api<G: L1GasPriceProvider>(
+async fn run_http_api(
     postgres_config: &PostgresConfig,
     tx_sender_config: &TxSenderConfig,
     state_keeper_config: &StateKeeperConfig,
@@ -1087,7 +1092,7 @@ async fn run_http_api<G: L1GasPriceProvider>(
     master_connection_pool: ConnectionPool,
     replica_connection_pool: ConnectionPool,
     stop_receiver: watch::Receiver<bool>,
-    gas_adjuster: Arc<G>,
+    batch_fee_model_input_provider: Arc<dyn BatchFeeModelInputProvider>,
     with_debug_namespace: bool,
     storage_caches: PostgresStorageCaches,
 ) -> anyhow::Result<ApiServerHandles> {
@@ -1097,7 +1102,7 @@ async fn run_http_api<G: L1GasPriceProvider>(
         state_keeper_config,
         replica_connection_pool.clone(),
         master_connection_pool,
-        gas_adjuster,
+        batch_fee_model_input_provider,
         storage_caches,
     )
     .await;
@@ -1127,13 +1132,13 @@ async fn run_http_api<G: L1GasPriceProvider>(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn run_ws_api<G: L1GasPriceProvider + Send + Sync + 'static>(
+async fn run_ws_api(
     postgres_config: &PostgresConfig,
     tx_sender_config: &TxSenderConfig,
     state_keeper_config: &StateKeeperConfig,
     internal_api: &InternalApiConfig,
     api_config: &ApiConfig,
-    gas_adjuster: Arc<G>,
+    batch_fee_model_input_provider: Arc<dyn BatchFeeModelInputProvider>,
     master_connection_pool: ConnectionPool,
     replica_connection_pool: ConnectionPool,
     stop_receiver: watch::Receiver<bool>,
@@ -1145,7 +1150,7 @@ async fn run_ws_api<G: L1GasPriceProvider + Send + Sync + 'static>(
         state_keeper_config,
         replica_connection_pool.clone(),
         master_connection_pool,
-        gas_adjuster,
+        batch_fee_model_input_provider,
         storage_caches,
     )
     .await;

--- a/core/lib/zksync_core/src/state_keeper/io/tests/tester.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/tests/tester.rs
@@ -44,7 +44,7 @@ impl Tester {
         }
     }
 
-    async fn create_gas_adjuster(&self) -> GasAdjuster<MockEthereum> {
+    async fn create_gas_adjuster(&self) -> GasAdjuster {
         let eth_client =
             MockEthereum::default().with_fee_history(vec![0, 4, 6, 8, 7, 5, 5, 8, 10, 9]);
 
@@ -59,7 +59,7 @@ impl Tester {
             max_l1_gas_price: None,
         };
 
-        GasAdjuster::new(eth_client, gas_adjuster_config)
+        GasAdjuster::new(Arc::new(eth_client), gas_adjuster_config)
             .await
             .unwrap()
     }

--- a/core/lib/zksync_core/src/state_keeper/mempool_actor.rs
+++ b/core/lib/zksync_core/src/state_keeper/mempool_actor.rs
@@ -33,9 +33,9 @@ pub async fn l2_tx_filter(
 }
 
 #[derive(Debug)]
-pub struct MempoolFetcher<G> {
+pub struct MempoolFetcher {
     mempool: MempoolGuard,
-    batch_fee_input_provider: Arc<G>,
+    batch_fee_input_provider: Arc<dyn BatchFeeModelInputProvider>,
     sync_interval: Duration,
     sync_batch_size: usize,
     stuck_tx_timeout: Option<Duration>,
@@ -43,10 +43,10 @@ pub struct MempoolFetcher<G> {
     transaction_hashes_sender: mpsc::UnboundedSender<Vec<H256>>,
 }
 
-impl<G: BatchFeeModelInputProvider> MempoolFetcher<G> {
+impl MempoolFetcher {
     pub fn new(
         mempool: MempoolGuard,
-        batch_fee_input_provider: Arc<G>,
+        batch_fee_input_provider: Arc<dyn BatchFeeModelInputProvider>,
         config: &MempoolConfig,
     ) -> Self {
         Self {

--- a/core/lib/zksync_core/src/utils/testonly.rs
+++ b/core/lib/zksync_core/src/utils/testonly.rs
@@ -20,9 +20,7 @@ use zksync_types::{
     StorageLog, H256, U256,
 };
 
-use crate::{
-    fee_model::BatchFeeModelInputProvider, genesis::GenesisParams, l1_gas_price::L1GasPriceProvider,
-};
+use crate::{fee_model::BatchFeeModelInputProvider, genesis::GenesisParams};
 
 /// Creates a miniblock header with the specified number and deterministic contents.
 pub(crate) fn create_miniblock(number: u32) -> MiniblockHeader {
@@ -203,20 +201,6 @@ pub(crate) async fn prepare_recovery_snapshot(
         .unwrap();
     storage.commit().await.unwrap();
     snapshot_recovery
-}
-
-/// Mock [`L1GasPriceProvider`] that returns a constant value.
-#[derive(Debug)]
-pub(crate) struct MockL1GasPriceProvider(pub u64);
-
-impl L1GasPriceProvider for MockL1GasPriceProvider {
-    fn estimate_effective_gas_price(&self) -> u64 {
-        self.0
-    }
-
-    fn estimate_effective_pubdata_price(&self) -> u64 {
-        self.0 * u64::from(zksync_system_constants::L1_GAS_PER_PUBDATA_BYTE)
-    }
 }
 
 /// Mock [`BatchFeeModelInputProvider`] implementation that returns a constant value.


### PR DESCRIPTION
## What ❔

- Removes `L1GasPriceProvider` trait.
- Changes the rest of the code to use `BatchFeeModelInputProvider` trait.

## Why ❔

`BatchFeeModelInputProvider` is a successor to `L1GasPriceProvider` and it defines a real interface that modules should use.
`L1GasPriceProvider` was only used to instantiate `BatchFeeModelInputProvider`, so it was generally useless as an abstraction, while still increasing the cognitive complexity.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
