### PR TITLE
chore(docker): Exclude trusted_setup from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -39,3 +39,4 @@ contracts/.git
 !bellman-cuda
 !prover/vk_setup_data_generator_server_fri/data/
 !.github/release-please/manifest.json
+!trusted_setup.json


### PR DESCRIPTION
## What ❔

Excludes `trusted_setup.json` from .dockerignore so witness generator docker image can be build 

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
