### PR TITLE
test: add info about how many instructions it takes to run benchmarks

### DIFF
--- a/.github/workflows/vm-perf-comparison.yml
+++ b/.github/workflows/vm-perf-comparison.yml
@@ -46,6 +46,7 @@ jobs:
           ci_run zk
           ci_run zk compiler system-contracts
           ci_run cargo bench --package vm-benchmark --bench iai | tee base-iai
+          ci_run cargo run --release --package vm-benchmark --bin instruction-counts | tee base-opcodes
           ci_run yarn workspace system-contracts clean
 
       - name: checkout PR
@@ -57,10 +58,11 @@ jobs:
           ci_run zk
           ci_run zk compiler system-contracts
           ci_run cargo bench --package vm-benchmark --bench iai | tee pr-iai
+          ci_run cargo run --release --package vm-benchmark --bin instruction-counts | tee pr-opcodes
 
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "speedup<<$EOF" >> $GITHUB_OUTPUT
-          ci_run cargo run --package vm-benchmark --release --bin compare_iai_results base-iai pr-iai >> $GITHUB_OUTPUT
+          ci_run cargo run --package vm-benchmark --release --bin compare_iai_results base-iai pr-iai base-opcodes pr-opcodes >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
         id: comparison
 

--- a/.github/workflows/vm-perf-comparison.yml
+++ b/.github/workflows/vm-perf-comparison.yml
@@ -46,7 +46,7 @@ jobs:
           ci_run zk
           ci_run zk compiler system-contracts
           ci_run cargo bench --package vm-benchmark --bench iai | tee base-iai
-          ci_run cargo run --release --package vm-benchmark --bin instruction-counts | tee base-opcodes
+          ci_run cargo run --release --package vm-benchmark --bin instruction-counts | tee base-opcodes || touch base-opcodes
           ci_run yarn workspace system-contracts clean
 
       - name: checkout PR
@@ -58,7 +58,7 @@ jobs:
           ci_run zk
           ci_run zk compiler system-contracts
           ci_run cargo bench --package vm-benchmark --bench iai | tee pr-iai
-          ci_run cargo run --release --package vm-benchmark --bin instruction-counts | tee pr-opcodes
+          ci_run cargo run --release --package vm-benchmark --bin instruction-counts | tee pr-opcodes || touch pr-opcodes
 
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "speedup<<$EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/vm-perf-comparison.yml
+++ b/.github/workflows/vm-perf-comparison.yml
@@ -46,7 +46,7 @@ jobs:
           ci_run zk
           ci_run zk compiler system-contracts
           ci_run cargo bench --package vm-benchmark --bench iai | tee base-iai
-          ci_run cargo run --release --package vm-benchmark --bin instruction-counts | tee base-opcodes || touch base-opcodes
+          ci_run cd core/tests/vm_benchmark && cargo run --release --bin instruction-counts | tee base-opcodes || touch base-opcodes
           ci_run yarn workspace system-contracts clean
 
       - name: checkout PR
@@ -58,7 +58,7 @@ jobs:
           ci_run zk
           ci_run zk compiler system-contracts
           ci_run cargo bench --package vm-benchmark --bench iai | tee pr-iai
-          ci_run cargo run --release --package vm-benchmark --bin instruction-counts | tee pr-opcodes || touch pr-opcodes
+          ci_run cd core/tests/vm_benchmark && cargo run --release --bin instruction-counts | tee pr-opcodes || touch pr-opcodes
 
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "speedup<<$EOF" >> $GITHUB_OUTPUT

--- a/core/tests/vm-benchmark/Cargo.toml
+++ b/core/tests/vm-benchmark/Cargo.toml
@@ -37,3 +37,7 @@ path = "src/compare_iai_results.rs"
 [[bin]]
 name = "find-slowest"
 path = "src/find_slowest.rs"
+
+[[bin]]
+name = "instruction-counts"
+path = "src/instruction_counts.rs"

--- a/core/tests/vm-benchmark/harness/src/instruction_counter.rs
+++ b/core/tests/vm-benchmark/harness/src/instruction_counter.rs
@@ -1,0 +1,40 @@
+use std::{cell::RefCell, rc::Rc};
+
+use multivm::{
+    interface::{dyn_tracers::vm_1_4_1::DynTracer, tracer::TracerExecutionStatus},
+    vm_latest::{BootloaderState, HistoryMode, SimpleMemory, VmTracer, ZkSyncVmState},
+};
+use zksync_state::WriteStorage;
+
+pub struct InstructionCounter {
+    count: usize,
+    output: Rc<RefCell<usize>>,
+}
+
+impl InstructionCounter {
+    pub fn new(output: Rc<RefCell<usize>>) -> Self {
+        Self { count: 0, output }
+    }
+}
+
+impl<S: WriteStorage, H: HistoryMode> VmTracer<S, H> for InstructionCounter {
+    fn finish_cycle(
+        &mut self,
+        _state: &mut ZkSyncVmState<S, H>,
+        _bootloader_state: &mut BootloaderState,
+    ) -> TracerExecutionStatus {
+        self.count += 1;
+        TracerExecutionStatus::Continue
+    }
+
+    fn after_vm_execution(
+        &mut self,
+        _state: &mut ZkSyncVmState<S, H>,
+        _bootloader_state: &BootloaderState,
+        _stop_reason: multivm::interface::tracer::VmExecutionStopReason,
+    ) {
+        *self.output.borrow_mut() = self.count;
+    }
+}
+
+impl<S: WriteStorage, H: HistoryMode> DynTracer<S, SimpleMemory<H>> for InstructionCounter {}

