### PR TITLE
fix(eth_sender): makes pubdata sending mode config backwards compatible

### DIFF
--- a/core/lib/config/src/configs/eth_sender.rs
+++ b/core/lib/config/src/configs/eth_sender.rs
@@ -35,7 +35,7 @@ impl ETHSenderConfig {
                 l1_batch_min_age_before_execute_seconds: None,
                 max_acceptable_priority_fee_in_gwei: 100000000000,
                 proof_loading_mode: ProofLoadingMode::OldProofFromDb,
-                pubdata_sending_mode: PubdataSendingMode::Calldata,
+                pubdata_sending_mode: Some(PubdataSendingMode::Calldata),
             },
             gas_adjuster: GasAdjusterConfig {
                 default_priority_fee_per_gas: 1000000000,
@@ -67,9 +67,8 @@ pub enum ProofLoadingMode {
     FriProofFromGcs,
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Default)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
 pub enum PubdataSendingMode {
-    #[default]
     Calldata,
     Blobs,
 }
@@ -109,7 +108,7 @@ pub struct SenderConfig {
     pub proof_loading_mode: ProofLoadingMode,
 
     /// The mode in which we send pubdata, either Calldata or Blobs
-    pub pubdata_sending_mode: PubdataSendingMode,
+    pub pubdata_sending_mode: Option<PubdataSendingMode>,
 }
 
 impl SenderConfig {

--- a/core/lib/config/src/testonly.rs
+++ b/core/lib/config/src/testonly.rs
@@ -490,7 +490,7 @@ impl RandomConfig for configs::eth_sender::SenderConfig {
             l1_batch_min_age_before_execute_seconds: g.gen(),
             max_acceptable_priority_fee_in_gwei: g.gen(),
             proof_loading_mode: g.gen(),
-            pubdata_sending_mode: PubdataSendingMode::Calldata,
+            pubdata_sending_mode: Some(PubdataSendingMode::Calldata),
         }
     }
 }

--- a/core/lib/env_config/src/eth_sender.rs
+++ b/core/lib/env_config/src/eth_sender.rs
@@ -26,9 +26,7 @@ impl FromEnv for GasAdjusterConfig {
 
 #[cfg(test)]
 mod tests {
-    use zksync_config::configs::eth_sender::{
-        ProofLoadingMode, ProofSendingMode, PubdataSendingMode,
-    };
+    use zksync_config::configs::eth_sender::{ProofLoadingMode, ProofSendingMode};
 
     use super::*;
     use crate::test_utils::{hash, EnvMutex};
@@ -56,7 +54,7 @@ mod tests {
                 l1_batch_min_age_before_execute_seconds: Some(1000),
                 max_acceptable_priority_fee_in_gwei: 100_000_000_000,
                 proof_loading_mode: ProofLoadingMode::OldProofFromDb,
-                pubdata_sending_mode: Some(PubdataSendingMode::Calldata),
+                pubdata_sending_mode: None,
             },
             gas_adjuster: GasAdjusterConfig {
                 default_priority_fee_per_gas: 20000000000,

--- a/core/lib/env_config/src/eth_sender.rs
+++ b/core/lib/env_config/src/eth_sender.rs
@@ -56,7 +56,7 @@ mod tests {
                 l1_batch_min_age_before_execute_seconds: Some(1000),
                 max_acceptable_priority_fee_in_gwei: 100_000_000_000,
                 proof_loading_mode: ProofLoadingMode::OldProofFromDb,
-                pubdata_sending_mode: PubdataSendingMode::Calldata,
+                pubdata_sending_mode: Some(PubdataSendingMode::Calldata),
             },
             gas_adjuster: GasAdjusterConfig {
                 default_priority_fee_per_gas: 20000000000,
@@ -106,7 +106,6 @@ mod tests {
             ETH_SENDER_SENDER_L1_BATCH_MIN_AGE_BEFORE_EXECUTE_SECONDS="1000"
             ETH_SENDER_SENDER_MAX_ACCEPTABLE_PRIORITY_FEE_IN_GWEI="100000000000"
             ETH_SENDER_SENDER_PROOF_LOADING_MODE="OldProofFromDb"
-            ETH_SENDER_SENDER_PUBDATA_SENDING_MODE="Calldata"
         "#;
         lock.set_env(config);
 

--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -23,6 +23,7 @@ use zksync_config::{
         },
         contracts::ProverAtGenesis,
         database::{MerkleTreeConfig, MerkleTreeMode},
+        eth_sender::PubdataSendingMode,
     },
     ApiConfig, ContractsConfig, DBConfig, ETHSenderConfig, PostgresConfig,
 };
@@ -372,7 +373,10 @@ pub async fn initialize_components(
     let mut gas_adjuster = GasAdjusterSingleton::new(
         eth_client_config.web3_url.clone(),
         gas_adjuster_config,
-        eth_sender_config.sender.pubdata_sending_mode,
+        eth_sender_config
+            .sender
+            .pubdata_sending_mode
+            .unwrap_or(PubdataSendingMode::Calldata),
     );
 
     let (stop_sender, stop_receiver) = watch::channel(false);
@@ -660,7 +664,11 @@ pub async fn initialize_components(
                 eth_sender.sender.clone(),
                 store_factory.create_store().await,
                 eth_client_blobs_addr.is_some(),
-                eth_sender.sender.pubdata_sending_mode.into(),
+                eth_sender
+                    .sender
+                    .pubdata_sending_mode
+                    .unwrap_or(PubdataSendingMode::Calldata)
+                    .into(),
                 kzg_settings.clone(),
             ),
             Arc::new(eth_client),


### PR DESCRIPTION
## What ❔

This config variable has become non-`Option`-al breaking all existing configs. This change makes this new config variable backwards compatible with existing configs.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
