### PR TITLE
chore: Add more buckets to CallTracer metrics

### DIFF
--- a/core/lib/multivm/src/tracers/call_tracer/metrics.rs
+++ b/core/lib/multivm/src/tracers/call_tracer/metrics.rs
@@ -4,10 +4,10 @@ use vise::{Buckets, Histogram, Metrics};
 #[metrics(prefix = "vm_call_tracer")]
 pub struct CallMetrics {
     /// Maximum call stack depth during the execution of the transaction.
-    #[metrics(buckets = Buckets::exponential(1.0..=64.0, 2.0))]
+    #[metrics(buckets = Buckets::exponential(1.0..=256.0, 2.0))]
     pub call_stack_depth: Histogram<usize>,
     /// Maximum number of near calls during the execution of the transaction.
-    #[metrics(buckets = Buckets::exponential(1.0..=64.0, 2.0))]
+    #[metrics(buckets = Buckets::exponential(1.0..=256.0, 2.0))]
     pub max_near_calls: Histogram<usize>,
 }
 

--- a/core/lib/multivm/src/tracers/call_tracer/metrics.rs
+++ b/core/lib/multivm/src/tracers/call_tracer/metrics.rs
@@ -4,10 +4,10 @@ use vise::{Buckets, Histogram, Metrics};
 #[metrics(prefix = "vm_call_tracer")]
 pub struct CallMetrics {
     /// Maximum call stack depth during the execution of the transaction.
-    #[metrics(buckets = Buckets::exponential(1.0..=256.0, 2.0))]
+    #[metrics(buckets = Buckets::exponential(1.0..=1024.0, 2.0))]
     pub call_stack_depth: Histogram<usize>,
     /// Maximum number of near calls during the execution of the transaction.
-    #[metrics(buckets = Buckets::exponential(1.0..=256.0, 2.0))]
+    #[metrics(buckets = Buckets::exponential(1.0..=1024.0, 2.0))]
     pub max_near_calls: Histogram<usize>,
 }
 


### PR DESCRIPTION
## What ❔

Add buckets 128-1024

## Why ❔

To have better understanding of stack depth

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
