### PR TITLE
feat(Gas Oracle): Use normal anyhow::Error for the `NativeErc20Fetcher`

### DIFF
--- a/core/lib/zksync_core/src/l1_gas_price/singleton.rs
+++ b/core/lib/zksync_core/src/l1_gas_price/singleton.rs
@@ -16,18 +16,8 @@ use crate::{l1_gas_price::GasAdjuster, native_token_fetcher::ConversionRateFetch
 pub struct GasAdjusterSingleton {
     web3_url: String,
     gas_adjuster_config: GasAdjusterConfig,
-    singleton: OnceCell<Result<Arc<GasAdjuster<QueryClient>>, Error>>,
+    singleton: OnceCell<anyhow::Result<Arc<GasAdjuster<QueryClient>>>>,
     erc20_fetcher_dyn: Option<Arc<dyn ConversionRateFetcher>>,
-}
-
-#[derive(thiserror::Error, Debug, Clone)]
-#[error(transparent)]
-pub struct Error(Arc<anyhow::Error>);
-
-impl From<anyhow::Error> for Error {
-    fn from(err: anyhow::Error) -> Self {
-        Self(Arc::new(err))
-    }
 }
 
 impl GasAdjusterSingleton {
@@ -44,8 +34,8 @@ impl GasAdjusterSingleton {
         }
     }
 
-    pub async fn get_or_init(&mut self) -> Result<Arc<GasAdjuster<QueryClient>>, Error> {
-        let adjuster = self
+    pub async fn get_or_init(&mut self) -> anyhow::Result<Arc<GasAdjuster<QueryClient>>> {
+        match self
             .singleton
             .get_or_init(|| async {
                 let query_client =
@@ -59,17 +49,23 @@ impl GasAdjusterSingleton {
                 .context("GasAdjuster::new()")?;
                 Ok(Arc::new(adjuster))
             })
-            .await;
-        adjuster.clone()
+            .await
+        {
+            Ok(adjuster) => Ok(adjuster.clone()),
+            Err(_e) => Err(anyhow::anyhow!("Failed to get or initialize GasAdjuster")),
+        }
     }
 
     pub fn run_if_initialized(
         self,
         stop_signal: watch::Receiver<bool>,
     ) -> Option<JoinHandle<anyhow::Result<()>>> {
-        let gas_adjuster = self.singleton.get()?.clone();
+        let gas_adjuster = match self.singleton.get()? {
+            Ok(gas_adjuster) => gas_adjuster.clone(),
+            Err(_e) => return None,
+        };
         Some(tokio::spawn(
-            async move { gas_adjuster?.run(stop_signal).await },
+            async move { gas_adjuster.run(stop_signal).await },
         ))
     }
 }


### PR DESCRIPTION
## What ❔

Remove `Error` struct that holds `anyhow::Error` inside.

## Why ❔

Keep error structure clean.

## Checklist
- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `zk fmt` and `zk lint`.