### PR TITLE
docs: small doc fixes

### DIFF
--- a/docs/guides/advanced/01_initialization.md
+++ b/docs/guides/advanced/01_initialization.md
@@ -72,10 +72,10 @@ docker container ls
 and then we can look at the Geth logs:
 
 ```shell
-docker logs zksync-2-dev-geth-1
+docker logs zksync-era-geth-1
 ```
 
-Where `zksync-2-dev-geth-1` is the container name, that we got from the first command.
+Where `zksync-era-geth-1` is the container name, that we got from the first command.
 
 If everything goes well, you should see that L1 blocks are being produced.
 
@@ -105,7 +105,7 @@ select * from miniblocks;
 Let's finish this article, by taking a look at our L1:
 
 ```shell
-docker container exec -it zksync-2-dev-geth-1  geth attach http://localhost:8545
+docker container exec -it zksync-era-geth-1  geth attach http://localhost:8545
 ```
 
 The command above will start a shell - and you can check that you're a (localnet) crypto trillionaire, by running:

--- a/docs/guides/advanced/02_deposits.md
+++ b/docs/guides/advanced/02_deposits.md
@@ -40,7 +40,7 @@ Now, let's see how many tokens we have:
 Unsurprisingly we have 0 on both - let's fix it by first transferring some tokens on L1:
 
 ```shell
-docker container exec -it zksync-2-dev-geth-1  geth attach http://localhost:8545
+docker container exec -it zksync-era-geth-1  geth attach http://localhost:8545
 // and inside:
 eth.sendTransaction({from: personal.listAccounts[0], to: "0x618263CE921F7dd5F4f40C29f6c524Aaf97b9bbd", value: "7400000000000000000"})
 ```
@@ -60,7 +60,7 @@ and now let's bridge it over to L2.
 For an easy way to bridge we'll use [zkSync CLI](https://github.com/matter-labs/zksync-cli)
 
 ```shell
-npx zksync-cli bridge deposit --chain=local-dockerized
+npx zksync-cli bridge deposit --chain=dockerized-node --amount 3 --pk=0x5090c024edb3bdf4ce2ebc2da96bedee925d9d77d729687e5e2d56382cf0a5a6 --to=0x618263CE921F7dd5F4f40C29f6c524Aaf97b9bbd
 # Amount of ETH to deposit: 3
 # Private key of the sender: 0x5090c024edb3bdf4ce2ebc2da96bedee925d9d77d729687e5e2d56382cf0a5a6
 # Recipient address on L2: 0x618263CE921F7dd5F4f40C29f6c524Aaf97b9bbd

--- a/docs/guides/advanced/03_withdrawals.md
+++ b/docs/guides/advanced/03_withdrawals.md
@@ -4,7 +4,7 @@ Assuming that you have completed [part 1](01_initialization.md) and [part 2](02_
 tokens back by simply calling the zksync-cli:
 
 ```bash
-npx zksync-cli bridge withdraw --chain=local-dockerized
+npx zksync-cli bridge withdraw --chain=dockerized-node
 ```
 
 And providing the account name (public address) and private key.
@@ -15,7 +15,7 @@ they didn't** - what happened?
 Actually we'll have to run one additional step:
 
 ```bash
-npx zksync-cli bridge withdraw-finalize --chain=local-dockerized
+npx zksync-cli bridge withdraw-finalize --chain=dockerized-node
 ```
 
 and pass the transaction that we received from the first call, into the `withdraw-finalize` call.


### PR DESCRIPTION
This PR contains small fixes to the `guides` docs. Mostly around container names / cli syntax.  