### PR TITLE
feat: A way to disable slow query logging for some queries

### DIFF
--- a/core/lib/dal/src/instrument.rs
+++ b/core/lib/dal/src/instrument.rs
@@ -103,6 +103,7 @@ struct InstrumentedData<'a> {
     location: &'static Location<'static>,
     args: QueryArgs<'a>,
     report_latency: bool,
+    slow_query_reporting_enabled: bool,
 }
 
 impl<'a> InstrumentedData<'a> {
@@ -112,6 +113,7 @@ impl<'a> InstrumentedData<'a> {
             location,
             args: QueryArgs::default(),
             report_latency: false,
+            slow_query_reporting_enabled: true,
         }
     }
 
@@ -125,6 +127,7 @@ impl<'a> InstrumentedData<'a> {
             location,
             args,
             report_latency,
+            slow_query_reporting_enabled,
         } = self;
         let started_at = Instant::now();
         tokio::pin!(query_future);
@@ -137,13 +140,15 @@ impl<'a> InstrumentedData<'a> {
             Ok(output) => output,
             Err(_) => {
                 let connection_tags = StorageProcessorTags::display(connection_tags);
-                tracing::warn!(
+                if slow_query_reporting_enabled {
+                    tracing::warn!(
                     "Query {name}{args} called at {file}:{line} [{connection_tags}] is executing for more than {slow_query_threshold:?}",
                     file = location.file(),
                     line = location.line()
                 );
-                REQUEST_METRICS.request_slow[&name].inc();
-                is_slow = true;
+                    REQUEST_METRICS.request_slow[&name].inc();
+                    is_slow = true;
+                }
                 query_future.await
             }
         };
@@ -193,6 +198,11 @@ impl<'a, Q> Instrumented<'a, Q> {
     /// Indicates that latency should be reported for all calls.
     pub fn report_latency(mut self) -> Self {
         self.data.report_latency = true;
+        self
+    }
+
+    pub fn disable_slow_query_reporting(mut self) -> Self {
+        self.data.slow_query_reporting_enabled = false;
         self
     }
 

--- a/core/lib/dal/src/instrument.rs
+++ b/core/lib/dal/src/instrument.rs
@@ -142,10 +142,10 @@ impl<'a> InstrumentedData<'a> {
                 let connection_tags = StorageProcessorTags::display(connection_tags);
                 if slow_query_reporting_enabled {
                     tracing::warn!(
-                    "Query {name}{args} called at {file}:{line} [{connection_tags}] is executing for more than {slow_query_threshold:?}",
-                    file = location.file(),
-                    line = location.line()
-                );
+                        "Query {name}{args} called at {file}:{line} [{connection_tags}] is executing for more than {slow_query_threshold:?}",
+                        file = location.file(),
+                        line = location.line()
+                    );
                     REQUEST_METRICS.request_slow[&name].inc();
                     is_slow = true;
                 }
@@ -201,7 +201,7 @@ impl<'a, Q> Instrumented<'a, Q> {
         self
     }
 
-    pub fn disable_slow_query_reporting(mut self) -> Self {
+    pub fn expect_slow_query(mut self) -> Self {
         self.data.slow_query_reporting_enabled = false;
         self
     }

--- a/core/lib/dal/src/snapshots_creator_dal.rs
+++ b/core/lib/dal/src/snapshots_creator_dal.rs
@@ -33,6 +33,7 @@ impl SnapshotsCreatorDal<'_, '_> {
         )
         .instrument("get_storage_logs_count")
         .report_latency()
+        .disable_slow_query_reporting()
         .fetch_one(self.storage)
         .await?
         .index;
@@ -60,6 +61,7 @@ impl SnapshotsCreatorDal<'_, '_> {
         .instrument("get_storage_logs_row_count")
         .with_arg("miniblock_number", &at_miniblock)
         .report_latency()
+        .disable_slow_query_reporting()
         .fetch_one(self.storage)
         .await?;
         Ok(row.count.unwrap_or(0) as u64)
@@ -116,6 +118,7 @@ impl SnapshotsCreatorDal<'_, '_> {
         .with_arg("min_hashed_key", &hashed_keys_range.start())
         .with_arg("max_hashed_key", &hashed_keys_range.end())
         .report_latency()
+        .disable_slow_query_reporting()
         .fetch_all(self.storage)
         .await?
         .iter()
@@ -151,6 +154,7 @@ impl SnapshotsCreatorDal<'_, '_> {
         )
         .instrument("get_all_factory_deps")
         .report_latency()
+        .disable_slow_query_reporting()
         .fetch_all(self.storage)
         .await?;
 

--- a/core/lib/dal/src/snapshots_creator_dal.rs
+++ b/core/lib/dal/src/snapshots_creator_dal.rs
@@ -33,7 +33,7 @@ impl SnapshotsCreatorDal<'_, '_> {
         )
         .instrument("get_storage_logs_count")
         .report_latency()
-        .disable_slow_query_reporting()
+        .expect_slow_query()
         .fetch_one(self.storage)
         .await?
         .index;
@@ -61,7 +61,7 @@ impl SnapshotsCreatorDal<'_, '_> {
         .instrument("get_storage_logs_row_count")
         .with_arg("miniblock_number", &at_miniblock)
         .report_latency()
-        .disable_slow_query_reporting()
+        .expect_slow_query()
         .fetch_one(self.storage)
         .await?;
         Ok(row.count.unwrap_or(0) as u64)
@@ -118,7 +118,7 @@ impl SnapshotsCreatorDal<'_, '_> {
         .with_arg("min_hashed_key", &hashed_keys_range.start())
         .with_arg("max_hashed_key", &hashed_keys_range.end())
         .report_latency()
-        .disable_slow_query_reporting()
+        .expect_slow_query()
         .fetch_all(self.storage)
         .await?
         .iter()
@@ -154,7 +154,7 @@ impl SnapshotsCreatorDal<'_, '_> {
         )
         .instrument("get_all_factory_deps")
         .report_latency()
-        .disable_slow_query_reporting()
+        .expect_slow_query()
         .fetch_all(self.storage)
         .await?;
 


### PR DESCRIPTION
## What ❔

A  way to disable slow query reporting on a per-query granularity

## Why ❔

Slow queries generate lots of spam and we expect some queries to be slow.
