### PR TITLE
feat: Moving 1.4.x to use the circuit_api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,20 +1206,6 @@ dependencies = [
 [[package]]
 name = "circuit_definitions"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0#aff36380e6a740f7286c9c522e1416b8d38327ce"
-dependencies = [
- "crossbeam 0.8.2",
- "derivative",
- "seq-macro",
- "serde",
- "snark_wrapper",
- "zk_evm 1.4.0",
- "zkevm_circuits 1.4.0",
-]
-
-[[package]]
-name = "circuit_definitions"
-version = "0.1.0"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1#4c6b8996f3f2bfef96ce193a5819b2e31a180830"
 dependencies = [
  "crossbeam 0.8.2",
@@ -1246,6 +1232,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "circuit_encodings"
+version = "0.1.40"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.0_improve#fd229d101e5bf1dd0467ed7846bc158b49a40135"
+dependencies = [
+ "derivative",
+ "serde",
+ "zk_evm 1.4.0",
+ "zkevm_circuits 1.4.0",
+]
+
+[[package]]
 name = "circuit_sequencer_api"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.3.3#aba8f2a32767b79838aca7d7d00d9d23144df32f"
@@ -1255,6 +1252,19 @@ dependencies = [
  "rayon",
  "serde",
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.3)",
+]
+
+[[package]]
+name = "circuit_sequencer_api"
+version = "0.1.40"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.0_improve#fd229d101e5bf1dd0467ed7846bc158b49a40135"
+dependencies = [
+ "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
+ "circuit_encodings",
+ "derivative",
+ "rayon",
+ "serde",
+ "zk_evm 1.4.0",
 ]
 
 [[package]]
@@ -3971,7 +3981,8 @@ name = "multivm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "circuit_sequencer_api",
+ "circuit_sequencer_api 0.1.0",
+ "circuit_sequencer_api 0.1.40",
  "ethabi",
  "hex",
  "itertools 0.10.5",
@@ -3984,7 +3995,6 @@ dependencies = [
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
  "zk_evm 1.4.0",
  "zk_evm 1.4.1",
- "zkevm_test_harness 1.4.0",
  "zkevm_test_harness 1.4.1",
  "zkevm_test_harness 1.4.2",
  "zksync_contracts",
@@ -8018,25 +8028,6 @@ dependencies = [
 [[package]]
 name = "zkevm-assembly"
 version = "1.3.2"
-source = "git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.3.2#3c61d450cbe6548068be8f313ed02f1bd229a865"
-dependencies = [
- "env_logger 0.9.3",
- "hex",
- "lazy_static",
- "log",
- "nom",
- "num-bigint 0.4.4",
- "num-traits",
- "sha3 0.10.8",
- "smallvec",
- "structopt",
- "thiserror",
- "zkevm_opcode_defs 1.3.2",
-]
-
-[[package]]
-name = "zkevm-assembly"
-version = "1.3.2"
 source = "git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.4.1#e381e5cc22c0c7ed95b50a73a402e7693c3e0824"
 dependencies = [
  "env_logger 0.9.3",
@@ -8056,7 +8047,7 @@ dependencies = [
 [[package]]
 name = "zkevm_circuits"
 version = "1.4.0"
-source = "git+https://github.com/matter-labs/era-zkevm_circuits.git?branch=main#fb3e2574b5c890342518fc930c145443f039a105"
+source = "git+https://github.com/matter-labs/era-zkevm_circuits.git?branch=v1.4.0#fb3e2574b5c890342518fc930c145443f039a105"
 dependencies = [
  "arrayvec 0.7.4",
  "bincode",
@@ -8136,29 +8127,6 @@ dependencies = [
 
 [[package]]
 name = "zkevm_test_harness"
-version = "1.4.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0#aff36380e6a740f7286c9c522e1416b8d38327ce"
-dependencies = [
- "bincode",
- "circuit_definitions 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0)",
- "codegen 0.2.0",
- "crossbeam 0.8.2",
- "derivative",
- "env_logger 0.10.0",
- "hex",
- "rand 0.4.6",
- "rayon",
- "serde",
- "serde_json",
- "smallvec",
- "structopt",
- "test-log",
- "tracing",
- "zkevm-assembly 1.3.2 (git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.3.2)",
-]
-
-[[package]]
-name = "zkevm_test_harness"
 version = "1.4.1"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1#4c6b8996f3f2bfef96ce193a5819b2e31a180830"
 dependencies = [
@@ -8183,7 +8151,7 @@ dependencies = [
  "test-log",
  "tracing",
  "walkdir",
- "zkevm-assembly 1.3.2 (git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.4.1)",
+ "zkevm-assembly",
 ]
 
 [[package]]
@@ -8212,7 +8180,7 @@ dependencies = [
  "test-log",
  "tracing",
  "walkdir",
- "zkevm-assembly 1.3.2 (git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.4.1)",
+ "zkevm-assembly",
 ]
 
 [[package]]
@@ -8266,10 +8234,10 @@ dependencies = [
 name = "zksync_commitment_utils"
 version = "0.1.0"
 dependencies = [
+ "circuit_sequencer_api 0.1.40",
  "multivm",
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
  "zk_evm 1.4.1",
- "zkevm_test_harness 1.4.0",
  "zkevm_test_harness 1.4.1",
  "zksync_types",
  "zksync_utils",
@@ -8725,7 +8693,7 @@ dependencies = [
 name = "zksync_l1_contract_interface"
 version = "0.1.0"
 dependencies = [
- "circuit_sequencer_api",
+ "circuit_sequencer_api 0.1.0",
  "codegen 0.1.0",
  "hex",
  "once_cell",
@@ -8891,7 +8859,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "chrono",
- "circuit_sequencer_api",
+ "circuit_sequencer_api 0.1.0",
  "serde",
  "serde_with",
  "strum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "circuit_encodings"
 version = "0.1.40"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.0_improve#fd229d101e5bf1dd0467ed7846bc158b49a40135"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0#39665dffd576cff5007c80dd0e1b5334e230bd3b"
 dependencies = [
  "derivative",
  "serde",
@@ -1184,7 +1184,7 @@ dependencies = [
 [[package]]
 name = "circuit_encodings"
 version = "0.1.41"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.1_improve#e1dc963fcc551135d8b5d8f2bd0aaf265e858676"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1#f7bd71fd4216e2c51ab7b09a95909fe48c75f35b"
 dependencies = [
  "derivative",
  "serde",
@@ -1195,7 +1195,7 @@ dependencies = [
 [[package]]
 name = "circuit_encodings"
 version = "0.1.42"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#be77320f0141469c4db2dfb032af199f75cc14a9"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#012dcc678990c695f97e5dd1f136dfa8fe376c16"
 dependencies = [
  "derivative",
  "serde",
@@ -1218,7 +1218,7 @@ dependencies = [
 [[package]]
 name = "circuit_sequencer_api"
 version = "0.1.40"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.0_improve#fd229d101e5bf1dd0467ed7846bc158b49a40135"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0#39665dffd576cff5007c80dd0e1b5334e230bd3b"
 dependencies = [
  "bellman_ce",
  "circuit_encodings 0.1.40",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "circuit_sequencer_api"
 version = "0.1.41"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.1_improve#e1dc963fcc551135d8b5d8f2bd0aaf265e858676"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1#f7bd71fd4216e2c51ab7b09a95909fe48c75f35b"
 dependencies = [
  "bellman_ce",
  "circuit_encodings 0.1.41",
@@ -1244,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "circuit_sequencer_api"
 version = "0.1.42"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#be77320f0141469c4db2dfb032af199f75cc14a9"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#012dcc678990c695f97e5dd1f136dfa8fe376c16"
 dependencies = [
  "bellman_ce",
  "circuit_encodings 0.1.42",
@@ -3402,7 +3402,7 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#be77320f0141469c4db2dfb032af199f75cc14a9"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#012dcc678990c695f97e5dd1f136dfa8fe376c16"
 dependencies = [
  "boojum",
  "derivative",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,7 +1195,7 @@ dependencies = [
 [[package]]
 name = "circuit_encodings"
 version = "0.1.42"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#81caeaef0e3332d29200bf8e92a93eb2dc7c9a07"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#be77320f0141469c4db2dfb032af199f75cc14a9"
 dependencies = [
  "derivative",
  "serde",
@@ -1244,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "circuit_sequencer_api"
 version = "0.1.42"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#81caeaef0e3332d29200bf8e92a93eb2dc7c9a07"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#be77320f0141469c4db2dfb032af199f75cc14a9"
 dependencies = [
  "bellman_ce",
  "circuit_encodings 0.1.42",
@@ -3402,7 +3402,7 @@ dependencies = [
 [[package]]
 name = "kzg"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#81caeaef0e3332d29200bf8e92a93eb2dc7c9a07"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#be77320f0141469c4db2dfb032af199f75cc14a9"
 dependencies = [
  "boojum",
  "derivative",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8616,7 +8616,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "chrono",
- "circuit_sequencer_api 0.1.42",
+ "circuit_sequencer_api 0.1.0",
  "serde",
  "serde_with",
  "strum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8616,7 +8616,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "chrono",
- "circuit_sequencer_api 0.1.0",
+ "circuit_sequencer_api 0.1.42",
  "serde",
  "serde_with",
  "strum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,20 +1206,6 @@ dependencies = [
 [[package]]
 name = "circuit_definitions"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1#4c6b8996f3f2bfef96ce193a5819b2e31a180830"
-dependencies = [
- "crossbeam 0.8.2",
- "derivative",
- "seq-macro",
- "serde",
- "snark_wrapper",
- "zk_evm 1.4.1",
- "zkevm_circuits 1.4.1",
-]
-
-[[package]]
-name = "circuit_definitions"
-version = "0.1.0"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#b91defc8bccff6275db2416323a096dcb74a4dff"
 dependencies = [
  "crossbeam 0.8.2",
@@ -1243,6 +1229,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "circuit_encodings"
+version = "0.1.41"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.1_improve#e1dc963fcc551135d8b5d8f2bd0aaf265e858676"
+dependencies = [
+ "derivative",
+ "serde",
+ "zk_evm 1.4.1",
+ "zkevm_circuits 1.4.1",
+]
+
+[[package]]
 name = "circuit_sequencer_api"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.3.3#aba8f2a32767b79838aca7d7d00d9d23144df32f"
@@ -1260,11 +1257,24 @@ version = "0.1.40"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.0_improve#fd229d101e5bf1dd0467ed7846bc158b49a40135"
 dependencies = [
  "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
- "circuit_encodings",
+ "circuit_encodings 0.1.40",
  "derivative",
  "rayon",
  "serde",
  "zk_evm 1.4.0",
+]
+
+[[package]]
+name = "circuit_sequencer_api"
+version = "0.1.41"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.1_improve#e1dc963fcc551135d8b5d8f2bd0aaf265e858676"
+dependencies = [
+ "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
+ "circuit_encodings 0.1.41",
+ "derivative",
+ "rayon",
+ "serde",
+ "zk_evm 1.4.1",
 ]
 
 [[package]]
@@ -3983,6 +3993,7 @@ dependencies = [
  "anyhow",
  "circuit_sequencer_api 0.1.0",
  "circuit_sequencer_api 0.1.40",
+ "circuit_sequencer_api 0.1.41",
  "ethabi",
  "hex",
  "itertools 0.10.5",
@@ -3995,8 +4006,7 @@ dependencies = [
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
  "zk_evm 1.4.0",
  "zk_evm 1.4.1",
- "zkevm_test_harness 1.4.1",
- "zkevm_test_harness 1.4.2",
+ "zkevm_test_harness",
  "zksync_contracts",
  "zksync_eth_signer",
  "zksync_state",
@@ -8127,40 +8137,11 @@ dependencies = [
 
 [[package]]
 name = "zkevm_test_harness"
-version = "1.4.1"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1#4c6b8996f3f2bfef96ce193a5819b2e31a180830"
-dependencies = [
- "bincode",
- "circuit_definitions 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1)",
- "codegen 0.2.0",
- "crossbeam 0.8.2",
- "curl",
- "derivative",
- "env_logger 0.10.0",
- "hex",
- "lazy_static",
- "rand 0.4.6",
- "rayon",
- "reqwest",
- "rescue_poseidon 0.4.1 (git+https://github.com/matter-labs/rescue-poseidon.git?branch=poseidon2)",
- "serde",
- "serde_json",
- "smallvec",
- "snark_wrapper",
- "structopt",
- "test-log",
- "tracing",
- "walkdir",
- "zkevm-assembly",
-]
-
-[[package]]
-name = "zkevm_test_harness"
 version = "1.4.2"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#b91defc8bccff6275db2416323a096dcb74a4dff"
 dependencies = [
  "bincode",
- "circuit_definitions 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2)",
+ "circuit_definitions",
  "codegen 0.2.0",
  "crossbeam 0.8.2",
  "curl",
@@ -8235,10 +8216,10 @@ name = "zksync_commitment_utils"
 version = "0.1.0"
 dependencies = [
  "circuit_sequencer_api 0.1.40",
+ "circuit_sequencer_api 0.1.41",
  "multivm",
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
  "zk_evm 1.4.1",
- "zkevm_test_harness 1.4.1",
  "zksync_types",
  "zksync_utils",
 ]
@@ -8702,7 +8683,7 @@ dependencies = [
  "serde_with",
  "sha2 0.10.8",
  "sha3 0.10.8",
- "zkevm_test_harness 1.4.2",
+ "zkevm_test_harness",
  "zksync_prover_interface",
  "zksync_types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,30 +655,7 @@ source = "git+https://github.com/matter-labs/bellman?branch=dev#5520aa2274afe73d
 dependencies = [
  "arrayvec 0.7.4",
  "bit-vec",
- "blake2s_const 0.6.0 (git+https://github.com/matter-labs/bellman?branch=dev)",
- "blake2s_simd",
- "byteorder",
- "cfg-if 1.0.0",
- "crossbeam 0.7.3",
- "futures 0.3.28",
- "hex",
- "lazy_static",
- "num_cpus",
- "pairing_ce 0.28.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.6",
- "serde",
- "smallvec",
- "tiny-keccak 1.5.0",
-]
-
-[[package]]
-name = "bellman_ce"
-version = "0.3.2"
-source = "git+https://github.com/matter-labs/bellman?branch=snark-wrapper#e01e5fa08a97a113e76ec8a69d06fe6cc2c82d17"
-dependencies = [
- "arrayvec 0.7.4",
- "bit-vec",
- "blake2s_const 0.6.0 (git+https://github.com/matter-labs/bellman?branch=snark-wrapper)",
+ "blake2s_const",
  "blake2s_simd",
  "byteorder",
  "cfg-if 1.0.0",
@@ -824,16 +801,6 @@ dependencies = [
 name = "blake2s_const"
 version = "0.6.0"
 source = "git+https://github.com/matter-labs/bellman?branch=dev#5520aa2274afe73d281373c92b007a2ecdebfbea"
-dependencies = [
- "arrayref",
- "arrayvec 0.5.2",
- "constant_time_eq",
-]
-
-[[package]]
-name = "blake2s_const"
-version = "0.6.0"
-source = "git+https://github.com/matter-labs/bellman?branch=snark-wrapper#e01e5fa08a97a113e76ec8a69d06fe6cc2c82d17"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.2",
@@ -1204,20 +1171,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "circuit_definitions"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#b91defc8bccff6275db2416323a096dcb74a4dff"
-dependencies = [
- "crossbeam 0.8.2",
- "derivative",
- "seq-macro",
- "serde",
- "snark_wrapper",
- "zk_evm 1.4.1",
- "zkevm_circuits 1.4.1",
-]
-
-[[package]]
 name = "circuit_encodings"
 version = "0.1.40"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.0_improve#fd229d101e5bf1dd0467ed7846bc158b49a40135"
@@ -1240,11 +1193,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "circuit_encodings"
+version = "0.1.42"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#81caeaef0e3332d29200bf8e92a93eb2dc7c9a07"
+dependencies = [
+ "derivative",
+ "serde",
+ "zk_evm 1.4.1",
+ "zkevm_circuits 1.4.1",
+]
+
+[[package]]
 name = "circuit_sequencer_api"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.3.3#aba8f2a32767b79838aca7d7d00d9d23144df32f"
 dependencies = [
- "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
+ "bellman_ce",
  "derivative",
  "rayon",
  "serde",
@@ -1256,7 +1220,7 @@ name = "circuit_sequencer_api"
 version = "0.1.40"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.0_improve#fd229d101e5bf1dd0467ed7846bc158b49a40135"
 dependencies = [
- "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
+ "bellman_ce",
  "circuit_encodings 0.1.40",
  "derivative",
  "rayon",
@@ -1269,8 +1233,21 @@ name = "circuit_sequencer_api"
 version = "0.1.41"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.1_improve#e1dc963fcc551135d8b5d8f2bd0aaf265e858676"
 dependencies = [
- "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
+ "bellman_ce",
  "circuit_encodings 0.1.41",
+ "derivative",
+ "rayon",
+ "serde",
+ "zk_evm 1.4.1",
+]
+
+[[package]]
+name = "circuit_sequencer_api"
+version = "0.1.42"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#81caeaef0e3332d29200bf8e92a93eb2dc7c9a07"
+dependencies = [
+ "bellman_ce",
+ "circuit_encodings 0.1.42",
  "derivative",
  "rayon",
  "serde",
@@ -1370,11 +1347,11 @@ version = "0.1.0"
 source = "git+https://github.com/matter-labs/solidity_plonk_verifier.git?branch=dev#82f96b7156551087f1c9bfe4f0ea68845b6debfc"
 dependencies = [
  "ethereum-types",
- "franklin-crypto 0.0.5 (git+https://github.com/matter-labs/franklin-crypto?branch=dev)",
+ "franklin-crypto",
  "handlebars",
  "hex",
  "paste",
- "rescue_poseidon 0.4.1 (git+https://github.com/matter-labs/rescue-poseidon)",
+ "rescue_poseidon",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1776,36 +1753,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "socket2 0.4.10",
- "winapi",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.70+curl-8.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0333d8849afe78a4c8102a429a446bfdd055832af071945520e835ae2d841e"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,32 +2055,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "envy"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,44 +2329,12 @@ version = "0.0.5"
 source = "git+https://github.com/matter-labs/franklin-crypto?branch=dev#5695d07c7bc604c2c39a27712ffac171d39ee1ed"
 dependencies = [
  "arr_macro",
- "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
+ "bellman_ce",
  "bit-vec",
  "blake2 0.9.2",
  "blake2-rfc_bellman_edition",
  "blake2s_simd",
  "byteorder",
- "digest 0.9.0",
- "hex",
- "indexmap 1.9.3",
- "itertools 0.10.5",
- "lazy_static",
- "num-bigint 0.4.4",
- "num-derive",
- "num-integer",
- "num-traits",
- "rand 0.4.6",
- "serde",
- "sha2 0.9.9",
- "sha3 0.9.1",
- "smallvec",
- "splitmut",
- "tiny-keccak 1.5.0",
-]
-
-[[package]]
-name = "franklin-crypto"
-version = "0.0.5"
-source = "git+https://github.com/matter-labs/franklin-crypto?branch=snark_wrapper#2546c63b91b59bdb0ad342d26f03fb57477550b2"
-dependencies = [
- "arr_macro",
- "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=snark-wrapper)",
- "bit-vec",
- "blake2 0.9.2",
- "blake2-rfc_bellman_edition",
- "blake2s_simd",
- "boojum",
- "byteorder",
- "derivative",
  "digest 0.9.0",
  "hex",
  "indexmap 1.9.3",
@@ -3024,12 +2913,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3245,17 +3128,6 @@ checksum = "21859b667d66a4c1dacd9df0863b3efb65785474255face87f5bca39dd8407c0"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi 0.3.3",
- "rustix",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3528,6 +3400,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "kzg"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#81caeaef0e3332d29200bf8e92a93eb2dc7c9a07"
+dependencies = [
+ "boojum",
+ "derivative",
+ "rayon",
+ "serde",
+ "serde_json",
+ "zkevm_circuits 1.4.1",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3608,7 +3493,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -3994,6 +3878,7 @@ dependencies = [
  "circuit_sequencer_api 0.1.0",
  "circuit_sequencer_api 0.1.40",
  "circuit_sequencer_api 0.1.41",
+ "circuit_sequencer_api 0.1.42",
  "ethabi",
  "hex",
  "itertools 0.10.5",
@@ -4006,7 +3891,6 @@ dependencies = [
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
  "zk_evm 1.4.0",
  "zk_evm 1.4.1",
- "zkevm_test_harness",
  "zksync_contracts",
  "zksync_eth_signer",
  "zksync_state",
@@ -5284,37 +5168,13 @@ dependencies = [
 [[package]]
 name = "rescue_poseidon"
 version = "0.4.1"
-source = "git+https://github.com/matter-labs/rescue-poseidon.git?branch=poseidon2#126937ef0e7a281f1ff9f512ac41a746a691a342"
-dependencies = [
- "addchain",
- "arrayvec 0.7.4",
- "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder",
- "derivative",
- "franklin-crypto 0.0.5 (git+https://github.com/matter-labs/franklin-crypto?branch=snark_wrapper)",
- "lazy_static",
- "log",
- "num-bigint 0.3.3",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.4.6",
- "serde",
- "sha3 0.9.1",
- "smallvec",
- "typemap_rev",
-]
-
-[[package]]
-name = "rescue_poseidon"
-version = "0.4.1"
 source = "git+https://github.com/matter-labs/rescue-poseidon#d059b5042df5ed80e151f05751410b524a54d16c"
 dependencies = [
  "addchain",
  "arrayvec 0.7.4",
  "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder",
- "franklin-crypto 0.0.5 (git+https://github.com/matter-labs/franklin-crypto?branch=dev)",
+ "franklin-crypto",
  "num-bigint 0.3.3",
  "num-integer",
  "num-iter",
@@ -6179,16 +6039,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "snark_wrapper"
-version = "0.1.0"
-source = "git+https://github.com/matter-labs/snark-wrapper.git?branch=main#76959cadabeec344b9fa1458728400d60340e496"
-dependencies = [
- "derivative",
- "rand 0.4.6",
- "rescue_poseidon 0.4.1 (git+https://github.com/matter-labs/rescue-poseidon.git?branch=poseidon2)",
-]
-
-[[package]]
 name = "snow"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6725,15 +6575,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "test-casing"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6747,17 +6588,6 @@ name = "test-casing-macro"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cfbe7811249c4c914b06141b8ac0f2cee2733fb883d05eb19668a45fc60c3d5"
-dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
-]
-
-[[package]]
-name = "test-log"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66edd6b6cd810743c0c71e1d085e92b01ce6a72782032e3f794c8284fe4bcdd"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
@@ -7175,12 +7005,6 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
-
-[[package]]
-name = "typemap_rev"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b08b0c1257381af16a5c3605254d529d3e7e109f3c62befc5d168968192998"
 
 [[package]]
 name = "typenum"
@@ -8036,25 +7860,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zkevm-assembly"
-version = "1.3.2"
-source = "git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.4.1#e381e5cc22c0c7ed95b50a73a402e7693c3e0824"
-dependencies = [
- "env_logger 0.9.3",
- "hex",
- "lazy_static",
- "log",
- "nom",
- "num-bigint 0.4.4",
- "num-traits",
- "sha3 0.10.8",
- "smallvec",
- "structopt",
- "thiserror",
- "zkevm_opcode_defs 1.4.1",
-]
-
-[[package]]
 name = "zkevm_circuits"
 version = "1.4.0"
 source = "git+https://github.com/matter-labs/era-zkevm_circuits.git?branch=v1.4.0#fb3e2574b5c890342518fc930c145443f039a105"
@@ -8133,35 +7938,6 @@ dependencies = [
  "lazy_static",
  "sha2 0.10.8",
  "sha3 0.10.8",
-]
-
-[[package]]
-name = "zkevm_test_harness"
-version = "1.4.2"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#b91defc8bccff6275db2416323a096dcb74a4dff"
-dependencies = [
- "bincode",
- "circuit_definitions",
- "codegen 0.2.0",
- "crossbeam 0.8.2",
- "curl",
- "derivative",
- "env_logger 0.10.0",
- "hex",
- "lazy_static",
- "rand 0.4.6",
- "rayon",
- "reqwest",
- "rescue_poseidon 0.4.1 (git+https://github.com/matter-labs/rescue-poseidon.git?branch=poseidon2)",
- "serde",
- "serde_json",
- "smallvec",
- "snark_wrapper",
- "structopt",
- "test-log",
- "tracing",
- "walkdir",
- "zkevm-assembly",
 ]
 
 [[package]]
@@ -8677,13 +8453,13 @@ dependencies = [
  "circuit_sequencer_api 0.1.0",
  "codegen 0.1.0",
  "hex",
+ "kzg",
  "once_cell",
  "serde",
  "serde_json",
  "serde_with",
  "sha2 0.10.8",
  "sha3 0.10.8",
- "zkevm_test_harness",
  "zksync_prover_interface",
  "zksync_types",
 ]

--- a/core/lib/commitment_utils/Cargo.toml
+++ b/core/lib/commitment_utils/Cargo.toml
@@ -12,7 +12,8 @@ categories = ["cryptography"]
 [dependencies]
 zksync_types = { path = "../../lib/types" }
 zksync_utils = { path = "../../lib/utils" }
-zkevm_test_harness_1_4_0 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.0", package = "zkevm_test_harness" }
+circuit_sequencer_api_1_4_0 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_v1.4.0_improve" }
+
 zkevm_test_harness_1_4_1 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.1", package = "zkevm_test_harness" }
 zk_evm_1_4_1 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.4.1" }
 zk_evm_1_3_3 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.3-rc2" }

--- a/core/lib/commitment_utils/Cargo.toml
+++ b/core/lib/commitment_utils/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["cryptography"]
 [dependencies]
 zksync_types = { path = "../../lib/types" }
 zksync_utils = { path = "../../lib/utils" }
-circuit_sequencer_api_1_4_0 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_v1.4.0_improve" }
-circuit_sequencer_api_1_4_1 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_v1.4.1_improve" }
+circuit_sequencer_api_1_4_0 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.0" }
+circuit_sequencer_api_1_4_1 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.1" }
 
 zk_evm_1_4_1 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.4.1" }
 zk_evm_1_3_3 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.3-rc2" }

--- a/core/lib/commitment_utils/Cargo.toml
+++ b/core/lib/commitment_utils/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["cryptography"]
 zksync_types = { path = "../../lib/types" }
 zksync_utils = { path = "../../lib/utils" }
 circuit_sequencer_api_1_4_0 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_v1.4.0_improve" }
+circuit_sequencer_api_1_4_1 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_v1.4.1_improve" }
 
-zkevm_test_harness_1_4_1 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.1", package = "zkevm_test_harness" }
 zk_evm_1_4_1 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.4.1" }
 zk_evm_1_3_3 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.3-rc2" }
 multivm = { path = "../../lib/multivm" }

--- a/core/lib/commitment_utils/src/lib.rs
+++ b/core/lib/commitment_utils/src/lib.rs
@@ -17,7 +17,7 @@ pub fn events_queue_commitment(
 ) -> Option<H256> {
     match VmVersion::from(protocol_version) {
         VmVersion::VmBoojumIntegration => Some(H256(
-            zkevm_test_harness_1_4_0::witness::utils::events_queue_commitment_fixed(
+            circuit_sequencer_api_1_4_0::commitments::events_queue_commitment_fixed(
                 &events_queue
                     .iter()
                     .map(|x| to_log_query_1_3_3(*x))
@@ -51,7 +51,7 @@ pub fn bootloader_initial_content_commitment(
 
     match VmVersion::from(protocol_version) {
         VmVersion::VmBoojumIntegration => Some(H256(
-            zkevm_test_harness_1_4_0::witness::utils::initial_heap_content_commitment_fixed(
+            circuit_sequencer_api_1_4_0::commitments::initial_heap_content_commitment_fixed(
                 &full_bootloader_memory,
             ),
         )),

--- a/core/lib/commitment_utils/src/lib.rs
+++ b/core/lib/commitment_utils/src/lib.rs
@@ -25,7 +25,7 @@ pub fn events_queue_commitment(
             ),
         )),
         VmVersion::Vm1_4_1 | VmVersion::Vm1_4_2 => Some(H256(
-            zkevm_test_harness_1_4_1::witness::utils::events_queue_commitment_fixed(
+            circuit_sequencer_api_1_4_1::commitments::events_queue_commitment_fixed(
                 &events_queue
                     .iter()
                     .map(|x| to_log_query_1_4_1(*x))
@@ -56,7 +56,7 @@ pub fn bootloader_initial_content_commitment(
             ),
         )),
         VmVersion::Vm1_4_1 | VmVersion::Vm1_4_2 => Some(H256(
-            zkevm_test_harness_1_4_1::witness::utils::initial_heap_content_commitment_fixed(
+            circuit_sequencer_api_1_4_1::commitments::initial_heap_content_commitment_fixed(
                 &full_bootloader_memory,
             ),
         )),

--- a/core/lib/l1_contract_interface/Cargo.toml
+++ b/core/lib/l1_contract_interface/Cargo.toml
@@ -20,7 +20,7 @@ codegen = { git = "https://github.com/matter-labs/solidity_plonk_verifier.git", 
 
 circuit_sequencer_api_1_3_3 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3" }
 # Used to calculate the kzg commitment and proofs
-kzg = { package = "kzg", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_v.1.4.2_improve" }
+kzg = { package = "kzg", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
 
 sha2 = "0.10.8"
 sha3 = "0.10.8"

--- a/core/lib/l1_contract_interface/Cargo.toml
+++ b/core/lib/l1_contract_interface/Cargo.toml
@@ -20,7 +20,8 @@ codegen = { git = "https://github.com/matter-labs/solidity_plonk_verifier.git", 
 
 circuit_sequencer_api_1_3_3 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3" }
 # Used to calculate the kzg commitment and proofs
-zkevm_test_harness_1_4_2 = { package = "zkevm_test_harness", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
+kzg = { package = "kzg", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_v.1.4.2_improve" }
+
 sha2 = "0.10.8"
 sha3 = "0.10.8"
 hex = "0.4"

--- a/core/lib/l1_contract_interface/src/i_executor/commit/kzg/mod.rs
+++ b/core/lib/l1_contract_interface/src/i_executor/commit/kzg/mod.rs
@@ -1,10 +1,7 @@
 use std::convert::TryInto;
 
-use sha2::Sha256;
-use sha3::{Digest, Keccak256};
-pub use zkevm_test_harness_1_4_2::kzg::KzgSettings;
-use zkevm_test_harness_1_4_2::{
-    kzg::{compute_commitment, compute_proof, compute_proof_poly},
+pub use kzg::KzgSettings;
+use kzg::{
     zkevm_circuits::{
         boojum::pairing::{
             bls12_381::{Fr, FrRepr, G1Affine},
@@ -17,7 +14,10 @@ use zkevm_test_harness_1_4_2::{
             zksync_pubdata_into_ethereum_4844_data, zksync_pubdata_into_monomial_form_poly,
         },
     },
+    {compute_commitment, compute_proof, compute_proof_poly},
 };
+use sha2::Sha256;
+use sha3::{Digest, Keccak256};
 use zksync_types::H256;
 
 use self::trusted_setup::KZG_SETTINGS;

--- a/core/lib/l1_contract_interface/src/i_executor/commit/kzg/mod.rs
+++ b/core/lib/l1_contract_interface/src/i_executor/commit/kzg/mod.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 pub use kzg::KzgSettings;
 use kzg::{
+    compute_commitment, compute_proof, compute_proof_poly,
     zkevm_circuits::{
         boojum::pairing::{
             bls12_381::{Fr, FrRepr, G1Affine},
@@ -14,7 +15,6 @@ use kzg::{
             zksync_pubdata_into_ethereum_4844_data, zksync_pubdata_into_monomial_form_poly,
         },
     },
-    {compute_commitment, compute_proof, compute_proof_poly},
 };
 use sha2::Sha256;
 use sha3::{Digest, Keccak256};

--- a/core/lib/l1_contract_interface/src/i_executor/commit/kzg/tests/mod.rs
+++ b/core/lib/l1_contract_interface/src/i_executor/commit/kzg/tests/mod.rs
@@ -1,11 +1,11 @@
 //! Tests for KZG commitments.
 
-use serde::{Deserialize, Serialize};
-use zkevm_test_harness_1_4_2::{
+use kzg::{
     boojum::pairing::{bls12_381::G1Compressed, EncodedPoint},
-    kzg::{verify_kzg_proof, verify_proof_poly},
     zkevm_circuits::eip_4844::ethereum_4844_data_into_zksync_pubdata,
+    {verify_kzg_proof, verify_proof_poly},
 };
+use serde::{Deserialize, Serialize};
 
 use super::*;
 

--- a/core/lib/l1_contract_interface/src/i_executor/commit/kzg/tests/mod.rs
+++ b/core/lib/l1_contract_interface/src/i_executor/commit/kzg/tests/mod.rs
@@ -2,8 +2,8 @@
 
 use kzg::{
     boojum::pairing::{bls12_381::G1Compressed, EncodedPoint},
+    verify_kzg_proof, verify_proof_poly,
     zkevm_circuits::eip_4844::ethereum_4844_data_into_zksync_pubdata,
-    {verify_kzg_proof, verify_proof_poly},
 };
 use serde::{Deserialize, Serialize};
 

--- a/core/lib/l1_contract_interface/src/i_executor/commit/kzg/trusted_setup.rs
+++ b/core/lib/l1_contract_interface/src/i_executor/commit/kzg/trusted_setup.rs
@@ -1,9 +1,7 @@
 use std::{convert::TryInto, iter};
 
-use once_cell::sync::Lazy;
-use zkevm_test_harness_1_4_2::{
+use kzg::{
     boojum::pairing::{bls12_381::G2Compressed, EncodedPoint},
-    kzg::KzgSettings,
     zkevm_circuits::{
         boojum::pairing::{
             bls12_381::{Fr, FrRepr, G1Compressed},
@@ -12,7 +10,9 @@ use zkevm_test_harness_1_4_2::{
         },
         eip_4844::input::ELEMENTS_PER_4844_BLOCK,
     },
+    KzgSettings,
 };
+use once_cell::sync::Lazy;
 
 const FIRST_ROOT_OF_UNITY: FrRepr = FrRepr([
     0xe206da11a5d36306,

--- a/core/lib/multivm/Cargo.toml
+++ b/core/lib/multivm/Cargo.toml
@@ -16,9 +16,9 @@ zk_evm_1_3_3 = { package = "zk_evm", git = "https://github.com/matter-labs/era-z
 zk_evm_1_3_1 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", tag= "v1.3.1-rc2" }
 
 circuit_sequencer_api_1_3_3 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3" }
-circuit_sequencer_api_1_4_0 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_v1.4.0_improve" }
-circuit_sequencer_api_1_4_1 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_v1.4.1_improve" }
-circuit_sequencer_api_1_4_2 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_v.1.4.2_improve" }
+circuit_sequencer_api_1_4_0 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.0" }
+circuit_sequencer_api_1_4_1 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.1" }
+circuit_sequencer_api_1_4_2 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
 
 zksync_types = { path = "../types" }
 zksync_state = { path = "../state" }

--- a/core/lib/multivm/Cargo.toml
+++ b/core/lib/multivm/Cargo.toml
@@ -17,8 +17,9 @@ zk_evm_1_3_1 = { package = "zk_evm", git = "https://github.com/matter-labs/era-z
 
 circuit_sequencer_api_1_3_3 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3" }
 circuit_sequencer_api_1_4_0 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_v1.4.0_improve" }
+circuit_sequencer_api_1_4_1 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_v1.4.1_improve" }
 
-zkevm_test_harness_1_4_1 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.1", package = "zkevm_test_harness" }
+
 zkevm_test_harness_1_4_2 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2", package = "zkevm_test_harness" }
 
 zksync_types = { path = "../types" }

--- a/core/lib/multivm/Cargo.toml
+++ b/core/lib/multivm/Cargo.toml
@@ -18,9 +18,7 @@ zk_evm_1_3_1 = { package = "zk_evm", git = "https://github.com/matter-labs/era-z
 circuit_sequencer_api_1_3_3 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3" }
 circuit_sequencer_api_1_4_0 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_v1.4.0_improve" }
 circuit_sequencer_api_1_4_1 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_v1.4.1_improve" }
-
-
-zkevm_test_harness_1_4_2 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2", package = "zkevm_test_harness" }
+circuit_sequencer_api_1_4_2 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_v.1.4.2_improve" }
 
 zksync_types = { path = "../types" }
 zksync_state = { path = "../state" }

--- a/core/lib/multivm/Cargo.toml
+++ b/core/lib/multivm/Cargo.toml
@@ -16,7 +16,8 @@ zk_evm_1_3_3 = { package = "zk_evm", git = "https://github.com/matter-labs/era-z
 zk_evm_1_3_1 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", tag= "v1.3.1-rc2" }
 
 circuit_sequencer_api_1_3_3 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3" }
-zkevm_test_harness_1_4_0 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.0", package = "zkevm_test_harness" }
+circuit_sequencer_api_1_4_0 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "mmzk_v1.4.0_improve" }
+
 zkevm_test_harness_1_4_1 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.1", package = "zkevm_test_harness" }
 zkevm_test_harness_1_4_2 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2", package = "zkevm_test_harness" }
 

--- a/core/lib/multivm/src/lib.rs
+++ b/core/lib/multivm/src/lib.rs
@@ -4,7 +4,6 @@
 
 pub use circuit_sequencer_api_1_4_1 as circuit_sequencer_api_latest;
 pub use zk_evm_1_4_1 as zk_evm_latest;
-
 pub use zksync_types::vm_version::VmVersion;
 
 pub use self::versions::{

--- a/core/lib/multivm/src/lib.rs
+++ b/core/lib/multivm/src/lib.rs
@@ -4,7 +4,6 @@
 
 pub use circuit_sequencer_api_1_4_1 as circuit_sequencer_api_latest;
 pub use zk_evm_1_4_1 as zk_evm_latest;
-pub use zkevm_test_harness_1_4_2 as zkevm_test_harness_latest;
 
 pub use zksync_types::vm_version::VmVersion;
 

--- a/core/lib/multivm/src/lib.rs
+++ b/core/lib/multivm/src/lib.rs
@@ -2,8 +2,10 @@
 #![warn(unused_extern_crates)]
 #![warn(unused_imports)]
 
+pub use circuit_sequencer_api_1_4_1 as circuit_sequencer_api_latest;
 pub use zk_evm_1_4_1 as zk_evm_latest;
-pub use zkevm_test_harness_1_4_1 as zkevm_test_harness_latest;
+pub use zkevm_test_harness_1_4_2 as zkevm_test_harness_latest;
+
 pub use zksync_types::vm_version::VmVersion;
 
 pub use self::versions::{

--- a/core/lib/multivm/src/versions/vm_1_4_1/tracers/circuits_capacity.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_1/tracers/circuits_capacity.rs
@@ -1,4 +1,4 @@
-use zkevm_test_harness_1_4_1::{geometry_config::get_geometry_config, toolset::GeometryConfig};
+use circuit_sequencer_api_1_4_1::{geometry_config::get_geometry_config, toolset::GeometryConfig};
 use zksync_types::circuit::{CircuitCycleStatistic, CircuitStatistic};
 
 // "Rich addressing" opcodes are opcodes that can write their return value/read the input onto the stack

--- a/core/lib/multivm/src/versions/vm_1_4_1/tracers/pubdata_tracer.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_1/tracers/pubdata_tracer.rs
@@ -1,10 +1,10 @@
 use std::marker::PhantomData;
 
+use circuit_sequencer_api_1_4_1::sort_storage_access::sort_storage_access_queries;
 use zk_evm_1_4_1::{
     aux_structures::Timestamp,
     tracing::{BeforeExecutionData, VmLocalStateData},
 };
-use zkevm_test_harness_1_4_1::witness::sort_storage_access::sort_storage_access_queries;
 use zksync_state::{StoragePtr, WriteStorage};
 use zksync_types::{
     event::{

--- a/core/lib/multivm/src/versions/vm_1_4_1/vm.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_1/vm.rs
@@ -1,4 +1,4 @@
-use zkevm_test_harness_1_4_1::witness::sort_storage_access::sort_storage_access_queries;
+use circuit_sequencer_api_1_4_1::sort_storage_access::sort_storage_access_queries;
 use zksync_state::{StoragePtr, WriteStorage};
 use zksync_types::{
     event::extract_l2tol1logs_from_l1_messenger,

--- a/core/lib/multivm/src/versions/vm_boojum_integration/tests/circuits.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/tests/circuits.rs
@@ -1,9 +1,11 @@
-use zkevm_test_harness_1_4_0::geometry_config::get_geometry_config;
+use circuit_sequencer_api_1_4_0::geometry_config::get_geometry_config;
 use zksync_types::{Address, Execute, U256};
 
 use crate::{
     interface::{TxExecutionMode, VmExecutionMode, VmInterface},
-    vm_boojum_integration::{constants::BLOCK_GAS_LIMIT, tests::tester::VmTesterBuilder, HistoryEnabled},
+    vm_boojum_integration::{
+        constants::BLOCK_GAS_LIMIT, tests::tester::VmTesterBuilder, HistoryEnabled,
+    },
 };
 
 // Checks that estimated number of circuits for simple transfer doesn't differ much

--- a/core/lib/multivm/src/versions/vm_boojum_integration/tracers/circuits_capacity.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/tracers/circuits_capacity.rs
@@ -1,4 +1,4 @@
-use zkevm_test_harness_1_4_0::{geometry_config::get_geometry_config, toolset::GeometryConfig};
+use circuit_sequencer_api_1_4_0::{geometry_config::get_geometry_config, toolset::GeometryConfig};
 use zksync_types::circuit::{CircuitCycleStatistic, CircuitStatistic};
 
 // "Rich addressing" opcodes are opcodes that can write their return value/read the input onto the stack

--- a/core/lib/multivm/src/versions/vm_boojum_integration/tracers/pubdata_tracer.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/tracers/pubdata_tracer.rs
@@ -1,10 +1,10 @@
 use std::marker::PhantomData;
 
+use circuit_sequencer_api_1_4_0::sort_storage_access::sort_storage_access_queries;
 use zk_evm_1_4_0::{
     aux_structures::Timestamp,
     tracing::{BeforeExecutionData, VmLocalStateData},
 };
-use zkevm_test_harness_1_4_0::witness::sort_storage_access::sort_storage_access_queries;
 use zksync_state::{StoragePtr, WriteStorage};
 use zksync_types::{
     event::{

--- a/core/lib/multivm/src/versions/vm_boojum_integration/vm.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/vm.rs
@@ -1,4 +1,4 @@
-use zkevm_test_harness_1_4_0::witness::sort_storage_access::sort_storage_access_queries;
+use circuit_sequencer_api_1_4_0::sort_storage_access::sort_storage_access_queries;
 use zksync_state::{StoragePtr, WriteStorage};
 use zksync_types::{
     event::extract_l2tol1logs_from_l1_messenger,

--- a/core/lib/multivm/src/versions/vm_latest/constants.rs
+++ b/core/lib/multivm/src/versions/vm_latest/constants.rs
@@ -1,5 +1,5 @@
-use circuit_sequencer_api_1_4_2::INITIAL_MONOTONIC_CYCLE_COUNTER;
 use circuit_sequencer_api_1_4_2::{BLOB_CHUNK_SIZE, ELEMENTS_PER_4844_BLOCK};
+
 use zk_evm_1_4_1::aux_structures::MemoryPage;
 pub use zk_evm_1_4_1::zkevm_opcode_defs::system_params::{
     ERGS_PER_CIRCUIT, INITIAL_STORAGE_WRITE_PUBDATA_BYTES,

--- a/core/lib/multivm/src/versions/vm_latest/constants.rs
+++ b/core/lib/multivm/src/versions/vm_latest/constants.rs
@@ -1,9 +1,8 @@
+use circuit_sequencer_api_1_4_2::INITIAL_MONOTONIC_CYCLE_COUNTER;
+use circuit_sequencer_api_1_4_2::{BLOB_CHUNK_SIZE, ELEMENTS_PER_4844_BLOCK};
 use zk_evm_1_4_1::aux_structures::MemoryPage;
 pub use zk_evm_1_4_1::zkevm_opcode_defs::system_params::{
     ERGS_PER_CIRCUIT, INITIAL_STORAGE_WRITE_PUBDATA_BYTES,
-};
-use zkevm_test_harness_1_4_2::zkevm_circuits::eip_4844::input::{
-    BLOB_CHUNK_SIZE, ELEMENTS_PER_4844_BLOCK,
 };
 use zksync_system_constants::{MAX_L2_TX_GAS_LIMIT, MAX_NEW_FACTORY_DEPS};
 

--- a/core/lib/multivm/src/versions/vm_latest/constants.rs
+++ b/core/lib/multivm/src/versions/vm_latest/constants.rs
@@ -1,5 +1,4 @@
 use circuit_sequencer_api_1_4_2::{BLOB_CHUNK_SIZE, ELEMENTS_PER_4844_BLOCK};
-
 use zk_evm_1_4_1::aux_structures::MemoryPage;
 pub use zk_evm_1_4_1::zkevm_opcode_defs::system_params::{
     ERGS_PER_CIRCUIT, INITIAL_STORAGE_WRITE_PUBDATA_BYTES,

--- a/core/lib/multivm/src/versions/vm_latest/tracers/circuits_capacity.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tracers/circuits_capacity.rs
@@ -1,4 +1,4 @@
-use zkevm_test_harness_1_4_2::{geometry_config::get_geometry_config, toolset::GeometryConfig};
+use circuit_sequencer_api_1_4_2::{geometry_config::get_geometry_config, toolset::GeometryConfig};
 use zksync_types::circuit::{CircuitCycleStatistic, CircuitStatistic};
 
 // "Rich addressing" opcodes are opcodes that can write their return value/read the input onto the stack

--- a/core/lib/multivm/src/versions/vm_latest/tracers/pubdata_tracer.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tracers/pubdata_tracer.rs
@@ -1,10 +1,10 @@
 use std::marker::PhantomData;
 
+use circuit_sequencer_api_1_4_2::sort_storage_access::sort_storage_access_queries;
 use zk_evm_1_4_1::{
     aux_structures::Timestamp,
     tracing::{BeforeExecutionData, VmLocalStateData},
 };
-use zkevm_test_harness_1_4_2::witness::sort_storage_access::sort_storage_access_queries;
 use zksync_state::{StoragePtr, WriteStorage};
 use zksync_types::{
     event::{

--- a/core/lib/multivm/src/versions/vm_latest/vm.rs
+++ b/core/lib/multivm/src/versions/vm_latest/vm.rs
@@ -1,4 +1,4 @@
-use zkevm_test_harness_1_4_2::witness::sort_storage_access::sort_storage_access_queries;
+use circuit_sequencer_api_1_4_2::sort_storage_access::sort_storage_access_queries;
 use zksync_state::{StoragePtr, WriteStorage};
 use zksync_types::{
     event::extract_l2tol1logs_from_l1_messenger,

--- a/core/lib/prover_interface/Cargo.toml
+++ b/core/lib/prover_interface/Cargo.toml
@@ -14,8 +14,8 @@ readme = "README.md"
 zksync_types = { path = "../types" }
 zksync_object_store = { path = "../object_store" }
 
-# Now, we can use the latest API to send the proofs to L1.
-circuit_sequencer_api = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
+# Soon, we'll be able to use the newest api.
+circuit_sequencer_api = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3" }
 
 serde = "1.0.90"
 strum = { version = "0.24", features = ["derive"] }

--- a/core/lib/prover_interface/Cargo.toml
+++ b/core/lib/prover_interface/Cargo.toml
@@ -14,7 +14,8 @@ readme = "README.md"
 zksync_types = { path = "../types" }
 zksync_object_store = { path = "../object_store" }
 
-circuit_sequencer_api_1_3_3 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3" }
+# Now, we can use the latest API to send the proofs to L1.
+circuit_sequencer_api = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
 
 serde = "1.0.90"
 strum = { version = "0.24", features = ["derive"] }

--- a/core/lib/prover_interface/Cargo.toml
+++ b/core/lib/prover_interface/Cargo.toml
@@ -14,8 +14,8 @@ readme = "README.md"
 zksync_types = { path = "../types" }
 zksync_object_store = { path = "../object_store" }
 
-# Soon, we'll be able to use the newest api.
-circuit_sequencer_api = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3" }
+# We can use the newest api to send proofs to L1.
+circuit_sequencer_api = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
 
 serde = "1.0.90"
 strum = { version = "0.24", features = ["derive"] }

--- a/core/lib/prover_interface/src/outputs.rs
+++ b/core/lib/prover_interface/src/outputs.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use circuit_sequencer_api_1_3_3::proof::FinalProof;
+use circuit_sequencer_api::proof::FinalProof;
 use serde::{Deserialize, Serialize};
 use zksync_object_store::{serialize_using_bincode, Bucket, StoredObject};
 use zksync_types::L1BatchNumber;

--- a/core/lib/zksync_core/src/genesis.rs
+++ b/core/lib/zksync_core/src/genesis.rs
@@ -4,9 +4,9 @@
 
 use anyhow::Context as _;
 use multivm::{
+    circuit_sequencer_api_latest::sort_storage_access::sort_storage_access_queries,
     utils::get_max_gas_per_pubdata_byte,
     zk_evm_latest::aux_structures::{LogQuery as MultiVmLogQuery, Timestamp as MultiVMTimestamp},
-    zkevm_test_harness_latest::witness::sort_storage_access::sort_storage_access_queries,
 };
 use zksync_contracts::{BaseSystemContracts, SET_CHAIN_ID_EVENT};
 use zksync_dal::StorageProcessor;

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -794,20 +794,6 @@ dependencies = [
 [[package]]
 name = "circuit_definitions"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1#4c6b8996f3f2bfef96ce193a5819b2e31a180830"
-dependencies = [
- "crossbeam 0.8.4",
- "derivative",
- "seq-macro",
- "serde",
- "snark_wrapper",
- "zk_evm 1.4.1",
- "zkevm_circuits 1.4.1",
-]
-
-[[package]]
-name = "circuit_definitions"
-version = "0.1.0"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#b91defc8bccff6275db2416323a096dcb74a4dff"
 dependencies = [
  "crossbeam 0.8.4",
@@ -831,6 +817,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "circuit_encodings"
+version = "0.1.41"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.1_improve#e1dc963fcc551135d8b5d8f2bd0aaf265e858676"
+dependencies = [
+ "derivative",
+ "serde",
+ "zk_evm 1.4.1",
+ "zkevm_circuits 1.4.1",
+]
+
+[[package]]
 name = "circuit_sequencer_api"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.3.3#aba8f2a32767b79838aca7d7d00d9d23144df32f"
@@ -848,11 +845,24 @@ version = "0.1.40"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.0_improve#fd229d101e5bf1dd0467ed7846bc158b49a40135"
 dependencies = [
  "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
- "circuit_encodings",
+ "circuit_encodings 0.1.40",
  "derivative",
  "rayon",
  "serde",
  "zk_evm 1.4.0",
+]
+
+[[package]]
+name = "circuit_sequencer_api"
+version = "0.1.41"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.1_improve#e1dc963fcc551135d8b5d8f2bd0aaf265e858676"
+dependencies = [
+ "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
+ "circuit_encodings 0.1.41",
+ "derivative",
+ "rayon",
+ "serde",
+ "zk_evm 1.4.1",
 ]
 
 [[package]]
@@ -3119,6 +3129,7 @@ dependencies = [
  "anyhow",
  "circuit_sequencer_api 0.1.0",
  "circuit_sequencer_api 0.1.40",
+ "circuit_sequencer_api 0.1.41",
  "hex",
  "itertools 0.10.5",
  "once_cell",
@@ -3129,7 +3140,6 @@ dependencies = [
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
  "zk_evm 1.4.0",
  "zk_evm 1.4.1",
- "zkevm_test_harness 1.4.1",
  "zkevm_test_harness 1.4.2",
  "zksync_contracts",
  "zksync_state",
@@ -4957,7 +4967,7 @@ dependencies = [
  "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "boojum",
  "boojum-cuda",
- "circuit_definitions 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2)",
+ "circuit_definitions",
  "cudart",
  "cudart-sys",
  "derivative",
@@ -6144,7 +6154,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
- "circuit_definitions 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2)",
+ "circuit_definitions",
  "clap 4.4.6",
  "hex",
  "itertools 0.10.5",
@@ -6847,40 +6857,11 @@ dependencies = [
 
 [[package]]
 name = "zkevm_test_harness"
-version = "1.4.1"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1#4c6b8996f3f2bfef96ce193a5819b2e31a180830"
-dependencies = [
- "bincode",
- "circuit_definitions 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1)",
- "codegen",
- "crossbeam 0.8.4",
- "curl",
- "derivative",
- "env_logger 0.11.2",
- "hex",
- "lazy_static",
- "rand 0.4.6",
- "rayon",
- "reqwest",
- "rescue_poseidon 0.4.1 (git+https://github.com/matter-labs/rescue-poseidon.git?branch=poseidon2)",
- "serde",
- "serde_json",
- "smallvec",
- "snark_wrapper",
- "structopt",
- "test-log",
- "tracing",
- "walkdir",
- "zkevm-assembly 1.3.2 (git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.4.1)",
-]
-
-[[package]]
-name = "zkevm_test_harness"
 version = "1.4.2"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#b91defc8bccff6275db2416323a096dcb74a4dff"
 dependencies = [
  "bincode",
- "circuit_definitions 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2)",
+ "circuit_definitions",
  "codegen",
  "crossbeam 0.8.4",
  "curl",
@@ -7191,7 +7172,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "circuit_definitions 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2)",
+ "circuit_definitions",
  "ctrlc",
  "futures 0.3.30",
  "local-ip-address",
@@ -7246,7 +7227,7 @@ dependencies = [
 name = "zksync_prover_fri_types"
 version = "0.1.0"
 dependencies = [
- "circuit_definitions 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2)",
+ "circuit_definitions",
  "serde",
  "zksync_object_store",
  "zksync_types",
@@ -7388,7 +7369,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
- "circuit_definitions 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2)",
+ "circuit_definitions",
  "const-decoder",
  "ctrlc",
  "futures 0.3.30",

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "circuit_encodings"
 version = "0.1.42"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#81caeaef0e3332d29200bf8e92a93eb2dc7c9a07"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#be77320f0141469c4db2dfb032af199f75cc14a9"
 dependencies = [
  "derivative",
  "serde",
@@ -879,7 +879,7 @@ dependencies = [
 [[package]]
 name = "circuit_sequencer_api"
 version = "0.1.42"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#81caeaef0e3332d29200bf8e92a93eb2dc7c9a07"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#be77320f0141469c4db2dfb032af199f75cc14a9"
 dependencies = [
  "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
  "circuit_encodings 0.1.42",

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -794,20 +794,6 @@ dependencies = [
 [[package]]
 name = "circuit_definitions"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0#aff36380e6a740f7286c9c522e1416b8d38327ce"
-dependencies = [
- "crossbeam 0.8.4",
- "derivative",
- "seq-macro",
- "serde",
- "snark_wrapper",
- "zk_evm 1.4.0",
- "zkevm_circuits 1.4.0",
-]
-
-[[package]]
-name = "circuit_definitions"
-version = "0.1.0"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1#4c6b8996f3f2bfef96ce193a5819b2e31a180830"
 dependencies = [
  "crossbeam 0.8.4",
@@ -834,6 +820,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "circuit_encodings"
+version = "0.1.40"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.0_improve#fd229d101e5bf1dd0467ed7846bc158b49a40135"
+dependencies = [
+ "derivative",
+ "serde",
+ "zk_evm 1.4.0",
+ "zkevm_circuits 1.4.0",
+]
+
+[[package]]
 name = "circuit_sequencer_api"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.3.3#aba8f2a32767b79838aca7d7d00d9d23144df32f"
@@ -843,6 +840,19 @@ dependencies = [
  "rayon",
  "serde",
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.3)",
+]
+
+[[package]]
+name = "circuit_sequencer_api"
+version = "0.1.40"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.0_improve#fd229d101e5bf1dd0467ed7846bc158b49a40135"
+dependencies = [
+ "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
+ "circuit_encodings",
+ "derivative",
+ "rayon",
+ "serde",
+ "zk_evm 1.4.0",
 ]
 
 [[package]]
@@ -3107,7 +3117,8 @@ name = "multivm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "circuit_sequencer_api",
+ "circuit_sequencer_api 0.1.0",
+ "circuit_sequencer_api 0.1.40",
  "hex",
  "itertools 0.10.5",
  "once_cell",
@@ -3118,7 +3129,6 @@ dependencies = [
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
  "zk_evm 1.4.0",
  "zk_evm 1.4.1",
- "zkevm_test_harness 1.4.0",
  "zkevm_test_harness 1.4.1",
  "zkevm_test_harness 1.4.2",
  "zksync_contracts",
@@ -6729,7 +6739,7 @@ dependencies = [
 [[package]]
 name = "zkevm_circuits"
 version = "1.4.0"
-source = "git+https://github.com/matter-labs/era-zkevm_circuits.git?branch=main#fb3e2574b5c890342518fc930c145443f039a105"
+source = "git+https://github.com/matter-labs/era-zkevm_circuits.git?branch=v1.4.0#fb3e2574b5c890342518fc930c145443f039a105"
 dependencies = [
  "arrayvec 0.7.4",
  "bincode",
@@ -6813,7 +6823,7 @@ version = "1.3.3"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.3.3#aba8f2a32767b79838aca7d7d00d9d23144df32f"
 dependencies = [
  "bincode",
- "circuit_sequencer_api",
+ "circuit_sequencer_api 0.1.0",
  "circuit_testing",
  "codegen",
  "crossbeam 0.8.4",
@@ -6832,29 +6842,6 @@ dependencies = [
  "test-log",
  "tracing",
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.3)",
- "zkevm-assembly 1.3.2 (git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.3.2)",
-]
-
-[[package]]
-name = "zkevm_test_harness"
-version = "1.4.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0#aff36380e6a740f7286c9c522e1416b8d38327ce"
-dependencies = [
- "bincode",
- "circuit_definitions 0.1.0 (git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0)",
- "codegen",
- "crossbeam 0.8.4",
- "derivative",
- "env_logger 0.11.2",
- "hex",
- "rand 0.4.6",
- "rayon",
- "serde",
- "serde_json",
- "smallvec",
- "structopt",
- "test-log",
- "tracing",
  "zkevm-assembly 1.3.2 (git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.3.2)",
 ]
 
@@ -7138,7 +7125,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
- "circuit_sequencer_api",
+ "circuit_sequencer_api 0.1.0",
  "ctrlc",
  "futures 0.3.30",
  "prometheus_exporter",
@@ -7288,7 +7275,7 @@ name = "zksync_prover_interface"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "circuit_sequencer_api",
+ "circuit_sequencer_api 0.1.0",
  "serde",
  "serde_with",
  "strum",

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -7280,7 +7280,7 @@ name = "zksync_prover_interface"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "circuit_sequencer_api 0.1.0",
+ "circuit_sequencer_api 0.1.42",
  "serde",
  "serde_with",
  "strum",

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -808,7 +808,7 @@ dependencies = [
 [[package]]
 name = "circuit_encodings"
 version = "0.1.40"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.0_improve#fd229d101e5bf1dd0467ed7846bc158b49a40135"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0#39665dffd576cff5007c80dd0e1b5334e230bd3b"
 dependencies = [
  "derivative",
  "serde",
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "circuit_encodings"
 version = "0.1.41"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.1_improve#e1dc963fcc551135d8b5d8f2bd0aaf265e858676"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1#f7bd71fd4216e2c51ab7b09a95909fe48c75f35b"
 dependencies = [
  "derivative",
  "serde",
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "circuit_encodings"
 version = "0.1.42"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#be77320f0141469c4db2dfb032af199f75cc14a9"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#012dcc678990c695f97e5dd1f136dfa8fe376c16"
 dependencies = [
  "derivative",
  "serde",
@@ -853,7 +853,7 @@ dependencies = [
 [[package]]
 name = "circuit_sequencer_api"
 version = "0.1.40"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.0_improve#fd229d101e5bf1dd0467ed7846bc158b49a40135"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.0#39665dffd576cff5007c80dd0e1b5334e230bd3b"
 dependencies = [
  "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
  "circuit_encodings 0.1.40",
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "circuit_sequencer_api"
 version = "0.1.41"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v1.4.1_improve#e1dc963fcc551135d8b5d8f2bd0aaf265e858676"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.1#f7bd71fd4216e2c51ab7b09a95909fe48c75f35b"
 dependencies = [
  "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
  "circuit_encodings 0.1.41",
@@ -879,7 +879,7 @@ dependencies = [
 [[package]]
 name = "circuit_sequencer_api"
 version = "0.1.42"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#be77320f0141469c4db2dfb032af199f75cc14a9"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#012dcc678990c695f97e5dd1f136dfa8fe376c16"
 dependencies = [
  "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
  "circuit_encodings 0.1.42",

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -7130,7 +7130,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
- "circuit_sequencer_api 0.1.0",
+ "circuit_sequencer_api 0.1.42",
  "ctrlc",
  "futures 0.3.30",
  "prometheus_exporter",

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -7130,7 +7130,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
- "circuit_sequencer_api 0.1.42",
+ "circuit_sequencer_api 0.1.0",
  "ctrlc",
  "futures 0.3.30",
  "prometheus_exporter",
@@ -7280,7 +7280,7 @@ name = "zksync_prover_interface"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "circuit_sequencer_api 0.1.42",
+ "circuit_sequencer_api 0.1.0",
  "serde",
  "serde_with",
  "strum",

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -794,8 +794,9 @@ dependencies = [
 [[package]]
 name = "circuit_definitions"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#b91defc8bccff6275db2416323a096dcb74a4dff"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#012dcc678990c695f97e5dd1f136dfa8fe376c16"
 dependencies = [
+ "circuit_encodings 0.1.42",
  "crossbeam 0.8.4",
  "derivative",
  "seq-macro",
@@ -2782,6 +2783,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "kzg"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#012dcc678990c695f97e5dd1f136dfa8fe376c16"
+dependencies = [
+ "boojum",
+ "derivative",
+ "rayon",
+ "serde",
+ "serde_json",
+ "zkevm_circuits 1.4.1",
 ]
 
 [[package]]
@@ -6753,8 +6767,8 @@ dependencies = [
 
 [[package]]
 name = "zkevm-assembly"
-version = "1.3.2"
-source = "git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.4.1#e381e5cc22c0c7ed95b50a73a402e7693c3e0824"
+version = "1.4.1"
+source = "git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.4.1#e59d5da67f18f8829c3cfaebb967265d73c168ed"
 dependencies = [
  "env_logger 0.9.3",
  "hex",
@@ -6862,7 +6876,7 @@ dependencies = [
  "codegen",
  "crossbeam 0.8.4",
  "derivative",
- "env_logger 0.9.3",
+ "env_logger 0.11.2",
  "hex",
  "num-bigint 0.4.4",
  "num-integer",
@@ -6876,22 +6890,24 @@ dependencies = [
  "test-log",
  "tracing",
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.3)",
- "zkevm-assembly 1.3.2 (git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.3.2)",
+ "zkevm-assembly 1.3.2",
 ]
 
 [[package]]
 name = "zkevm_test_harness"
 version = "1.4.2"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#b91defc8bccff6275db2416323a096dcb74a4dff"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.4.2#012dcc678990c695f97e5dd1f136dfa8fe376c16"
 dependencies = [
  "bincode",
  "circuit_definitions",
+ "circuit_sequencer_api 0.1.42",
  "codegen",
  "crossbeam 0.8.4",
  "curl",
  "derivative",
  "env_logger 0.11.2",
  "hex",
+ "kzg",
  "lazy_static",
  "rand 0.4.6",
  "rayon",
@@ -6905,7 +6921,7 @@ dependencies = [
  "test-log",
  "tracing",
  "walkdir",
- "zkevm-assembly 1.3.2 (git+https://github.com/matter-labs/era-zkEVM-assembly.git?branch=v1.4.1)",
+ "zkevm-assembly 1.4.1",
 ]
 
 [[package]]
@@ -7130,7 +7146,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
- "circuit_sequencer_api 0.1.0",
+ "circuit_sequencer_api 0.1.42",
  "ctrlc",
  "futures 0.3.30",
  "prometheus_exporter",
@@ -7280,7 +7296,7 @@ name = "zksync_prover_interface"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "circuit_sequencer_api 0.1.0",
+ "circuit_sequencer_api 0.1.42",
  "serde",
  "serde_with",
  "strum",

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -828,6 +828,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "circuit_encodings"
+version = "0.1.42"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#81caeaef0e3332d29200bf8e92a93eb2dc7c9a07"
+dependencies = [
+ "derivative",
+ "serde",
+ "zk_evm 1.4.1",
+ "zkevm_circuits 1.4.1",
+]
+
+[[package]]
 name = "circuit_sequencer_api"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=v1.3.3#aba8f2a32767b79838aca7d7d00d9d23144df32f"
@@ -859,6 +870,19 @@ source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=m
 dependencies = [
  "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
  "circuit_encodings 0.1.41",
+ "derivative",
+ "rayon",
+ "serde",
+ "zk_evm 1.4.1",
+]
+
+[[package]]
+name = "circuit_sequencer_api"
+version = "0.1.42"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness.git?branch=mmzk_v.1.4.2_improve#81caeaef0e3332d29200bf8e92a93eb2dc7c9a07"
+dependencies = [
+ "bellman_ce 0.3.2 (git+https://github.com/matter-labs/bellman?branch=dev)",
+ "circuit_encodings 0.1.42",
  "derivative",
  "rayon",
  "serde",
@@ -3130,6 +3154,7 @@ dependencies = [
  "circuit_sequencer_api 0.1.0",
  "circuit_sequencer_api 0.1.40",
  "circuit_sequencer_api 0.1.41",
+ "circuit_sequencer_api 0.1.42",
  "hex",
  "itertools 0.10.5",
  "once_cell",
@@ -3140,7 +3165,6 @@ dependencies = [
  "zk_evm 1.3.3 (git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2)",
  "zk_evm 1.4.0",
  "zk_evm 1.4.1",
- "zkevm_test_harness 1.4.2",
  "zksync_contracts",
  "zksync_state",
  "zksync_system_constants",

--- a/prover/proof_fri_compressor/Cargo.toml
+++ b/prover/proof_fri_compressor/Cargo.toml
@@ -22,7 +22,7 @@ vk_setup_data_generator_server_fri = { path = "../vk_setup_data_generator_server
 vlog = { path = "../../core/lib/vlog" }
 
 zkevm_test_harness_1_3_3 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3", package = "zkevm_test_harness" }
-circuit_sequencer_api = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3" }
+circuit_sequencer_api = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
 
 zkevm_test_harness = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
 

--- a/prover/proof_fri_compressor/Cargo.toml
+++ b/prover/proof_fri_compressor/Cargo.toml
@@ -22,7 +22,7 @@ vk_setup_data_generator_server_fri = { path = "../vk_setup_data_generator_server
 vlog = { path = "../../core/lib/vlog" }
 
 zkevm_test_harness_1_3_3 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3", package = "zkevm_test_harness" }
-circuit_sequencer_api_1_3_3 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3" }
+circuit_sequencer_api = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
 
 zkevm_test_harness = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
 

--- a/prover/proof_fri_compressor/Cargo.toml
+++ b/prover/proof_fri_compressor/Cargo.toml
@@ -22,7 +22,7 @@ vk_setup_data_generator_server_fri = { path = "../vk_setup_data_generator_server
 vlog = { path = "../../core/lib/vlog" }
 
 zkevm_test_harness_1_3_3 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3", package = "zkevm_test_harness" }
-circuit_sequencer_api = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
+circuit_sequencer_api = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3" }
 
 zkevm_test_harness = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
 

--- a/prover/proof_fri_compressor/src/compressor.rs
+++ b/prover/proof_fri_compressor/src/compressor.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Instant};
 
 use anyhow::Context as _;
 use async_trait::async_trait;
-use circuit_sequencer_api_1_3_3::proof::FinalProof;
+use circuit_sequencer_api::proof::FinalProof;
 use tokio::task::JoinHandle;
 use zkevm_test_harness::proof_wrapper_utils::{wrap_proof, WrapperConfig};
 use zkevm_test_harness_1_3_3::{

--- a/prover/witness_generator/src/tests.rs
+++ b/prover/witness_generator/src/tests.rs
@@ -1,7 +1,7 @@
 use std::iter;
 
 use const_decoder::Decoder::Hex;
-use multivm::zkevm_test_harness_latest::kzg::KzgSettings;
+use zkevm_test_harness::kzg::KzgSettings;
 use zkevm_test_harness::witness::tree::{BinarySparseStorageTree, ZkSyncStorageLeaf};
 use zksync_prover_interface::inputs::{PrepareBasicCircuitsJob, StorageLogMetadata};
 use zksync_types::U256;

--- a/prover/witness_generator/src/tests.rs
+++ b/prover/witness_generator/src/tests.rs
@@ -1,8 +1,10 @@
 use std::iter;
 
 use const_decoder::Decoder::Hex;
-use zkevm_test_harness::kzg::KzgSettings;
-use zkevm_test_harness::witness::tree::{BinarySparseStorageTree, ZkSyncStorageLeaf};
+use zkevm_test_harness::{
+    kzg::KzgSettings,
+    witness::tree::{BinarySparseStorageTree, ZkSyncStorageLeaf},
+};
 use zksync_prover_interface::inputs::{PrepareBasicCircuitsJob, StorageLogMetadata};
 use zksync_types::U256;
 


### PR DESCRIPTION
## What ❔

* Now moving version 1.4.0, 1.4.1 and 1.4.2 to use the new circuit_sequencer_api

## Why ❔

* To improve compilation speeds.
