### PR TITLE
fix(contract-verifier): allow other zksolc settings

### DIFF
--- a/core/bin/contract-verifier/src/verifier.rs
+++ b/core/bin/contract-verifier/src/verifier.rs
@@ -305,13 +305,16 @@ impl ContractVerifier {
                     enabled: request.req.optimization_used,
                     mode: request.req.optimizer_mode.and_then(|s| s.chars().next()),
                 };
+                let optimizer_value = serde_json::to_value(optimizer).unwrap();
 
                 let settings = Settings {
-                    libraries: None,
                     output_selection: Some(default_output_selection),
-                    optimizer,
                     is_system: request.req.is_system,
-                    metadata: None,
+                    other: serde_json::Value::Object(
+                        vec![("optimizer".to_string(), optimizer_value)]
+                            .into_iter()
+                            .collect(),
+                    ),
                 };
 
                 Ok(ZkSolcInput::StandardJson(StandardJson {

--- a/core/bin/contract-verifier/src/zksolc_utils.rs
+++ b/core/bin/contract-verifier/src/zksolc_utils.rs
@@ -34,6 +34,9 @@ pub struct Source {
     pub content: String,
 }
 
+/// Compiler settings.
+/// There are fields like `output_selection` and `is_system` which are accessed by contract verifier explicitly.
+/// Other fields are accumulated in `other`, this way every field that was in the original request will be passed to a compiler.
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Settings {

--- a/core/bin/contract-verifier/src/zksolc_utils.rs
+++ b/core/bin/contract-verifier/src/zksolc_utils.rs
@@ -35,37 +35,16 @@ pub struct Source {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub enum MetadataHash {
-    /// Do not include bytecode hash.
-    #[serde(rename = "none")]
-    None,
-}
-
-#[derive(Debug, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Metadata {
-    /// The bytecode hash mode.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub bytecode_hash: Option<MetadataHash>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Settings {
-    /// The linker library addresses.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub libraries: Option<HashMap<String, HashMap<String, String>>>,
     /// The output selection filters.
     pub output_selection: Option<serde_json::Value>,
-    /// The optimizer settings.
-    #[serde(default)]
-    pub optimizer: Optimizer,
-    /// The metadata settings.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<Metadata>,
     /// Flag for system compilation mode.
     #[serde(default)]
     pub is_system: bool,
+    /// Other fields.
+    #[serde(flatten)]
+    pub other: serde_json::Value,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/docker/contract-verifier/Dockerfile
+++ b/docker/contract-verifier/Dockerfile
@@ -28,6 +28,13 @@ RUN for VERSION in $(seq -f "v1.3.%g" 9 17); do \
     chmod +x /etc/zkvyper-bin/$VERSION/zkvyper; \
     done
 
+# install zkvyper 1.4.x
+RUN for VERSION in $(seq -f "v1.4.%g" 0 0); do \
+    mkdir -p /etc/zkvyper-bin/$VERSION && \
+    wget https://github.com/matter-labs/zkvyper-bin/raw/main/linux-amd64/zkvyper-linux-amd64-musl-$VERSION -O /etc/zkvyper-bin/$VERSION/zkvyper && \
+    chmod +x /etc/zkvyper-bin/$VERSION/zkvyper; \
+    done
+
 # install solc
 COPY docker/contract-verifier/install-all-solc.sh install-all-solc.sh
 RUN bash ./install-all-solc.sh


### PR DESCRIPTION
## What ❔

Contract verifier allows any fields in standard json input settings and passes them to zksolc.

## Why ❔

New fields are added to settings from time to time, contract verifier should just accept them and pass to zksolc.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
