### PR TITLE
docs: fix typo in introduction

### DIFF
--- a/docs/specs/introduction.md
+++ b/docs/specs/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-The goal of the ZK Stack is to power the internet of value. Value needs to be secured, and only blockchains are able
+The goal of the ZK Stack is to power the internet of value. Value needs to be secured, and only blockchains are able to
 provide the level of security that the internet needs. The ZK Stack can be used to launch zero-knowledge rollups, which
 are extra secure blockchains.
 


### PR DESCRIPTION
The typo in the introduction is in the sentence:

"Value needs to be secured, and only blockchains are able provide the level of security that the internet needs."

The correction would be to add "to" between "are" and "able":

"Value needs to be secured, and only blockchains are able to provide the level of security that the internet needs."

## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
