### PR TITLE
fix(vm): fix match clause in `get_max_gas_per_pubdata_byte`

### DIFF
--- a/core/lib/multivm/src/utils.rs
+++ b/core/lib/multivm/src/utils.rs
@@ -253,8 +253,8 @@ pub fn get_max_gas_per_pubdata_byte(version: VmVersion) -> u64 {
         VmVersion::VmBoojumIntegration => {
             crate::vm_boojum_integration::constants::MAX_GAS_PER_PUBDATA_BYTE
         }
-        VmVersion::Vm1_4_1 => crate::vm_latest::constants::MAX_GAS_PER_PUBDATA_BYTE,
-        VmVersion::Vm1_4_2 => crate::vm_1_4_1::constants::MAX_GAS_PER_PUBDATA_BYTE,
+        VmVersion::Vm1_4_1 => crate::vm_1_4_1::constants::MAX_GAS_PER_PUBDATA_BYTE,
+        VmVersion::Vm1_4_2 => crate::vm_latest::constants::MAX_GAS_PER_PUBDATA_BYTE,
     }
 }
 


### PR DESCRIPTION
## What ❔

Fix match clause in `get_max_gas_per_pubdata_byte`. `crate::vm_latest::constants::MAX_GAS_PER_PUBDATA_BYTE == crate::vm_1_4_1::constants::MAX_GAS_PER_PUBDATA_BYTE` so it should have no effect, but it's still a bug

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
