### PR TITLE
chore(node_framework): Emit logs on context/resource access

### DIFF
--- a/core/lib/dal/src/connection/mod.rs
+++ b/core/lib/dal/src/connection/mod.rs
@@ -63,6 +63,11 @@ impl ConnectionPoolBuilder {
         self
     }
 
+    /// Returns the maximum number of connections that can be allocated by the pool.
+    pub fn max_size(&self) -> u32 {
+        self.max_size
+    }
+
     /// Builds a connection pool from this builder.
     pub async fn build(&self) -> anyhow::Result<ConnectionPool> {
         let options = PgPoolOptions::new()

--- a/core/node/node_framework/src/implementations/resources/pools.rs
+++ b/core/node/node_framework/src/implementations/resources/pools.rs
@@ -1,10 +1,18 @@
+use std::sync::{
+    atomic::{AtomicU32, Ordering},
+    Arc,
+};
+
 use zksync_dal::{connection::ConnectionPoolBuilder, ConnectionPool};
 
 use crate::resource::Resource;
 
 /// Represents a connection pool to the master database.
 #[derive(Debug, Clone)]
-pub struct MasterPoolResource(ConnectionPoolBuilder);
+pub struct MasterPoolResource {
+    connections_count: Arc<AtomicU32>,
+    builder: ConnectionPoolBuilder,
+}
 
 impl Resource for MasterPoolResource {
     fn resource_id() -> crate::resource::ResourceId {
@@ -14,21 +22,48 @@ impl Resource for MasterPoolResource {
 
 impl MasterPoolResource {
     pub fn new(builder: ConnectionPoolBuilder) -> Self {
-        Self(builder)
+        Self {
+            connections_count: Arc::new(AtomicU32::new(0)),
+            builder,
+        }
     }
 
     pub async fn get(&self) -> anyhow::Result<ConnectionPool> {
-        self.0.build().await
+        let result = self.builder.build().await;
+
+        if result.is_ok() {
+            self.connections_count
+                .fetch_add(self.builder.max_size(), Ordering::Relaxed);
+            let total_connections = self.connections_count.load(Ordering::Relaxed);
+            tracing::info!(
+                "Created a new master pool. Master pool total connections count: {total_connections}"
+            );
+        }
+
+        result
     }
 
     pub async fn get_singleton(&self) -> anyhow::Result<ConnectionPool> {
-        self.0.build_singleton().await
+        let result = self.builder.build_singleton().await;
+
+        if result.is_ok() {
+            self.connections_count.fetch_add(1, Ordering::Relaxed);
+            let total_connections = self.connections_count.load(Ordering::Relaxed);
+            tracing::info!(
+                "Created a new master pool. Master pool total connections count: {total_connections}"
+            );
+        }
+
+        result
     }
 }
 
 /// Represents a connection pool to the replica database.
 #[derive(Debug, Clone)]
-pub struct ReplicaPoolResource(ConnectionPoolBuilder);
+pub struct ReplicaPoolResource {
+    connections_count: Arc<AtomicU32>,
+    builder: ConnectionPoolBuilder,
+}
 
 impl Resource for ReplicaPoolResource {
     fn resource_id() -> crate::resource::ResourceId {
@@ -38,21 +73,48 @@ impl Resource for ReplicaPoolResource {
 
 impl ReplicaPoolResource {
     pub fn new(builder: ConnectionPoolBuilder) -> Self {
-        Self(builder)
+        Self {
+            connections_count: Arc::new(AtomicU32::new(0)),
+            builder,
+        }
     }
 
     pub async fn get(&self) -> anyhow::Result<ConnectionPool> {
-        self.0.build().await
+        let result = self.builder.build().await;
+
+        if result.is_ok() {
+            self.connections_count
+                .fetch_add(self.builder.max_size(), Ordering::Relaxed);
+            let total_connections = self.connections_count.load(Ordering::Relaxed);
+            tracing::info!(
+                "Created a new replica pool. Master pool total connections count: {total_connections}"
+            );
+        }
+
+        result
     }
 
     pub async fn get_singleton(&self) -> anyhow::Result<ConnectionPool> {
-        self.0.build_singleton().await
+        let result = self.builder.build_singleton().await;
+
+        if result.is_ok() {
+            self.connections_count.fetch_add(1, Ordering::Relaxed);
+            let total_connections = self.connections_count.load(Ordering::Relaxed);
+            tracing::info!(
+                "Created a new replica pool. Master pool total connections count: {total_connections}"
+            );
+        }
+
+        result
     }
 }
 
 /// Represents a connection pool to the prover database.
 #[derive(Debug, Clone)]
-pub struct ProverPoolResource(ConnectionPoolBuilder);
+pub struct ProverPoolResource {
+    connections_count: Arc<AtomicU32>,
+    builder: ConnectionPoolBuilder,
+}
 
 impl Resource for ProverPoolResource {
     fn resource_id() -> crate::resource::ResourceId {
@@ -62,14 +124,38 @@ impl Resource for ProverPoolResource {
 
 impl ProverPoolResource {
     pub fn new(builder: ConnectionPoolBuilder) -> Self {
-        Self(builder)
+        Self {
+            connections_count: Arc::new(AtomicU32::new(0)),
+            builder,
+        }
     }
 
     pub async fn get(&self) -> anyhow::Result<ConnectionPool> {
-        self.0.build().await
+        let result = self.builder.build().await;
+
+        if result.is_ok() {
+            self.connections_count
+                .fetch_add(self.builder.max_size(), Ordering::Relaxed);
+            let total_connections = self.connections_count.load(Ordering::Relaxed);
+            tracing::info!(
+                "Created a new prover pool. Master pool total connections count: {total_connections}"
+            );
+        }
+
+        result
     }
 
     pub async fn get_singleton(&self) -> anyhow::Result<ConnectionPool> {
-        self.0.build_singleton().await
+        let result = self.builder.build_singleton().await;
+
+        if result.is_ok() {
+            self.connections_count.fetch_add(1, Ordering::Relaxed);
+            let total_connections = self.connections_count.load(Ordering::Relaxed);
+            tracing::info!(
+                "Created a new prover pool. Master pool total connections count: {total_connections}"
+            );
+        }
+
+        result
     }
 }

--- a/core/node/node_framework/src/resource/resource_collection.rs
+++ b/core/node/node_framework/src/resource/resource_collection.rs
@@ -90,6 +90,10 @@ impl<T: Resource + Clone> ResourceCollection<T> {
 
         let mut handle = self.resources.lock().unwrap();
         handle.push(resource);
+        tracing::info!(
+            "A new item has been added to the resource collection {}",
+            Self::resource_id()
+        );
         Ok(())
     }
 
@@ -99,6 +103,11 @@ impl<T: Resource + Clone> ResourceCollection<T> {
         // is actually spawned (per framework rules). For most cases, this check will resolve immediately, unless
         // some tasks would spawn something from the `IntoZkSyncTask` impl.
         self.wired.changed().await.expect("Sender can't be dropped");
+
+        tracing::info!(
+            "Resource collection {} has been resolved",
+            Self::resource_id()
+        );
 
         let handle = self.resources.lock().unwrap();
         (*handle).clone()

--- a/core/node/node_framework/src/resource/unique.rs
+++ b/core/node/node_framework/src/resource/unique.rs
@@ -30,6 +30,15 @@ impl<T: 'static + Send> Unique<T> {
 
     /// Takes the resource from the container.
     pub fn take(&self) -> Option<T> {
-        self.inner.lock().unwrap().take()
+        let result = self.inner.lock().unwrap().take();
+
+        if result.is_some() {
+            tracing::info!(
+                "Resource {} has been taken",
+                std::any::type_name::<Unique<T>>()
+            );
+        }
+
+        result
     }
 }

--- a/core/node/node_framework/src/service/mod.rs
+++ b/core/node/node_framework/src/service/mod.rs
@@ -90,7 +90,8 @@ impl ZkStackService {
         let runtime_handle = self.runtime.handle().clone();
         for layer in wiring_layers {
             let name = layer.layer_name().to_string();
-            let task_result = runtime_handle.block_on(layer.wire(ServiceContext::new(&mut self)));
+            let task_result =
+                runtime_handle.block_on(layer.wire(ServiceContext::new(&name, &mut self)));
             if let Err(err) = task_result {
                 // We don't want to bail on the first error, since it'll provide worse DevEx:
                 // People likely want to fix as much problems as they can in one go, rather than have


### PR DESCRIPTION
## What ❔

- Adds more logs when the node is being configured. We can certainly improve it further (e.g. print task name in resource-related logs or use prettier type output for Unique), but I think it's a good starting point.

## Why ❔

- Logs are helpful for debugging, especially in dynamic systems like the new framework.

New logs look roughly as follows:
![image](https://github.com/matter-labs/zksync-era/assets/12111581/cd99dd63-6e72-41cb-bedd-db5827e628f1)
