### PR TITLE
docs(prover): Add quick-setup for GPU provers + doc tweaks

### DIFF
--- a/prover/prover_fri/README.md
+++ b/prover/prover_fri/README.md
@@ -73,7 +73,7 @@ installation as a pre-requisite, alongside these machine specs:
    zk f cargo run --release --bin zksync_prover_fri_gateway
    ```
 
-5. Run 4 witness generators to generate witness for each round :
+5. Run 4 witness generators to generate witness for each round:
 
    ```console
    API_PROMETHEUS_LISTENER_PORT=3116 zk f cargo run --release --bin zksync_witness_generator -- --round=basic_circuits


### PR DESCRIPTION
A quick doc update, clarifying what the current setup is.
This is useful in the context of prover setups.