### PR TITLE
fix(ci): Fix syntax error in `build-docker-image-from-tag` workflow yaml

### DIFF
--- a/.github/workflows/build-docker-from-tag.yml
+++ b/.github/workflows/build-docker-from-tag.yml
@@ -29,8 +29,6 @@ jobs:
       prover_fri_gpu_key_id: ${{ steps.extract-prover-fri-setup-key-ids.outputs.gpu_short_commit_sha }}
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
-        with:
-
       - name: Generate output with git tag
         id: set
         run: |


### PR DESCRIPTION
This prevents us from releasing a new version. failed build: https://github.com/matter-labs/zksync-era/actions/runs/8116928319