### PR TITLE
fix(gas-adjuster): Use `internal_pubdata_pricing_multiplier` for pubdata price calculation

### DIFF
--- a/core/lib/zksync_core/src/l1_gas_price/gas_adjuster/mod.rs
+++ b/core/lib/zksync_core/src/l1_gas_price/gas_adjuster/mod.rs
@@ -196,7 +196,7 @@ impl GasAdjuster {
                     .set(blob_base_fee_median.as_u64());
                 let calculated_price = blob_base_fee_median.as_u64() as f64
                     * BLOB_GAS_PER_BYTE as f64
-                    * self.config.internal_l1_pricing_multiplier;
+                    * self.config.internal_pubdata_pricing_multiplier;
 
                 self.bound_blob_base_fee(calculated_price)
             }


### PR DESCRIPTION
## What ❔

Use `internal_pubdata_pricing_multiplier` for pubdata price calculation

## Why ❔

This is the correct multiplier to use in this case

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.
