### PR TITLE
perf(db): Remove obsolete indexes

### DIFF
--- a/core/lib/dal/migrations/20240306155535_remove_obsolete_indexes.down.sql
+++ b/core/lib/dal/migrations/20240306155535_remove_obsolete_indexes.down.sql
@@ -1,0 +1,4 @@
+CREATE INDEX IF NOT EXISTS events_tx_initiator_address_idx
+    ON events (tx_initiator_address);
+CREATE INDEX IF NOT EXISTS transactions_contract_address_idx
+    ON transactions (contract_address);

--- a/core/lib/dal/migrations/20240306155535_remove_obsolete_indexes.up.sql
+++ b/core/lib/dal/migrations/20240306155535_remove_obsolete_indexes.up.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS transactions_contract_address_idx;
+DROP INDEX IF EXISTS events_tx_initiator_address;


### PR DESCRIPTION
## What ❔

Migration that removes `transactions_contract_address_idx`, `events_tx_initiator_address`

## Why ❔

They are not used

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
