### PR TITLE
fix: wrap config values with spaces into quotes

### DIFF
--- a/infrastructure/zk/src/env.ts
+++ b/infrastructure/zk/src/env.ts
@@ -148,7 +148,12 @@ export function mergeInitToEnv() {
     }
     let output = '';
     for (const envVar in env) {
-        output += `${envVar}=${env[envVar]}\n`;
+        let envVal = env[envVar];
+        // wrap the value into double quotes if it has spaces in it
+        if (envVal.indexOf(' ') >= 0) {
+            envVal = '"' + envVal + '"';
+        }
+        output += `${envVar}=${envVal}\n`;
     }
     fs.writeFileSync(process.env.ENV_FILE!, output);
 }


### PR DESCRIPTION
If a config value with spaces is not wrapped into double quotes, such config will get loaded by the server incorrectly leading to unpredictable system behaviour.
