### PR TITLE
feat: Enhance requireMsgValue function with tolerance range

### DIFF
--- a/core/tests/ts-integration/contracts/context/context.sol
+++ b/core/tests/ts-integration/contracts/context/context.sol
@@ -35,8 +35,8 @@ contract Context {
         return block.basefee;
     }
 
-    function requireMsgValue(uint256 _requiredValue) external payable {
-        require(msg.value == _requiredValue);
+    function requireMsgValue(uint256 _requiredValue, uint256 _tolerance) external payable {
+        require(msg.value >= _requiredValue - _tolerance && msg.value <= _requiredValue + _tolerance, "msg.value is out of range");
     }
 
     uint256 public valueOnCreate;


### PR DESCRIPTION
This commit modifies the `requireMsgValue` function to provide more flexibility in value comparison by introducing a tolerance range. The function now accepts an additional parameter `_tolerance` and checks if the `msg.value` falls within the range of `_requiredValue - _tolerance` and `_requiredValue + _tolerance`. This enhancement allows for small deviations in the value sent with the message, making the contract more accommodating to potential value fluctuations or rounding errors.

## What ❔

This PR enhances the requireMsgValue function in the Context contract by introducing a tolerance range for value comparison. It adds a new parameter _tolerance to the function, which is used to define an acceptable range around the _requiredValue. The function now checks if the msg.value falls within the range of _requiredValue - _tolerance and _requiredValue + _tolerance.


## Why ❔

The previous implementation of the requireMsgValue function strictly required the msg.value to be equal to the _requiredValue. While this ensures an exact match, it can be too restrictive in certain scenarios where small deviations or rounding errors might occur. By introducing a tolerance range, the function becomes more flexible and can accommodate these potential variations, making the contract more robust and user-friendly.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).

- [x] Tests for the changes have been added / updated.

- [x] Documentation comments have been added / updated.

- [x] Code has been formatted via zk fmt and zk lint.

- [x] Spellcheck has been run via zk spellcheck.

- [x] Linkcheck has been run via zk linkcheck.
