### PR TITLE
chore: Use gauge for call tracer metrics

### DIFF
--- a/core/lib/multivm/src/tracers/call_tracer/metrics.rs
+++ b/core/lib/multivm/src/tracers/call_tracer/metrics.rs
@@ -1,14 +1,13 @@
-use vise::{Buckets, Histogram, Metrics};
+use vise::{Gauge, Metrics};
 
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "vm_call_tracer")]
 pub struct CallMetrics {
     /// Maximum call stack depth during the execution of the transaction.
-    #[metrics(buckets = Buckets::exponential(1.0..=64.0, 2.0))]
-    pub call_stack_depth: Histogram<usize>,
+    pub call_stack_depth: Gauge<usize>,
     /// Maximum number of near calls during the execution of the transaction.
     #[metrics(buckets = Buckets::exponential(1.0..=64.0, 2.0))]
-    pub max_near_calls: Histogram<usize>,
+    pub max_near_calls: Gauge<usize>,
 }
 
 #[vise::register]

--- a/core/lib/multivm/src/tracers/call_tracer/metrics.rs
+++ b/core/lib/multivm/src/tracers/call_tracer/metrics.rs
@@ -6,7 +6,6 @@ pub struct CallMetrics {
     /// Maximum call stack depth during the execution of the transaction.
     pub call_stack_depth: Gauge<usize>,
     /// Maximum number of near calls during the execution of the transaction.
-    #[metrics(buckets = Buckets::exponential(1.0..=64.0, 2.0))]
     pub max_near_calls: Gauge<usize>,
 }
 

--- a/core/lib/multivm/src/tracers/call_tracer/mod.rs
+++ b/core/lib/multivm/src/tracers/call_tracer/mod.rs
@@ -29,8 +29,8 @@ struct FarcallAndNearCallCount {
 
 impl Drop for CallTracer {
     fn drop(&mut self) {
-        CALL_METRICS.call_stack_depth.observe(self.max_stack_depth);
-        CALL_METRICS.max_near_calls.observe(self.max_near_calls);
+        CALL_METRICS.call_stack_depth.set(self.max_stack_depth);
+        CALL_METRICS.max_near_calls.set(self.max_near_calls);
     }
 }
 


### PR DESCRIPTION
## What ❔

Use Gauge instead of histogram for CallTracer metrics

## Why ❔

For better obsevability

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
