### PR TITLE
Update fee_model.md (Fixing Typo in the formula)

### DIFF
--- a/docs/specs/zk_evm/fee_model.md
+++ b/docs/specs/zk_evm/fee_model.md
@@ -316,7 +316,7 @@ Given the tx.gasLimit, it should find the maximal `overhead_gas(tx)`, such that 
 transaction, that is, if we denote by _Oop_ the overhead proposed by the operator, the following equation should hold:
 
 $$
-O_{op} ≤ overhead_gas(tx)
+O_{op} ≤ overhead\_gas(tx)
 $$
 
 for the $tx.bodyGasLimit$ we use the $tx.bodyGasLimit$ = $tx.gasLimit − O_{op}$.


### PR DESCRIPTION
Fixing small typo in the following formula which wasn't displayed correctly:
$$
O_{op} ≤ overhead_gas(tx) 
$$

into

$$
O_{op} ≤ overhead\_gas(tx)
$$