### PR TITLE
feat(validator): added blob validator address to env

### DIFF
--- a/etc/env/base/eth_sender.toml
+++ b/etc/env/base/eth_sender.toml
@@ -5,6 +5,8 @@
 [eth_sender.sender]
 # operator_private_key is defined in the `private.toml`
 # operator_commit_eth_addr is defined in the `private.toml`
+# operator_blobs_private_key is defined in the `private.toml`
+# operator_blobs_eth_addr is defined in the `private.toml`
 
 # Amount of confirmations required to consider L1 transaction committed.
 wait_confirmations=1

--- a/etc/env/base/private.toml
+++ b/etc/env/base/private.toml
@@ -13,6 +13,9 @@ operator_private_key="0x27593fea79697e947890ecbecce7901b0008345e5d7259710d0dd5e5
 # Derived from the `OPERATOR_PRIVATE_KEY`.
 operator_commit_eth_addr="0xde03a0B5963f75f1C8485B355fF6D30f3093BDE7"
 
+operator_blobs_private_key="0x6cc45a68e083295a641bd52560bafb0f098e5050372e45e0c343c945e23e641f"
+operator_blobs_eth_addr="0xE847224766a47614aF9C7F429004B8efd410d146"
+
 [consensus]
 config_path = "etc/env/consensus_config.json"
 # generated with zksync_consensus_tools/src/bin/keys.rs


### PR DESCRIPTION
## What ❔

Given 2 address approach for blob txns vs regular ones we need a second sender address

## Why ❔

mempool rules dictate an account can only have 1 txn in the blob pool or regular pool

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
