### PR TITLE
chore: log when tx spends more than 10m in mempool

### DIFF
--- a/core/lib/zksync_core/src/state_keeper/io/seal_logic.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/seal_logic.rs
@@ -463,11 +463,20 @@ impl MiniblockSealCommand {
 
         let progress = MINIBLOCK_METRICS.start(MiniblockSealStage::ReportTxMetrics, is_fictive);
         self.miniblock.executed_transactions.iter().for_each(|tx| {
+            let inclusion_delay = Duration::from_millis(
+                Utc::now().timestamp_millis() as u64 - tx.transaction.received_timestamp_ms,
+            );
+            if inclusion_delay > Duration::from_secs(600) {
+                tracing::info!(
+                    tx_hash = hex::encode(tx.hash),
+                    inclusion_delay_ms = inclusion_delay.as_millis(),
+                    received_timestamp_ms = tx.transaction.received_timestamp_ms,
+                    "Transaction spent >10m in mempool before being included in a miniblock"
+                )
+            }
             KEEPER_METRICS
                 .transaction_inclusion_delay
-                .observe(Duration::from_millis(
-                    Utc::now().timestamp_millis() as u64 - tx.transaction.received_timestamp_ms,
-                ))
+                .observe(inclusion_delay)
         });
         progress.observe(Some(self.miniblock.executed_transactions.len()));
 


### PR DESCRIPTION
## What ❔

Added a logging event when we encounter a tx that spent more than 10m in mempool.

## Why ❔

Part of the investigation on why there are spikes in `transaction_inclusion_delay` metric. Generally inclusion delay tends to be 1-2s, but occasionally spikes up to several hours. Hopefully this log gives us insight into whether there are legitimate transactions that spend a significant amount of time in the pool or the problem is somewhere else.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.
