### PR TITLE
fix(core): drop correct index of proof_generation_details table in database migration

### DIFF
--- a/core/lib/dal/README.md
+++ b/core/lib/dal/README.md
@@ -117,4 +117,4 @@ resources).
 [`zksync_state`]: ../state
 [`snapshots_creator`]: ../../bin/snapshots_creator
 [`snapshots_applier`]: ../snapshots_applier
-[`EXPLAIN`]: https://www.postgresql.org/docs/14/sql-explain.html
+[`explain`]: https://www.postgresql.org/docs/14/sql-explain.html

--- a/core/lib/dal/migrations/20230810090211_add_proof_generation_details_table.down.sql
+++ b/core/lib/dal/migrations/20230810090211_add_proof_generation_details_table.down.sql
@@ -1,3 +1,3 @@
 DROP TABLE IF EXISTS proof_generation_details;
 
-DROP INDEX IF EXISTS idx_l1_batches_status_prover_taken_at;
+DROP INDEX IF EXISTS idx_proof_generation_details_status_prover_taken_at;


### PR DESCRIPTION
## What ❔

Fix the problem that dropping the wrong index of the proof_generation_details table  during the migration process.

## Why ❔

In `20230810090211_add_proof_generation_details_table.up.sql`, we create the `proof_generation_details` table and the `idx_proof_generation_details_status_prover_taken_at` index. Symmetrically, we should drop the table and the index in 
`20230810090211_add_proof_generation_details_table.down.sql`. But In fact, the index `idx_l1_batches_status_prover_taken_at` was deleted in `20230810090211_add_proof_generation_details_table.down.sql`, which was never created.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.
