### PR TITLE
chore: Replace  test harness with just opcode_defs in constants generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6705,7 +6705,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "zkevm_test_harness 1.3.3",
+ "zkevm_opcode_defs 1.4.1",
  "zksync_contracts",
  "zksync_state",
  "zksync_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6705,7 +6705,6 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "zkevm_opcode_defs 1.4.1",
  "zksync_contracts",
  "zksync_state",
  "zksync_types",

--- a/core/bin/system-constants-generator/Cargo.toml
+++ b/core/bin/system-constants-generator/Cargo.toml
@@ -16,8 +16,8 @@ zksync_types = { path = "../../lib/types" }
 zksync_utils = { path = "../../lib/utils" }
 zksync_contracts = { path = "../../lib/contracts" }
 multivm = { path = "../../lib/multivm" }
-zkevm_test_harness_1_3_3 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3", package = "zkevm_test_harness" }
 
+zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs.git", branch = "v1.4.1"}
 codegen = "0.2.0"
 
 serde = "1.0"

--- a/core/bin/system-constants-generator/Cargo.toml
+++ b/core/bin/system-constants-generator/Cargo.toml
@@ -17,7 +17,6 @@ zksync_utils = { path = "../../lib/utils" }
 zksync_contracts = { path = "../../lib/contracts" }
 multivm = { path = "../../lib/multivm" }
 
-zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs.git", branch = "v1.4.1"}
 codegen = "0.2.0"
 
 serde = "1.0"

--- a/core/bin/system-constants-generator/README.md
+++ b/core/bin/system-constants-generator/README.md
@@ -1,0 +1,3 @@
+# Tool used to regenerate the constants
+
+We use this tool to regenerate the constants (mostly for gas), that are later included in multiple system contracts.

--- a/core/bin/system-constants-generator/src/main.rs
+++ b/core/bin/system-constants-generator/src/main.rs
@@ -6,7 +6,7 @@ use multivm::{
     vm_latest::constants::MAX_VM_PUBDATA_PER_BATCH,
 };
 use serde::{Deserialize, Serialize};
-use zkevm_test_harness_1_3_3::zk_evm::zkevm_opcode_defs::{
+use zkevm_opcode_defs::{
     circuit_prices::{
         ECRECOVER_CIRCUIT_COST_IN_ERGS, KECCAK256_CIRCUIT_COST_IN_ERGS, SHA256_CIRCUIT_COST_IN_ERGS,
     },

--- a/core/bin/system-constants-generator/src/main.rs
+++ b/core/bin/system-constants-generator/src/main.rs
@@ -13,7 +13,6 @@ use multivm::{
     },
 };
 use serde::{Deserialize, Serialize};
-
 use zksync_types::{
     IntrinsicSystemGasConstants, ProtocolVersionId, GUARANTEED_PUBDATA_IN_TX,
     L1_GAS_PER_PUBDATA_BYTE, MAX_NEW_FACTORY_DEPS, REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE,

--- a/core/bin/system-constants-generator/src/main.rs
+++ b/core/bin/system-constants-generator/src/main.rs
@@ -4,14 +4,16 @@ use codegen::{Block, Scope};
 use multivm::{
     utils::{get_bootloader_encoding_space, get_bootloader_max_txs_in_batch},
     vm_latest::constants::MAX_VM_PUBDATA_PER_BATCH,
+    zk_evm_latest::zkevm_opcode_defs::{
+        circuit_prices::{
+            ECRECOVER_CIRCUIT_COST_IN_ERGS, KECCAK256_CIRCUIT_COST_IN_ERGS,
+            SHA256_CIRCUIT_COST_IN_ERGS,
+        },
+        system_params::MAX_TX_ERGS_LIMIT,
+    },
 };
 use serde::{Deserialize, Serialize};
-use zkevm_opcode_defs::{
-    circuit_prices::{
-        ECRECOVER_CIRCUIT_COST_IN_ERGS, KECCAK256_CIRCUIT_COST_IN_ERGS, SHA256_CIRCUIT_COST_IN_ERGS,
-    },
-    system_params::MAX_TX_ERGS_LIMIT,
-};
+
 use zksync_types::{
     IntrinsicSystemGasConstants, ProtocolVersionId, GUARANTEED_PUBDATA_IN_TX,
     L1_GAS_PER_PUBDATA_BYTE, MAX_NEW_FACTORY_DEPS, REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE,

--- a/core/bin/system-constants-generator/src/utils.rs
+++ b/core/bin/system-constants-generator/src/utils.rs
@@ -323,7 +323,8 @@ pub(super) fn execute_user_txs_in_test_gas_vm(
         if !accept_failure {
             assert!(
                 !tx_execution_result.result.is_failed(),
-                "A transaction has failed"
+                "A transaction has failed: {:?}",
+                tx_execution_result.result
             );
         }
     }


### PR DESCRIPTION
## What ❔

* Replacing old evm_test_harness with opcode defs


## Why ❔

* To improve compilation speed, and not depend on unneeded methods.
