### PR TITLE
feat: Use unwrap for contract address for transaction receipt

### DIFF
--- a/core/lib/dal/src/models/storage_transaction.rs
+++ b/core/lib/dal/src/models/storage_transaction.rs
@@ -361,15 +361,15 @@ impl From<StorageTransactionReceipt> for TransactionReceipt {
             l1_batch_tx_index: storage_receipt.l1_batch_tx_index.map(U64::from),
             l1_batch_number: storage_receipt.l1_batch_number.map(U64::from),
             from: H160::from_slice(&storage_receipt.initiator_address),
-            to: storage_receipt
-                .transfer_to
-                .or(storage_receipt.execute_contract_address)
-                .map(|addr| {
-                    serde_json::from_value::<Address>(addr)
-                        .expect("invalid address value in the database")
-                })
-                // For better compatibility with various clients, we never return null.
-                .or_else(|| Some(Address::default())),
+            to: Some(
+                serde_json::from_value::<Address>(
+                    storage_receipt
+                        .transfer_to
+                        .or(storage_receipt.execute_contract_address)
+                        .unwrap(),
+                )
+                .expect("invalid address value in the database"),
+            ),
             cumulative_gas_used: Default::default(), // TODO: Should be actually calculated (SMA-1183).
             gas_used: {
                 let refunded_gas: U256 = storage_receipt.refunded_gas.into();


### PR DESCRIPTION
## What ❔

Use `unwrap()` on `transactions.data -> contractAddress` field in transactions table.
## Why ❔

Seems there are no NULL values for this field, PR is intended to ensure this(to be able to return NULL values later).

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.
