### PR TITLE
feat(en): Enable Merkle tree client on EN

### DIFF
--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -262,6 +262,7 @@ async fn init_tasks(
         .build()
         .await
         .context("failed to build a tree_pool")?;
+    let tree_reader = Arc::new(metadata_calculator.tree_reader());
     let tree_handle = task::spawn(metadata_calculator.run(tree_pool, tree_stop_receiver));
 
     let commitment_generator_pool = singleton_pool_builder
@@ -340,6 +341,7 @@ async fn init_tasks(
             .with_tx_sender(tx_sender.clone())
             .with_vm_barrier(vm_barrier.clone())
             .with_sync_state(sync_state.clone())
+            .with_tree_api(tree_reader.clone())
             .enable_api_namespaces(config.optional.api_namespaces())
             .build()
             .context("failed to build HTTP JSON-RPC server")?
@@ -358,6 +360,7 @@ async fn init_tasks(
             .with_tx_sender(tx_sender)
             .with_vm_barrier(vm_barrier)
             .with_sync_state(sync_state)
+            .with_tree_api(tree_reader)
             .enable_api_namespaces(config.optional.api_namespaces())
             .build()
             .context("failed to build WS JSON-RPC server")?

--- a/core/lib/config/src/configs/api.rs
+++ b/core/lib/config/src/configs/api.rs
@@ -207,8 +207,8 @@ impl Web3JsonRpcConfig {
             .unwrap_or(NonZeroU32::new(6000).unwrap())
     }
 
-    pub fn tree_api_url(&self) -> Option<String> {
-        self.tree_api_url.clone()
+    pub fn tree_api_url(&self) -> Option<&str> {
+        self.tree_api_url.as_deref()
     }
 }
 

--- a/core/lib/health_check/src/lib.rs
+++ b/core/lib/health_check/src/lib.rs
@@ -271,6 +271,17 @@ impl fmt::Debug for dyn CheckHealth {
     }
 }
 
+#[async_trait]
+impl<T: CheckHealth + ?Sized> CheckHealth for Arc<T> {
+    fn name(&self) -> &'static str {
+        (**self).name()
+    }
+
+    async fn check_health(&self) -> Health {
+        (**self).check_health().await
+    }
+}
+
 /// Basic implementation of [`CheckHealth`] trait that can be updated using a matching [`HealthUpdater`].
 #[derive(Debug, Clone)]
 pub struct ReactiveHealthCheck {

--- a/core/lib/merkle_tree/src/errors.rs
+++ b/core/lib/merkle_tree/src/errors.rs
@@ -138,8 +138,10 @@ impl error::Error for DeserializeError {}
 /// Error accessing a specific tree version.
 #[derive(Debug)]
 pub struct NoVersionError {
-    pub(crate) missing_version: u64,
-    pub(crate) version_count: u64,
+    /// Missing requested version of the tree.
+    pub missing_version: u64,
+    /// Current number of versions in the tree.
+    pub version_count: u64,
 }
 
 impl fmt::Display for NoVersionError {
@@ -151,12 +153,12 @@ impl fmt::Display for NoVersionError {
         if missing_version >= version_count {
             write!(
                 formatter,
-                "Version {missing_version} does not exist in Merkle tree; it has {version_count} versions"
+                "version {missing_version} does not exist in Merkle tree; it has {version_count} versions"
             )
         } else {
             write!(
                 formatter,
-                "Version {missing_version} was pruned from Merkle tree"
+                "version {missing_version} was pruned from Merkle tree"
             )
         }
     }

--- a/core/lib/web3_decl/src/namespaces/zks.rs
+++ b/core/lib/web3_decl/src/namespaces/zks.rs
@@ -117,5 +117,5 @@ pub trait ZksNamespace {
         address: Address,
         keys: Vec<H256>,
         l1_batch_number: L1BatchNumber,
-    ) -> RpcResult<Proof>;
+    ) -> RpcResult<Option<Proof>>;
 }

--- a/core/lib/zksync_core/src/api_server/tree/mod.rs
+++ b/core/lib/zksync_core/src/api_server/tree/mod.rs
@@ -18,6 +18,8 @@ use zksync_types::{L1BatchNumber, H256, U256};
 use self::metrics::{MerkleTreeApiMethod, API_METRICS};
 use crate::metadata_calculator::{AsyncTreeReader, MerkleTreeInfo};
 
+// FIXME: healthcheck for HTTP client; lazy client
+
 mod metrics;
 #[cfg(test)]
 mod tests;
@@ -34,7 +36,7 @@ struct TreeProofsResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub(crate) struct TreeEntryWithProof {
+pub struct TreeEntryWithProof {
     #[serde(default, skip_serializing_if = "H256::is_zero")]
     pub value: H256,
     #[serde(default, skip_serializing_if = "TreeEntryWithProof::is_zero")]
@@ -86,7 +88,7 @@ impl IntoResponse for TreeApiError {
 
 /// Client accessing Merkle tree API.
 #[async_trait]
-pub(crate) trait TreeApiClient {
+pub trait TreeApiClient: 'static + Send + Sync + fmt::Debug {
     /// Obtains general information about the tree.
     async fn get_info(&self) -> anyhow::Result<MerkleTreeInfo>;
 

--- a/core/lib/zksync_core/src/api_server/tree/mod.rs
+++ b/core/lib/zksync_core/src/api_server/tree/mod.rs
@@ -16,9 +16,9 @@ use zksync_merkle_tree::NoVersionError;
 use zksync_types::{L1BatchNumber, H256, U256};
 
 use self::metrics::{MerkleTreeApiMethod, API_METRICS};
-use crate::metadata_calculator::{AsyncTreeReader, MerkleTreeInfo};
+use crate::metadata_calculator::{AsyncTreeReader, LazyAsyncTreeReader, MerkleTreeInfo};
 
-// FIXME: healthcheck for HTTP client; lazy client
+// FIXME: healthcheck for HTTP client
 
 mod metrics;
 #[cfg(test)]
@@ -62,59 +62,117 @@ impl TreeEntryWithProof {
     }
 }
 
+/// Server-side tree API error.
 #[derive(Debug)]
-enum TreeApiError {
+enum TreeApiServerError {
     NoTreeVersion(NoVersionError),
 }
 
-impl IntoResponse for TreeApiError {
-    fn into_response(self) -> Response {
-        let (status, title, detail) = match self {
-            Self::NoTreeVersion(err) => {
-                (StatusCode::NOT_FOUND, "L1 batch not found", err.to_string())
-            }
-        };
+// Contains the same fields as `NoVersionError` and is serializable.
+#[derive(Debug, Serialize, Deserialize)]
+struct NoVersionErrorData {
+    missing_version: u64,
+    version_count: u64,
+}
 
-        // Loosely conforms to HTTP Problem Details RFC: <https://datatracker.ietf.org/doc/html/rfc7807>
-        let body = serde_json::json!({
-            "type": "/errors#l1-batch-not-found",
-            "title": title,
-            "detail": detail,
-        });
-        let headers = [(header::CONTENT_TYPE, "application/problem+json")];
-        (status, headers, Json(body)).into_response()
+impl From<NoVersionError> for NoVersionErrorData {
+    fn from(err: NoVersionError) -> Self {
+        Self {
+            missing_version: err.missing_version,
+            version_count: err.version_count,
+        }
     }
+}
+
+impl From<NoVersionErrorData> for NoVersionError {
+    fn from(data: NoVersionErrorData) -> Self {
+        Self {
+            missing_version: data.missing_version,
+            version_count: data.version_count,
+        }
+    }
+}
+
+// Loosely conforms to HTTP Problem Details RFC: <https://datatracker.ietf.org/doc/html/rfc7807>
+#[derive(Debug, Serialize)]
+struct Problem<T> {
+    r#type: &'static str,
+    title: &'static str,
+    detail: String,
+    #[serde(flatten)]
+    data: T,
+}
+
+const PROBLEM_CONTENT_TYPE: &str = "application/problem+json";
+
+impl IntoResponse for TreeApiServerError {
+    fn into_response(self) -> Response {
+        let headers = [(header::CONTENT_TYPE, PROBLEM_CONTENT_TYPE)];
+        match self {
+            Self::NoTreeVersion(err) => {
+                let body = Problem {
+                    r#type: "/errors#l1-batch-not-found",
+                    title: "L1 batch not found",
+                    detail: err.to_string(),
+                    data: NoVersionErrorData::from(err),
+                };
+                (StatusCode::NOT_FOUND, headers, Json(body)).into_response()
+            }
+        }
+    }
+}
+
+/// Client-side tree API error used by [`TreeApiClient`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum TreeApiError {
+    #[error(transparent)]
+    NoVersion(NoVersionError),
+    #[error("tree API is temporarily not available because the Merkle tree isn't initialized; repeat request later")]
+    NotReady,
+    /// Catch-all variant for internal errors.
+    #[error("internal error")]
+    Internal(#[from] anyhow::Error),
 }
 
 /// Client accessing Merkle tree API.
 #[async_trait]
 pub trait TreeApiClient: 'static + Send + Sync + fmt::Debug {
     /// Obtains general information about the tree.
-    async fn get_info(&self) -> anyhow::Result<MerkleTreeInfo>;
+    async fn get_info(&self) -> Result<MerkleTreeInfo, TreeApiError>;
 
     /// Obtains proofs for the specified `hashed_keys` at the specified tree version (= L1 batch number).
     async fn get_proofs(
         &self,
         l1_batch_number: L1BatchNumber,
         hashed_keys: Vec<U256>,
-    ) -> anyhow::Result<Vec<TreeEntryWithProof>>;
+    ) -> Result<Vec<TreeEntryWithProof>, TreeApiError>;
 }
 
 /// In-memory client implementation.
 #[async_trait]
-impl TreeApiClient for AsyncTreeReader {
-    async fn get_info(&self) -> anyhow::Result<MerkleTreeInfo> {
-        Ok(self.clone().info().await)
+impl TreeApiClient for LazyAsyncTreeReader {
+    async fn get_info(&self) -> Result<MerkleTreeInfo, TreeApiError> {
+        if let Some(reader) = self.read() {
+            Ok(reader.info().await)
+        } else {
+            Err(TreeApiError::NotReady)
+        }
     }
 
     async fn get_proofs(
         &self,
         l1_batch_number: L1BatchNumber,
         hashed_keys: Vec<U256>,
-    ) -> anyhow::Result<Vec<TreeEntryWithProof>> {
-        self.get_proofs_inner(l1_batch_number, hashed_keys)
-            .await
-            .map_err(Into::into)
+    ) -> Result<Vec<TreeEntryWithProof>, TreeApiError> {
+        if let Some(reader) = self.read() {
+            reader
+                .get_proofs_inner(l1_batch_number, hashed_keys)
+                .await
+                .map_err(TreeApiError::NoVersion)
+        } else {
+            Err(TreeApiError::NotReady)
+        }
     }
 }
 
@@ -138,7 +196,7 @@ impl TreeApiHttpClient {
 
 #[async_trait]
 impl TreeApiClient for TreeApiHttpClient {
-    async fn get_info(&self) -> anyhow::Result<MerkleTreeInfo> {
+    async fn get_info(&self) -> Result<MerkleTreeInfo, TreeApiError> {
         let response = self
             .inner
             .get(&self.info_url)
@@ -148,17 +206,17 @@ impl TreeApiClient for TreeApiHttpClient {
         let response = response
             .error_for_status()
             .context("Requesting tree info returned non-OK response")?;
-        response
+        Ok(response
             .json()
             .await
-            .context("Failed deserializing tree info")
+            .context("Failed deserializing tree info")?)
     }
 
     async fn get_proofs(
         &self,
         l1_batch_number: L1BatchNumber,
         hashed_keys: Vec<U256>,
-    ) -> anyhow::Result<Vec<TreeEntryWithProof>> {
+    ) -> Result<Vec<TreeEntryWithProof>, TreeApiError> {
         let response = self
             .inner
             .post(&self.proofs_url)
@@ -168,12 +226,26 @@ impl TreeApiClient for TreeApiHttpClient {
             })
             .send()
             .await
-            .with_context(|| format!("Failed requesting proofs for L1 batch #{l1_batch_number}"))?;
+            .with_context(|| format!("failed requesting proofs for L1 batch #{l1_batch_number}"))?;
+
+        let is_problem = response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .map_or(false, |header| *header == PROBLEM_CONTENT_TYPE);
+        if response.status() == StatusCode::NOT_FOUND && is_problem {
+            // Try to parse `NoVersionError` from the response body.
+            let problem_data: NoVersionErrorData = response
+                .json()
+                .await
+                .context("failed parsing error response")?;
+            return Err(TreeApiError::NoVersion(problem_data.into()));
+        }
+
         let response = response.error_for_status().with_context(|| {
-            format!("Requesting proofs for L1 batch #{l1_batch_number} returned non-OK response")
+            format!("requesting proofs for L1 batch #{l1_batch_number} returned non-OK response")
         })?;
         let response: TreeProofsResponse = response.json().await.with_context(|| {
-            format!("Failed deserializing proofs for L1 batch #{l1_batch_number}")
+            format!("failed deserializing proofs for L1 batch #{l1_batch_number}")
         })?;
         Ok(response.entries)
     }
@@ -202,12 +274,12 @@ impl AsyncTreeReader {
     async fn get_proofs_handler(
         State(this): State<Self>,
         Json(request): Json<TreeProofsRequest>,
-    ) -> Result<Json<TreeProofsResponse>, TreeApiError> {
+    ) -> Result<Json<TreeProofsResponse>, TreeApiServerError> {
         let latency = API_METRICS.latency[&MerkleTreeApiMethod::GetProofs].start();
         let entries = this
             .get_proofs_inner(request.l1_batch_number, request.hashed_keys)
             .await
-            .map_err(TreeApiError::NoTreeVersion)?;
+            .map_err(TreeApiServerError::NoTreeVersion)?;
         let response = TreeProofsResponse { entries };
         latency.observe();
         Ok(Json(response))

--- a/core/lib/zksync_core/src/api_server/tree/tests.rs
+++ b/core/lib/zksync_core/src/api_server/tree/tests.rs
@@ -2,6 +2,7 @@
 
 use std::net::Ipv4Addr;
 
+use assert_matches::assert_matches;
 use tempfile::TempDir;
 use zksync_dal::ConnectionPool;
 
@@ -23,6 +24,7 @@ async fn merkle_tree_api() {
 
     let (stop_sender, stop_receiver) = watch::channel(false);
     let api_server = tree_reader
+        .wait()
         .await
         .create_api_server(&api_addr, stop_receiver.clone())
         .unwrap();
@@ -60,21 +62,43 @@ async fn merkle_tree_api() {
         .get_proofs(L1BatchNumber(10), vec![])
         .await
         .unwrap_err();
-    let err = format!("{err:?}");
-    // Check that the error message contains all necessary info to troubleshoot it.
-    assert!(
-        err.contains("Requesting proofs for L1 batch #10 returned non-OK response"),
-        "{}",
-        err
-    );
-    assert!(err.contains("404 Not Found"), "{}", err);
-    assert!(
-        err.contains(&format!("http://{local_addr}/proofs")),
-        "{}",
-        err
-    );
+    let TreeApiError::NoVersion(err) = err else {
+        panic!("Unexpected error: {err:?}");
+    };
+    assert_eq!(err.version_count, 6);
+    assert_eq!(err.missing_version, 10);
 
     // Stop the calculator and the tree API server.
     stop_sender.send_replace(true);
     api_server_task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn local_merkle_tree_client() {
+    let pool = ConnectionPool::test_pool().await;
+    let temp_dir = TempDir::new().expect("failed get temporary directory for RocksDB");
+    let (calculator, _) = setup_calculator(temp_dir.path(), &pool).await;
+
+    reset_db_state(&pool, 5).await;
+    let tree_reader = calculator.tree_reader();
+
+    let err = tree_reader.get_info().await.unwrap_err();
+    assert_matches!(err, TreeApiError::NotReady);
+
+    // Wait until the calculator processes initial L1 batches.
+    run_calculator(calculator, pool).await;
+
+    let tree_info = tree_reader.get_info().await.unwrap();
+    assert!(tree_info.leaf_count > 20);
+    assert_eq!(tree_info.next_l1_batch_number, L1BatchNumber(6));
+
+    let err = tree_reader
+        .get_proofs(L1BatchNumber(10), vec![])
+        .await
+        .unwrap_err();
+    let TreeApiError::NoVersion(err) = err else {
+        panic!("Unexpected error: {err:?}");
+    };
+    assert_eq!(err.version_count, 6);
+    assert_eq!(err.missing_version, 10);
 }

--- a/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/zks.rs
@@ -162,7 +162,7 @@ impl ZksNamespaceServer for ZksNamespace {
         address: Address,
         keys: Vec<H256>,
         l1_batch_number: L1BatchNumber,
-    ) -> RpcResult<Proof> {
+    ) -> RpcResult<Option<Proof>> {
         self.get_proofs_impl(address, keys, l1_batch_number)
             .await
             .map_err(|err| self.current_method().map_err(err))

--- a/core/lib/zksync_core/src/api_server/web3/mod.rs
+++ b/core/lib/zksync_core/src/api_server/web3/mod.rs
@@ -242,6 +242,7 @@ impl ApiBuilder {
     }
 
     pub fn with_tree_api(mut self, tree_api: Arc<dyn TreeApiClient>) -> Self {
+        tracing::info!("Using tree API client: {tree_api:?}");
         self.optional.tree_api = Some(tree_api);
         self
     }

--- a/core/lib/zksync_core/src/api_server/web3/mod.rs
+++ b/core/lib/zksync_core/src/api_server/web3/mod.rs
@@ -37,7 +37,7 @@ use self::{
 use crate::{
     api_server::{
         execution_sandbox::{BlockStartInfo, VmConcurrencyBarrier},
-        tree::TreeApiHttpClient,
+        tree::TreeApiClient,
         tx_sender::TxSender,
     },
     sync_layer::SyncState,
@@ -115,7 +115,7 @@ struct OptionalApiParams {
     batch_request_size_limit: Option<usize>,
     response_body_size_limit: Option<usize>,
     websocket_requests_per_minute_limit: Option<NonZeroU32>,
-    tree_api_url: Option<String>,
+    tree_api: Option<Arc<dyn TreeApiClient>>,
     pub_sub_events_sender: Option<mpsc::UnboundedSender<PubSubEvent>>,
 }
 
@@ -241,8 +241,8 @@ impl ApiBuilder {
         self
     }
 
-    pub fn with_tree_api(mut self, tree_api_url: Option<String>) -> Self {
-        self.optional.tree_api_url = tree_api_url;
+    pub fn with_tree_api(mut self, tree_api: Arc<dyn TreeApiClient>) -> Self {
+        self.optional.tree_api = Some(tree_api);
         self
     }
 
@@ -318,10 +318,7 @@ impl ApiServer {
             api_config: self.config,
             start_info,
             last_sealed_miniblock,
-            tree_api: self
-                .optional
-                .tree_api_url
-                .map(|url| TreeApiHttpClient::new(url.as_str())),
+            tree_api: self.optional.tree_api,
         })
     }
 

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
@@ -516,7 +516,6 @@ impl ZksNamespace {
             Err(TreeApiError::NotReady) => return Err(Web3Error::TreeApiUnavailable),
             Err(TreeApiError::NoVersion(err)) => {
                 return if err.missing_version > err.version_count {
-                    // FIXME: should we distinguish the case when the tree is catching up?
                     Ok(None)
                 } else {
                     Err(Web3Error::InternalError(anyhow::anyhow!(

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
@@ -26,10 +26,7 @@ use zksync_web3_decl::{
     types::{Address, Token, H256},
 };
 
-use crate::api_server::{
-    tree::TreeApiClient,
-    web3::{backend_jsonrpsee::MethodTracer, RpcState},
-};
+use crate::api_server::web3::{backend_jsonrpsee::MethodTracer, RpcState};
 
 #[derive(Debug)]
 pub(crate) struct ZksNamespace {
@@ -505,14 +502,15 @@ impl ZksNamespace {
             .iter()
             .map(|key| StorageKey::new(AccountTreeId::new(address), *key).hashed_key_u256())
             .collect();
-        let proofs = self
+        let tree_api = self
             .state
             .tree_api
-            .as_ref()
-            .ok_or(Web3Error::TreeApiUnavailable)?
+            .as_deref()
+            .ok_or(Web3Error::TreeApiUnavailable)?;
+        let proofs = tree_api
             .get_proofs(l1_batch_number, hashed_keys)
             .await
-            .context("get_proofs")?;
+            .context("get_proofs")?; // FIXME: reconsider error handling
 
         let storage_proof = proofs
             .into_iter()

--- a/core/lib/zksync_core/src/api_server/web3/state.rs
+++ b/core/lib/zksync_core/src/api_server/web3/state.rs
@@ -27,7 +27,7 @@ use super::{
 use crate::{
     api_server::{
         execution_sandbox::{BlockArgs, BlockArgsError, BlockStartInfo},
-        tree::TreeApiHttpClient,
+        tree::TreeApiClient,
         tx_sender::{tx_sink::TxSink, TxSender},
     },
     sync_layer::SyncState,
@@ -203,7 +203,7 @@ pub(crate) struct RpcState {
     pub(super) current_method: Arc<MethodTracer>,
     pub(super) installed_filters: Option<Arc<Mutex<Filters>>>,
     pub(super) connection_pool: ConnectionPool,
-    pub(super) tree_api: Option<TreeApiHttpClient>,
+    pub(super) tree_api: Option<Arc<dyn TreeApiClient>>,
     pub(super) tx_sender: TxSender,
     pub(super) sync_state: Option<SyncState>,
     pub(super) api_config: InternalApiConfig,

--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -948,6 +948,7 @@ async fn run_tree(
         let stop_receiver = stop_receiver.clone();
         task_futures.push(tokio::spawn(async move {
             tree_reader
+                .wait()
                 .await
                 .run_api_server(address, stop_receiver)
                 .await

--- a/core/lib/zksync_core/src/metadata_calculator/helpers.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/helpers.rs
@@ -26,7 +26,7 @@ use super::metrics::{LoadChangesStage, TreeUpdateStage, METRICS};
 
 /// General information about the Merkle tree.
 #[derive(Debug, Serialize, Deserialize)]
-pub(crate) struct MerkleTreeInfo {
+pub struct MerkleTreeInfo {
     pub mode: MerkleTreeMode,
     pub root_hash: H256,
     pub next_l1_batch_number: L1BatchNumber,

--- a/core/lib/zksync_core/src/metadata_calculator/helpers.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/helpers.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::BTreeMap,
+    future,
     future::Future,
     path::{Path, PathBuf},
     time::Duration,
@@ -11,6 +12,7 @@ use anyhow::Context as _;
 use serde::{Deserialize, Serialize};
 #[cfg(test)]
 use tokio::sync::mpsc;
+use tokio::sync::watch;
 use zksync_config::configs::database::MerkleTreeMode;
 use zksync_dal::StorageProcessor;
 use zksync_health_check::{Health, HealthStatus};
@@ -227,6 +229,30 @@ impl AsyncTreeReader {
         tokio::task::spawn_blocking(move || self.inner.entries_with_proofs(l1_batch_number, &keys))
             .await
             .unwrap()
+    }
+}
+
+/// Lazily initialized [`AsyncTreeReader`].
+#[derive(Debug)]
+pub struct LazyAsyncTreeReader(pub(super) watch::Receiver<Option<AsyncTreeReader>>);
+
+impl LazyAsyncTreeReader {
+    /// Returns a reader if it is initialized.
+    pub(crate) fn read(&self) -> Option<AsyncTreeReader> {
+        self.0.borrow().clone()
+    }
+
+    /// Waits until the tree is initialized and returns a reader for it.
+    pub(crate) async fn wait(mut self) -> AsyncTreeReader {
+        loop {
+            if let Some(reader) = self.0.borrow().clone() {
+                break reader;
+            }
+            if self.0.changed().await.is_err() {
+                tracing::info!("Tree dropped without getting ready; not resolving tree reader");
+                future::pending::<()>().await;
+            }
+        }
     }
 }
 

--- a/core/lib/zksync_core/src/metadata_calculator/mod.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/mod.rs
@@ -2,7 +2,6 @@
 //! stores them in the DB.
 
 use std::{
-    future::{self, Future},
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -17,6 +16,7 @@ use zksync_dal::ConnectionPool;
 use zksync_health_check::{HealthUpdater, ReactiveHealthCheck};
 use zksync_object_store::ObjectStore;
 
+pub use self::helpers::LazyAsyncTreeReader;
 pub(crate) use self::helpers::{AsyncTreeReader, L1BatchWithLogs, MerkleTreeInfo};
 use self::{
     helpers::{create_db, Delayer, GenericAsyncTree, MerkleTreeHealth},
@@ -109,19 +109,8 @@ impl MetadataCalculator {
     }
 
     /// Returns a reference to the tree reader.
-    pub(crate) fn tree_reader(&self) -> impl Future<Output = AsyncTreeReader> {
-        let mut receiver = self.tree_reader.subscribe();
-        async move {
-            loop {
-                if let Some(reader) = receiver.borrow().clone() {
-                    break reader;
-                }
-                if receiver.changed().await.is_err() {
-                    tracing::info!("Tree dropped without getting ready; not resolving tree reader");
-                    future::pending::<()>().await;
-                }
-            }
-        }
+    pub fn tree_reader(&self) -> LazyAsyncTreeReader {
+        LazyAsyncTreeReader(self.tree_reader.subscribe())
     }
 
     async fn create_tree(&self) -> anyhow::Result<GenericAsyncTree> {

--- a/core/lib/zksync_core/src/metadata_calculator/recovery/tests.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/recovery/tests.rs
@@ -272,7 +272,7 @@ async fn entire_recovery_workflow(case: RecoveryWorkflowCase) {
     match case {
         // Wait until the tree is fully initialized and stop the calculator.
         RecoveryWorkflowCase::Stop => {
-            let tree_info = tree_reader.await.info().await;
+            let tree_info = tree_reader.wait().await.info().await;
             assert_eq!(tree_info.root_hash, snapshot_recovery.l1_batch_root_hash);
             assert_eq!(tree_info.leaf_count, 200);
             assert_eq!(
@@ -283,7 +283,7 @@ async fn entire_recovery_workflow(case: RecoveryWorkflowCase) {
 
         // Emulate state keeper adding a new L1 batch to Postgres.
         RecoveryWorkflowCase::CreateBatch => {
-            tree_reader.await;
+            tree_reader.wait().await;
 
             let mut storage = storage.start_transaction().await.unwrap();
             let mut new_logs = gen_storage_logs(500..600, 1).pop().unwrap();

--- a/core/node/node_framework/examples/main_node.rs
+++ b/core/node/node_framework/examples/main_node.rs
@@ -35,6 +35,7 @@ use zksync_node_framework::{
         },
         web3_api::{
             server::{Web3ServerLayer, Web3ServerOptionalConfig},
+            tree_api_client::TreeApiClientLayer,
             tx_sender::{PostgresStorageCachesConfig, TxSenderLayer},
             tx_sink::TxSinkLayer,
         },
@@ -167,6 +168,13 @@ impl MainNodeBuilder {
         Ok(self)
     }
 
+    fn add_tree_api_client_layer(mut self) -> anyhow::Result<Self> {
+        let rpc_config = ApiConfig::from_env()?.web3_json_rpc;
+        self.node
+            .add_layer(TreeApiClientLayer::http(rpc_config.tree_api_url));
+        Ok(self)
+    }
+
     fn add_http_web3_api_layer(mut self) -> anyhow::Result<Self> {
         let rpc_config = ApiConfig::from_env()?.web3_json_rpc;
         let contracts_config = ContractsConfig::from_env()?;
@@ -186,7 +194,6 @@ impl MainNodeBuilder {
             subscriptions_limit: Some(rpc_config.subscriptions_limit()),
             batch_request_size_limit: Some(rpc_config.max_batch_request_size()),
             response_body_size_limit: Some(rpc_config.max_response_body_size()),
-            tree_api_url: rpc_config.tree_api_url(),
             ..Default::default()
         };
         self.node.add_layer(Web3ServerLayer::http(
@@ -220,7 +227,6 @@ impl MainNodeBuilder {
             websocket_requests_per_minute_limit: Some(
                 rpc_config.websocket_requests_per_minute_limit(),
             ),
-            tree_api_url: rpc_config.tree_api_url(),
         };
         self.node.add_layer(Web3ServerLayer::ws(
             rpc_config.ws_port,
@@ -258,6 +264,7 @@ fn main() -> anyhow::Result<()> {
         .add_proof_data_handler_layer()?
         .add_healthcheck_layer()?
         .add_tx_sender_layer()?
+        .add_tree_api_client_layer()?
         .add_http_web3_api_layer()?
         .add_ws_web3_api_layer()?
         .build()

--- a/core/node/node_framework/src/implementations/layers/web3_api/mod.rs
+++ b/core/node/node_framework/src/implementations/layers/web3_api/mod.rs
@@ -1,3 +1,4 @@
 pub mod server;
+pub mod tree_api_client;
 pub mod tx_sender;
 pub mod tx_sink;

--- a/core/node/node_framework/src/implementations/layers/web3_api/tree_api_client.rs
+++ b/core/node/node_framework/src/implementations/layers/web3_api/tree_api_client.rs
@@ -1,0 +1,35 @@
+use std::sync::Arc;
+
+use zksync_core::api_server::tree::TreeApiHttpClient;
+
+use crate::{
+    implementations::resources::web3_api::TreeApiClientResource,
+    service::ServiceContext,
+    wiring_layer::{WiringError, WiringLayer},
+};
+
+#[derive(Debug)]
+pub struct TreeApiClientLayer {
+    url: Option<String>,
+}
+
+impl TreeApiClientLayer {
+    pub fn http(url: Option<String>) -> Self {
+        Self { url }
+    }
+}
+
+#[async_trait::async_trait]
+impl WiringLayer for TreeApiClientLayer {
+    fn layer_name(&self) -> &'static str {
+        "tree_api_client_layer"
+    }
+
+    async fn wire(self: Box<Self>, mut context: ServiceContext<'_>) -> Result<(), WiringError> {
+        if let Some(url) = &self.url {
+            let client = TreeApiHttpClient::new(url);
+            context.insert_resource(TreeApiClientResource(Arc::new(client)))?;
+        }
+        Ok(())
+    }
+}

--- a/core/node/node_framework/src/implementations/resources/web3_api.rs
+++ b/core/node/node_framework/src/implementations/resources/web3_api.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use zksync_core::api_server::tx_sender::{tx_sink::TxSink, TxSender};
+use zksync_core::api_server::{
+    tree::TreeApiClient,
+    tx_sender::{tx_sink::TxSink, TxSender},
+};
 
 use crate::resource::{Resource, ResourceId};
 
@@ -19,5 +22,14 @@ pub struct TxSinkResource(pub Arc<dyn TxSink>);
 impl Resource for TxSinkResource {
     fn resource_id() -> ResourceId {
         "api/tx_sink".into()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TreeApiClientResource(pub Arc<dyn TreeApiClient>);
+
+impl Resource for TreeApiClientResource {
+    fn resource_id() -> ResourceId {
+        "api/tree_api_client".into()
     }
 }


### PR DESCRIPTION
## What ❔

Enables Merkle tree client on EN so that `zks_getProof` can work properly.

## Why ❔

This endpoint won't produce overhead and could be useful for some EN operators. Also, it allows checking Merkle tree consistency after snapshot recovery more easily.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.