### PR TITLE
fix(prover): Fix initial prover migration

### DIFF
--- a/prover/prover_dal/migrations/20240131134938_initial-prover-migration.up.sql
+++ b/prover/prover_dal/migrations/20240131134938_initial-prover-migration.up.sql
@@ -178,7 +178,7 @@ COMMENT ON TABLE prover_jobs_fri IS 'Prover jobs. Each is picked by a WVG and is
 CREATE INDEX IF NOT EXISTS idx_prover_jobs_fri_circuit_id_agg_batch_num
     ON prover_jobs_fri (circuit_id, aggregation_round, l1_batch_number)
     WHERE (status = ANY (ARRAY['queued'::text, 'in_progress'::text, 'in_gpu_proof'::text, 'failed'::text]));
-CREATE INDEX IF NOT idx_prover_jobs_fri_queued_order
+CREATE INDEX IF NOT EXISTS idx_prover_jobs_fri_queued_order
     ON prover_jobs_fri (aggregation_round DESC, l1_batch_number, id)
     WHERE (status = 'queued'::text);
 CREATE INDEX IF NOT EXISTS idx_prover_jobs_fri_queued_order2


### PR DESCRIPTION
IF NOT EXISTS was missing for 1 index.
This causes migrations on already existing environments (testnet, boojnet, mainnet) not to work. This PR addresses the miss.
