### PR TITLE
fix(docs): fix typo mistakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
     name: CI for Docs
     uses: ./.github/workflows/ci-docs-reusable.yml
 
-  # What needs to be ran for both core and prover
+  # What needs to be run for both core and prover
   ci-for-common:
     needs: changed_files
     if: ${{ (needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.all == 'true') && !contains(github.ref_name, 'release-please--branches') }}

--- a/docs/guides/advanced/advanced_debugging.md
+++ b/docs/guides/advanced/advanced_debugging.md
@@ -64,7 +64,7 @@ Afterwards you need to add something like this to your launch.json:
 
 ## Debugging contracts in vscode (using hardhat)
 
-Assuming that you created project in hardhat, that you'd normally test with `hardhat test` - you also also test it with
+Assuming that you created project in hardhat, that you'd normally test with `hardhat test` - you also test it with
 vscode (which is super powerful - especially as you can have both binaries' debug sessions running in VSCode at the same
 time).
 
@@ -124,7 +124,7 @@ detailed flame graph.
 Currently this is quite a complex process, but we're working on making it a little bit smoother.
 
 You start by installing the 'compiler-tester' repo (see its README.md instructions for details) - it is quite heavy as
-it needs the LLVM etc etc.
+it needs the LLVM etc.
 
 Afterwards, you can look at one of the tests (for example
 [tests/solidity/simple/default.sol](https://github.com/matter-labs/era-compiler-tests/blob/main/solidity/simple/default.sol)).

--- a/docs/specs/data_availability/compression.md
+++ b/docs/specs/data_availability/compression.md
@@ -18,7 +18,7 @@ Once a key has been used, it can already use the 4 or 5 byte enumeration index a
 cheaper for keys that has been used already. The opportunity comes when remembering the ids for accounts to spare some
 bytes on nonce/balance key, but ultimately the complexity may not be worth it.
 
-There is some room for optimization of the keys that are being written for the first time, however, optimizing those is
+There is some room for optimization of the keys that are being written for the first time, however, optimizing those are
 more complex and achieves only a one-time effect (when the key is published for the first time), so they may be in scope
 of the future upgrades.
 

--- a/docs/specs/prover/circuit_testing.md
+++ b/docs/specs/prover/circuit_testing.md
@@ -38,7 +38,7 @@ Now the constraint system is ready! We can start the main part of the test!
 ![Contest(8).png](<./img/circuit_testing/Contest(8).png>)
 
 Here we have hard coded a secret key with its associated public key, and generate a signature. We will test our circuit
-on these inputs! Next we “allocate” these inputs as witnessess:
+on these inputs! Next we “allocate” these inputs as witnesses:
 
 ![Contest(9).png](<./img/circuit_testing/Contest(9).png>)
 


### PR DESCRIPTION
## What ❔

This PR fixes typo errors in documentation.

## Why ❔

To ensure that the documentation is professional and free of grammatical and typographical errors.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [+] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [+] Tests for the changes have been added / updated.
- [+] Documentation comments have been added / updated.
- [+] ode has been formatted via `zk fmt` and `zk lint`.
- [+Spellcheck has been run via `zk spellcheck`.
- [+] Linkcheck has been run via `zk linkcheck`.
