### PR TITLE
feat(Validium): Commit data generation mode cross-check in EN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8685,6 +8685,7 @@ dependencies = [
  "zksync_contracts",
  "zksync_core",
  "zksync_dal",
+ "zksync_eth_client",
  "zksync_health_check",
  "zksync_object_store",
  "zksync_snapshots_applier",

--- a/core/bin/external_node/Cargo.toml
+++ b/core/bin/external_node/Cargo.toml
@@ -14,6 +14,7 @@ publish = false # We don't want to publish our binaries.
 zksync_core = { path = "../../lib/zksync_core" }
 zksync_dal = { path = "../../lib/dal" }
 zksync_config = { path = "../../lib/config" }
+zksync_eth_client = { path = "../../lib/eth_client" }
 zksync_storage = { path = "../../lib/storage" }
 zksync_utils = { path = "../../lib/utils" }
 zksync_state = { path = "../../lib/state" }

--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -258,7 +258,7 @@ async fn init_tasks(
         }
     };
     let consistency_checker = ConsistencyChecker::new(
-        eth_client,
+        Box::new(eth_client),
         10, // TODO (BFT-97): Make it a part of a proper EN config
         singleton_pool_builder
             .build()

--- a/core/lib/zksync_core/src/consistency_checker/mod.rs
+++ b/core/lib/zksync_core/src/consistency_checker/mod.rs
@@ -209,7 +209,7 @@ impl ConsistencyChecker {
     const DEFAULT_SLEEP_INTERVAL: Duration = Duration::from_secs(5);
 
     pub fn new(
-        l1_client: impl EthInterface,
+        l1_client: Box<dyn EthInterface>,
         max_batches_to_recheck: u32,
         pool: ConnectionPool,
         l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
@@ -219,7 +219,7 @@ impl ConsistencyChecker {
             contract: zksync_contracts::zksync_contract(),
             max_batches_to_recheck,
             sleep_interval: Self::DEFAULT_SLEEP_INTERVAL,
-            l1_client: Box::new(l1_client),
+            l1_client,
             event_handler: Box::new(health_updater),
             l1_data_mismatch_behavior: L1DataMismatchBehavior::Log,
             pool,

--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -30,7 +30,7 @@ use zksync_contracts::{governance_contract, BaseSystemContracts};
 use zksync_dal::{healthcheck::ConnectionPoolHealthCheck, ConnectionPool};
 use zksync_eth_client::{
     clients::{PKSigningClient, QueryClient},
-    CallFunctionArgs, Error as EthClientError, EthInterface,
+    CallFunctionArgs, EthInterface,
 };
 use zksync_health_check::{AppHealthCheck, HealthStatus, ReactiveHealthCheck};
 use zksync_object_store::{ObjectStore, ObjectStoreFactory};
@@ -44,7 +44,7 @@ use zksync_types::{
     },
     protocol_version::{L1VerifierConfig, VerifierParams},
     system_contracts::get_system_smart_contracts,
-    web3::{contract::tokens::Detokenize, ethabi},
+    web3::contract::tokens::Detokenize,
     L2ChainId, PackedEthSignature, ProtocolVersionId,
 };
 
@@ -54,8 +54,7 @@ use crate::{
         execution_sandbox::{VmConcurrencyBarrier, VmConcurrencyLimiter},
         healthcheck::HealthCheckHandle,
         tx_sender::{ApiContracts, TxSender, TxSenderBuilder, TxSenderConfig},
-        web3,
-        web3::{state::InternalApiConfig, ApiServerHandles, Namespace},
+        web3::{self, state::InternalApiConfig, ApiServerHandles, Namespace},
     },
     basic_witness_input_producer::BasicWitnessInputProducer,
     commitment_generator::CommitmentGenerator,
@@ -79,6 +78,7 @@ use crate::{
     state_keeper::{
         create_state_keeper, MempoolFetcher, MempoolGuard, MiniblockSealer, SequencerSealer,
     },
+    utils::ensure_l1_batch_commit_data_generation_mode,
 };
 
 pub mod api_server;
@@ -101,7 +101,7 @@ pub mod reorg_detector;
 pub mod state_keeper;
 pub mod sync_layer;
 pub mod temp_config_store;
-mod utils;
+pub mod utils;
 
 /// Inserts the initial information about zkSync tokens into the database.
 pub async fn genesis_init(
@@ -296,53 +296,6 @@ impl FromStr for Components {
             other => Err(format!("{} is not a valid component name", other)),
         }
     }
-}
-
-async fn ensure_l1_batch_commit_data_generation_mode(
-    state_keeper_config: &StateKeeperConfig,
-    contracts_config: &ContractsConfig,
-    eth_client: &impl EthInterface,
-) -> anyhow::Result<()> {
-    let selected_l1_batch_commit_data_generator_mode = state_keeper_config
-        .l1_batch_commit_data_generator_mode
-        .clone();
-    match get_pubdata_pricing_mode(&contracts_config, eth_client).await {
-        // Getters contract support getPubdataPricingMode method
-        Ok(l1_contract_pubdata_pricing_mode) => {
-            let l1_contract_batch_commitment_mode =
-                L1BatchCommitDataGeneratorMode::from_tokens(l1_contract_pubdata_pricing_mode)
-                    .context(
-                        "Unable to parse L1BatchCommitDataGeneratorMode received from L1 contract",
-                    )?;
-
-            // contracts mode == server mode
-            anyhow::ensure!(
-                l1_contract_batch_commitment_mode == selected_l1_batch_commit_data_generator_mode,
-                "The selected L1BatchCommitDataGeneratorMode ({:?}) does not match the commitment mode used on L1 contract ({:?})",
-                selected_l1_batch_commit_data_generator_mode,
-                l1_contract_batch_commitment_mode
-            );
-
-            Ok(())
-        }
-        // Getters contract does not support getPubdataPricingMode method
-        Err(EthClientError::Contract(_)) => {
-            tracing::warn!("Getters contract does not support getPubdataPricingMode method");
-            Ok(())
-        }
-        Err(err) => anyhow::bail!(err),
-    }
-}
-
-async fn get_pubdata_pricing_mode(
-    contracts_config: &ContractsConfig,
-    eth_client: &impl EthInterface,
-) -> Result<Vec<ethabi::Token>, EthClientError> {
-    let args = CallFunctionArgs::new("getPubdataPricingMode", ()).for_contract(
-        contracts_config.diamond_proxy_addr,
-        zksync_contracts::zksync_contract(),
-    );
-    eth_client.call_contract_function(args).await
 }
 
 pub async fn initialize_components(
@@ -686,8 +639,8 @@ pub async fn initialize_components(
             .context("state_keeper_config")?;
 
         ensure_l1_batch_commit_data_generation_mode(
-            &state_keeper_config,
-            &contracts_config,
+            state_keeper_config.l1_batch_commit_data_generator_mode,
+            contracts_config.diamond_init_addr,
             &eth_client,
         )
         .await?;


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

This PR:
- Adds a cross-check of the commit data generation mode (Validium or Rollup) between the deployed L1 contracts and the config set in the server.
- Updates the ConsistencyChecker `new` method to receive an `impl EthInterface` instead of receiving an Ethereum client URL to instantiate one.
- Moves the function that contains the main logic to `utils` module given that it is used both in EN and in `zksync_core`.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

The mode was being cross-checked in the server, but it should also be cross-checked in the EN.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.

## Aditional Information

Unit tests for the function in question will be added in the `zksync_core` module in another PR
