### PR TITLE
chore: fix MIT license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following questions will be answered by the following resources:
 zkSync Era is distributed under the terms of either
 
 - Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <https://opensource.org/license/mit/>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <https://opensource.org/blog/license/mit/>)
 
 at your option.
 


### PR DESCRIPTION
## What ❔

https://opensource.org/license/mit/ -> https://opensource.org/blog/license/mit/

## Why ❔

CI is broken, seems like https://opensource.org changed the base URL for the license pages

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.
