### PR TITLE
feat: API tests higher timeout

### DIFF
--- a/core/lib/zksync_core/src/api_server/web3/tests/mod.rs
+++ b/core/lib/zksync_core/src/api_server/web3/tests/mod.rs
@@ -57,7 +57,7 @@ mod snapshots;
 mod vm;
 mod ws;
 
-const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+const TEST_TIMEOUT: Duration = Duration::from_secs(30);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 impl ApiServerHandles {


### PR DESCRIPTION
## What ❔

Increased timeout for API tests as they started to consistently fail on my Thinkpad X1. Obviously this is only silver-taping stuff and I would really like to fix this permanently, but I don't think I have bandwidth for it now.