### PR TITLE
feat(healthcheck): Various healthcheck improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8697,6 +8697,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "vise",
 ]
 
 [[package]]

--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -142,6 +142,14 @@ pub struct OptionalENConfig {
     /// Enabled JSON RPC API namespaces.
     api_namespaces: Option<Vec<Namespace>>,
 
+    // Health checks
+    /// Time limit in milliseconds to mark a health check as slow and log the corresponding warning.
+    /// If not specified, the default value in the health check crate will be used.
+    healthcheck_slow_time_limit_ms: Option<u64>,
+    /// Time limit in milliseconds to abort a health check and return "not ready" status for the corresponding component.
+    /// If not specified, the default value in the health check crate will be used.
+    healthcheck_hard_time_limit_ms: Option<u64>,
+
     // Gas estimation config
     /// The factor by which to scale the gasLimit
     #[serde(default = "OptionalENConfig::default_estimate_gas_scale_factor")]
@@ -367,6 +375,16 @@ impl OptionalENConfig {
 
     pub fn max_response_body_size(&self) -> usize {
         self.max_response_body_size_mb * BYTES_IN_MEGABYTE
+    }
+
+    pub fn healthcheck_slow_time_limit(&self) -> Option<Duration> {
+        self.healthcheck_slow_time_limit_ms
+            .map(Duration::from_millis)
+    }
+
+    pub fn healthcheck_hard_time_limit(&self) -> Option<Duration> {
+        self.healthcheck_hard_time_limit_ms
+            .map(Duration::from_millis)
     }
 }
 

--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -505,7 +505,10 @@ async fn main() -> anyhow::Result<()> {
 
     let main_node_client = <dyn MainNodeClient>::json_rpc(&main_node_url)
         .context("Failed creating JSON-RPC client for main node")?;
-    let app_health = Arc::new(AppHealthCheck::default());
+    let app_health = Arc::new(AppHealthCheck::new(
+        config.optional.healthcheck_slow_time_limit(),
+        config.optional.healthcheck_hard_time_limit(),
+    ));
     app_health.insert_custom_component(Arc::new(MainNodeHealthCheck::from(
         main_node_client.clone(),
     )));

--- a/core/lib/config/src/configs/api.rs
+++ b/core/lib/config/src/configs/api.rs
@@ -206,11 +206,25 @@ impl Web3JsonRpcConfig {
 pub struct HealthCheckConfig {
     /// Port to which the REST server is listening.
     pub port: u16,
+    /// Time limit in milliseconds to mark a health check as slow and log the corresponding warning.
+    /// If not specified, the default value in the health check crate will be used.
+    pub slow_time_limit_ms: Option<u64>,
+    /// Time limit in milliseconds to abort a health check and return "not ready" status for the corresponding component.
+    /// If not specified, the default value in the health check crate will be used.
+    pub hard_time_limit_ms: Option<u64>,
 }
 
 impl HealthCheckConfig {
     pub fn bind_addr(&self) -> SocketAddr {
         SocketAddr::new("0.0.0.0".parse().unwrap(), self.port)
+    }
+
+    pub fn slow_time_limit(&self) -> Option<Duration> {
+        self.slow_time_limit_ms.map(Duration::from_millis)
+    }
+
+    pub fn hard_time_limit(&self) -> Option<Duration> {
+        self.hard_time_limit_ms.map(Duration::from_millis)
     }
 }
 

--- a/core/lib/config/src/testonly.rs
+++ b/core/lib/config/src/testonly.rs
@@ -209,7 +209,11 @@ impl RandomConfig for configs::api::Web3JsonRpcConfig {
 
 impl RandomConfig for configs::api::HealthCheckConfig {
     fn sample(g: &mut Gen<impl Rng>) -> Self {
-        Self { port: g.gen() }
+        Self {
+            port: g.gen(),
+            slow_time_limit_ms: g.gen(),
+            hard_time_limit_ms: g.gen(),
+        }
     }
 }
 

--- a/core/lib/env_config/src/api.rs
+++ b/core/lib/env_config/src/api.rs
@@ -97,7 +97,11 @@ mod tests {
                 pushgateway_url: "http://127.0.0.1:9091".into(),
                 push_interval_ms: Some(100),
             },
-            healthcheck: HealthCheckConfig { port: 8081 },
+            healthcheck: HealthCheckConfig {
+                port: 8081,
+                slow_time_limit_ms: Some(250),
+                hard_time_limit_ms: Some(2_000),
+            },
             merkle_tree: MerkleTreeApiConfig { port: 8082 },
         }
     }
@@ -136,6 +140,8 @@ mod tests {
             API_PROMETHEUS_PUSHGATEWAY_URL="http://127.0.0.1:9091"
             API_PROMETHEUS_PUSH_INTERVAL_MS=100
             API_HEALTHCHECK_PORT=8081
+            API_HEALTHCHECK_SLOW_TIME_LIMIT_MS=250
+            API_HEALTHCHECK_HARD_TIME_LIMIT_MS=2000
             API_MERKLE_TREE_PORT=8082
         "#;
         lock.set_env(config);

--- a/core/lib/health_check/Cargo.toml
+++ b/core/lib/health_check/Cargo.toml
@@ -10,6 +10,8 @@ keywords = ["blockchain", "zksync"]
 categories = ["cryptography"]
 
 [dependencies]
+vise = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
+
 async-trait = "0.1"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/core/lib/health_check/README.md
+++ b/core/lib/health_check/README.md
@@ -1,0 +1,121 @@
+# Health Monitoring
+
+Healthcheck infrastructure for node components allowing components to signal their current health state.
+Health states for all components run by the node are aggregated and are exposed as an HTTP `GET /health` endpoint
+bound to a dedicated healthcheck port, both for the main node and external node. This endpoint can be used
+as a readiness probe for Kubernetes, or used in other automations.
+
+## Main concepts
+
+**Component** is a logically isolated part of a node that affects the ability of the node to handle requests (aka node health).
+Components are supposed to run indefinitely until the node receives a stop signal.
+
+- Internal components correspond to one or more Tokio tasks. Examples of internal components are: JSON-RPC API server, Merkle tree,
+  consistency checker, reorg detector.
+- External components correspond to another process that the node communicates with. Examples of external components are:
+  Postgres connection pool, main node JSON-RPC (for the external node).
+
+Each component can report its health, which consists of 2 parts:
+
+- **Status**, e.g., "not ready", "ready", "shut down", "panicked"; see the crate code for a full list.
+- **Details**, a JSON value with the component-specific schema. E.g., Merkle tree reports its L1 batch "cursor" as a part of this information.
+
+Health from all components is aggregated into **application health**, which has its own status computed as the worst of
+component statuses. Application health is returned by the `/health` endpoint.
+
+## `/health` endpoint format
+
+`/health` will return current application health encoded as a JSON object. The HTTP status of the response is 20x
+if the application is healthy, and 50x if it is not.
+
+> **Warning.** The schema of data returned by the `/health` endpoint is not stable at this point and can change
+> without notice. Use at your own risk.
+
+<details>
+<summary>Example of endpoint output for an external node:</summary>
+
+```json
+{
+  "status": "ready",
+  "components": {
+    "sync_state": {
+      "status": "ready",
+      "details": {
+        "is_synced": true,
+        "local_block": 91,
+        "main_node_block": 91
+      }
+    },
+    "connection_pool": {
+      "status": "ready",
+      "details": {
+        "max_size": 50,
+        "pool_size": 10
+      }
+    },
+    "tree": {
+      "status": "ready",
+      "details": {
+        "leaf_count": 12624,
+        "mode": "full",
+        "next_l1_batch_number": 26,
+        "root_hash": "0x54d537798f9ebd1b6463e3773c3549a389709987d559fdcd8d402a652a33fb68",
+        "stage": "main_loop"
+      }
+    },
+    "snapshot_recovery": {
+      "status": "ready",
+      "details": {
+        "factory_deps_recovered": true,
+        "snapshot_l1_batch": 24,
+        "snapshot_miniblock": 89,
+        "storage_logs_chunk_count": 10,
+        "storage_logs_chunks_left_to_process": 0,
+        "tokens_recovered": true
+      }
+    },
+    "consistency_checker": {
+      "status": "ready",
+      "details": {
+        "first_checked_batch": 25,
+        "last_checked_batch": 25
+      }
+    },
+    "ws_api": {
+      "status": "ready"
+    },
+    "prometheus_exporter": {
+      "status": "ready"
+    },
+    "reorg_detector": {
+      "status": "ready",
+      "details": {
+        "last_correct_l1_batch": 25,
+        "last_correct_miniblock": 91
+      }
+    },
+    "main_node_http_rpc": {
+      "status": "ready"
+    },
+    "batch_status_updater": {
+      "status": "ready",
+      "details": {
+        "last_committed_l1_batch": 25,
+        "last_executed_l1_batch": 25,
+        "last_proven_l1_batch": 25
+      }
+    },
+    "commitment_generator": {
+      "status": "ready",
+      "details": {
+        "l1_batch_number": 25
+      }
+    },
+    "http_api": {
+      "status": "ready"
+    }
+  }
+}
+```
+</details>
+

--- a/core/lib/health_check/README.md
+++ b/core/lib/health_check/README.md
@@ -1,35 +1,36 @@
 # Health Monitoring
 
-Healthcheck infrastructure for node components allowing components to signal their current health state.
-Health states for all components run by the node are aggregated and are exposed as an HTTP `GET /health` endpoint
-bound to a dedicated healthcheck port, both for the main node and external node. This endpoint can be used
-as a readiness probe for Kubernetes, or used in other automations.
+Healthcheck infrastructure for node components allowing components to signal their current health state. Health states
+for all components run by the node are aggregated and are exposed as an HTTP `GET /health` endpoint bound to a dedicated
+healthcheck port, both for the main node and external node. This endpoint can be used as a readiness probe for
+Kubernetes, or used in other automations.
 
 ## Main concepts
 
-**Component** is a logically isolated part of a node that affects the ability of the node to handle requests (aka node health).
-Components are supposed to run indefinitely until the node receives a stop signal.
+**Component** is a logically isolated part of a node that affects the ability of the node to handle requests (aka node
+health). Components are supposed to run indefinitely until the node receives a stop signal.
 
-- Internal components correspond to one or more Tokio tasks. Examples of internal components are: JSON-RPC API server, Merkle tree,
-  consistency checker, reorg detector.
-- External components correspond to another process that the node communicates with. Examples of external components are:
-  Postgres connection pool, main node JSON-RPC (for the external node).
+- Internal components correspond to one or more Tokio tasks. Examples of internal components are: JSON-RPC API server,
+  Merkle tree, consistency checker, reorg detector.
+- External components correspond to another process that the node communicates with. Examples of external components
+  are: Postgres connection pool, main node JSON-RPC (for the external node).
 
 Each component can report its health, which consists of 2 parts:
 
 - **Status**, e.g., "not ready", "ready", "shut down", "panicked"; see the crate code for a full list.
-- **Details**, a JSON value with the component-specific schema. E.g., Merkle tree reports its L1 batch "cursor" as a part of this information.
+- **Details**, a JSON value with the component-specific schema. E.g., Merkle tree reports its L1 batch "cursor" as a
+  part of this information.
 
 Health from all components is aggregated into **application health**, which has its own status computed as the worst of
 component statuses. Application health is returned by the `/health` endpoint.
 
 ## `/health` endpoint format
 
-`/health` will return current application health encoded as a JSON object. The HTTP status of the response is 20x
-if the application is healthy, and 50x if it is not.
+`/health` will return current application health encoded as a JSON object. The HTTP status of the response is 20x if the
+application is healthy, and 50x if it is not.
 
-> **Warning.** The schema of data returned by the `/health` endpoint is not stable at this point and can change
-> without notice. Use at your own risk.
+> **Warning.** The schema of data returned by the `/health` endpoint is not stable at this point and can change without
+> notice. Use at your own risk.
 
 <details>
 <summary>Example of endpoint output for an external node:</summary>
@@ -117,5 +118,5 @@ if the application is healthy, and 50x if it is not.
   }
 }
 ```
-</details>
 
+</details>

--- a/core/lib/health_check/src/lib.rs
+++ b/core/lib/health_check/src/lib.rs
@@ -93,12 +93,18 @@ pub struct AppHealthCheck {
 
 impl Default for AppHealthCheck {
     fn default() -> Self {
-        Self::new(Duration::from_millis(500), Duration::from_secs(5))
+        Self::new(None, None)
     }
 }
 
 impl AppHealthCheck {
-    pub fn new(slow_time_limit: Duration, hard_time_limit: Duration) -> Self {
+    pub fn new(slow_time_limit: Option<Duration>, hard_time_limit: Option<Duration>) -> Self {
+        const DEFAULT_SLOW_TIME_LIMIT: Duration = Duration::from_millis(500);
+        const DEFAULT_HARD_TIME_LIMIT: Duration = Duration::from_secs(3);
+
+        let slow_time_limit = slow_time_limit.unwrap_or(DEFAULT_SLOW_TIME_LIMIT);
+        let hard_time_limit = hard_time_limit.unwrap_or(DEFAULT_HARD_TIME_LIMIT);
+        tracing::debug!("Created app health with time limits: slow={slow_time_limit:?}, hard={hard_time_limit:?}");
         Self {
             components: Mutex::default(),
             slow_time_limit,

--- a/core/lib/health_check/src/lib.rs
+++ b/core/lib/health_check/src/lib.rs
@@ -12,6 +12,9 @@ use futures::future;
 use serde::Serialize;
 use tokio::sync::watch;
 
+#[cfg(test)]
+mod tests;
+
 /// Health status returned as a part of `Health`.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -350,143 +353,5 @@ impl Drop for HealthUpdater {
             HealthStatus::ShutDown
         };
         self.update(terminal_health.into());
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use assert_matches::assert_matches;
-
-    use super::*;
-
-    #[tokio::test]
-    async fn updating_health_status() {
-        let (health_check, health_updater) = ReactiveHealthCheck::new("test");
-        assert_eq!(health_check.name(), "test");
-        assert_matches!(
-            health_check.check_health().await.status(),
-            HealthStatus::NotReady
-        );
-
-        health_updater.update(HealthStatus::Ready.into());
-        assert_matches!(
-            health_check.check_health().await.status(),
-            HealthStatus::Ready
-        );
-
-        drop(health_updater);
-        assert_matches!(
-            health_check.check_health().await.status(),
-            HealthStatus::ShutDown
-        );
-    }
-
-    #[tokio::test]
-    async fn updating_health_status_after_freeze() {
-        let (health_check, health_updater) = ReactiveHealthCheck::new("test");
-        health_updater.update(HealthStatus::Ready.into());
-        health_updater.freeze();
-
-        assert_matches!(
-            health_check.check_health().await.status(),
-            HealthStatus::Ready
-        );
-    }
-
-    #[tokio::test]
-    async fn updating_health_status_after_panic() {
-        let (health_check, health_updater) = ReactiveHealthCheck::new("test");
-        let task = tokio::spawn(async move {
-            health_updater.update(HealthStatus::Ready.into());
-            panic!("oops");
-        });
-        assert!(task.await.unwrap_err().is_panic());
-
-        assert_matches!(
-            health_check.check_health().await.status(),
-            HealthStatus::Panicked
-        );
-    }
-
-    #[tokio::test]
-    async fn updating_health_status_return_value() {
-        let (health_check, health_updater) = ReactiveHealthCheck::new("test");
-        assert_matches!(
-            health_check.check_health().await.status(),
-            HealthStatus::NotReady
-        );
-
-        let updated = health_updater.update(HealthStatus::Ready.into());
-        assert!(updated);
-        assert_matches!(
-            health_check.check_health().await.status(),
-            HealthStatus::Ready
-        );
-
-        let updated = health_updater.update(HealthStatus::Ready.into());
-        assert!(!updated);
-
-        let health: Health = HealthStatus::Ready.into();
-        let health = health.with_details("new details are treated as status change");
-        let updated = health_updater.update(health);
-        assert!(updated);
-    }
-
-    #[tokio::test]
-    async fn aggregating_health_checks() {
-        let (first_check, first_updater) = ReactiveHealthCheck::new("first");
-        let (second_check, second_updater) = ReactiveHealthCheck::new("second");
-        let checks = AppHealthCheck {
-            components: Mutex::new(vec![Arc::new(first_check), Arc::new(second_check)]),
-            ..AppHealthCheck::default()
-        };
-
-        let app_health = checks.check_health().await;
-        assert!(!app_health.is_healthy());
-        assert_matches!(app_health.inner.status(), HealthStatus::NotReady);
-        assert_matches!(
-            app_health.components["first"].status,
-            HealthStatus::NotReady
-        );
-        assert_matches!(
-            app_health.components["second"].status,
-            HealthStatus::NotReady
-        );
-
-        first_updater.update(HealthStatus::Ready.into());
-
-        let app_health = checks.check_health().await;
-        assert!(!app_health.is_healthy());
-        assert_matches!(app_health.inner.status(), HealthStatus::NotReady);
-        assert_matches!(app_health.components["first"].status, HealthStatus::Ready);
-        assert_matches!(
-            app_health.components["second"].status,
-            HealthStatus::NotReady
-        );
-
-        second_updater.update(HealthStatus::Affected.into());
-
-        let app_health = checks.check_health().await;
-        assert!(app_health.is_healthy());
-        assert_matches!(app_health.inner.status(), HealthStatus::Affected);
-        assert_matches!(app_health.components["first"].status, HealthStatus::Ready);
-        assert_matches!(
-            app_health.components["second"].status,
-            HealthStatus::Affected
-        );
-
-        drop(first_updater);
-
-        let app_health = checks.check_health().await;
-        assert!(!app_health.is_healthy());
-        assert_matches!(app_health.inner.status(), HealthStatus::ShutDown);
-        assert_matches!(
-            app_health.components["first"].status,
-            HealthStatus::ShutDown
-        );
-        assert_matches!(
-            app_health.components["second"].status,
-            HealthStatus::Affected
-        );
     }
 }

--- a/core/lib/health_check/src/metrics.rs
+++ b/core/lib/health_check/src/metrics.rs
@@ -1,0 +1,43 @@
+//! Metrics for health checks.
+
+use std::time::Duration;
+
+use vise::{Buckets, EncodeLabelSet, EncodeLabelValue, Family, Histogram, Metrics, Unit};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue)]
+#[metrics(rename_all = "snake_case")]
+pub(crate) enum CheckResult {
+    Slow,
+    TimedOut,
+    Dropped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelSet)]
+struct AbnormalCheckLabels {
+    component: &'static str,
+    result: CheckResult,
+}
+
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "healthcheck")]
+pub(crate) struct HealthMetrics {
+    /// Latency for abnormal checks. Includes slow, dropped and timed out checks (distinguished by the "result" label);
+    /// skips normal checks.
+    #[metrics(buckets = Buckets::LATENCIES, unit = Unit::Seconds)]
+    abnormal_check_latency: Family<AbnormalCheckLabels, Histogram<Duration>>,
+}
+
+impl HealthMetrics {
+    pub fn observe_abnormal_check(
+        &self,
+        component: &'static str,
+        result: CheckResult,
+        duration: Duration,
+    ) {
+        let labels = AbnormalCheckLabels { component, result };
+        self.abnormal_check_latency[&labels].observe(duration);
+    }
+}
+
+#[vise::register]
+pub(crate) static METRICS: vise::Global<HealthMetrics> = vise::Global::new();

--- a/core/lib/health_check/src/tests.rs
+++ b/core/lib/health_check/src/tests.rs
@@ -1,0 +1,136 @@
+//! Tests for health checks.
+
+use assert_matches::assert_matches;
+
+use super::*;
+
+#[tokio::test]
+async fn updating_health_status() {
+    let (health_check, health_updater) = ReactiveHealthCheck::new("test");
+    assert_eq!(health_check.name(), "test");
+    assert_matches!(
+        health_check.check_health().await.status(),
+        HealthStatus::NotReady
+    );
+
+    health_updater.update(HealthStatus::Ready.into());
+    assert_matches!(
+        health_check.check_health().await.status(),
+        HealthStatus::Ready
+    );
+
+    drop(health_updater);
+    assert_matches!(
+        health_check.check_health().await.status(),
+        HealthStatus::ShutDown
+    );
+}
+
+#[tokio::test]
+async fn updating_health_status_after_freeze() {
+    let (health_check, health_updater) = ReactiveHealthCheck::new("test");
+    health_updater.update(HealthStatus::Ready.into());
+    health_updater.freeze();
+
+    assert_matches!(
+        health_check.check_health().await.status(),
+        HealthStatus::Ready
+    );
+}
+
+#[tokio::test]
+async fn updating_health_status_after_panic() {
+    let (health_check, health_updater) = ReactiveHealthCheck::new("test");
+    let task = tokio::spawn(async move {
+        health_updater.update(HealthStatus::Ready.into());
+        panic!("oops");
+    });
+    assert!(task.await.unwrap_err().is_panic());
+
+    assert_matches!(
+        health_check.check_health().await.status(),
+        HealthStatus::Panicked
+    );
+}
+
+#[tokio::test]
+async fn updating_health_status_return_value() {
+    let (health_check, health_updater) = ReactiveHealthCheck::new("test");
+    assert_matches!(
+        health_check.check_health().await.status(),
+        HealthStatus::NotReady
+    );
+
+    let updated = health_updater.update(HealthStatus::Ready.into());
+    assert!(updated);
+    assert_matches!(
+        health_check.check_health().await.status(),
+        HealthStatus::Ready
+    );
+
+    let updated = health_updater.update(HealthStatus::Ready.into());
+    assert!(!updated);
+
+    let health: Health = HealthStatus::Ready.into();
+    let health = health.with_details("new details are treated as status change");
+    let updated = health_updater.update(health);
+    assert!(updated);
+}
+
+#[tokio::test]
+async fn aggregating_health_checks() {
+    let (first_check, first_updater) = ReactiveHealthCheck::new("first");
+    let (second_check, second_updater) = ReactiveHealthCheck::new("second");
+    let checks = AppHealthCheck {
+        components: Mutex::new(vec![Arc::new(first_check), Arc::new(second_check)]),
+        ..AppHealthCheck::default()
+    };
+
+    let app_health = checks.check_health().await;
+    assert!(!app_health.is_healthy());
+    assert_matches!(app_health.inner.status(), HealthStatus::NotReady);
+    assert_matches!(
+        app_health.components["first"].status,
+        HealthStatus::NotReady
+    );
+    assert_matches!(
+        app_health.components["second"].status,
+        HealthStatus::NotReady
+    );
+
+    first_updater.update(HealthStatus::Ready.into());
+
+    let app_health = checks.check_health().await;
+    assert!(!app_health.is_healthy());
+    assert_matches!(app_health.inner.status(), HealthStatus::NotReady);
+    assert_matches!(app_health.components["first"].status, HealthStatus::Ready);
+    assert_matches!(
+        app_health.components["second"].status,
+        HealthStatus::NotReady
+    );
+
+    second_updater.update(HealthStatus::Affected.into());
+
+    let app_health = checks.check_health().await;
+    assert!(app_health.is_healthy());
+    assert_matches!(app_health.inner.status(), HealthStatus::Affected);
+    assert_matches!(app_health.components["first"].status, HealthStatus::Ready);
+    assert_matches!(
+        app_health.components["second"].status,
+        HealthStatus::Affected
+    );
+
+    drop(first_updater);
+
+    let app_health = checks.check_health().await;
+    assert!(!app_health.is_healthy());
+    assert_matches!(app_health.inner.status(), HealthStatus::ShutDown);
+    assert_matches!(
+        app_health.components["first"].status,
+        HealthStatus::ShutDown
+    );
+    assert_matches!(
+        app_health.components["second"].status,
+        HealthStatus::Affected
+    );
+}

--- a/core/lib/protobuf_config/src/api.rs
+++ b/core/lib/protobuf_config/src/api.rs
@@ -191,16 +191,22 @@ impl ProtoRepr for proto::ContractVerificationApi {
 
 impl ProtoRepr for proto::HealthCheck {
     type Type = api::HealthCheckConfig;
+
     fn read(&self) -> anyhow::Result<Self::Type> {
         Ok(Self::Type {
             port: required(&self.port)
-                .and_then(|p| Ok((*p).try_into()?))
+                .and_then(|&port| Ok(port.try_into()?))
                 .context("port")?,
+            slow_time_limit_ms: self.slow_time_limit_ms,
+            hard_time_limit_ms: self.hard_time_limit_ms,
         })
     }
+
     fn build(this: &Self::Type) -> Self {
         Self {
             port: Some(this.port.into()),
+            slow_time_limit_ms: this.slow_time_limit_ms,
+            hard_time_limit_ms: this.hard_time_limit_ms,
         }
     }
 }

--- a/core/lib/protobuf_config/src/proto/api.proto
+++ b/core/lib/protobuf_config/src/proto/api.proto
@@ -44,6 +44,8 @@ message ContractVerificationApi {
 
 message HealthCheck {
   optional uint32 port = 1; // required; u16
+  optional uint64 slow_time_limit_ms = 2; // optional; ms
+  optional uint64 hard_time_limit_ms = 3; // optional; ms
 }
 
 message MerkleTreeApi {

--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -328,7 +328,15 @@ pub async fn initialize_components(
             .await
             .context("failed to build replica_connection_pool")?;
 
-    let app_health = Arc::new(AppHealthCheck::default());
+    let health_check_config = configs
+        .health_check_config
+        .clone()
+        .context("health_check_config")?;
+    let app_health = Arc::new(AppHealthCheck::new(
+        health_check_config.slow_time_limit(),
+        health_check_config.hard_time_limit(),
+    ));
+
     let contracts_config = configs
         .contracts_config
         .clone()
@@ -747,13 +755,8 @@ pub async fn initialize_components(
     // Run healthcheck server for all components.
     let db_health_check = ConnectionPoolHealthCheck::new(replica_connection_pool);
     app_health.insert_custom_component(Arc::new(db_health_check));
-
-    let healtcheck_api_config = configs
-        .health_check_config
-        .clone()
-        .context("health_check_config")?;
     let health_check_handle =
-        HealthCheckHandle::spawn_server(healtcheck_api_config.bind_addr(), app_health);
+        HealthCheckHandle::spawn_server(health_check_config.bind_addr(), app_health);
 
     if let Some(task) = gas_adjuster.run_if_initialized(stop_receiver.clone()) {
         task_futures.push(task);

--- a/core/lib/zksync_core/src/reorg_detector/tests.rs
+++ b/core/lib/zksync_core/src/reorg_detector/tests.rs
@@ -162,6 +162,10 @@ impl HandleReorgDetectorEvent for mpsc::UnboundedSender<(MiniblockNumber, L1Batc
     fn report_divergence(&mut self, _diverged_l1_batch: L1BatchNumber) {
         // Do nothing
     }
+
+    fn start_shutting_down(&mut self) {
+        // Do nothing
+    }
 }
 
 fn create_mock_detector(client: MockMainNodeClient, pool: ConnectionPool) -> ReorgDetector {

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -7039,6 +7039,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "vise",
 ]
 
 [[package]]


### PR DESCRIPTION
## What ❔

- Adds `HeathStatus::ShuttingDown` set immediately after a component receives a termination signal. Makes the `/health` endpoint conforming to K8s readiness probe expectations.
- Makes slow / hard time limits for health checks configurable and decreases their values by default.
- Adds metric for slow, timed out and dropped health checks.

## Why ❔

Improves healthcheck observability.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.