### PR TITLE
fix: typo and terminology

### DIFF
--- a/docs/guides/repositories.md
+++ b/docs/guides/repositories.md
@@ -6,8 +6,8 @@
 
 | Public repository                                                     | Description                                                                                                                                                             |
 | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [zksync-era](https://github.com/matter-labs/zksync-era)               | zk server logic, including the APIs and database accesses                                                                                                               |
-| [zksync-wallet-vue](https://github.com/matter-labs/zksync-wallet-vue) | Wallet frontend                                                                                                                                                         |
+| [zksync-era](https://github.com/matter-labs/zksync-era)               | zksync-era server logic, including the APIs and database accesses                                                                                                       |
+| [zksync-wallet-vue](https://github.com/matter-labs/zksync-wallet-vue) | Wallet front end                                                                                                                                                        |
 | [era-contracts](https://github.com/matter-labs/era-contracts)         | L1 & L2 contracts, that are used to manage bridges and communication between L1 & L2. Privileged contracts that are running on L2 (like Bootloader or ContractDeployer) |
 
 ### Compiler


### PR DESCRIPTION
First change, zk is not indicating it is zksync era or lite, therefore we should make it more clear in the description.

Second change, Consistency in Terminology: Ensure consistency in how you refer to similar items. For example, if you refer to "front end" in one place and "frontend" in another, choose one and stick with it.

Since we use front end multiple times in line 19-21, we would better to change line 10 to front end as well.

## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
