### PR TITLE
fix: Add EIP4844 to fri_prover_group_config

### DIFF
--- a/core/lib/env_config/src/fri_prover_group.rs
+++ b/core/lib/env_config/src/fri_prover_group.rs
@@ -68,7 +68,7 @@ impl FromEnv for FriProverGroupConfig {
             group_11: groups.remove("group_11").unwrap_or_default(),
             group_12: groups.remove("group_12").unwrap_or_default(),
         };
-        config.validate();
+        config.validate()?;
         Ok(config)
     }
 }

--- a/core/lib/env_config/src/fri_prover_group.rs
+++ b/core/lib/env_config/src/fri_prover_group.rs
@@ -105,6 +105,7 @@ mod tests {
                 CircuitIdRoundTuple::new(11, 0),
                 CircuitIdRoundTuple::new(12, 0),
                 CircuitIdRoundTuple::new(13, 0),
+                CircuitIdRoundTuple::new(255, 0),
             ]
             .into_iter()
             .collect::<HashSet<_>>(),
@@ -172,6 +173,10 @@ mod tests {
             (
                 "FRI_PROVER_GROUP_GROUP_4_2",
                 CircuitIdRoundTuple::new(13, 0),
+            ),
+            (
+                "FRI_PROVER_GROUP_GROUP_4_3",
+                CircuitIdRoundTuple::new(255, 0),
             ),
             ("FRI_PROVER_GROUP_GROUP_5_0", CircuitIdRoundTuple::new(5, 0)),
             ("FRI_PROVER_GROUP_GROUP_6_0", CircuitIdRoundTuple::new(3, 1)),
@@ -284,6 +289,16 @@ mod tests {
         assert_eq!(
             Some(4),
             fri_prover_group_config.get_group_id_for_circuit_id_and_aggregation_round(12, 0)
+        );
+
+        assert_eq!(
+            Some(4),
+            fri_prover_group_config.get_group_id_for_circuit_id_and_aggregation_round(13, 0)
+        );
+
+        assert_eq!(
+            Some(4),
+            fri_prover_group_config.get_group_id_for_circuit_id_and_aggregation_round(255, 0)
         );
 
         assert_eq!(

--- a/etc/env/base/fri_prover_group.toml
+++ b/etc/env/base/fri_prover_group.toml
@@ -3,7 +3,7 @@ group_0 = [{"circuit_id"=1,"aggregation_round"=3},{"circuit_id"=2,"aggregation_r
 group_1 = [{"circuit_id"=1,"aggregation_round"=0}]
 group_2 = [{"circuit_id"=2,"aggregation_round"=0},{"circuit_id"=4,"aggregation_round"=0},{"circuit_id"=6,"aggregation_round"=0},{"circuit_id"=9,"aggregation_round"=0}]
 group_3 = [{"circuit_id"=3,"aggregation_round"=0}]
-group_4 = [{"circuit_id"=11,"aggregation_round"=0},{"circuit_id"=12,"aggregation_round"=0},{"circuit_id"=13,"aggregation_round"=0}]
+group_4 = [{"circuit_id"=11,"aggregation_round"=0},{"circuit_id"=12,"aggregation_round"=0},{"circuit_id"=13,"aggregation_round"=0},{"circuit_id"=255,"aggregation_round"=0}]
 group_5 = [{"circuit_id"=5,"aggregation_round"=0}]
 group_6 = [{"circuit_id"=3,"aggregation_round"=1}]
 group_7 = [{"circuit_id"=7,"aggregation_round"=0}]


### PR DESCRIPTION
255 corresponds to EIP4844. This is added to the group of expected circuits (base circuit as of 4844). Additionally, fixed panicing config by turning it into an Result.

This is needed for 4844 release and prevents outages caused by the part of the config that was touched.