### PR TITLE
fix: default postgreSQL port

### DIFF
--- a/docs/guides/external-node/prepared_configs/testnet-sepolia-config.env
+++ b/docs/guides/external-node/prepared_configs/testnet-sepolia-config.env
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------------
 
 # URL of the Postgres DB.
-DATABASE_URL=postgres://postgres@localhost/zksync_local_ext_node
+DATABASE_URL=postgres://postgres@localhost:5432/zksync_local_ext_node
 # PostgreSQL connection pool size
 DATABASE_POOL_SIZE=50
 


### PR DESCRIPTION
Specify the default PostgreSQL port for clarity, especially for users unfamiliar with PostgreSQL.

## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
