### PR TITLE
feat(node_framework): Add a custom setup hook

### DIFF
--- a/core/node/node_framework/examples/main_node.rs
+++ b/core/node/node_framework/examples/main_node.rs
@@ -159,7 +159,7 @@ fn main() -> anyhow::Result<()> {
         .add_proof_data_handler_layer()?
         .add_healthcheck_layer()?
         .build()
-        .with_setup(|pre_run| {
+        .run_with_setup(|pre_run| {
             Box::pin(async move {
                 // We want to make sure that the healthcheck server is the very first
                 // thing that starts.
@@ -171,7 +171,4 @@ fn main() -> anyhow::Result<()> {
                 Ok(())
             })
         })
-        .run()?;
-
-    Ok(())
 }

--- a/core/node/node_framework/examples/main_node.rs
+++ b/core/node/node_framework/examples/main_node.rs
@@ -158,6 +158,18 @@ fn main() -> anyhow::Result<()> {
         .add_proof_data_handler_layer()?
         .add_healthcheck_layer()?
         .build()
+        .with_setup(|pre_run| {
+            Box::pin(async move {
+                // We want to make sure that the healthcheck server is the very first
+                // thing that starts.
+                pre_run.launch_task("healthcheck_server")?;
+
+                // ...imagine that there is some setup work here -- ensuring genesis state, running some migration,
+                // loading some data, etc..
+
+                Ok(())
+            })
+        })
         .run()?;
 
     Ok(())

--- a/core/node/node_framework/examples/main_node.rs
+++ b/core/node/node_framework/examples/main_node.rs
@@ -17,7 +17,7 @@ use zksync_node_framework::{
     implementations::layers::{
         eth_watch::EthWatchLayer,
         fee_input::SequencerFeeInputLayer,
-        healtcheck_server::HealthCheckLayer,
+        healtcheck_server::{HealthCheckLayer, HealthCheckTask},
         metadata_calculator::MetadataCalculatorLayer,
         object_store::ObjectStoreLayer,
         pools_layer::PoolsLayerBuilder,
@@ -29,6 +29,7 @@ use zksync_node_framework::{
         },
     },
     service::ZkStackService,
+    task::Task,
 };
 
 struct MainNodeBuilder {
@@ -162,7 +163,7 @@ fn main() -> anyhow::Result<()> {
             Box::pin(async move {
                 // We want to make sure that the healthcheck server is the very first
                 // thing that starts.
-                pre_run.launch_task("healthcheck_server")?;
+                pre_run.launch_task(HealthCheckTask::name())?;
 
                 // ...imagine that there is some setup work here -- ensuring genesis state, running some migration,
                 // loading some data, etc..

--- a/core/node/node_framework/src/implementations/layers/eth_watch.rs
+++ b/core/node/node_framework/src/implementations/layers/eth_watch.rs
@@ -69,7 +69,7 @@ struct EthWatchTask {
 
 #[async_trait::async_trait]
 impl Task for EthWatchTask {
-    fn name(&self) -> &'static str {
+    fn name() -> &'static str {
         "eth_watch"
     }
 

--- a/core/node/node_framework/src/implementations/layers/fee_input.rs
+++ b/core/node/node_framework/src/implementations/layers/fee_input.rs
@@ -70,7 +70,7 @@ struct GasAdjusterTask {
 
 #[async_trait::async_trait]
 impl Task for GasAdjusterTask {
-    fn name(&self) -> &'static str {
+    fn name() -> &'static str {
         "gas_adjuster"
     }
 

--- a/core/node/node_framework/src/implementations/layers/healtcheck_server.rs
+++ b/core/node/node_framework/src/implementations/layers/healtcheck_server.rs
@@ -45,7 +45,7 @@ impl WiringLayer for HealthCheckLayer {
 }
 
 #[derive(Debug)]
-struct HealthCheckTask {
+pub struct HealthCheckTask {
     config: HealthCheckConfig,
     app_health_check: Arc<AppHealthCheck>,
 }

--- a/core/node/node_framework/src/implementations/layers/healtcheck_server.rs
+++ b/core/node/node_framework/src/implementations/layers/healtcheck_server.rs
@@ -52,7 +52,7 @@ pub struct HealthCheckTask {
 
 #[async_trait::async_trait]
 impl Task for HealthCheckTask {
-    fn name(&self) -> &'static str {
+    fn name() -> &'static str {
         "healthcheck_server"
     }
 

--- a/core/node/node_framework/src/implementations/layers/metadata_calculator.rs
+++ b/core/node/node_framework/src/implementations/layers/metadata_calculator.rs
@@ -63,7 +63,7 @@ impl WiringLayer for MetadataCalculatorLayer {
 
 #[async_trait::async_trait]
 impl Task for MetadataCalculatorTask {
-    fn name(&self) -> &'static str {
+    fn name() -> &'static str {
         "metadata_calculator"
     }
 

--- a/core/node/node_framework/src/implementations/layers/prometheus_exporter.rs
+++ b/core/node/node_framework/src/implementations/layers/prometheus_exporter.rs
@@ -48,7 +48,7 @@ impl WiringLayer for PrometheusExporterLayer {
 
 #[async_trait::async_trait]
 impl Task for PrometheusExporterTask {
-    fn name(&self) -> &'static str {
+    fn name() -> &'static str {
         "prometheus_exporter"
     }
 

--- a/core/node/node_framework/src/implementations/layers/proof_data_handler.rs
+++ b/core/node/node_framework/src/implementations/layers/proof_data_handler.rs
@@ -70,7 +70,7 @@ struct ProofDataHandlerTask {
 
 #[async_trait::async_trait]
 impl Task for ProofDataHandlerTask {
-    fn name(&self) -> &'static str {
+    fn name() -> &'static str {
         "proof_data_handler"
     }
 

--- a/core/node/node_framework/src/implementations/layers/state_keeper/mempool_io.rs
+++ b/core/node/node_framework/src/implementations/layers/state_keeper/mempool_io.rs
@@ -132,7 +132,7 @@ struct MiniblockSealerTask(MiniblockSealer);
 
 #[async_trait::async_trait]
 impl Task for MiniblockSealerTask {
-    fn name(&self) -> &'static str {
+    fn name() -> &'static str {
         "state_keeper/miniblock_sealer"
     }
 
@@ -147,7 +147,7 @@ struct MempoolFetcherTask(MempoolFetcher);
 
 #[async_trait::async_trait]
 impl Task for MempoolFetcherTask {
-    fn name(&self) -> &'static str {
+    fn name() -> &'static str {
         "state_keeper/mempool_fetcher"
     }
 

--- a/core/node/node_framework/src/implementations/layers/state_keeper/mod.rs
+++ b/core/node/node_framework/src/implementations/layers/state_keeper/mod.rs
@@ -65,7 +65,7 @@ struct StateKeeperTask {
 
 #[async_trait::async_trait]
 impl Task for StateKeeperTask {
-    fn name(&self) -> &'static str {
+    fn name() -> &'static str {
         "state_keeper"
     }
 

--- a/core/node/node_framework/src/service/context.rs
+++ b/core/node/node_framework/src/service/context.rs
@@ -48,20 +48,6 @@ impl<'a> ServiceContext<'a> {
     ///
     /// Panics if the resource with the specified name exists, but is not of the requested type.
     pub async fn get_resource<T: Resource + Clone>(&mut self) -> Result<T, WiringError> {
-        #[allow(clippy::borrowed_box)]
-        let downcast_clone = |resource: &Box<dyn StoredResource>| {
-            resource
-                .downcast_ref::<T>()
-                .unwrap_or_else(|| {
-                    panic!(
-                        "Resource {} is not of type {}",
-                        T::resource_id(),
-                        std::any::type_name::<T>()
-                    )
-                })
-                .clone()
-        };
-
         let name = T::resource_id();
         // Check whether the resource is already available.
         if let Some(resource) = self.service.resources.get(&name) {
@@ -129,4 +115,18 @@ impl<'a> ServiceContext<'a> {
         );
         Ok(())
     }
+}
+
+#[allow(clippy::borrowed_box)]
+pub(super) fn downcast_clone<T: Resource + Clone>(resource: &Box<dyn StoredResource>) -> T {
+    resource
+        .downcast_ref::<T>()
+        .unwrap_or_else(|| {
+            panic!(
+                "Resource {} is not of type {}",
+                T::resource_id(),
+                std::any::type_name::<T>()
+            )
+        })
+        .clone()
 }

--- a/core/node/node_framework/src/service/context.rs
+++ b/core/node/node_framework/src/service/context.rs
@@ -34,8 +34,8 @@ impl<'a> ServiceContext<'a> {
 
     /// Adds a task to the service.
     /// Added tasks will be launched after the wiring process will be finished.
-    pub fn add_task(&mut self, task: Box<dyn Task>) -> &mut Self {
-        tracing::info!("Layer {} has added a new task: {}", self.layer, task.name());
+    pub fn add_task<T: Task>(&mut self, task: Box<T>) -> &mut Self {
+        tracing::info!("Layer {} has added a new task: {}", self.layer, T::name());
         self.service.tasks.push(task);
         self
     }

--- a/core/node/node_framework/src/service/mod.rs
+++ b/core/node/node_framework/src/service/mod.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, fmt};
 use futures::{future::BoxFuture, FutureExt};
 use tokio::{runtime::Runtime, sync::watch};
 
+use self::pre_run::PreRun;
 pub use self::{context::ServiceContext, stop_receiver::StopReceiver};
 use crate::{
     resource::{ResourceId, StoredResource},
@@ -11,9 +12,12 @@ use crate::{
 };
 
 mod context;
+mod pre_run;
 mod stop_receiver;
 #[cfg(test)]
 mod tests;
+
+pub type SetupHook = Box<dyn FnOnce(&mut PreRun) -> BoxFuture<anyhow::Result<()>> + Send>;
 
 /// "Manager" class for a set of tasks. Collects all the resources and tasks,
 /// then runs tasks until completion.
@@ -25,6 +29,7 @@ mod tests;
 ///   - invokes a `wire` method on each added wiring layer. If any of the layers fails,
 ///     the service will return an error. If no layers have added a task, the service will
 ///     also return an error.
+///   - invokes a setup hook if it was provided.
 ///   - waits for any of the tasks to finish.
 ///   - sends stop signal to all the tasks.
 ///   - waits for the remaining tasks to finish.
@@ -37,6 +42,8 @@ pub struct ZkStackService {
     layers: Vec<Box<dyn WiringLayer>>,
     /// Tasks added to the service.
     tasks: Vec<Box<dyn Task>>,
+
+    setup_hook: Option<SetupHook>,
 
     /// Sender used to stop the tasks.
     stop_sender: watch::Sender<bool>,
@@ -67,6 +74,7 @@ impl ZkStackService {
             resources: HashMap::default(),
             layers: Vec::new(),
             tasks: Vec::new(),
+            setup_hook: None,
             stop_sender,
             runtime,
         };
@@ -79,6 +87,22 @@ impl ZkStackService {
     /// `wire` method of every layer in the order they were added.
     pub fn add_layer<T: WiringLayer>(&mut self, layer: T) -> &mut Self {
         self.layers.push(Box::new(layer));
+        self
+    }
+
+    /// Setups a hook that will be called before the service starts running the tasks.
+    ///
+    /// This hook will be invoked after all the wiring layers have been processed and all the tasks
+    /// have been added to the service, but before any of the tasks are started. During the setup, the
+    /// hook can launch any added tasks and access resources through the [`PreRun`] object.
+    ///
+    /// The node will block on the hook execution if its provided, so if it's a long-running operation,
+    /// it is adviced to start the supplementary tasks, such as healtcheck server, in the hook itself.
+    pub fn with_setup<F>(mut self, setup: F) -> Self
+    where
+        F: FnOnce(&mut PreRun) -> BoxFuture<anyhow::Result<()>> + Send + 'static,
+    {
+        self.setup_hook = Some(Box::new(setup));
         self
     }
 
@@ -132,17 +156,30 @@ impl ZkStackService {
             resource.stored_resource_wired();
         }
 
+        let mut pre_run = pre_run::PreRun {
+            rt_handle: self.runtime.handle().clone(),
+            resources: self.resources,
+            unstarted_tasks: tasks,
+            join_handles: Vec::new(),
+        };
+
+        if let Some(pre_run_hook) = self.setup_hook.take() {
+            let future = pre_run_hook(&mut pre_run);
+            self.runtime.block_on(future)?;
+        }
+
         // Prepare tasks for running.
         let rt_handle = self.runtime.handle().clone();
-        let join_handles: Vec<_> = tasks
-            .iter_mut()
-            .map(|task| {
-                let task = task.task.take().expect(
-                    "Tasks are created by the node and must be Some prior to calling this method",
-                );
-                rt_handle.spawn(task).fuse()
-            })
-            .collect();
+        let mut join_handles: Vec<_> = pre_run.join_handles;
+        let mut tasks = pre_run.unstarted_tasks;
+
+        for task in &mut tasks {
+            let Some(task) = task.task.take() else {
+                // The task was started during the pre-run.
+                continue;
+            };
+            join_handles.push(rt_handle.spawn(task).fuse());
+        }
 
         // Run the tasks until one of them exits.
         // TODO (QIT-24): wrap every task into a timeout to prevent hanging.

--- a/core/node/node_framework/src/service/mod.rs
+++ b/core/node/node_framework/src/service/mod.rs
@@ -97,7 +97,7 @@ impl ZkStackService {
     /// hook can launch any added tasks and access resources through the [`PreRun`] object.
     ///
     /// The node will block on the hook execution if its provided, so if it's a long-running operation,
-    /// it is adviced to start the supplementary tasks, such as healtcheck server, in the hook itself.
+    /// it is advised to start the supplementary tasks, such as healthcheck server, in the hook itself.
     pub fn with_setup<F>(mut self, setup: F) -> Self
     where
         F: FnOnce(&mut PreRun) -> BoxFuture<anyhow::Result<()>> + Send + 'static,

--- a/core/node/node_framework/src/service/mod.rs
+++ b/core/node/node_framework/src/service/mod.rs
@@ -98,12 +98,12 @@ impl ZkStackService {
     ///
     /// The node will block on the hook execution if its provided, so if it's a long-running operation,
     /// it is advised to start the supplementary tasks, such as healthcheck server, in the hook itself.
-    pub fn with_setup<F>(mut self, setup: F) -> Self
+    pub fn run_with_setup<F>(mut self, setup: F) -> anyhow::Result<()>
     where
         F: FnOnce(&mut PreRun) -> BoxFuture<anyhow::Result<()>> + Send + 'static,
     {
         self.setup_hook = Some(Box::new(setup));
-        self
+        self.run()
     }
 
     /// Runs the system.

--- a/core/node/node_framework/src/service/mod.rs
+++ b/core/node/node_framework/src/service/mod.rs
@@ -7,7 +7,7 @@ use self::pre_run::PreRun;
 pub use self::{context::ServiceContext, stop_receiver::StopReceiver};
 use crate::{
     resource::{ResourceId, StoredResource},
-    task::Task,
+    task::StoredTask,
     wiring_layer::{WiringError, WiringLayer},
 };
 
@@ -41,7 +41,7 @@ pub struct ZkStackService {
     /// List of wiring layers.
     layers: Vec<Box<dyn WiringLayer>>,
     /// Tasks added to the service.
-    tasks: Vec<Box<dyn Task>>,
+    tasks: Vec<Box<dyn StoredTask>>,
 
     setup_hook: Option<SetupHook>,
 

--- a/core/node/node_framework/src/service/pre_run.rs
+++ b/core/node/node_framework/src/service/pre_run.rs
@@ -3,12 +3,11 @@ use std::{collections::HashMap, fmt};
 use futures::{future::Fuse, FutureExt};
 use tokio::task::JoinHandle;
 
+use super::TaskRepr;
 use crate::{
     resource::{Resource, ResourceId, StoredResource},
     service::context::downcast_clone,
 };
-
-use super::TaskRepr;
 
 /// The service state available right before the service is started.
 /// This means that all the resources and tasks are already added, but no tasks are running yet.

--- a/core/node/node_framework/src/service/pre_run.rs
+++ b/core/node/node_framework/src/service/pre_run.rs
@@ -1,0 +1,66 @@
+use std::{collections::HashMap, fmt};
+
+use futures::{future::Fuse, FutureExt};
+use tokio::task::JoinHandle;
+
+use crate::{
+    resource::{Resource, ResourceId, StoredResource},
+    service::context::downcast_clone,
+};
+
+use super::TaskRepr;
+
+/// The service state available right before the service is started.
+/// This means that all the resources and tasks are already added, but no tasks are running yet.
+/// This state can be used to launch tasks and retrieve resources during the custom service setup.
+pub struct PreRun {
+    pub(super) rt_handle: tokio::runtime::Handle,
+    pub(super) resources: HashMap<ResourceId, Box<dyn StoredResource>>,
+    pub(super) unstarted_tasks: Vec<TaskRepr>,
+    pub(super) join_handles: Vec<Fuse<JoinHandle<anyhow::Result<()>>>>,
+}
+
+impl fmt::Debug for PreRun {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let resources = self.resources.keys().collect::<Vec<_>>();
+        let tasks = self
+            .unstarted_tasks
+            .iter()
+            .map(|t| &t.name)
+            .collect::<Vec<_>>();
+        f.debug_struct("PreRun")
+            .field("resources", &resources)
+            .field("tasks", &tasks)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PreRun {
+    /// Launches a task specified by its name.
+    /// Returns an error if there is no such task or if it's already running.
+    pub fn launch_task(&mut self, name: &str) -> anyhow::Result<()> {
+        let task = self
+            .unstarted_tasks
+            .iter()
+            .position(|t| t.name == name)
+            .ok_or_else(|| anyhow::format_err!("Task {} not found", name))?;
+        let task_future = self.unstarted_tasks[task]
+            .task
+            .take()
+            .ok_or_else(|| anyhow::format_err!("Task {} is already running", name))?;
+        self.join_handles
+            .push(self.rt_handle.spawn(task_future).fuse());
+        Ok(())
+    }
+
+    /// Attempts to retrieve a resource.
+    /// Returns `None` if the resource is not found.
+    pub fn get_resource<T: Resource + Clone>(&self) -> Option<T> {
+        let name = T::resource_id();
+        // Check whether the resource is already available.
+        if let Some(resource) = self.resources.get(&name) {
+            return Some(downcast_clone(resource));
+        }
+        None
+    }
+}

--- a/core/node/node_framework/src/service/tests.rs
+++ b/core/node/node_framework/src/service/tests.rs
@@ -3,8 +3,9 @@ use std::sync::{Arc, Mutex};
 use anyhow::anyhow;
 use tokio::runtime::Runtime;
 
-use crate::service::{
-    ServiceContext, StopReceiver, Task, WiringError, WiringLayer, ZkStackService,
+use crate::{
+    service::{ServiceContext, StopReceiver, WiringError, WiringLayer, ZkStackService},
+    task::Task,
 };
 
 // `ZkStack` Service's `new()` method has to have a check for nested runtime.
@@ -110,7 +111,7 @@ struct ErrorTask;
 
 #[async_trait::async_trait]
 impl Task for ErrorTask {
-    fn name(&self) -> &'static str {
+    fn name() -> &'static str {
         "error_task"
     }
     async fn run(self: Box<Self>, _stop_receiver: StopReceiver) -> anyhow::Result<()> {
@@ -158,7 +159,7 @@ struct SuccessfulTask(Arc<Mutex<bool>>);
 
 #[async_trait::async_trait]
 impl Task for SuccessfulTask {
-    fn name(&self) -> &'static str {
+    fn name() -> &'static str {
         "successful_task"
     }
     async fn run(self: Box<Self>, _stop_receiver: StopReceiver) -> anyhow::Result<()> {
@@ -175,7 +176,7 @@ struct RemainingTask(Arc<Mutex<bool>>);
 
 #[async_trait::async_trait]
 impl Task for RemainingTask {
-    fn name(&self) -> &'static str {
+    fn name() -> &'static str {
         "remaining_task"
     }
     async fn run(self: Box<Self>, mut stop_receiver: StopReceiver) -> anyhow::Result<()> {

--- a/core/node/node_framework/src/task.rs
+++ b/core/node/node_framework/src/task.rs
@@ -9,7 +9,7 @@ use crate::service::StopReceiver;
 #[async_trait::async_trait]
 pub trait Task: 'static + Send {
     /// Unique name of the task.
-    fn name(&self) -> &'static str;
+    fn name() -> &'static str;
 
     /// Runs the task.
     ///
@@ -36,5 +36,31 @@ pub trait Task: 'static + Send {
     /// following this rule may cause the tasks that properly implement this hook to malfunction.
     fn after_node_shutdown(&self) -> Option<BoxFuture<'static, ()>> {
         None
+    }
+}
+
+/// Internal, object-safe version of [`Task`].
+///
+/// This trait is implemented for any type that implements [`Task`], so there is no need to
+/// implement it manually.
+#[async_trait::async_trait]
+pub(crate) trait StoredTask: 'static + Send {
+    fn name(&self) -> &'static str;
+    async fn run(self: Box<Self>, stop_receiver: StopReceiver) -> anyhow::Result<()>;
+    fn after_node_shutdown(&self) -> Option<BoxFuture<'static, ()>>;
+}
+
+#[async_trait::async_trait]
+impl<T: Task> StoredTask for T {
+    fn name(&self) -> &'static str {
+        T::name()
+    }
+
+    async fn run(self: Box<Self>, stop_receiver: StopReceiver) -> anyhow::Result<()> {
+        Task::run(self, stop_receiver).await
+    }
+
+    fn after_node_shutdown(&self) -> Option<BoxFuture<'static, ()>> {
+        Task::after_node_shutdown(self)
     }
 }


### PR DESCRIPTION
⚠️ To be superseded by a different approach.

## What ❔

Adds the ability to implement a custom setup hook with access to context able to retrieve resources and spawn tasks early.

## Why ❔

Often there may be some code that we want to run before we actually launch the node. As a simple case, check if the genesis batch info is present in the DB. It would be nice to do it:
- From within the framework to avoid responsibility split.
- With access to the service lifecycle (e.g. if we're performing some long operation, we would want to first spawn the healthcheck server).

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
