### PR TITLE
chore: build rust binaries with nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,126 @@
 {
   "nodes": {
-    "root": {
+    "flake-utils": {
       "inputs": {
-        "stable": "stable"
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     },
-    "stable": {
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
       "locked": {
-        "lastModified": 1705331948,
-        "narHash": "sha256-qjQXfvrAT1/RKDFAMdl8Hw3m4tLVvMCc8fMqzJv0pP4=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1708294118,
+        "narHash": "sha256-evZzmLW7qoHXf76VCepvun1esZDxHfVRFUJtumD7L2M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b8dd8be3c790215716e7c12b247f45ca525867e2",
+        "rev": "e0da498ad77ac8909a980f07eff060862417ccf7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixos-23.11",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1706487304,
+        "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "90f456026d284c22b3e3497be980b2e47d0b28ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1708481452,
+        "narHash": "sha256-s07K6pwJtnB7Z/3wbkf4iaYXj+H5CuDD94I8hohm3Ig=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3d6647bf9d1f8e537b0d026c51ea25c0cdd92055",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,43 +1,216 @@
+###################################################################################################
+#
+# To build the rust components with this flake, run:
+# $ nix build .#cargoDeps
+# set `cargoHash` below to the result of the build
+# then
+# $ nix build .#zksync_server
+# or
+# $ nix build .#zksync_server.contract_verifier
+# $ nix build .#zksync_server.external_node
+# $ nix build .#zksync_server.server
+# $ nix build .#zksync_server.snapshots_creator
+# $ nix build .#zksync_server.block_reverter
+#
+# To enter the development shell, run:
+# $ nix develop --impure
+#
+# To vendor the dependencies manually, run:
+# $ nix shell .#cargo-vendor -c cargo vendor --no-merge-sources
+#
+###################################################################################################
 {
-  description = "zkSync development shell";
+  description = "zkSync-era";
   inputs = {
-    stable.url = "github:NixOS/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
   };
-  outputs = { self, stable }: {
-    formatter.x86_64-linux = stable.legacyPackages.x86_64-linux.nixpkgs-fmt;
-    devShells.x86_64-linux.default =
-      with import stable { system = "x86_64-linux"; };
-      pkgs.mkShell.override { stdenv = pkgs.stdenvAdapters.useMoldLinker pkgs.gccStdenv; } {
-        name = "zkSync";
-        src = ./.;
-        buildInputs = [
-          docker-compose
-          nodejs
-          yarn
-          axel
-          libclang
-          openssl
-          pkg-config
-          postgresql
-          python3
-          solc
-          sqlx-cli
-          rustup
-        ];
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        ###########################################################################################
+        # This changes every time `Cargo.lock` changes. Set to `null` to force re-vendoring
+        cargoHash = null;
+        # cargoHash = "sha256-UzIR9KhfOXFIHpj1pCjzfBmvuyvqrtbtAvVunS7djPQ=";
+        ###########################################################################################
+        officialRelease = false;
 
-        # for RocksDB and other Rust bindgen libraries
-        LIBCLANG_PATH = lib.makeLibraryPath [ libclang.lib ];
-        BINDGEN_EXTRA_CLANG_ARGS = ''-I"${libclang.lib}/lib/clang/${builtins.elemAt (builtins.splitVersion libclang.version) 0}/include"'';
+        versionSuffix =
+          if officialRelease
+          then ""
+          else "pre${builtins.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}_${self.shortRev or "dirty"}";
 
-        shellHook = ''
-          export ZKSYNC_HOME=$PWD
-          export PATH=$ZKSYNC_HOME/bin:$PATH
-        '';
+        pkgs = import nixpkgs { inherit system; overlays = [ rust-overlay.overlays.default ]; };
 
-        # hardhat solc requires ld-linux
-        # Nixos has to fake it with nix-ld
-        NIX_LD_LIBRARY_PATH = lib.makeLibraryPath [];
-        NIX_LD = builtins.readFile "${stdenv.cc}/nix-support/dynamic-linker";
-      };
-  };
+        # patched version of cargo to support `cargo vendor` for vendoring dependencies
+        # see https://github.com/matter-labs/zksync-era/issues/1086
+        # used as `cargo vendor --no-merge-sources`
+        cargo-vendor = pkgs.rustPlatform.buildRustPackage rec {
+          pname = "cargo-vendor";
+          version = "0.78.0";
+          src = pkgs.fetchFromGitHub {
+            owner = "haraldh";
+            repo = "cargo";
+            rev = "3ee1557d2bd95ca9d0224c5dbf1d1e2d67186455";
+            hash = "sha256-A8xrOG+NmF8dQ7tA9I2vJSNHlYxsH44ZRXdptLblCXk=";
+          };
+          doCheck = false;
+          cargoHash = "sha256-LtuNtdoX+FF/bG5LQc+L2HkFmgCtw5xM/m0/0ShlX2s=";
+          nativeBuildInputs = [
+            pkgs.pkg-config
+            pkgs.rustPlatform.bindgenHook
+          ];
+          buildInputs = [
+            pkgs.openssl
+          ];
+        };
+
+        # custom import-cargo-lock to import Cargo.lock file and vendor dependencies
+        # see https://github.com/matter-labs/zksync-era/issues/1086
+        import-cargo-lock = { lib, cacert, runCommand }: { src, cargoHash ? null } @ args:
+          runCommand "import-cargo-lock"
+            {
+              inherit src;
+              nativeBuildInputs = [ cargo-vendor cacert ];
+              preferLocalBuild = true;
+              outputHashMode = "recursive";
+              outputHashAlgo = "sha256";
+              outputHash = if cargoHash != null then cargoHash else lib.fakeSha256;
+            }
+            ''
+              mkdir -p $out/.cargo
+              mkdir -p $out/cargo-vendor-dir
+
+              HOME=$(pwd)
+              pushd ${src}
+              HOME=$HOME cargo vendor --no-merge-sources $out/cargo-vendor-dir > $out/.cargo/config
+              sed -i -e "s#$out#import-cargo-lock#g" $out/.cargo/config
+              cp $(pwd)/Cargo.lock $out/Cargo.lock
+              popd
+            ''
+        ;
+        cargoDeps = pkgs.buildPackages.callPackage import-cargo-lock { } { inherit src; inherit cargoHash; };
+
+        rustVersion = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain;
+
+        stdenv = pkgs.stdenvAdapters.useMoldLinker pkgs.clangStdenv;
+
+        rustPlatform = (pkgs.makeRustPlatform {
+          cargo = rustVersion;
+          rustc = rustVersion;
+          inherit stdenv;
+        });
+        zksync_server_cargoToml = (builtins.fromTOML (builtins.readFile ./core/bin/zksync_server/Cargo.toml));
+
+        hardeningEnable = [ "fortify3" "pie" "relro" ];
+
+        src = with pkgs.lib.fileset; toSource {
+          root = ./.;
+          fileset = unions [
+            ./Cargo.lock
+            ./Cargo.toml
+            ./core
+            ./sdk
+            ./.github/release-please/manifest.json
+          ];
+        };
+
+        zksync_server = with pkgs; stdenv.mkDerivation {
+          pname = "zksync";
+          version = zksync_server_cargoToml.package.version + versionSuffix;
+
+          updateAutotoolsGnuConfigScriptsPhase = ":";
+
+          nativeBuildInputs = [
+            pkg-config
+            rustPlatform.bindgenHook
+            rustPlatform.cargoSetupHook
+            rustPlatform.cargoBuildHook
+            rustPlatform.cargoInstallHook
+          ];
+
+          buildInputs = [
+            libclang
+            openssl
+          ];
+
+          inherit src;
+          cargoBuildFlags = "--all";
+          cargoBuildType = "release";
+          inherit cargoDeps;
+
+          inherit hardeningEnable;
+
+          outputs = [
+            "out"
+            "contract_verifier"
+            "external_node"
+            "server"
+            "snapshots_creator"
+            "block_reverter"
+          ];
+
+          postInstall = ''
+            mkdir -p $out/nix-support
+            for i in $outputs; do
+              [[ $i == "out" ]] && continue
+              mkdir -p "''${!i}/bin"
+              echo "''${!i}" >> $out/nix-support/propagated-user-env-packages
+              if [[ -e "$out/bin/zksync_$i" ]]; then
+                mv "$out/bin/zksync_$i" "''${!i}/bin"
+              else
+                mv "$out/bin/$i" "''${!i}/bin"
+              fi
+            done
+
+            mkdir -p $external_node/nix-support
+            echo "block_reverter" >> $external_node/nix-support/propagated-user-env-packages
+
+            mv $out/bin/merkle_tree_consistency_checker $server/bin
+            mkdir -p $server/nix-support
+            echo "block_reverter" >> $server/nix-support/propagated-user-env-packages
+          '';
+        };
+      in
+      {
+        formatter = pkgs.nixpkgs-fmt;
+
+        packages = {
+          inherit zksync_server;
+          default = zksync_server;
+          inherit cargo-vendor;
+          inherit cargoDeps;
+        };
+
+        devShells = with pkgs;{
+          default = pkgs.mkShell.override { inherit stdenv; } {
+            inputsFrom = [ zksync_server ];
+
+            packages = [
+              docker-compose
+              nodejs
+              yarn
+              axel
+              postgresql
+              python3
+              solc
+              sqlx-cli
+            ];
+
+            inherit hardeningEnable;
+
+            shellHook = ''
+              export ZKSYNC_HOME=$PWD
+              export PATH=$ZKSYNC_HOME/bin:$PATH
+            '';
+
+            # hardhat solc requires ld-linux
+            # Nixos has to fake it with nix-ld
+            NIX_LD_LIBRARY_PATH = lib.makeLibraryPath [ ];
+            NIX_LD = builtins.readFile "${clangStdenv.cc}/nix-support/dynamic-linker";
+          };
+        };
+      });
 }
+


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->
Build the rust binaries with the nix flake.

To do that, we have to vendor zksync-era with a custom patched `cargo`... **sigh** See https://github.com/matter-labs/zksync-era/issues/1086

To build the rust components with this flake, first run:
```
$ nix build .#cargoDeps
```
set `cargoHash` in `flake.nix` to the result of the build then
```
$ nix build .#zksync_server
```
or
```
$ nix build .#zksync_server.contract_verifier
$ nix build .#zksync_server.external_node
$ nix build .#zksync_server.server
$ nix build .#zksync_server.snapshots_creator
$ nix build .#zksync_server.block_reverter
```

To enter the development shell, run:
```
$ nix develop --impure
```

To vendor the dependencies manually, run:
```
$ nix shell .#cargo-vendor -c cargo vendor --no-merge-sources
```

## Why ❔

- [x] Enable reproducible builds for the binaries

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
