### PR TITLE
refactor(state_keeper): Rename batch executor family of types

### DIFF
--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -25,8 +25,8 @@ use zksync_core::{
     reorg_detector::ReorgDetector,
     setup_sigint_handler,
     state_keeper::{
-        seal_criteria::NoopSealer, L1BatchExecutorBuilder, MainBatchExecutorBuilder,
-        MiniblockSealer, MiniblockSealerHandle, ZkSyncStateKeeper,
+        seal_criteria::NoopSealer, BatchExecutor, MainBatchExecutor, MiniblockSealer,
+        MiniblockSealerHandle, ZkSyncStateKeeper,
     },
     sync_layer::{
         batch_status_updater::BatchStatusUpdater, external_io::ExternalIO,
@@ -70,16 +70,15 @@ async fn build_state_keeper(
     // We only need call traces on the external node if the `debug_` namespace is enabled.
     let save_call_traces = config.optional.api_namespaces().contains(&Namespace::Debug);
 
-    let batch_executor_base: Box<dyn L1BatchExecutorBuilder> =
-        Box::new(MainBatchExecutorBuilder::new(
-            state_keeper_db_path,
-            connection_pool.clone(),
-            max_allowed_l2_tx_gas_limit,
-            save_call_traces,
-            false,
-            config.optional.enum_index_migration_chunk_size,
-            true,
-        ));
+    let batch_executor_base: Box<dyn BatchExecutor> = Box::new(MainBatchExecutor::new(
+        state_keeper_db_path,
+        connection_pool.clone(),
+        max_allowed_l2_tx_gas_limit,
+        save_call_traces,
+        false,
+        config.optional.enum_index_migration_chunk_size,
+        true,
+    ));
 
     let main_node_url = config.required.main_node_url()?;
     let main_node_client = <dyn MainNodeClient>::json_rpc(&main_node_url)

--- a/core/lib/zksync_core/src/consensus/testonly.rs
+++ b/core/lib/zksync_core/src/consensus/testonly.rs
@@ -24,8 +24,7 @@ use crate::{
     },
     genesis::{ensure_genesis_state, GenesisParams},
     state_keeper::{
-        seal_criteria::NoopSealer, tests::MockBatchExecutorBuilder, MiniblockSealer,
-        ZkSyncStateKeeper,
+        seal_criteria::NoopSealer, tests::MockBatchExecutor, MiniblockSealer, ZkSyncStateKeeper,
     },
     sync_layer::{
         sync_action::{ActionQueue, ActionQueueSender, SyncAction},
@@ -445,7 +444,7 @@ impl StateKeeperRunner {
                 ZkSyncStateKeeper::new(
                     stop_receiver,
                     Box::new(io),
-                    Box::new(MockBatchExecutorBuilder),
+                    Box::new(MockBatchExecutor),
                     Arc::new(NoopSealer),
                 )
                 .run(),

--- a/core/lib/zksync_core/src/state_keeper/batch_executor/main_executor.rs
+++ b/core/lib/zksync_core/src/state_keeper/batch_executor/main_executor.rs
@@ -17,6 +17,7 @@ use zksync_state::{RocksdbStorage, StorageView, WriteStorage};
 use zksync_types::{vm_trace::Call, Transaction, U256};
 use zksync_utils::bytecode::CompressedBytecodeInfo;
 
+use super::{BatchExecutor, BatchExecutorHandle, Command, TxExecutionResult};
 use crate::{
     metrics::{InteractionType, TxStage, APP_METRICS},
     state_keeper::{
@@ -24,8 +25,6 @@ use crate::{
         types::ExecutionMetricsForCriteria,
     },
 };
-
-use super::{BatchExecutor, BatchExecutorHandle, Command, TxExecutionResult};
 
 /// The default implementation of [`BatchExecutor`].
 /// Creates a "real" batch executor which maintains the VM (as opposed to the test builder which doesn't use the VM).

--- a/core/lib/zksync_core/src/state_keeper/batch_executor/main_executor.rs
+++ b/core/lib/zksync_core/src/state_keeper/batch_executor/main_executor.rs
@@ -1,0 +1,415 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use multivm::{
+    interface::{
+        ExecutionResult, FinishedL1Batch, Halt, L1BatchEnv, L2BlockEnv, SystemEnv, VmExecutionMode,
+        VmExecutionResultAndLogs, VmInterface, VmInterfaceHistoryEnabled,
+    },
+    tracers::CallTracer,
+    vm_latest::HistoryEnabled,
+    MultiVMTracer, VmInstance,
+};
+use once_cell::sync::OnceCell;
+use tokio::sync::{mpsc, watch};
+use zksync_dal::ConnectionPool;
+use zksync_state::{RocksdbStorage, StorageView, WriteStorage};
+use zksync_types::{vm_trace::Call, Transaction, U256};
+use zksync_utils::bytecode::CompressedBytecodeInfo;
+
+use crate::{
+    metrics::{InteractionType, TxStage, APP_METRICS},
+    state_keeper::{
+        metrics::{TxExecutionStage, EXECUTOR_METRICS, KEEPER_METRICS},
+        types::ExecutionMetricsForCriteria,
+    },
+};
+
+use super::{BatchExecutor, BatchExecutorHandle, Command, TxExecutionResult};
+
+/// The default implementation of [`BatchExecutor`].
+/// Creates a "real" batch executor which maintains the VM (as opposed to the test builder which doesn't use the VM).
+#[derive(Debug, Clone)]
+pub struct MainBatchExecutor {
+    state_keeper_db_path: String,
+    pool: ConnectionPool,
+    save_call_traces: bool,
+    max_allowed_tx_gas_limit: U256,
+    upload_witness_inputs_to_gcs: bool,
+    enum_index_migration_chunk_size: usize,
+    optional_bytecode_compression: bool,
+}
+
+impl MainBatchExecutor {
+    pub fn new(
+        state_keeper_db_path: String,
+        pool: ConnectionPool,
+        max_allowed_tx_gas_limit: U256,
+        save_call_traces: bool,
+        upload_witness_inputs_to_gcs: bool,
+        enum_index_migration_chunk_size: usize,
+        optional_bytecode_compression: bool,
+    ) -> Self {
+        Self {
+            state_keeper_db_path,
+            pool,
+            save_call_traces,
+            max_allowed_tx_gas_limit,
+            upload_witness_inputs_to_gcs,
+            enum_index_migration_chunk_size,
+            optional_bytecode_compression,
+        }
+    }
+}
+
+#[async_trait]
+impl BatchExecutor for MainBatchExecutor {
+    async fn init_batch(
+        &mut self,
+        l1_batch_params: L1BatchEnv,
+        system_env: SystemEnv,
+        stop_receiver: &watch::Receiver<bool>,
+    ) -> Option<BatchExecutorHandle> {
+        let mut secondary_storage = RocksdbStorage::builder(self.state_keeper_db_path.as_ref())
+            .await
+            .expect("Failed initializing state keeper storage");
+        secondary_storage.enable_enum_index_migration(self.enum_index_migration_chunk_size);
+        let mut conn = self
+            .pool
+            .access_storage_tagged("state_keeper")
+            .await
+            .unwrap();
+        let secondary_storage = secondary_storage
+            .synchronize(&mut conn, stop_receiver)
+            .await
+            .expect("Failed synchronizing secondary state keeper storage")?;
+
+        // Since we process `BatchExecutor` commands one-by-one (the next command is never enqueued
+        // until a previous command is processed), capacity 1 is enough for the commands channel.
+        let (commands_sender, commands_receiver) = mpsc::channel(1);
+        let executor = CommandReceiver {
+            save_call_traces: self.save_call_traces,
+            max_allowed_tx_gas_limit: self.max_allowed_tx_gas_limit,
+            optional_bytecode_compression: self.optional_bytecode_compression,
+            commands: commands_receiver,
+        };
+        let upload_witness_inputs_to_gcs = self.upload_witness_inputs_to_gcs;
+
+        let handle = tokio::task::spawn_blocking(move || {
+            executor.run(
+                secondary_storage,
+                l1_batch_params,
+                system_env,
+                upload_witness_inputs_to_gcs,
+            )
+        });
+        Some(BatchExecutorHandle {
+            handle,
+            commands: commands_sender,
+        })
+    }
+}
+
+/// Implementation of the "primary" (non-test) batch executor.
+/// Upon launch, it initializes the VM object with provided block context and properties, and keeps invoking the commands
+/// sent to it one by one until the batch is finished.
+///
+/// One `CommandReceiver` can execute exactly one batch, so once the batch is sealed, a new `CommandReceiver` object must
+/// be constructed.
+#[derive(Debug)]
+struct CommandReceiver {
+    save_call_traces: bool,
+    max_allowed_tx_gas_limit: U256,
+    optional_bytecode_compression: bool,
+    commands: mpsc::Receiver<Command>,
+}
+
+impl CommandReceiver {
+    pub(super) fn run(
+        mut self,
+        secondary_storage: RocksdbStorage,
+        l1_batch_params: L1BatchEnv,
+        system_env: SystemEnv,
+        upload_witness_inputs_to_gcs: bool,
+    ) {
+        tracing::info!("Starting executing batch #{:?}", &l1_batch_params.number);
+
+        let storage_view = StorageView::new(secondary_storage).to_rc_ptr();
+
+        let mut vm = VmInstance::new(l1_batch_params, system_env, storage_view.clone());
+
+        while let Some(cmd) = self.commands.blocking_recv() {
+            match cmd {
+                Command::ExecuteTx(tx, resp) => {
+                    let result = self.execute_tx(&tx, &mut vm);
+                    resp.send(result).unwrap();
+                }
+                Command::RollbackLastTx(resp) => {
+                    self.rollback_last_tx(&mut vm);
+                    resp.send(()).unwrap();
+                }
+                Command::StartNextMiniblock(l2_block_env, resp) => {
+                    self.start_next_miniblock(l2_block_env, &mut vm);
+                    resp.send(()).unwrap();
+                }
+                Command::FinishBatch(resp) => {
+                    let vm_block_result = self.finish_batch(&mut vm);
+                    let witness_block_state = if upload_witness_inputs_to_gcs {
+                        Some(storage_view.borrow_mut().witness_block_state())
+                    } else {
+                        None
+                    };
+                    resp.send((vm_block_result, witness_block_state)).unwrap();
+
+                    // `storage_view` cannot be accessed while borrowed by the VM,
+                    // so this is the only point at which storage metrics can be obtained
+                    let metrics = storage_view.as_ref().borrow_mut().metrics();
+                    EXECUTOR_METRICS.batch_storage_interaction_duration[&InteractionType::GetValue]
+                        .observe(metrics.time_spent_on_get_value);
+                    EXECUTOR_METRICS.batch_storage_interaction_duration[&InteractionType::SetValue]
+                        .observe(metrics.time_spent_on_set_value);
+                    return;
+                }
+            }
+        }
+        // State keeper can exit because of stop signal, so it's OK to exit mid-batch.
+        tracing::info!("State keeper exited with an unfinished batch");
+    }
+
+    fn execute_tx<S: WriteStorage>(
+        &self,
+        tx: &Transaction,
+        vm: &mut VmInstance<S, HistoryEnabled>,
+    ) -> TxExecutionResult {
+        // Save pre-`execute_next_tx` VM snapshot.
+        vm.make_snapshot();
+
+        // Reject transactions with too big gas limit.
+        // They are also rejected on the API level, but
+        // we need to secure ourselves in case some tx will somehow get into mempool.
+        if tx.gas_limit() > self.max_allowed_tx_gas_limit {
+            tracing::warn!(
+                "Found tx with too big gas limit in state keeper, hash: {:?}, gas_limit: {}",
+                tx.hash(),
+                tx.gas_limit()
+            );
+            return TxExecutionResult::RejectedByVm {
+                reason: Halt::TooBigGasLimit,
+            };
+        }
+
+        // Execute the transaction.
+        let latency = KEEPER_METRICS.tx_execution_time[&TxExecutionStage::Execution].start();
+        let (tx_result, compressed_bytecodes, call_tracer_result) =
+            if self.optional_bytecode_compression {
+                self.execute_tx_in_vm_with_optional_compression(tx, vm)
+            } else {
+                self.execute_tx_in_vm(tx, vm)
+            };
+        latency.observe();
+        APP_METRICS.processed_txs[&TxStage::StateKeeper].inc();
+        APP_METRICS.processed_l1_txs[&TxStage::StateKeeper].inc_by(tx.is_l1().into());
+
+        if let ExecutionResult::Halt { reason } = tx_result.result {
+            return match reason {
+                Halt::BootloaderOutOfGas => TxExecutionResult::BootloaderOutOfGasForTx,
+                _ => TxExecutionResult::RejectedByVm { reason },
+            };
+        }
+
+        let tx_metrics = ExecutionMetricsForCriteria::new(Some(tx), &tx_result);
+
+        if !vm.has_enough_gas_for_batch_tip() {
+            return TxExecutionResult::BootloaderOutOfGasForBlockTip;
+        }
+
+        let (bootloader_dry_run_result, bootloader_dry_run_metrics) = self.dryrun_block_tip(vm);
+        match &bootloader_dry_run_result.result {
+            ExecutionResult::Success { .. } => TxExecutionResult::Success {
+                tx_result: Box::new(tx_result),
+                tx_metrics: Box::new(tx_metrics),
+                bootloader_dry_run_metrics: Box::new(bootloader_dry_run_metrics),
+                bootloader_dry_run_result: Box::new(bootloader_dry_run_result),
+                compressed_bytecodes,
+                call_tracer_result,
+            },
+            ExecutionResult::Revert { .. } => {
+                unreachable!(
+                    "VM must not revert when finalizing block (except `BootloaderOutOfGas`)"
+                );
+            }
+            ExecutionResult::Halt { reason } => match reason {
+                Halt::BootloaderOutOfGas => TxExecutionResult::BootloaderOutOfGasForBlockTip,
+                _ => {
+                    panic!("VM must not revert when finalizing block (except `BootloaderOutOfGas`). Reason: {:#?}", reason)
+                }
+            },
+        }
+    }
+
+    fn rollback_last_tx<S: WriteStorage>(&self, vm: &mut VmInstance<S, HistoryEnabled>) {
+        let latency = KEEPER_METRICS.tx_execution_time[&TxExecutionStage::TxRollback].start();
+        vm.rollback_to_the_latest_snapshot();
+        latency.observe();
+    }
+
+    fn start_next_miniblock<S: WriteStorage>(
+        &self,
+        l2_block_env: L2BlockEnv,
+        vm: &mut VmInstance<S, HistoryEnabled>,
+    ) {
+        vm.start_new_l2_block(l2_block_env);
+    }
+
+    fn finish_batch<S: WriteStorage>(
+        &self,
+        vm: &mut VmInstance<S, HistoryEnabled>,
+    ) -> FinishedL1Batch {
+        // The vm execution was paused right after the last transaction was executed.
+        // There is some post-processing work that the VM needs to do before the block is fully processed.
+        let result = vm.finish_batch();
+        if result.block_tip_execution_result.result.is_failed() {
+            panic!(
+                "VM must not fail when finalizing block: {:#?}",
+                result.block_tip_execution_result.result
+            );
+        }
+        result
+    }
+
+    fn execute_tx_in_vm_with_optional_compression<S: WriteStorage>(
+        &self,
+        tx: &Transaction,
+        vm: &mut VmInstance<S, HistoryEnabled>,
+    ) -> (
+        VmExecutionResultAndLogs,
+        Vec<CompressedBytecodeInfo>,
+        Vec<Call>,
+    ) {
+        // Note, that the space where we can put the calldata for compressing transactions
+        // is limited and the transactions do not pay for taking it.
+        // In order to not let the accounts spam the space of compressed bytecodes with bytecodes
+        // that will not be published (e.g. due to out of gas), we use the following scheme:
+        // We try to execute the transaction with compressed bytecodes.
+        // If it fails and the compressed bytecodes have not been published,
+        // it means that there is no sense in polluting the space of compressed bytecodes,
+        // and so we re-execute the transaction, but without compression.
+
+        // Saving the snapshot before executing
+        vm.make_snapshot();
+
+        let call_tracer_result = Arc::new(OnceCell::default());
+        let tracer = if self.save_call_traces {
+            vec![CallTracer::new(call_tracer_result.clone()).into_tracer_pointer()]
+        } else {
+            vec![]
+        };
+
+        if let (Ok(()), result) =
+            vm.inspect_transaction_with_bytecode_compression(tracer.into(), tx.clone(), true)
+        {
+            let compressed_bytecodes = vm.get_last_tx_compressed_bytecodes();
+            vm.pop_snapshot_no_rollback();
+
+            let trace = Arc::try_unwrap(call_tracer_result)
+                .unwrap()
+                .take()
+                .unwrap_or_default();
+            return (result, compressed_bytecodes, trace);
+        }
+        vm.rollback_to_the_latest_snapshot();
+
+        let call_tracer_result = Arc::new(OnceCell::default());
+        let tracer = if self.save_call_traces {
+            vec![CallTracer::new(call_tracer_result.clone()).into_tracer_pointer()]
+        } else {
+            vec![]
+        };
+
+        let result =
+            vm.inspect_transaction_with_bytecode_compression(tracer.into(), tx.clone(), false);
+        result
+            .0
+            .expect("Compression can't fail if we don't apply it");
+        let compressed_bytecodes = vm.get_last_tx_compressed_bytecodes();
+
+        // TODO implement tracer manager which will be responsible
+        // for collecting result from all tracers and save it to the database
+        let trace = Arc::try_unwrap(call_tracer_result)
+            .unwrap()
+            .take()
+            .unwrap_or_default();
+        (result.1, compressed_bytecodes, trace)
+    }
+
+    // Err when transaction is rejected.
+    // `Ok(TxExecutionStatus::Success)` when the transaction succeeded
+    // `Ok(TxExecutionStatus::Failure)` when the transaction failed.
+    // Note that failed transactions are considered properly processed and are included in blocks
+    fn execute_tx_in_vm<S: WriteStorage>(
+        &self,
+        tx: &Transaction,
+        vm: &mut VmInstance<S, HistoryEnabled>,
+    ) -> (
+        VmExecutionResultAndLogs,
+        Vec<CompressedBytecodeInfo>,
+        Vec<Call>,
+    ) {
+        let call_tracer_result = Arc::new(OnceCell::default());
+        let tracer = if self.save_call_traces {
+            vec![CallTracer::new(call_tracer_result.clone()).into_tracer_pointer()]
+        } else {
+            vec![]
+        };
+
+        let (published_bytecodes, mut result) =
+            vm.inspect_transaction_with_bytecode_compression(tracer.into(), tx.clone(), true);
+        if published_bytecodes.is_ok() {
+            let compressed_bytecodes = vm.get_last_tx_compressed_bytecodes();
+
+            let trace = Arc::try_unwrap(call_tracer_result)
+                .unwrap()
+                .take()
+                .unwrap_or_default();
+            (result, compressed_bytecodes, trace)
+        } else {
+            // Transaction failed to publish bytecodes, we reject it so initiator doesn't pay fee.
+            result.result = ExecutionResult::Halt {
+                reason: Halt::FailedToPublishCompressedBytecodes,
+            };
+            (result, Default::default(), Default::default())
+        }
+    }
+
+    fn dryrun_block_tip<S: WriteStorage>(
+        &self,
+        vm: &mut VmInstance<S, HistoryEnabled>,
+    ) -> (VmExecutionResultAndLogs, ExecutionMetricsForCriteria) {
+        let total_latency =
+            KEEPER_METRICS.tx_execution_time[&TxExecutionStage::DryRunRollback].start();
+        let stage_latency =
+            KEEPER_METRICS.tx_execution_time[&TxExecutionStage::DryRunMakeSnapshot].start();
+        // Save pre-`execute_till_block_end` VM snapshot.
+        vm.make_snapshot();
+        stage_latency.observe();
+
+        let stage_latency =
+            KEEPER_METRICS.tx_execution_time[&TxExecutionStage::DryRunExecuteBlockTip].start();
+        let block_tip_result = vm.execute(VmExecutionMode::Bootloader);
+        stage_latency.observe();
+
+        let stage_latency =
+            KEEPER_METRICS.tx_execution_time[&TxExecutionStage::DryRunGetExecutionMetrics].start();
+        let metrics = ExecutionMetricsForCriteria::new(None, &block_tip_result);
+        stage_latency.observe();
+
+        let stage_latency = KEEPER_METRICS.tx_execution_time
+            [&TxExecutionStage::DryRunRollbackToLatestSnapshot]
+            .start();
+        // Rollback to the pre-`execute_till_block_end` state.
+        vm.rollback_to_the_latest_snapshot();
+        stage_latency.observe();
+        total_latency.observe();
+        (block_tip_result, metrics)
+    }
+}

--- a/core/lib/zksync_core/src/state_keeper/batch_executor/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/batch_executor/mod.rs
@@ -1,35 +1,25 @@
-use std::{fmt, sync::Arc};
+use std::fmt;
 
 use async_trait::async_trait;
-use multivm::{
-    interface::{
-        ExecutionResult, FinishedL1Batch, Halt, L1BatchEnv, L2BlockEnv, SystemEnv, VmExecutionMode,
-        VmExecutionResultAndLogs, VmInterface, VmInterfaceHistoryEnabled,
-    },
-    tracers::CallTracer,
-    vm_latest::HistoryEnabled,
-    MultiVMTracer, VmInstance,
+use multivm::interface::{
+    FinishedL1Batch, Halt, L1BatchEnv, L2BlockEnv, SystemEnv, VmExecutionResultAndLogs,
 };
-use once_cell::sync::OnceCell;
 use tokio::{
     sync::{mpsc, oneshot, watch},
     task::JoinHandle,
 };
-use zksync_dal::ConnectionPool;
-use zksync_state::{RocksdbStorage, StorageView, WriteStorage};
-use zksync_types::{vm_trace::Call, witness_block_state::WitnessBlockState, Transaction, U256};
+use zksync_types::{vm_trace::Call, witness_block_state::WitnessBlockState, Transaction};
 use zksync_utils::bytecode::CompressedBytecodeInfo;
 
-use crate::{
-    metrics::{InteractionType, TxStage, APP_METRICS},
-    state_keeper::{
-        metrics::{ExecutorCommand, TxExecutionStage, EXECUTOR_METRICS, KEEPER_METRICS},
-        types::ExecutionMetricsForCriteria,
-    },
+use crate::state_keeper::{
+    metrics::{ExecutorCommand, EXECUTOR_METRICS},
+    types::ExecutionMetricsForCriteria,
 };
 
 #[cfg(test)]
 mod tests;
+
+pub mod main_executor;
 
 /// Representation of a transaction executed in the virtual machine.
 #[derive(Debug, Clone)]
@@ -70,82 +60,13 @@ impl TxExecutionResult {
 /// The only requirement is to return a [`BatchExecutorHandle`], which does its work
 /// by communicating with the externally initialized thread.
 #[async_trait]
-pub trait L1BatchExecutorBuilder: 'static + Send + Sync + fmt::Debug {
+pub trait BatchExecutor: 'static + Send + Sync + fmt::Debug {
     async fn init_batch(
         &mut self,
         l1_batch_params: L1BatchEnv,
         system_env: SystemEnv,
         stop_receiver: &watch::Receiver<bool>,
     ) -> Option<BatchExecutorHandle>;
-}
-
-/// The default implementation of [`L1BatchExecutorBuilder`].
-/// Creates a "real" batch executor which maintains the VM (as opposed to the test builder which doesn't use the VM).
-#[derive(Debug, Clone)]
-pub struct MainBatchExecutorBuilder {
-    state_keeper_db_path: String,
-    pool: ConnectionPool,
-    save_call_traces: bool,
-    max_allowed_tx_gas_limit: U256,
-    upload_witness_inputs_to_gcs: bool,
-    enum_index_migration_chunk_size: usize,
-    optional_bytecode_compression: bool,
-}
-
-impl MainBatchExecutorBuilder {
-    pub fn new(
-        state_keeper_db_path: String,
-        pool: ConnectionPool,
-        max_allowed_tx_gas_limit: U256,
-        save_call_traces: bool,
-        upload_witness_inputs_to_gcs: bool,
-        enum_index_migration_chunk_size: usize,
-        optional_bytecode_compression: bool,
-    ) -> Self {
-        Self {
-            state_keeper_db_path,
-            pool,
-            save_call_traces,
-            max_allowed_tx_gas_limit,
-            upload_witness_inputs_to_gcs,
-            enum_index_migration_chunk_size,
-            optional_bytecode_compression,
-        }
-    }
-}
-
-#[async_trait]
-impl L1BatchExecutorBuilder for MainBatchExecutorBuilder {
-    async fn init_batch(
-        &mut self,
-        l1_batch_params: L1BatchEnv,
-        system_env: SystemEnv,
-        stop_receiver: &watch::Receiver<bool>,
-    ) -> Option<BatchExecutorHandle> {
-        let mut secondary_storage = RocksdbStorage::builder(self.state_keeper_db_path.as_ref())
-            .await
-            .expect("Failed initializing state keeper storage");
-        secondary_storage.enable_enum_index_migration(self.enum_index_migration_chunk_size);
-        let mut conn = self
-            .pool
-            .access_storage_tagged("state_keeper")
-            .await
-            .unwrap();
-        let secondary_storage = secondary_storage
-            .synchronize(&mut conn, stop_receiver)
-            .await
-            .expect("Failed synchronizing secondary state keeper storage")?;
-
-        Some(BatchExecutorHandle::new(
-            self.save_call_traces,
-            self.max_allowed_tx_gas_limit,
-            secondary_storage,
-            l1_batch_params,
-            system_env,
-            self.upload_witness_inputs_to_gcs,
-            self.optional_bytecode_compression,
-        ))
-    }
 }
 
 /// A public interface for interaction with the `BatchExecutor`.
@@ -158,41 +79,6 @@ pub struct BatchExecutorHandle {
 }
 
 impl BatchExecutorHandle {
-    // TODO: to be removed once testing in stage2 is done
-    #[allow(clippy::too_many_arguments)]
-    pub(super) fn new(
-        save_call_traces: bool,
-        max_allowed_tx_gas_limit: U256,
-        secondary_storage: RocksdbStorage,
-        l1_batch_env: L1BatchEnv,
-        system_env: SystemEnv,
-        upload_witness_inputs_to_gcs: bool,
-        optional_bytecode_compression: bool,
-    ) -> Self {
-        // Since we process `BatchExecutor` commands one-by-one (the next command is never enqueued
-        // until a previous command is processed), capacity 1 is enough for the commands channel.
-        let (commands_sender, commands_receiver) = mpsc::channel(1);
-        let executor = BatchExecutor {
-            save_call_traces,
-            max_allowed_tx_gas_limit,
-            optional_bytecode_compression,
-            commands: commands_receiver,
-        };
-
-        let handle = tokio::task::spawn_blocking(move || {
-            executor.run(
-                secondary_storage,
-                l1_batch_env,
-                system_env,
-                upload_witness_inputs_to_gcs,
-            )
-        });
-        Self {
-            handle,
-            commands: commands_sender,
-        }
-    }
-
     /// Creates a batch executor handle from the provided sender and thread join handle.
     /// Can be used to inject an alternative batch executor implementation.
     #[cfg(test)]
@@ -284,308 +170,4 @@ pub(super) enum Command {
     StartNextMiniblock(L2BlockEnv, oneshot::Sender<()>),
     RollbackLastTx(oneshot::Sender<()>),
     FinishBatch(oneshot::Sender<(FinishedL1Batch, Option<WitnessBlockState>)>),
-}
-
-/// Implementation of the "primary" (non-test) batch executor.
-/// Upon launch, it initializes the VM object with provided block context and properties, and keeps applying
-/// transactions until the batch is sealed.
-///
-/// One `BatchExecutor` can execute exactly one batch, so once the batch is sealed, a new `BatchExecutor` object must
-/// be constructed.
-#[derive(Debug)]
-pub(super) struct BatchExecutor {
-    save_call_traces: bool,
-    max_allowed_tx_gas_limit: U256,
-    optional_bytecode_compression: bool,
-    commands: mpsc::Receiver<Command>,
-}
-
-impl BatchExecutor {
-    pub(super) fn run(
-        mut self,
-        secondary_storage: RocksdbStorage,
-        l1_batch_params: L1BatchEnv,
-        system_env: SystemEnv,
-        upload_witness_inputs_to_gcs: bool,
-    ) {
-        tracing::info!("Starting executing batch #{:?}", &l1_batch_params.number);
-
-        let storage_view = StorageView::new(secondary_storage).to_rc_ptr();
-
-        let mut vm = VmInstance::new(l1_batch_params, system_env, storage_view.clone());
-
-        while let Some(cmd) = self.commands.blocking_recv() {
-            match cmd {
-                Command::ExecuteTx(tx, resp) => {
-                    let result = self.execute_tx(&tx, &mut vm);
-                    resp.send(result).unwrap();
-                }
-                Command::RollbackLastTx(resp) => {
-                    self.rollback_last_tx(&mut vm);
-                    resp.send(()).unwrap();
-                }
-                Command::StartNextMiniblock(l2_block_env, resp) => {
-                    self.start_next_miniblock(l2_block_env, &mut vm);
-                    resp.send(()).unwrap();
-                }
-                Command::FinishBatch(resp) => {
-                    let vm_block_result = self.finish_batch(&mut vm);
-                    let witness_block_state = if upload_witness_inputs_to_gcs {
-                        Some(storage_view.borrow_mut().witness_block_state())
-                    } else {
-                        None
-                    };
-                    resp.send((vm_block_result, witness_block_state)).unwrap();
-
-                    // `storage_view` cannot be accessed while borrowed by the VM,
-                    // so this is the only point at which storage metrics can be obtained
-                    let metrics = storage_view.as_ref().borrow_mut().metrics();
-                    EXECUTOR_METRICS.batch_storage_interaction_duration[&InteractionType::GetValue]
-                        .observe(metrics.time_spent_on_get_value);
-                    EXECUTOR_METRICS.batch_storage_interaction_duration[&InteractionType::SetValue]
-                        .observe(metrics.time_spent_on_set_value);
-                    return;
-                }
-            }
-        }
-        // State keeper can exit because of stop signal, so it's OK to exit mid-batch.
-        tracing::info!("State keeper exited with an unfinished batch");
-    }
-
-    fn execute_tx<S: WriteStorage>(
-        &self,
-        tx: &Transaction,
-        vm: &mut VmInstance<S, HistoryEnabled>,
-    ) -> TxExecutionResult {
-        // Save pre-`execute_next_tx` VM snapshot.
-        vm.make_snapshot();
-
-        // Reject transactions with too big gas limit.
-        // They are also rejected on the API level, but
-        // we need to secure ourselves in case some tx will somehow get into mempool.
-        if tx.gas_limit() > self.max_allowed_tx_gas_limit {
-            tracing::warn!(
-                "Found tx with too big gas limit in state keeper, hash: {:?}, gas_limit: {}",
-                tx.hash(),
-                tx.gas_limit()
-            );
-            return TxExecutionResult::RejectedByVm {
-                reason: Halt::TooBigGasLimit,
-            };
-        }
-
-        // Execute the transaction.
-        let latency = KEEPER_METRICS.tx_execution_time[&TxExecutionStage::Execution].start();
-        let (tx_result, compressed_bytecodes, call_tracer_result) =
-            if self.optional_bytecode_compression {
-                self.execute_tx_in_vm_with_optional_compression(tx, vm)
-            } else {
-                self.execute_tx_in_vm(tx, vm)
-            };
-        latency.observe();
-        APP_METRICS.processed_txs[&TxStage::StateKeeper].inc();
-        APP_METRICS.processed_l1_txs[&TxStage::StateKeeper].inc_by(tx.is_l1().into());
-
-        if let ExecutionResult::Halt { reason } = tx_result.result {
-            return match reason {
-                Halt::BootloaderOutOfGas => TxExecutionResult::BootloaderOutOfGasForTx,
-                _ => TxExecutionResult::RejectedByVm { reason },
-            };
-        }
-
-        let tx_metrics = ExecutionMetricsForCriteria::new(Some(tx), &tx_result);
-
-        if !vm.has_enough_gas_for_batch_tip() {
-            return TxExecutionResult::BootloaderOutOfGasForBlockTip;
-        }
-
-        let (bootloader_dry_run_result, bootloader_dry_run_metrics) = self.dryrun_block_tip(vm);
-        match &bootloader_dry_run_result.result {
-            ExecutionResult::Success { .. } => TxExecutionResult::Success {
-                tx_result: Box::new(tx_result),
-                tx_metrics: Box::new(tx_metrics),
-                bootloader_dry_run_metrics: Box::new(bootloader_dry_run_metrics),
-                bootloader_dry_run_result: Box::new(bootloader_dry_run_result),
-                compressed_bytecodes,
-                call_tracer_result,
-            },
-            ExecutionResult::Revert { .. } => {
-                unreachable!(
-                    "VM must not revert when finalizing block (except `BootloaderOutOfGas`)"
-                );
-            }
-            ExecutionResult::Halt { reason } => match reason {
-                Halt::BootloaderOutOfGas => TxExecutionResult::BootloaderOutOfGasForBlockTip,
-                _ => {
-                    panic!("VM must not revert when finalizing block (except `BootloaderOutOfGas`). Reason: {:#?}", reason)
-                }
-            },
-        }
-    }
-
-    fn rollback_last_tx<S: WriteStorage>(&self, vm: &mut VmInstance<S, HistoryEnabled>) {
-        let latency = KEEPER_METRICS.tx_execution_time[&TxExecutionStage::TxRollback].start();
-        vm.rollback_to_the_latest_snapshot();
-        latency.observe();
-    }
-
-    fn start_next_miniblock<S: WriteStorage>(
-        &self,
-        l2_block_env: L2BlockEnv,
-        vm: &mut VmInstance<S, HistoryEnabled>,
-    ) {
-        vm.start_new_l2_block(l2_block_env);
-    }
-
-    fn finish_batch<S: WriteStorage>(
-        &self,
-        vm: &mut VmInstance<S, HistoryEnabled>,
-    ) -> FinishedL1Batch {
-        // The vm execution was paused right after the last transaction was executed.
-        // There is some post-processing work that the VM needs to do before the block is fully processed.
-        let result = vm.finish_batch();
-        if result.block_tip_execution_result.result.is_failed() {
-            panic!(
-                "VM must not fail when finalizing block: {:#?}",
-                result.block_tip_execution_result.result
-            );
-        }
-        result
-    }
-
-    fn execute_tx_in_vm_with_optional_compression<S: WriteStorage>(
-        &self,
-        tx: &Transaction,
-        vm: &mut VmInstance<S, HistoryEnabled>,
-    ) -> (
-        VmExecutionResultAndLogs,
-        Vec<CompressedBytecodeInfo>,
-        Vec<Call>,
-    ) {
-        // Note, that the space where we can put the calldata for compressing transactions
-        // is limited and the transactions do not pay for taking it.
-        // In order to not let the accounts spam the space of compressed bytecodes with bytecodes
-        // that will not be published (e.g. due to out of gas), we use the following scheme:
-        // We try to execute the transaction with compressed bytecodes.
-        // If it fails and the compressed bytecodes have not been published,
-        // it means that there is no sense in polluting the space of compressed bytecodes,
-        // and so we re-execute the transaction, but without compression.
-
-        // Saving the snapshot before executing
-        vm.make_snapshot();
-
-        let call_tracer_result = Arc::new(OnceCell::default());
-        let tracer = if self.save_call_traces {
-            vec![CallTracer::new(call_tracer_result.clone()).into_tracer_pointer()]
-        } else {
-            vec![]
-        };
-
-        if let (Ok(()), result) =
-            vm.inspect_transaction_with_bytecode_compression(tracer.into(), tx.clone(), true)
-        {
-            let compressed_bytecodes = vm.get_last_tx_compressed_bytecodes();
-            vm.pop_snapshot_no_rollback();
-
-            let trace = Arc::try_unwrap(call_tracer_result)
-                .unwrap()
-                .take()
-                .unwrap_or_default();
-            return (result, compressed_bytecodes, trace);
-        }
-        vm.rollback_to_the_latest_snapshot();
-
-        let call_tracer_result = Arc::new(OnceCell::default());
-        let tracer = if self.save_call_traces {
-            vec![CallTracer::new(call_tracer_result.clone()).into_tracer_pointer()]
-        } else {
-            vec![]
-        };
-
-        let result =
-            vm.inspect_transaction_with_bytecode_compression(tracer.into(), tx.clone(), false);
-        result
-            .0
-            .expect("Compression can't fail if we don't apply it");
-        let compressed_bytecodes = vm.get_last_tx_compressed_bytecodes();
-
-        // TODO implement tracer manager which will be responsible
-        // for collecting result from all tracers and save it to the database
-        let trace = Arc::try_unwrap(call_tracer_result)
-            .unwrap()
-            .take()
-            .unwrap_or_default();
-        (result.1, compressed_bytecodes, trace)
-    }
-
-    // Err when transaction is rejected.
-    // `Ok(TxExecutionStatus::Success)` when the transaction succeeded
-    // `Ok(TxExecutionStatus::Failure)` when the transaction failed.
-    // Note that failed transactions are considered properly processed and are included in blocks
-    fn execute_tx_in_vm<S: WriteStorage>(
-        &self,
-        tx: &Transaction,
-        vm: &mut VmInstance<S, HistoryEnabled>,
-    ) -> (
-        VmExecutionResultAndLogs,
-        Vec<CompressedBytecodeInfo>,
-        Vec<Call>,
-    ) {
-        let call_tracer_result = Arc::new(OnceCell::default());
-        let tracer = if self.save_call_traces {
-            vec![CallTracer::new(call_tracer_result.clone()).into_tracer_pointer()]
-        } else {
-            vec![]
-        };
-
-        let (published_bytecodes, mut result) =
-            vm.inspect_transaction_with_bytecode_compression(tracer.into(), tx.clone(), true);
-        if published_bytecodes.is_ok() {
-            let compressed_bytecodes = vm.get_last_tx_compressed_bytecodes();
-
-            let trace = Arc::try_unwrap(call_tracer_result)
-                .unwrap()
-                .take()
-                .unwrap_or_default();
-            (result, compressed_bytecodes, trace)
-        } else {
-            // Transaction failed to publish bytecodes, we reject it so initiator doesn't pay fee.
-            result.result = ExecutionResult::Halt {
-                reason: Halt::FailedToPublishCompressedBytecodes,
-            };
-            (result, Default::default(), Default::default())
-        }
-    }
-
-    fn dryrun_block_tip<S: WriteStorage>(
-        &self,
-        vm: &mut VmInstance<S, HistoryEnabled>,
-    ) -> (VmExecutionResultAndLogs, ExecutionMetricsForCriteria) {
-        let total_latency =
-            KEEPER_METRICS.tx_execution_time[&TxExecutionStage::DryRunRollback].start();
-        let stage_latency =
-            KEEPER_METRICS.tx_execution_time[&TxExecutionStage::DryRunMakeSnapshot].start();
-        // Save pre-`execute_till_block_end` VM snapshot.
-        vm.make_snapshot();
-        stage_latency.observe();
-
-        let stage_latency =
-            KEEPER_METRICS.tx_execution_time[&TxExecutionStage::DryRunExecuteBlockTip].start();
-        let block_tip_result = vm.execute(VmExecutionMode::Bootloader);
-        stage_latency.observe();
-
-        let stage_latency =
-            KEEPER_METRICS.tx_execution_time[&TxExecutionStage::DryRunGetExecutionMetrics].start();
-        let metrics = ExecutionMetricsForCriteria::new(None, &block_tip_result);
-        stage_latency.observe();
-
-        let stage_latency = KEEPER_METRICS.tx_execution_time
-            [&TxExecutionStage::DryRunRollbackToLatestSnapshot]
-            .start();
-        // Rollback to the pre-`execute_till_block_end` state.
-        vm.rollback_to_the_latest_snapshot();
-        stage_latency.observe();
-        total_latency.observe();
-        (block_tip_result, metrics)
-    }
 }

--- a/core/lib/zksync_core/src/state_keeper/batch_executor/tests/tester.rs
+++ b/core/lib/zksync_core/src/state_keeper/batch_executor/tests/tester.rs
@@ -28,7 +28,7 @@ use crate::{
     state_keeper::{
         batch_executor::{BatchExecutorHandle, TxExecutionResult},
         tests::{default_l1_batch_env, default_system_env, BASE_SYSTEM_CONTRACTS},
-        L1BatchExecutorBuilder, MainBatchExecutorBuilder,
+        BatchExecutor, MainBatchExecutor,
     },
     utils::testonly::prepare_recovery_snapshot,
 };
@@ -103,7 +103,7 @@ impl Tester {
         l1_batch_env: L1BatchEnv,
         system_env: SystemEnv,
     ) -> BatchExecutorHandle {
-        let mut builder = MainBatchExecutorBuilder::new(
+        let mut builder = MainBatchExecutor::new(
             self.db_dir.path().to_str().unwrap().to_owned(),
             self.pool.clone(),
             self.config.max_allowed_tx_gas_limit.into(),

--- a/core/lib/zksync_core/src/state_keeper/keeper.rs
+++ b/core/lib/zksync_core/src/state_keeper/keeper.rs
@@ -15,7 +15,7 @@ use zksync_types::{
 };
 
 use super::{
-    batch_executor::{BatchExecutorHandle, L1BatchExecutorBuilder, TxExecutionResult},
+    batch_executor::{BatchExecutor, BatchExecutorHandle, TxExecutionResult},
     extractors,
     io::{MiniblockParams, PendingBatchData, StateKeeperIO},
     metrics::{AGGREGATION_METRICS, KEEPER_METRICS, L1_BATCH_METRICS},
@@ -60,7 +60,7 @@ impl Error {
 pub struct ZkSyncStateKeeper {
     stop_receiver: watch::Receiver<bool>,
     io: Box<dyn StateKeeperIO>,
-    batch_executor_base: Box<dyn L1BatchExecutorBuilder>,
+    batch_executor_base: Box<dyn BatchExecutor>,
     sealer: Arc<dyn ConditionalSealer>,
 }
 
@@ -68,7 +68,7 @@ impl ZkSyncStateKeeper {
     pub fn new(
         stop_receiver: watch::Receiver<bool>,
         io: Box<dyn StateKeeperIO>,
-        batch_executor_base: Box<dyn L1BatchExecutorBuilder>,
+        batch_executor_base: Box<dyn BatchExecutor>,
         sealer: Arc<dyn ConditionalSealer>,
     ) -> Self {
         Self {

--- a/core/lib/zksync_core/src/state_keeper/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/mod.rs
@@ -9,7 +9,7 @@ use zksync_dal::ConnectionPool;
 use zksync_object_store::ObjectStore;
 
 pub use self::{
-    batch_executor::{L1BatchExecutorBuilder, MainBatchExecutorBuilder},
+    batch_executor::{main_executor::MainBatchExecutor, BatchExecutor},
     io::{mempool::MempoolIO, MiniblockSealer, MiniblockSealerHandle, StateKeeperIO},
     keeper::ZkSyncStateKeeper,
     mempool_actor::MempoolFetcher,
@@ -44,7 +44,7 @@ pub(crate) async fn create_state_keeper(
     object_store: Arc<dyn ObjectStore>,
     stop_receiver: watch::Receiver<bool>,
 ) -> ZkSyncStateKeeper {
-    let batch_executor_base = MainBatchExecutorBuilder::new(
+    let batch_executor_base = MainBatchExecutor::new(
         db_config.state_keeper_db_path.clone(),
         pool.clone(),
         state_keeper_config.max_allowed_l2_tx_gas_limit.into(),

--- a/core/lib/zksync_core/src/state_keeper/tests/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/tests/mod.rs
@@ -33,7 +33,7 @@ use self::tester::{
     bootloader_tip_out_of_gas, pending_batch_data, random_tx, rejected_exec, successful_exec,
     successful_exec_with_metrics, TestScenario,
 };
-pub(crate) use self::tester::{MockBatchExecutorBuilder, TestBatchExecutorBuilder};
+pub(crate) use self::tester::{MockBatchExecutor, TestBatchExecutorBuilder};
 use crate::{
     gas_tracker::l1_batch_base_cost,
     state_keeper::{

--- a/core/lib/zksync_core/src/state_keeper/tests/tester.rs
+++ b/core/lib/zksync_core/src/state_keeper/tests/tester.rs
@@ -23,7 +23,7 @@ use zksync_types::{
 
 use crate::{
     state_keeper::{
-        batch_executor::{BatchExecutorHandle, Command, L1BatchExecutorBuilder, TxExecutionResult},
+        batch_executor::{BatchExecutor, BatchExecutorHandle, Command, TxExecutionResult},
         io::{MiniblockParams, PendingBatchData, StateKeeperIO},
         seal_criteria::{IoSealCriteria, SequencerSealer},
         tests::{default_l1_batch_env, default_vm_block_result, BASE_SYSTEM_CONTRACTS},
@@ -448,7 +448,7 @@ impl TestBatchExecutorBuilder {
 }
 
 #[async_trait]
-impl L1BatchExecutorBuilder for TestBatchExecutorBuilder {
+impl BatchExecutor for TestBatchExecutorBuilder {
     async fn init_batch(
         &mut self,
         _l1batch_params: L1BatchEnv,
@@ -770,13 +770,13 @@ impl StateKeeperIO for TestIO {
     }
 }
 
-/// `L1BatchExecutorBuilder` which doesn't check anything at all. Accepts all transactions.
+/// `BatchExecutor` which doesn't check anything at all. Accepts all transactions.
 // FIXME: move to `utils`?
 #[derive(Debug)]
-pub(crate) struct MockBatchExecutorBuilder;
+pub(crate) struct MockBatchExecutor;
 
 #[async_trait]
-impl L1BatchExecutorBuilder for MockBatchExecutorBuilder {
+impl BatchExecutor for MockBatchExecutor {
     async fn init_batch(
         &mut self,
         _l1batch_params: L1BatchEnv,

--- a/core/node/node_framework/examples/main_node.rs
+++ b/core/node/node_framework/examples/main_node.rs
@@ -17,8 +17,8 @@ use zksync_node_framework::{
         object_store::ObjectStoreLayer,
         pools_layer::PoolsLayerBuilder,
         state_keeper::{
-            main_node_batch_executor_builder::MainNodeBatchExecutorBuilderLayer,
-            mempool_io::MempoolIOLayer, StateKeeperLayer,
+            main_batch_executor::MainBatchExecutorLayer, mempool_io::MempoolIOLayer,
+            StateKeeperLayer,
         },
     },
     service::ZkStackService,
@@ -85,10 +85,8 @@ impl MainNodeBuilder {
             StateKeeperConfig::from_env()?,
             MempoolConfig::from_env()?,
         );
-        let main_node_batch_executor_builder_layer = MainNodeBatchExecutorBuilderLayer::new(
-            DBConfig::from_env()?,
-            StateKeeperConfig::from_env()?,
-        );
+        let main_node_batch_executor_builder_layer =
+            MainBatchExecutorLayer::new(DBConfig::from_env()?, StateKeeperConfig::from_env()?);
         let state_keeper_layer = StateKeeperLayer;
         self.node
             .add_layer(mempool_io_layer)

--- a/core/node/node_framework/src/implementations/layers/state_keeper/main_batch_executor.rs
+++ b/core/node/node_framework/src/implementations/layers/state_keeper/main_batch_executor.rs
@@ -1,22 +1,20 @@
 use zksync_config::{configs::chain::StateKeeperConfig, DBConfig};
-use zksync_core::state_keeper::MainBatchExecutorBuilder;
+use zksync_core::state_keeper::MainBatchExecutor;
 
 use crate::{
-    implementations::resources::{
-        pools::MasterPoolResource, state_keeper::L1BatchExecutorBuilderResource,
-    },
+    implementations::resources::{pools::MasterPoolResource, state_keeper::BatchExecutorResource},
     resource::Unique,
     service::ServiceContext,
     wiring_layer::{WiringError, WiringLayer},
 };
 
 #[derive(Debug)]
-pub struct MainNodeBatchExecutorBuilderLayer {
+pub struct MainBatchExecutorLayer {
     db_config: DBConfig,
     state_keeper_config: StateKeeperConfig,
 }
 
-impl MainNodeBatchExecutorBuilderLayer {
+impl MainBatchExecutorLayer {
     pub fn new(db_config: DBConfig, state_keeper_config: StateKeeperConfig) -> Self {
         Self {
             db_config,
@@ -26,15 +24,15 @@ impl MainNodeBatchExecutorBuilderLayer {
 }
 
 #[async_trait::async_trait]
-impl WiringLayer for MainNodeBatchExecutorBuilderLayer {
+impl WiringLayer for MainBatchExecutorLayer {
     fn layer_name(&self) -> &'static str {
-        "main_node_batch_executor_builder_layer"
+        "main_batch_executor_layer"
     }
 
     async fn wire(self: Box<Self>, mut context: ServiceContext<'_>) -> Result<(), WiringError> {
         let master_pool = context.get_resource::<MasterPoolResource>().await?;
 
-        let builder = MainBatchExecutorBuilder::new(
+        let builder = MainBatchExecutor::new(
             self.db_config.state_keeper_db_path,
             master_pool.get_singleton().await?,
             self.state_keeper_config.max_allowed_l2_tx_gas_limit.into(),
@@ -44,9 +42,7 @@ impl WiringLayer for MainNodeBatchExecutorBuilderLayer {
             false,
         );
 
-        context.insert_resource(L1BatchExecutorBuilderResource(Unique::new(Box::new(
-            builder,
-        ))))?;
+        context.insert_resource(BatchExecutorResource(Unique::new(Box::new(builder))))?;
         Ok(())
     }
 }

--- a/core/node/node_framework/src/implementations/layers/state_keeper/mod.rs
+++ b/core/node/node_framework/src/implementations/layers/state_keeper/mod.rs
@@ -2,16 +2,16 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use zksync_core::state_keeper::{
-    seal_criteria::ConditionalSealer, L1BatchExecutorBuilder, StateKeeperIO, ZkSyncStateKeeper,
+    seal_criteria::ConditionalSealer, BatchExecutor, StateKeeperIO, ZkSyncStateKeeper,
 };
 use zksync_storage::RocksDB;
 
-pub mod main_node_batch_executor_builder;
+pub mod main_batch_executor;
 pub mod mempool_io;
 
 use crate::{
     implementations::resources::state_keeper::{
-        ConditionalSealerResource, L1BatchExecutorBuilderResource, StateKeeperIOResource,
+        BatchExecutorResource, ConditionalSealerResource, StateKeeperIOResource,
     },
     service::{ServiceContext, StopReceiver},
     task::Task,
@@ -20,7 +20,7 @@ use crate::{
 
 /// Requests:
 /// - `StateKeeperIOResource`
-/// - `L1BatchExecutorBuilderResource`
+/// - `BatchExecutorResource`
 /// - `ConditionalSealerResource`
 ///
 #[derive(Debug)]
@@ -40,7 +40,7 @@ impl WiringLayer for StateKeeperLayer {
             .take()
             .context("StateKeeperIO was provided but taken by some other task")?;
         let batch_executor_base = context
-            .get_resource::<L1BatchExecutorBuilderResource>()
+            .get_resource::<BatchExecutorResource>()
             .await?
             .0
             .take()
@@ -58,7 +58,7 @@ impl WiringLayer for StateKeeperLayer {
 
 struct StateKeeperTask {
     io: Box<dyn StateKeeperIO>,
-    batch_executor_base: Box<dyn L1BatchExecutorBuilder>,
+    batch_executor_base: Box<dyn BatchExecutor>,
     sealer: Arc<dyn ConditionalSealer>,
 }
 

--- a/core/node/node_framework/src/implementations/resources/state_keeper.rs
+++ b/core/node/node_framework/src/implementations/resources/state_keeper.rs
@@ -1,8 +1,6 @@
 use std::sync::Arc;
 
-use zksync_core::state_keeper::{
-    seal_criteria::ConditionalSealer, L1BatchExecutorBuilder, StateKeeperIO,
-};
+use zksync_core::state_keeper::{seal_criteria::ConditionalSealer, BatchExecutor, StateKeeperIO};
 
 use crate::resource::{Resource, ResourceId, Unique};
 
@@ -16,11 +14,11 @@ impl Resource for StateKeeperIOResource {
 }
 
 #[derive(Debug, Clone)]
-pub struct L1BatchExecutorBuilderResource(pub Unique<Box<dyn L1BatchExecutorBuilder>>);
+pub struct BatchExecutorResource(pub Unique<Box<dyn BatchExecutor>>);
 
-impl Resource for L1BatchExecutorBuilderResource {
+impl Resource for BatchExecutorResource {
     fn resource_id() -> ResourceId {
-        "state_keeper/l1_batch_executor_builder".into()
+        "state_keeper/batch_executor".into()
     }
 }
 


### PR DESCRIPTION
## What ❔

- Does a set of renames:
  - `L1BatchExecutorBuilder` -> `BatchExecutor`
  - `MainBatchExecutorBuilder` -> `MainBatchExecutor`
  - `BatchExecutor` -> `CommandReceiver` (as it's just a "processing" part of `MainBatchExecutor`)
  - Similar changes in the framework.
- Moves the implementation of `MainBatchExecutor` to a separate file.
- Removes some temporary misplaced constructor for `BatchExecutorHandle`.

## Why ❔

- Less Enterprise™
- Better logical structure

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
