### PR TITLE
feat(Validium): unit tests for `ensure_l1_batch_commit_data_generation_mode`

### DIFF
--- a/checks-config/era.dic
+++ b/checks-config/era.dic
@@ -908,3 +908,4 @@ stateful
 DeployRequest
 getPubdataPricingMode
 Uint
+implementors

--- a/core/lib/zksync_core/src/utils/mod.rs
+++ b/core/lib/zksync_core/src/utils/mod.rs
@@ -203,8 +203,8 @@ pub async fn ensure_l1_batch_commit_data_generation_mode(
             Ok(())
         }
         // Getters contract does not support getPubdataPricingMode method.
-        // This case is accepted for backwards compatibility with older contracts, but warned
-        // in case the wrong contract address was passed by the caller.
+        // This case is accepted for backwards compatibility with older contracts, but emits a
+        // warning in case the wrong contract address was passed by the caller.
         Err(EthClientError::Contract(_)) => {
             tracing::warn!("Getters contract does not support getPubdataPricingMode method");
             Ok(())

--- a/core/lib/zksync_core/src/utils/mod.rs
+++ b/core/lib/zksync_core/src/utils/mod.rs
@@ -178,6 +178,7 @@ async fn get_pubdata_pricing_mode(
     eth_client.call_contract_function(args).await
 }
 
+#[must_use]
 pub async fn ensure_l1_batch_commit_data_generation_mode(
     selected_l1_batch_commit_data_generator_mode: L1BatchCommitDataGeneratorMode,
     diamond_proxy_address: Address,

--- a/core/lib/zksync_core/src/utils/mod.rs
+++ b/core/lib/zksync_core/src/utils/mod.rs
@@ -215,6 +215,7 @@ pub async fn ensure_l1_batch_commit_data_generation_mode(
 
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
     use std::sync::Mutex;
 
     use zksync_eth_client::{ContractCall, ExecutedTxStatus, FailureInfo, RawTransactionBytes};
@@ -420,39 +421,47 @@ mod tests {
     #[tokio::test]
     async fn ensure_l1_batch_commit_data_generation_mode_succeeds_when_both_match() {
         let addr = Address::repeat_byte(0x01);
-        assert!(ensure_l1_batch_commit_data_generation_mode(
-            L1BatchCommitDataGeneratorMode::Rollup,
-            addr,
-            &MockEthereumForCommitGenerationMode::with_rollup_contract(),
-        )
-        .await
-        .is_ok(),);
-        assert!(ensure_l1_batch_commit_data_generation_mode(
-            L1BatchCommitDataGeneratorMode::Validium,
-            addr,
-            &MockEthereumForCommitGenerationMode::with_validium_contract(),
-        )
-        .await
-        .is_ok(),);
+        assert_matches!(
+            ensure_l1_batch_commit_data_generation_mode(
+                L1BatchCommitDataGeneratorMode::Rollup,
+                addr,
+                &MockEthereumForCommitGenerationMode::with_rollup_contract(),
+            )
+            .await,
+            Ok(())
+        );
+        assert_matches!(
+            ensure_l1_batch_commit_data_generation_mode(
+                L1BatchCommitDataGeneratorMode::Validium,
+                addr,
+                &MockEthereumForCommitGenerationMode::with_validium_contract(),
+            )
+            .await,
+            Ok(())
+        );
     }
 
     #[tokio::test]
     async fn ensure_l1_batch_commit_data_generation_mode_succeeds_on_legacy_contracts() {
         let addr = Address::repeat_byte(0x01);
-        assert!(ensure_l1_batch_commit_data_generation_mode(
-            L1BatchCommitDataGeneratorMode::Rollup,
-            addr,
-            &MockEthereumForCommitGenerationMode::with_legacy_contract(),
-        )
-        .await
-        .is_ok(),);
-        assert!(ensure_l1_batch_commit_data_generation_mode(
-            L1BatchCommitDataGeneratorMode::Validium,
-            addr,
-            &MockEthereumForCommitGenerationMode::with_legacy_contract(),
-        )
-        .await
-        .is_ok(),);
+        assert_matches!(
+            ensure_l1_batch_commit_data_generation_mode(
+                L1BatchCommitDataGeneratorMode::Rollup,
+                addr,
+                &MockEthereumForCommitGenerationMode::with_legacy_contract(),
+            )
+            .await,
+            Ok(())
+        );
+        assert_matches!(
+            ensure_l1_batch_commit_data_generation_mode(
+                L1BatchCommitDataGeneratorMode::Validium,
+                addr,
+                &MockEthereumForCommitGenerationMode::with_legacy_contract(),
+            )
+            .await,
+            Ok(())
+        );
     }
 
     #[tokio::test]

--- a/core/lib/zksync_core/src/utils/mod.rs
+++ b/core/lib/zksync_core/src/utils/mod.rs
@@ -178,7 +178,6 @@ async fn get_pubdata_pricing_mode(
     eth_client.call_contract_function(args).await
 }
 
-#[must_use]
 pub async fn ensure_l1_batch_commit_data_generation_mode(
     selected_l1_batch_commit_data_generator_mode: L1BatchCommitDataGeneratorMode,
     diamond_proxy_address: Address,

--- a/core/lib/zksync_core/src/utils/mod.rs
+++ b/core/lib/zksync_core/src/utils/mod.rs
@@ -215,9 +215,9 @@ pub async fn ensure_l1_batch_commit_data_generation_mode(
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
     use std::sync::Mutex;
 
+    use assert_matches::assert_matches;
     use zksync_eth_client::{ContractCall, ExecutedTxStatus, FailureInfo, RawTransactionBytes};
     use zksync_types::{
         web3::types::{Block, BlockId, BlockNumber, Filter, Log, Transaction, TransactionReceipt},


### PR DESCRIPTION
## What ❔

1. Add a set of unit tests for `ensure_l1_batch_commit_data_generation_mode`, making sure the right kind of errors or lack thereof are returned for a given set of parameters and L1 responses. It required a mock for `EthInterface` to return the needed values.
2. Annotate `ensure_l1_batch_commit_data_generation_mode` to make sure we use the result, otherwise we may end up in inconsistent state.

## Why ❔

QA

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
