### PR TITLE
chore(tests): Wait for deployed L2 bridge before starting tests

### DIFF
--- a/core/tests/ts-integration/src/env.ts
+++ b/core/tests/ts-integration/src/env.ts
@@ -8,6 +8,7 @@ import { Reporter } from './reporter';
 /**
  * Attempts to connect to server.
  * This function returns once connection can be established, or throws an exception in case of timeout.
+ * It also waits for L2 ERC20 bridge to be deployed.
  *
  * This function is expected to be called *before* loading an environment via `loadTestEnvironment`,
  * because the latter expects server to be running and may throw otherwise.
@@ -29,6 +30,12 @@ export async function waitForServer() {
     for (let i = 0; i < maxAttempts; ++i) {
         try {
             await l2Provider.getNetwork(); // Will throw if the server is not ready yet.
+            const bridgeAddress = (await l2Provider.getDefaultBridgeAddresses()).erc20L2;
+            const code = await l2Provider.getCode(bridgeAddress);
+            if (code == '0x') {
+                throw Error('L2 ERC20 bridge is not deployed yet, server is not ready');
+            }
+
             ready = true;
             reporter.finishAction();
             return;


### PR DESCRIPTION
## What ❔

Wait for deployed L2 bridge before starting tests

## Why ❔

Deployed L2 bridge is required for correct gas estimation of deposits. 

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
