### PR TITLE
fix(en): fail fast if we don't request correct number of txs from man node

### DIFF
--- a/core/lib/zksync_core/src/sync_layer/fetcher.rs
+++ b/core/lib/zksync_core/src/sync_layer/fetcher.rs
@@ -54,6 +54,16 @@ impl TryFrom<SyncBlock> for FetchedBlock {
     type Error = anyhow::Error;
 
     fn try_from(block: SyncBlock) -> anyhow::Result<Self> {
+        let Some(transactions) = block.transactions else {
+            return Err(anyhow::anyhow!("Transactions are always requested"));
+        };
+
+        if transactions.is_empty() && !block.last_in_batch {
+            return Err(anyhow::anyhow!(
+                "Only last miniblock of the batch can be empty"
+            ));
+        }
+
         Ok(Self {
             number: block.number,
             l1_batch_number: block.l1_batch_number,
@@ -66,9 +76,7 @@ impl TryFrom<SyncBlock> for FetchedBlock {
             fair_pubdata_price: block.fair_pubdata_price,
             virtual_blocks: block.virtual_blocks.unwrap_or(0),
             operator_address: block.operator_address,
-            transactions: block
-                .transactions
-                .context("Transactions are always requested")?,
+            transactions,
         })
     }
 }


### PR DESCRIPTION

## What ❔
Only the last miniblock in batch can have 0 txs. Fail fast if the main node returned wrong value 

## Why ❔

It allows to find discrepancy faster

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
