### PR TITLE
feat: Start using a new test harness interface without generics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,7 +1234,7 @@ dependencies = [
 [[package]]
 name = "circuit_definitions"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#aa09f683a62e9ceeb457272909625f49f413f9d9"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#b91defc8bccff6275db2416323a096dcb74a4dff"
 dependencies = [
  "crossbeam 0.8.2",
  "derivative",
@@ -8080,7 +8080,7 @@ dependencies = [
 [[package]]
 name = "zkevm-assembly"
 version = "1.3.2"
-source = "git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.4.1#50282016d01bd2fd147021dd558209778db2268b"
+source = "git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.4.1#e381e5cc22c0c7ed95b50a73a402e7693c3e0824"
 dependencies = [
  "env_logger 0.9.3",
  "hex",
@@ -8259,7 +8259,7 @@ dependencies = [
 [[package]]
 name = "zkevm_test_harness"
 version = "1.4.2"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#aa09f683a62e9ceeb457272909625f49f413f9d9"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#b91defc8bccff6275db2416323a096dcb74a4dff"
 dependencies = [
  "bincode",
  "circuit_definitions 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2)",

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -4929,7 +4929,7 @@ dependencies = [
 [[package]]
 name = "shivini"
 version = "0.2.0"
-source = "git+https://github.com/matter-labs/era-shivini.git?branch=v1.4.2#d006620f1afe34d2f6e22b463606901ed75e48b9"
+source = "git+https://github.com/matter-labs/era-shivini.git?branch=v1.4.2#11d9882896874b0411376747b10ddbab56014f0d"
 dependencies = [
  "bincode",
  "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "circuit_definitions"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#d9da285c2e8a5fedddd2e9c2a893769ebd12a6ed"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#b91defc8bccff6275db2416323a096dcb74a4dff"
 dependencies = [
  "crossbeam 0.8.4",
  "derivative",
@@ -6698,7 +6698,7 @@ dependencies = [
 [[package]]
 name = "zkevm-assembly"
 version = "1.3.2"
-source = "git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.4.1#50282016d01bd2fd147021dd558209778db2268b"
+source = "git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.4.1#e381e5cc22c0c7ed95b50a73a402e7693c3e0824"
 dependencies = [
  "env_logger 0.9.3",
  "hex",
@@ -6877,7 +6877,7 @@ dependencies = [
 [[package]]
 name = "zkevm_test_harness"
 version = "1.4.2"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#d9da285c2e8a5fedddd2e9c2a893769ebd12a6ed"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#b91defc8bccff6275db2416323a096dcb74a4dff"
 dependencies = [
  "bincode",
  "circuit_definitions 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2)",
@@ -6885,7 +6885,7 @@ dependencies = [
  "crossbeam 0.8.4",
  "curl",
  "derivative",
- "env_logger 0.9.3",
+ "env_logger 0.11.2",
  "hex",
  "lazy_static",
  "rand 0.4.6",

--- a/prover/prover_fri/src/prover_job_processor.rs
+++ b/prover/prover_fri/src/prover_job_processor.rs
@@ -122,7 +122,7 @@ impl Prover {
 
     fn prove_eip4844(
         job_id: u32,
-        circuit: EIP4844Circuit<GoldilocksField, ZkSyncDefaultRoundFunction>,
+        circuit: EIP4844Circuit,
         artifact: Arc<GoldilocksProverSetupData>,
     ) -> FriProofWrapper {
         let worker = Worker::new();
@@ -195,11 +195,7 @@ impl Prover {
 
     fn prove_base_layer(
         job_id: u32,
-        circuit: ZkSyncBaseLayerCircuit<
-            GoldilocksField,
-            VmWitnessOracle<GoldilocksField>,
-            ZkSyncDefaultRoundFunction,
-        >,
+        circuit: ZkSyncBaseLayerCircuit,
         _config: Arc<FriProverConfig>,
         artifact: Arc<GoldilocksProverSetupData>,
     ) -> FriProofWrapper {

--- a/prover/prover_fri/src/prover_job_processor.rs
+++ b/prover/prover_fri/src/prover_job_processor.rs
@@ -12,16 +12,13 @@ use zksync_env_config::FromEnv;
 use zksync_object_store::ObjectStore;
 use zksync_prover_fri_types::{
     circuit_definitions::{
-        aux_definitions::witness_oracle::VmWitnessOracle,
         base_layer_proof_config,
-        boojum::{
-            cs::implementations::pow::NoPow, field::goldilocks::GoldilocksField, worker::Worker,
-        },
+        boojum::{cs::implementations::pow::NoPow, worker::Worker},
         circuit_definitions::{
             base_layer::{ZkSyncBaseLayerCircuit, ZkSyncBaseLayerProof},
             recursion_layer::{ZkSyncRecursionLayerProof, ZkSyncRecursiveLayerCircuit},
         },
-        recursion_layer_proof_config, ZkSyncDefaultRoundFunction,
+        recursion_layer_proof_config,
     },
     CircuitWrapper, FriProofWrapper, ProverJob, ProverServiceDataKey,
 };

--- a/prover/prover_fri/src/utils.rs
+++ b/prover/prover_fri/src/utils.rs
@@ -146,8 +146,8 @@ pub fn verify_proof(
             verify_recursion_layer_proof::<NoPow>(recursive_circuit, proof, vk),
             recursive_circuit.numeric_circuit_type(),
         ),
-        CircuitWrapper::Eip4844(circuit) => (
-            verify_eip4844_proof::<NoPow>(circuit, proof, vk),
+        CircuitWrapper::Eip4844(_) => (
+            verify_eip4844_proof::<NoPow>(proof, vk),
             ProverServiceDataKey::eip4844().circuit_id,
         ),
     };

--- a/prover/prover_fri_types/src/lib.rs
+++ b/prover/prover_fri_types/src/lib.rs
@@ -2,7 +2,6 @@ use std::env;
 
 pub use circuit_definitions;
 use circuit_definitions::{
-    aux_definitions::witness_oracle::VmWitnessOracle,
     boojum::{cs::implementations::witness::WitnessVec, field::goldilocks::GoldilocksField},
     circuit_definitions::{
         base_layer::{ZkSyncBaseLayerCircuit, ZkSyncBaseLayerProof, ZkSyncBaseProof},
@@ -14,7 +13,6 @@ use circuit_definitions::{
     zkevm_circuits::scheduler::{
         aux::BaseLayerCircuitType, block_header::BlockAuxilaryOutputWitness,
     },
-    ZkSyncDefaultRoundFunction,
 };
 use zksync_object_store::{serialize_using_bincode, Bucket, StoredObject};
 use zksync_types::{basic_fri_types::AggregationRound, L1BatchNumber};
@@ -29,15 +27,9 @@ pub const EIP_4844_CIRCUIT_ID: u8 = 255;
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum CircuitWrapper {
-    Base(
-        ZkSyncBaseLayerCircuit<
-            GoldilocksField,
-            VmWitnessOracle<GoldilocksField>,
-            ZkSyncDefaultRoundFunction,
-        >,
-    ),
+    Base(ZkSyncBaseLayerCircuit),
     Recursive(ZkSyncRecursiveLayerCircuit),
-    Eip4844(EIP4844Circuit<GoldilocksField, ZkSyncDefaultRoundFunction>),
+    Eip4844(EIP4844Circuit),
 }
 
 impl StoredObject for CircuitWrapper {

--- a/prover/witness_generator/src/basic_circuits.rs
+++ b/prover/witness_generator/src/basic_circuits.rs
@@ -33,7 +33,6 @@ use zksync_prover_fri_types::{
         boojum::{
             field::goldilocks::{GoldilocksExt2, GoldilocksField},
             gadgets::recursion::recursive_tree_hasher::CircuitGoldilocksPoseidon2Sponge,
-            implementations::poseidon2::Poseidon2Goldilocks,
         },
         zkevm_circuits::scheduler::{
             block_header::BlockAuxilaryOutputWitness, input::SchedulerCircuitInstanceWitness,
@@ -66,10 +65,8 @@ use crate::{
     },
 };
 
-type Eip4844Circuit = ZkSyncUniformCircuitInstance<
-    GoldilocksField,
-    EIP4844InstanceSynthesisFunction<GoldilocksField, Poseidon2Goldilocks>,
->;
+type Eip4844Circuit =
+    ZkSyncUniformCircuitInstance<GoldilocksField, EIP4844InstanceSynthesisFunction>;
 
 type Eip4844Witness = EIP4844OutputDataWitness<GoldilocksField>;
 

--- a/prover/witness_generator/src/utils.rs
+++ b/prover/witness_generator/src/utils.rs
@@ -1,8 +1,7 @@
 use std::io::{BufWriter, Write as _};
 
-use circuit_definitions::{
-    aux_definitions::witness_oracle::VmWitnessOracle,
-    circuit_definitions::{base_layer::ZkSyncBaseLayerCircuit, eip4844::EIP4844Circuit},
+use circuit_definitions::circuit_definitions::{
+    base_layer::ZkSyncBaseLayerCircuit, eip4844::EIP4844Circuit,
 };
 use multivm::utils::get_used_bootloader_memory_bytes;
 use once_cell::sync::Lazy;
@@ -20,7 +19,6 @@ use zksync_prover_fri_types::{
         },
         encodings::recursion_request::RecursionQueueSimulator,
         zkevm_circuits::scheduler::input::SchedulerCircuitInstanceWitness,
-        ZkSyncDefaultRoundFunction,
     },
     keys::{AggregationsKey, ClosedFormInputKey, FriCircuitKey},
     CircuitWrapper, FriProofWrapper, EIP_4844_CIRCUIT_ID,
@@ -119,11 +117,7 @@ impl StoredObject for SchedulerPartialInputWrapper {
 
 pub async fn save_circuit(
     block_number: L1BatchNumber,
-    circuit: ZkSyncBaseLayerCircuit<
-        GoldilocksField,
-        VmWitnessOracle<GoldilocksField>,
-        ZkSyncDefaultRoundFunction,
-    >,
+    circuit: ZkSyncBaseLayerCircuit,
     sequence_number: usize,
     object_store: &dyn ObjectStore,
 ) -> (u8, String) {
@@ -144,7 +138,7 @@ pub async fn save_circuit(
 
 pub async fn save_eip_4844_circuit(
     block_number: L1BatchNumber,
-    circuit: EIP4844Circuit<GoldilocksField, ZkSyncDefaultRoundFunction>,
+    circuit: EIP4844Circuit,
     sequence_number: usize,
     object_store: &dyn ObjectStore,
     depth: u16,

--- a/prover/witness_vector_generator/src/generator.rs
+++ b/prover/witness_vector_generator/src/generator.rs
@@ -77,8 +77,6 @@ impl WitnessVectorGenerator {
             }
             CircuitWrapper::Eip4844(circuit) => synthesis::<
                 _,
-                _,
-                _,
                 StCircuitResolver<GoldilocksField, <ProvingCSConfig as CSConfig>::ResolverConfig>,
             >(circuit, &finalization_hints),
         };


### PR DESCRIPTION
## What ❔

* Start using the new version of the 1.4.2 test harness, that doesn't export generics

## Why ❔

* This should improve the compilation speed.
