### PR TITLE
fix(Validium): Make `l1_batch_commit_data_generator_mode` a non-mandatory attribute

### DIFF
--- a/core/lib/config/src/configs/chain.rs
+++ b/core/lib/config/src/configs/chain.rs
@@ -52,6 +52,10 @@ pub enum L1BatchCommitDataGeneratorMode {
     Validium,
 }
 
+fn default_l1_batch_commit_data_generator_mode() -> L1BatchCommitDataGeneratorMode {
+    L1BatchCommitDataGeneratorMode::Rollup
+}
+
 #[derive(Debug, Deserialize, Clone, PartialEq, Default)]
 pub struct StateKeeperConfig {
     /// The max number of slots for txs in a block before it should be sealed by the slots sealer.
@@ -123,7 +127,7 @@ pub struct StateKeeperConfig {
 
     /// Number of keys that is processed by enum_index migration in State Keeper each L1 batch.
     pub enum_index_migration_chunk_size: Option<usize>,
-
+    #[serde(default = "default_l1_batch_commit_data_generator_mode")]
     pub l1_batch_commit_data_generator_mode: L1BatchCommitDataGeneratorMode,
 }
 

--- a/core/lib/config/src/configs/chain.rs
+++ b/core/lib/config/src/configs/chain.rs
@@ -52,10 +52,6 @@ pub enum L1BatchCommitDataGeneratorMode {
     Validium,
 }
 
-fn default_l1_batch_commit_data_generator_mode() -> L1BatchCommitDataGeneratorMode {
-    L1BatchCommitDataGeneratorMode::Rollup
-}
-
 #[derive(Debug, Deserialize, Clone, PartialEq, Default)]
 pub struct StateKeeperConfig {
     /// The max number of slots for txs in a block before it should be sealed by the slots sealer.
@@ -127,7 +123,7 @@ pub struct StateKeeperConfig {
 
     /// Number of keys that is processed by enum_index migration in State Keeper each L1 batch.
     pub enum_index_migration_chunk_size: Option<usize>,
-    #[serde(default = "default_l1_batch_commit_data_generator_mode")]
+    #[serde(default)]
     pub l1_batch_commit_data_generator_mode: L1BatchCommitDataGeneratorMode,
 }
 

--- a/core/lib/env_config/src/chain.rs
+++ b/core/lib/env_config/src/chain.rs
@@ -207,7 +207,7 @@ mod tests {
     }
 
     #[test]
-    fn deafult_state_keeper_mode() {
+    fn default_state_keeper_mode() {
         assert_eq!(
             StateKeeperConfig::default().l1_batch_commit_data_generator_mode,
             L1BatchCommitDataGeneratorMode::Rollup

--- a/core/lib/env_config/src/chain.rs
+++ b/core/lib/env_config/src/chain.rs
@@ -205,4 +205,12 @@ mod tests {
         let actual = CircuitBreakerConfig::from_env().unwrap();
         assert_eq!(actual, expected_circuit_breaker_config());
     }
+
+    #[test]
+    fn deafult_state_keeper_mode() {
+        assert_eq!(
+            StateKeeperConfig::default().l1_batch_commit_data_generator_mode,
+            L1BatchCommitDataGeneratorMode::Rollup
+        );
+    }
 }


### PR DESCRIPTION
## Description

This pull request addresses the issue regarding the `l1_batch_commit_data_generator_mode` field in the `StateKeeperConfig` struct. The issue stems from the absence of an explicit default value and the lack of `Option` marking, potentially causing the node to enter a crash loop if deployed to an existing environment without prior configuration updates.

Resolves #168.

## Proposed Solution

To resolve this issue, the following changes have been implemented:

1. **Using `serde` with Default Value:** The `serde` attribute has been applied to the `L1BatchCommitDataGeneratorMode` enum, setting `Rollup` as the default value. This ensures that if the field is not explicitly provided in the configuration, `Rollup` will be used by default.

2. **Backward Compatibility:** The solution is designed to be backward-compatible, ensuring a smooth transition for existing environments. This is achieved by providing a default value and utilizing `serde` for serialization and deserialization.

## Changes Made

- Updated the `StateKeeperConfig` struct to utilize `serde(default)` with the default value attribute.

## Testing

```sh
zk test rust --package zksync_env_config --lib -j 1 -- chain::tests::default_state_keeper_mode
```

## Impact

This PR aims to resolve the issue while maintaining backward compatibility. It ensures that the `l1_batch_commit_data_generator_mode` field is properly handled, preventing potential crash loops in existing environments.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