--- a/core/tests/vm-benchmark/harness/src/instruction_counter.rs
+++ b/core/tests/vm-benchmark/harness/src/instruction_counter.rs
@@ -11,6 +11,7 @@ pub struct InstructionCounter {
     output: Rc<RefCell<usize>>,
 }
 
+/// A tracer that counts the number of instructions executed by the VM.
 impl InstructionCounter {
     pub fn new(output: Rc<RefCell<usize>>) -> Self {
         Self { count: 0, output }

--- a/core/tests/vm-benchmark/src/compare_iai_results.rs
+++ b/core/tests/vm-benchmark/src/compare_iai_results.rs
@@ -1,32 +1,50 @@
-use std::{collections::HashMap, fs::File, io::BufReader};
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{BufRead, BufReader},
+};
 
 use vm_benchmark::parse_iai::parse_iai;
 
 fn main() {
-    let args: [String; 2] = std::env::args()
+    let [iai_before, iai_after, opcodes_before, opcodes_after] = std::env::args()
         .skip(1)
         .take(2)
         .collect::<Vec<_>>()
         .try_into()
-        .expect("expected two arguments");
+        .expect("expected four arguments");
 
-    let before = get_name_to_cycles(&args[0]);
-    let after = get_name_to_cycles(&args[1]);
+    let iai_before = get_name_to_cycles(&iai_before);
+    let iai_after = get_name_to_cycles(&iai_after);
+    let opcodes_before = get_name_to_opcodes(&opcodes_before);
+    let opcodes_after = get_name_to_opcodes(&opcodes_after);
 
-    let mut header_written = false;
+    let mut nonzero_diff = false;
 
-    for (name, cycles) in before {
-        if let Some(&cycles2) = after.get(&name) {
-            let change = ((cycles2 as f64) - (cycles as f64)) / (cycles as f64);
-            if change.abs() > 0.02 {
-                if !header_written {
-                    println!("Benchmark name | Difference in runtime\n--- | ---");
-                    header_written = true;
+    for (name, cycles) in iai_before {
+        if let Some(&cycles2) = iai_after.get(&name) {
+            let cycles_diff = ((cycles2 as f64) - (cycles as f64)) / (cycles as f64);
+            let opcodes_diff = opcodes_after.get(&name).cloned().unwrap_or_default()
+                - opcodes_before.get(&name).cloned().unwrap_or_default();
+            if cycles_diff.abs() > 0.02 {
+                // write the header before writing the first line of diff
+                if !nonzero_diff {
+                    println!("Benchmark name | change in estimated runtime | change in number of opcodes executed \n--- | --- | ---");
+                    nonzero_diff = true;
                 }
 
-                println!("{} | {:+.1}%", name, change * 100.0);
+                println!(
+                    "{} | {:+.1}% | {:+}",
+                    name,
+                    cycles_diff * 100.0,
+                    opcodes_diff
+                );
             }
         }
+    }
+
+    if nonzero_diff {
+        println!("\n Changes in number of opcodes executed indicate that the gas price of the benchmark has changed, which causes it run out of gas at a different time. Or that it is behaving completely differently.");
     }
 }
 
@@ -36,4 +54,18 @@ fn get_name_to_cycles(filename: &str) -> HashMap<String, u64> {
     ))
     .map(|x| (x.name, x.cycles))
     .collect()
+}
+
+fn get_name_to_opcodes(filename: &str) -> HashMap<String, u64> {
+    BufReader::new(File::open(filename).expect("failed to open file"))
+        .lines()
+        .map(|line| {
+            let line = line.unwrap();
+            let mut it = line.split_whitespace();
+            (
+                it.next().unwrap().to_string(),
+                it.next().unwrap().parse().unwrap(),
+            )
+        })
+        .collect()
 }

--- a/core/tests/vm-benchmark/src/compare_iai_results.rs
+++ b/core/tests/vm-benchmark/src/compare_iai_results.rs
@@ -9,7 +9,7 @@ use vm_benchmark::parse_iai::parse_iai;
 fn main() {
     let [iai_before, iai_after, opcodes_before, opcodes_after] = std::env::args()
         .skip(1)
-        .take(2)
+        .take(4)
         .collect::<Vec<_>>()
         .try_into()
         .expect("expected four arguments");

--- a/core/tests/vm-benchmark/src/instruction_counts.rs
+++ b/core/tests/vm-benchmark/src/instruction_counts.rs
@@ -1,0 +1,16 @@
+use vm_benchmark_harness::{cut_to_allowed_bytecode_size, get_deploy_tx, BenchmarkingVm};
+
+fn main() {
+    for path in std::fs::read_dir("deployment_benchmarks").unwrap() {
+        let path = path.unwrap().path();
+
+        let test_contract = std::fs::read(&path).expect("failed to read file");
+
+        let code = cut_to_allowed_bytecode_size(&test_contract).unwrap();
+        let tx = get_deploy_tx(code);
+
+        let name = path.file_name().unwrap().to_str().unwrap();
+
+        println!("{} {}", name, BenchmarkingVm::new().instruction_count(&tx));
+    }
+}

--- a/core/tests/vm-benchmark/src/instruction_counts.rs
+++ b/core/tests/vm-benchmark/src/instruction_counts.rs
@@ -1,3 +1,5 @@
+//! Runs all benchmarks and prints out the number of zkEVM opcodes each one executed.
+
 use vm_benchmark_harness::{cut_to_allowed_bytecode_size, get_deploy_tx, BenchmarkingVm};
 
 fn main() {


### PR DESCRIPTION
This makes the automatic VM performance reporting also report changes in number of instructions executed. Those changes can be used to identify cases where performance hasn't actually changed but gas prices have changed.