### PR TITLE
fix(consistency_checker): Fix consistency checker for large pubdata

### DIFF
--- a/core/lib/zksync_core/src/consistency_checker/mod.rs
+++ b/core/lib/zksync_core/src/consistency_checker/mod.rs
@@ -8,7 +8,10 @@ use zksync_dal::{ConnectionPool, StorageProcessor};
 use zksync_eth_client::{clients::QueryClient, Error as L1ClientError, EthInterface};
 use zksync_health_check::{Health, HealthStatus, HealthUpdater, ReactiveHealthCheck};
 use zksync_l1_contract_interface::{
-    i_executor::{commit::kzg::KzgSettings, structures::CommitBatchInfo},
+    i_executor::{
+        commit::kzg::{KzgSettings, ZK_SYNC_BYTES_PER_BLOB},
+        structures::CommitBatchInfo,
+    },
     Tokenizable,
 };
 use zksync_types::{pubdata_da::PubdataDA, web3::ethabi, L1BatchNumber, H256};
@@ -183,9 +186,18 @@ impl LocalL1BatchCommitData {
             return Ok(None);
         }
 
-        // Encoding data using `PubdataDA::Blobs` or `PubdataDA::Blobs` never panics because we check
-        // protocol version in `CommitBatchInfo`.
-        let variants = vec![PubdataDA::Calldata, PubdataDA::Blobs];
+        // Encoding data using `PubdataDA::Blobs` never panics.
+        let mut variants = vec![PubdataDA::Blobs];
+        // For `PubdataDA::Calldata` it's required that the pubdata fits into a single blob.
+        let pubdata_len = l1_batch
+            .header
+            .pubdata_input
+            .as_ref()
+            .unwrap_or(&l1_batch.construct_pubdata())
+            .len();
+        if pubdata_len <= ZK_SYNC_BYTES_PER_BLOB {
+            variants.push(PubdataDA::Calldata);
+        }
 
         // Iterate over possible `PubdataDA` used for encoding `CommitBatchInfo`.
         let l1_commit_data_variants = variants


### PR DESCRIPTION
## What ❔

ConsistencyChecker shouldn't try enconding pubdata in Calldata mode, if pubdata doesn't fit into one blob

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
