### PR TITLE
remove CSReferenceAssembly structure instantiation in GPU prover

### DIFF
--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -410,7 +410,7 @@ dependencies = [
  "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -579,13 +579,13 @@ dependencies = [
 [[package]]
 name = "boojum"
 version = "0.2.0"
-source = "git+https://github.com/matter-labs/era-boojum?branch=main#03888f0fbf810a18e98d010dd11891fe32097352"
+source = "git+https://github.com/matter-labs/era-boojum?branch=main#a4bb73f4164c5bae4087fef43c0052e5bb556a06"
 dependencies = [
  "arrayvec 0.7.4",
  "bincode",
  "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "const_format",
- "convert_case 0.6.0",
+ "convert_case",
  "crossbeam 0.8.4",
  "crypto-bigint 0.5.5",
  "cs_derive 0.1.0 (git+https://github.com/matter-labs/era-boojum?branch=main)",
@@ -937,15 +937,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "cs_derive"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-boojum?branch=main#03888f0fbf810a18e98d010dd11891fe32097352"
+source = "git+https://github.com/matter-labs/era-boojum?branch=main#a4bb73f4164c5bae4087fef43c0052e5bb556a06"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.78",
@@ -1388,7 +1379,7 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case 0.4.0",
+ "convert_case",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "rustc_version",
@@ -4876,8 +4867,8 @@ dependencies = [
 
 [[package]]
 name = "shivini"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-shivini.git?branch=v1.4.1#f4bf41f45a1c5bb3a9e487114bc314d68d4e1aaf"
+version = "0.2.0"
+source = "git+https://github.com/matter-labs/era-shivini.git?branch=rr-gpu-config#77d29a01a081241198be4a9fdb6630aa8c7a79c3"
 dependencies = [
  "bincode",
  "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/prover/prover_fri/Cargo.toml
+++ b/prover/prover_fri/Cargo.toml
@@ -20,7 +20,7 @@ zksync_prover_fri_utils = { path = "../prover_fri_utils" }
 zksync_prover_fri_types = { path = "../prover_fri_types" }
 zksync_utils = { path = "../../core/lib/utils" }
 vk_setup_data_generator_server_fri = { path = "../vk_setup_data_generator_server_fri" }
-shivini = { git = "https://github.com/matter-labs/era-shivini.git", branch = "v1.4.1", optional = true, features = [
+shivini = { git = "https://github.com/matter-labs/era-shivini.git", branch = "rr-gpu-config", optional = true, features = [
     "circuit_definitions",
     "zksync",
 ] }

--- a/prover/prover_fri/src/gpu_prover_job_processor.rs
+++ b/prover/prover_fri/src/gpu_prover_job_processor.rs
@@ -121,7 +121,6 @@ pub mod gpu_prover {
         ) -> ProverArtifacts {
             let worker = Worker::new();
             let GpuProverJob {
-                assembly,
                 witness_vector_artifacts,
             } = job;
             let WitnessVectorArtifacts {
@@ -129,12 +128,14 @@ pub mod gpu_prover {
                 prover_job,
             } = witness_vector_artifacts;
 
-            let (proof_config, circuit_id) = match &prover_job.circuit_wrapper {
+            let (gpu_proof_config, proof_config, circuit_id) = match &prover_job.circuit_wrapper {
                 CircuitWrapper::Base(base_circuit) => (
+                    base_circuit.clone().into(),
                     base_layer_proof_config(),
                     base_circuit.numeric_circuit_type(),
                 ),
                 CircuitWrapper::Recursive(recursive_circuit) => (
+                    recursive_circuit.clone().into(),
                     base_layer_proof_config(),
                     recursive_circuit.numeric_circuit_type(),
                 ),
@@ -142,13 +143,12 @@ pub mod gpu_prover {
 
             let started_at = Instant::now();
             let proof = gpu_prove_from_external_witness_data::<
-                _,
                 DefaultTranscript,
                 DefaultTreeHasher,
                 NoPow,
                 _,
             >(
-                &assembly,
+                &gpu_proof_config,
                 &witness_vector,
                 proof_config,
                 &setup_data.setup,

--- a/prover/prover_fri/src/socket_listener.rs
+++ b/prover/prover_fri/src/socket_listener.rs
@@ -3,9 +3,6 @@ pub mod gpu_socket_listener {
     use std::{net::SocketAddr, time::Instant};
 
     use anyhow::Context as _;
-    use shivini::synthesis_utils::{
-        init_base_layer_cs_for_repeated_proving, init_recursive_layer_cs_for_repeated_proving,
-    };
     use tokio::{
         io::copy,
         net::{TcpListener, TcpStream},
@@ -16,15 +13,11 @@ pub mod gpu_socket_listener {
         ConnectionPool,
     };
     use zksync_object_store::bincode;
-    use zksync_prover_fri_types::{CircuitWrapper, ProverServiceDataKey, WitnessVectorArtifacts};
-    use zksync_types::basic_fri_types::AggregationRound;
-    use zksync_vk_setup_data_server_fri::{
-        get_finalization_hints, get_round_for_recursive_circuit_type,
-    };
+    use zksync_prover_fri_types::WitnessVectorArtifacts;
 
     use crate::{
         metrics::METRICS,
-        utils::{GpuProverJob, ProvingAssembly, SharedWitnessVectorQueue},
+        utils::{GpuProverJob, SharedWitnessVectorQueue},
     };
 
     pub(crate) struct SocketListener {
@@ -128,16 +121,9 @@ pub mod gpu_socket_listener {
                 "Deserialized witness vector after {:?}",
                 started_at.elapsed()
             );
-            let assembly = generate_assembly_for_repeated_proving(
-                witness_vector.prover_job.circuit_wrapper.clone(),
-                witness_vector.prover_job.job_id,
-                witness_vector.prover_job.setup_data_key.circuit_id,
-            )
-            .context("generate_assembly_for_repeated_proving()")?;
             tracing::info!("Generated assembly after {:?}", started_at.elapsed());
             let gpu_prover_job = GpuProverJob {
                 witness_vector_artifacts: witness_vector,
-                assembly,
             };
             // acquiring lock from queue and updating db must be done atomically otherwise it results in `TOCTTOU`
             // Time-of-Check to Time-of-Use
@@ -170,42 +156,5 @@ pub mod gpu_socket_listener {
             );
             Ok(())
         }
-    }
-
-    pub fn generate_assembly_for_repeated_proving(
-        circuit_wrapper: CircuitWrapper,
-        job_id: u32,
-        circuit_id: u8,
-    ) -> anyhow::Result<ProvingAssembly> {
-        let started_at = Instant::now();
-        let cs = match circuit_wrapper {
-            CircuitWrapper::Base(base_circuit) => {
-                let key = ProverServiceDataKey::new(
-                    base_circuit.numeric_circuit_type(),
-                    AggregationRound::BasicCircuits,
-                );
-                let finalization_hint =
-                    get_finalization_hints(key).context("get_finalization_hints()")?;
-                init_base_layer_cs_for_repeated_proving(base_circuit, &finalization_hint)
-            }
-            CircuitWrapper::Recursive(recursive_circuit) => {
-                let key = ProverServiceDataKey::new(
-                    recursive_circuit.numeric_circuit_type(),
-                    get_round_for_recursive_circuit_type(recursive_circuit.numeric_circuit_type()),
-                );
-                let finalization_hint =
-                    get_finalization_hints(key).context("get_finalization_hints()")?;
-                init_recursive_layer_cs_for_repeated_proving(recursive_circuit, &finalization_hint)
-            }
-        };
-        tracing::info!(
-            "Successfully generated assembly without witness vector for job: {}, took: {:?}",
-            job_id,
-            started_at.elapsed()
-        );
-
-        METRICS.gpu_assembly_generation_time[&circuit_id.to_string()].observe(started_at.elapsed());
-
-        Ok(cs)
     }
 }

--- a/prover/prover_fri/src/utils.rs
+++ b/prover/prover_fri/src/utils.rs
@@ -12,11 +12,7 @@ use zksync_prover_fri_types::{
             algebraic_props::{
                 round_function::AbsorptionModeOverwrite, sponge::GoldilocksPoseidon2Sponge,
             },
-            config::ProvingCSConfig,
-            cs::implementations::{
-                pow::NoPow, proof::Proof, reference_cs::CSReferenceAssembly,
-                verifier::VerificationKey,
-            },
+            cs::implementations::{pow::NoPow, proof::Proof, verifier::VerificationKey},
             field::goldilocks::{GoldilocksExt2, GoldilocksField},
         },
         circuit_definitions::recursion_layer::{
@@ -39,8 +35,6 @@ pub type H = GoldilocksPoseidon2Sponge<AbsorptionModeOverwrite>;
 pub type Ext = GoldilocksExt2;
 
 #[cfg(feature = "gpu")]
-pub type ProvingAssembly = CSReferenceAssembly<F, F, ProvingCSConfig>;
-#[cfg(feature = "gpu")]
 pub type SharedWitnessVectorQueue = Arc<Mutex<FixedSizeQueue<GpuProverJob>>>;
 
 pub struct ProverArtifacts {
@@ -60,7 +54,6 @@ impl ProverArtifacts {
 #[cfg(feature = "gpu")]
 pub struct GpuProverJob {
     pub witness_vector_artifacts: WitnessVectorArtifacts,
-    pub assembly: ProvingAssembly,
 }
 
 pub async fn save_proof(

--- a/prover/vk_setup_data_generator_server_fri/Cargo.toml
+++ b/prover/vk_setup_data_generator_server_fri/Cargo.toml
@@ -30,7 +30,7 @@ zkevm_test_harness = { git = "https://github.com/matter-labs/era-zkevm_test_harn
 circuit_definitions = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.1", features = [
     "log_tracing",
 ] }
-shivini = { git = "https://github.com/matter-labs/era-shivini.git", branch = "v1.4.1", optional = true }
+shivini = { git = "https://github.com/matter-labs/era-shivini.git", branch = "rr-gpu-config", optional = true }
 zksync_config = { path = "../../core/lib/config" }
 zksync_env_config = { path = "../../core/lib/env_config" }
 


### PR DESCRIPTION
## What ❔

This PR removes an expensive instantiation of a CSReferenceAssembly structure inside the FRI GPU prover.
The prerequisite is https://github.com/matter-labs/era-shivini/pull/37

## Why ❔

The instantiation of a CSReferenceAssembly structure is too expensive and needed to be replaced with a faster alternative.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
