### PR TITLE
chore: corrected spelling word in comment

### DIFF
--- a/core/node/node_framework/src/resource/mod.rs
+++ b/core/node/node_framework/src/resource/mod.rs
@@ -35,7 +35,7 @@ pub(crate) trait StoredResource: 'static + std::any::Any + Send + Sync {
     /// An object-safe version of [`Resource::resource_id`].
     fn stored_resource_id(&self) -> ResourceId;
 
-    /// An object-safe version of [`Resource::on_resoure_wired`].
+    /// An object-safe version of [`Resource::on_resource_wired`].
     fn stored_resource_wired(&mut self);
 }
 

--- a/core/tests/ts-integration/src/context-owner.ts
+++ b/core/tests/ts-integration/src/context-owner.ts
@@ -456,7 +456,7 @@ export async function sendTransfers(
                 gasPrice
             };
 
-            reporter?.debug(`Inititated ETH transfer with nonce: ${tx.nonce}`);
+            reporter?.debug(`Initiated ETH transfer with nonce: ${tx.nonce}`);
             return wallet.sendTransaction(tx).then((tx) => {
                 reporter?.debug(`Sent ETH transfer tx: ${tx.hash}, nonce: ${tx.nonce}`);
                 return tx.wait();
@@ -467,7 +467,7 @@ export async function sendTransfers(
                 nonce: txNonce,
                 gasPrice
             });
-            reporter?.debug(`Inititated ERC20 transfer with nonce: ${txNonce}`);
+            reporter?.debug(`Initiated ERC20 transfer with nonce: ${txNonce}`);
             // @ts-ignore
             return tx.then((tx) => {
                 reporter?.debug(`Sent ERC20 transfer tx: ${tx.hash}, nonce: ${tx.nonce}`);


### PR DESCRIPTION
## What ❔
The word of `Initiated` and `resource` is the correct spelling, only log info and comment has been rectified, in this commit.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔
Because spelling was incorrect.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
