### PR TITLE
fix: Copy trusted_setup in root for witness generators

### DIFF
--- a/docker/witness-generator/Dockerfile
+++ b/docker/witness-generator/Dockerfile
@@ -11,7 +11,7 @@ FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y curl libpq5 ca-certificates && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /usr/src/zksync/trusted_setup.json /usr/bin/trusted_setup.json
+COPY --from=builder /usr/src/zksync/trusted_setup.json /trusted_setup.json
 
 COPY prover/vk_setup_data_generator_server_fri/data/ /prover/vk_setup_data_generator_server_fri/data/
 


### PR DESCRIPTION
Currently, everything is ran from root.
The file itself should belong somewhere else, but for now this is consistent with server usage. We should move it into /config/trusted_setup.json or something similar.

