### PR TITLE
fix(eth-sender): adjust the blob tx fees taking into account the current prices

### DIFF
--- a/core/lib/zksync_core/src/eth_sender/eth_tx_manager.rs
+++ b/core/lib/zksync_core/src/eth_sender/eth_tx_manager.rs
@@ -119,6 +119,10 @@ impl EthTxManager {
         tx: &EthTx,
         time_in_mempool: u32,
     ) -> Result<EthFee, ETHSenderError> {
+        let base_fee_per_gas = self.gas_adjuster.get_base_fee(0);
+        let priority_fee_per_gas = self.gas_adjuster.get_priority_fee();
+        let blob_base_fee_per_gas = Some(self.gas_adjuster.get_blob_base_fee());
+
         if tx.blob_sidecar.is_some() {
             if time_in_mempool != 0 {
                 // for blob transactions on re-sending need to double all gas prices
@@ -129,15 +133,20 @@ impl EthTxManager {
                     .unwrap()
                     .unwrap();
                 return Ok(EthFee {
-                    base_fee_per_gas: previous_sent_tx.base_fee_per_gas * 2,
-                    priority_fee_per_gas: previous_sent_tx.priority_fee_per_gas * 2,
-                    blob_base_fee_per_gas: previous_sent_tx.blob_base_fee_per_gas.map(|v| v * 2),
+                    base_fee_per_gas: std::cmp::max(
+                        previous_sent_tx.base_fee_per_gas * 2,
+                        base_fee_per_gas,
+                    ),
+                    priority_fee_per_gas: std::cmp::max(
+                        previous_sent_tx.priority_fee_per_gas * 2,
+                        priority_fee_per_gas,
+                    ),
+                    blob_base_fee_per_gas: std::cmp::max(
+                        previous_sent_tx.blob_base_fee_per_gas.map(|v| v * 2),
+                        blob_base_fee_per_gas,
+                    ),
                 });
             }
-            let base_fee_per_gas = self.gas_adjuster.get_base_fee(0);
-            let priority_fee_per_gas = self.gas_adjuster.get_priority_fee();
-            let blob_base_fee_per_gas = Some(self.gas_adjuster.get_blob_base_fee());
-
             return Ok(EthFee {
                 base_fee_per_gas,
                 priority_fee_per_gas,


### PR DESCRIPTION
## What ❔

It has been noted that simply doubling previous prices in case of blob transactions may not be a good enough method to get them actually included. While doubling the prices for replacement transactions is a _necessary_ thing to do it may not be enough, consider a situation where an initial blob gas price has been for any reason estimated to be very low. After a couple of operations of resending the growth of normal fees would quickly outpace the growth of the blob fees:

```
    "maxFeePerBlobGas": "0x680",
    "maxFeePerGas": "0x6b864500fc0",
    "maxPriorityFeePerGas": "0x2540be4000",
```

But this does not reflect the current effective blob (or normal 1559) prices onchain. Because at this moment the actual blob prices may be at `"maxFeePerBlobGas": "0x54c8a469d"` already. So as a solution: take the `max` of doubled previous prices or the current estimates.


## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
