### PR TITLE
feat: change EN main node fetcher concurrency factor

### DIFF
--- a/core/lib/zksync_core/src/sync_layer/client.rs
+++ b/core/lib/zksync_core/src/sync_layer/client.rs
@@ -17,7 +17,8 @@ use zksync_web3_decl::{
 use super::metrics::{CachedMethod, FETCHER_METRICS};
 
 /// Maximum number of concurrent requests to the main node.
-const MAX_CONCURRENT_REQUESTS: usize = 100;
+/// It can' be very high to not trigger rate limiting.
+const MAX_CONCURRENT_REQUESTS: usize = 30;
 
 /// Client abstracting connection to the main node.
 #[async_trait]


### PR DESCRIPTION
Decreasing EN concurrency so that it doesn't trigger 429 errors
It's mostly a band-aid until we fix it in a more organized way