### PR TITLE
feat(Validium): add validium support for external node

### DIFF
--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -4,6 +4,7 @@ use anyhow::Context;
 use serde::Deserialize;
 use url::Url;
 use zksync_basic_types::{Address, L1ChainId, L2ChainId};
+use zksync_config::{configs::chain::L1BatchCommitDataGeneratorMode, ObjectStoreConfig};
 use zksync_consensus_roles::node;
 use zksync_core::{
     api_server::{
@@ -18,8 +19,6 @@ use zksync_web3_decl::{
     jsonrpsee::http_client::{HttpClient, HttpClientBuilder},
     namespaces::{EthNamespaceClient, ZksNamespaceClient},
 };
-
-use zksync_config::{configs::chain::L1BatchCommitDataGeneratorMode, ObjectStoreConfig};
 
 #[cfg(test)]
 mod tests;

--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -4,7 +4,6 @@ use anyhow::Context;
 use serde::Deserialize;
 use url::Url;
 use zksync_basic_types::{Address, L1ChainId, L2ChainId};
-use zksync_config::ObjectStoreConfig;
 use zksync_consensus_roles::node;
 use zksync_core::{
     api_server::{
@@ -19,6 +18,8 @@ use zksync_web3_decl::{
     jsonrpsee::http_client::{HttpClient, HttpClientBuilder},
     namespaces::{EthNamespaceClient, ZksNamespaceClient},
 };
+
+use zksync_config::{configs::chain::L1BatchCommitDataGeneratorMode, ObjectStoreConfig};
 
 #[cfg(test)]
 mod tests;
@@ -200,6 +201,9 @@ pub struct OptionalENConfig {
     /// 0 means that sealing is synchronous; this is mostly useful for performance comparison, testing etc.
     #[serde(default = "OptionalENConfig::default_miniblock_seal_queue_capacity")]
     pub miniblock_seal_queue_capacity: usize,
+
+    #[serde(default = "OptionalENConfig::default_l1_batch_commit_data_generator_mode")]
+    pub l1_batch_commit_data_generator_mode: L1BatchCommitDataGeneratorMode,
 }
 
 impl OptionalENConfig {
@@ -306,6 +310,10 @@ impl OptionalENConfig {
         10
     }
 
+    const fn default_l1_batch_commit_data_generator_mode() -> L1BatchCommitDataGeneratorMode {
+        L1BatchCommitDataGeneratorMode::Rollup
+    }
+
     pub fn polling_interval(&self) -> Duration {
         Duration::from_millis(self.polling_interval)
     }
@@ -384,6 +392,8 @@ pub struct RequiredENConfig {
     pub state_cache_path: String,
     /// Fast SSD path. Used as a RocksDB dir for the Merkle tree (*new* implementation).
     pub merkle_tree_path: String,
+    /// External node mode. Same as in the main node.
+    pub l1_batch_commit_data_generator_mode: L1BatchCommitDataGeneratorMode,
 }
 
 impl RequiredENConfig {

--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -391,8 +391,6 @@ pub struct RequiredENConfig {
     pub state_cache_path: String,
     /// Fast SSD path. Used as a RocksDB dir for the Merkle tree (*new* implementation).
     pub merkle_tree_path: String,
-    /// External node mode. Same as in the main node.
-    pub l1_batch_commit_data_generator_mode: L1BatchCommitDataGeneratorMode,
 }
 
 impl RequiredENConfig {

--- a/core/bin/external_node/src/config/tests.rs
+++ b/core/bin/external_node/src/config/tests.rs
@@ -25,6 +25,10 @@ fn parsing_optional_config_from_empty_env() {
         128 * BYTES_IN_MEGABYTE
     );
     assert_eq!(config.max_response_body_size(), 10 * BYTES_IN_MEGABYTE);
+    assert_eq!(
+        config.l1_batch_commit_data_generator_mode,
+        L1BatchCommitDataGeneratorMode::Rollup
+    );
 }
 
 #[test]
@@ -44,6 +48,7 @@ fn parsing_optional_config_from_env() {
         ("EN_MERKLE_TREE_MULTI_GET_CHUNK_SIZE", "1000"),
         ("EN_MERKLE_TREE_BLOCK_CACHE_SIZE_MB", "32"),
         ("EN_MAX_RESPONSE_BODY_SIZE_MB", "1"),
+        ("EN_L1_BATCH_COMMIT_DATA_GENERATOR_MODE", "Validium"),
     ];
     let env_vars = env_vars
         .into_iter()
@@ -70,4 +75,8 @@ fn parsing_optional_config_from_env() {
         32 * BYTES_IN_MEGABYTE
     );
     assert_eq!(config.max_response_body_size(), BYTES_IN_MEGABYTE);
+    assert_eq!(
+        config.l1_batch_commit_data_generator_mode,
+        L1BatchCommitDataGeneratorMode::Validium
+    );
 }

--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -8,7 +8,7 @@ use prometheus_exporter::PrometheusExporterConfig;
 use tokio::{sync::watch, task, time::sleep};
 use zksync_basic_types::{Address, L2ChainId};
 use zksync_concurrency::{ctx, scope};
-use zksync_config::configs::database::MerkleTreeMode;
+use zksync_config::configs::{chain::L1BatchCommitDataGeneratorMode, database::MerkleTreeMode};
 use zksync_core::{
     api_server::{
         execution_sandbox::VmConcurrencyLimiter,
@@ -37,7 +37,10 @@ use zksync_dal::{healthcheck::ConnectionPoolHealthCheck, ConnectionPool};
 use zksync_health_check::{CheckHealth, HealthStatus, ReactiveHealthCheck};
 use zksync_state::PostgresStorageCaches;
 use zksync_storage::RocksDB;
-use zksync_types::l1_batch_commit_data_generator::RollupModeL1BatchCommitDataGenerator;
+use zksync_types::l1_batch_commit_data_generator::{
+    L1BatchCommitDataGenerator, RollupModeL1BatchCommitDataGenerator,
+    ValidiumModeL1BatchCommitDataGenerator,
+};
 use zksync_utils::wait_for_tasks::wait_for_tasks;
 
 use crate::{
@@ -241,6 +244,7 @@ async fn init_tasks(
     healthchecks.push(Box::new(metadata_calculator.tree_health_check()));
 
     let l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator> = match config
+        .optional
         .l1_batch_commit_data_generator_mode
     {
         L1BatchCommitDataGeneratorMode::Rollup => Arc::new(RollupModeL1BatchCommitDataGenerator {}),

--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -240,8 +240,14 @@ async fn init_tasks(
         .context("failed initializing metadata calculator")?;
     healthchecks.push(Box::new(metadata_calculator.tree_health_check()));
 
-    let l1_batch_commit_data_generator = Arc::new(RollupModeL1BatchCommitDataGenerator {});
-
+    let l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator> = match config
+        .l1_batch_commit_data_generator_mode
+    {
+        L1BatchCommitDataGeneratorMode::Rollup => Arc::new(RollupModeL1BatchCommitDataGenerator {}),
+        L1BatchCommitDataGeneratorMode::Validium => {
+            Arc::new(ValidiumModeL1BatchCommitDataGenerator {})
+        }
+    };
     let consistency_checker = ConsistencyChecker::new(
         &config
             .required


### PR DESCRIPTION
## What

This pull request addresses the need to dynamically set the L1CommitGeneratorMode of the external node based on the configuration value l1_batch_commit_data_generator_mode in the etc/env/ext-node.toml file. If the configuration value is set, the external node will be configured for Validium; otherwise, the default mode will be Rollup.
Changes Made
Added logic to check for the presence of l1_batch_commit_data_generator_mode in etc/env/ext-node.toml.
If the value is set, the L1CommitGeneratorMode of the external node is set to "validium."
If the value is not set, the default mode "rollup" is used.
Users can manually update the configuration by adding l1_batch_commit_data_generator_mode="Validium" to the ext-node.toml file.

## Why ❔

Need to add Valiidium support to EN

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.