### PR TITLE
feat(db): Configurable maximum number of open RocksDB files

### DIFF
--- a/core/lib/merkle_tree/src/storage/rocksdb.rs
+++ b/core/lib/merkle_tree/src/storage/rocksdb.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use rayon::prelude::*;
-use zksync_storage::{db::NamedColumnFamily, rocksdb, rocksdb::DBPinnableSlice, RocksDB};
+use zksync_storage::{db::{NamedColumnFamily, RocksDBOptions}, rocksdb, rocksdb::DBPinnableSlice, RocksDB};
 
 use crate::{
     errors::{DeserializeError, ErrorContext},

--- a/core/lib/merkle_tree/src/storage/rocksdb.rs
+++ b/core/lib/merkle_tree/src/storage/rocksdb.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use rayon::prelude::*;
-use zksync_storage::{db::{NamedColumnFamily, RocksDBOptions}, rocksdb, rocksdb::DBPinnableSlice, RocksDB};
+use zksync_storage::{db::NamedColumnFamily, rocksdb, rocksdb::DBPinnableSlice, RocksDB};
 
 use crate::{
     errors::{DeserializeError, ErrorContext},

--- a/core/lib/merkle_tree/src/storage/rocksdb.rs
+++ b/core/lib/merkle_tree/src/storage/rocksdb.rs
@@ -74,15 +74,6 @@ impl RocksDBWrapper {
         Ok(Self::from(RocksDB::new(path)?))
     }
 
-    /// Creates a new wrapper, initializing RocksDB with explicit options.
-    ///
-    /// # Errors
-    ///
-    /// Propagates RocksDB I/O errors.
-    pub fn with_options(path: &Path, options: RocksDBOptions) -> Result<Self, rocksdb::Error> {
-        Ok(Self::from(RocksDB::with_options(path, options)?))
-    }
-
     /// Sets the chunk size for multi-get operations. The requested keys will be split
     /// into chunks of this size and requested in parallel using `rayon`. Setting chunk size
     /// to a large value (e.g., `usize::MAX`) will effectively disable parallelism.

--- a/core/lib/merkle_tree/src/storage/rocksdb.rs
+++ b/core/lib/merkle_tree/src/storage/rocksdb.rs
@@ -74,6 +74,15 @@ impl RocksDBWrapper {
         Ok(Self::from(RocksDB::new(path)?))
     }
 
+    /// Creates a new wrapper, initializing RocksDB with explicit options.
+    ///
+    /// # Errors
+    ///
+    /// Propagates RocksDB I/O errors.
+    pub fn with_options(path: &Path, options: RocksDBOptions) -> Result<Self, rocksdb::Error> {
+        Ok(Self::from(RocksDB::with_options(path, options)?))
+    }
+
     /// Sets the chunk size for multi-get operations. The requested keys will be split
     /// into chunks of this size and requested in parallel using `rayon`. Setting chunk size
     /// to a large value (e.g., `usize::MAX`) will effectively disable parallelism.

--- a/core/lib/storage/src/db.rs
+++ b/core/lib/storage/src/db.rs
@@ -310,7 +310,7 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
         let caches = RocksDBCaches::new(options.block_cache_capacity);
         let mut db_options = Self::rocksdb_options(None, None);
         let max_open_files = if let Some(non_zero) = options.max_open_files {
-            i32::try_from(non_zero.get()).ok().unwrap_or(i32::MAX)
+            i32::try_from(non_zero.get()).unwrap_or(i32::MAX)
         } else {
             -1
         };

--- a/core/lib/zksync_core/src/metadata_calculator/helpers.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/helpers.rs
@@ -100,7 +100,7 @@ fn create_db_sync(
             block_cache_capacity: Some(block_cache_capacity),
             large_memtable_capacity: Some(memtable_capacity),
             stalled_writes_retries: StalledWritesRetries::new(stalled_writes_timeout),
-            max_open_files: -1,
+            max_open_files: None,
         },
     )?;
     if cfg!(test) {

--- a/core/lib/zksync_core/src/metadata_calculator/helpers.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/helpers.rs
@@ -100,6 +100,7 @@ fn create_db_sync(
             block_cache_capacity: Some(block_cache_capacity),
             large_memtable_capacity: Some(memtable_capacity),
             stalled_writes_retries: StalledWritesRetries::new(stalled_writes_timeout),
+            max_open_files: -1,
         },
     )?;
     if cfg!(test) {


### PR DESCRIPTION
## What ❔

Added a field to RocksDBOptions, which is used as an argument to rocksdb::Options::set_max_open_files().

## Why ❔

This allows Merkle tree users to limit the number of open files required by RocksDB, which otherwise grows beyond normal OS limits (8192 files) and requires large amounts of memory (currently, beyond 32GB).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
  - current (integration) tests run as before
  - external program requiring the change is now running
- [x] Documentation comments have been added / updated.
  - all new fields and methods are documented
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
  - no links added (nor modified)