### PR TITLE
feat: Decide when to send proofs based on database and not based on GCS contents

### DIFF
--- a/core/lib/config/src/configs/eth_sender.rs
+++ b/core/lib/config/src/configs/eth_sender.rs
@@ -34,7 +34,6 @@ impl ETHSenderConfig {
                 timestamp_criteria_max_allowed_lag: 30,
                 l1_batch_min_age_before_execute_seconds: None,
                 max_acceptable_priority_fee_in_gwei: 100000000000,
-                proof_loading_mode: ProofLoadingMode::OldProofFromDb,
                 pubdata_sending_mode: PubdataSendingMode::Calldata,
             },
             gas_adjuster: GasAdjusterConfig {
@@ -59,12 +58,6 @@ pub enum ProofSendingMode {
     OnlyRealProofs,
     OnlySampledProofs,
     SkipEveryProof,
-}
-
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
-pub enum ProofLoadingMode {
-    OldProofFromDb,
-    FriProofFromGcs,
 }
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Default)]
@@ -104,9 +97,6 @@ pub struct SenderConfig {
     pub l1_batch_min_age_before_execute_seconds: Option<u64>,
     // Max acceptable fee for sending tx it acts as a safeguard to prevent sending tx with very high fees.
     pub max_acceptable_priority_fee_in_gwei: u64,
-
-    /// The mode in which proofs are loaded, either from DB/GCS for FRI/Old proof.
-    pub proof_loading_mode: ProofLoadingMode,
 
     /// The mode in which we send pubdata, either Calldata or Blobs
     pub pubdata_sending_mode: PubdataSendingMode,

--- a/core/lib/config/src/testonly.rs
+++ b/core/lib/config/src/testonly.rs
@@ -458,15 +458,6 @@ impl RandomConfig for configs::eth_sender::ProofSendingMode {
     }
 }
 
-impl RandomConfig for configs::eth_sender::ProofLoadingMode {
-    fn sample(g: &mut Gen<impl Rng>) -> Self {
-        match g.rng.gen_range(0..2) {
-            0 => Self::OldProofFromDb,
-            _ => Self::FriProofFromGcs,
-        }
-    }
-}
-
 impl RandomConfig for configs::eth_sender::PubdataSendingMode {
     fn sample(g: &mut Gen<impl Rng>) -> Self {
         match g.rng.gen_range(0..2) {
@@ -495,7 +486,6 @@ impl RandomConfig for configs::eth_sender::SenderConfig {
             timestamp_criteria_max_allowed_lag: g.gen(),
             l1_batch_min_age_before_execute_seconds: g.gen(),
             max_acceptable_priority_fee_in_gwei: g.gen(),
-            proof_loading_mode: g.gen(),
             pubdata_sending_mode: PubdataSendingMode::Calldata,
         }
     }

--- a/core/lib/env_config/src/eth_sender.rs
+++ b/core/lib/env_config/src/eth_sender.rs
@@ -26,9 +26,7 @@ impl FromEnv for GasAdjusterConfig {
 
 #[cfg(test)]
 mod tests {
-    use zksync_config::configs::eth_sender::{
-        ProofLoadingMode, ProofSendingMode, PubdataSendingMode,
-    };
+    use zksync_config::configs::eth_sender::{ProofSendingMode, PubdataSendingMode};
 
     use super::*;
     use crate::test_utils::{hash, EnvMutex};
@@ -55,7 +53,6 @@ mod tests {
                 proof_sending_mode: ProofSendingMode::SkipEveryProof,
                 l1_batch_min_age_before_execute_seconds: Some(1000),
                 max_acceptable_priority_fee_in_gwei: 100_000_000_000,
-                proof_loading_mode: ProofLoadingMode::OldProofFromDb,
                 pubdata_sending_mode: PubdataSendingMode::Calldata,
             },
             gas_adjuster: GasAdjusterConfig {

--- a/core/lib/protobuf_config/src/eth_sender.rs
+++ b/core/lib/protobuf_config/src/eth_sender.rs
@@ -24,24 +24,6 @@ impl proto::ProofSendingMode {
     }
 }
 
-impl proto::ProofLoadingMode {
-    fn new(x: &configs::eth_sender::ProofLoadingMode) -> Self {
-        use configs::eth_sender::ProofLoadingMode as From;
-        match x {
-            From::OldProofFromDb => Self::OldProofFromDb,
-            From::FriProofFromGcs => Self::FriProofFromGcs,
-        }
-    }
-
-    fn parse(&self) -> configs::eth_sender::ProofLoadingMode {
-        use configs::eth_sender::ProofLoadingMode as To;
-        match self {
-            Self::OldProofFromDb => To::OldProofFromDb,
-            Self::FriProofFromGcs => To::FriProofFromGcs,
-        }
-    }
-}
-
 impl proto::PubdataSendingMode {
     fn new(x: &configs::eth_sender::PubdataSendingMode) -> Self {
         use configs::eth_sender::PubdataSendingMode as From;
@@ -120,10 +102,7 @@ impl ProtoRepr for proto::Sender {
                 &self.max_acceptable_priority_fee_in_gwei,
             )
             .context("max_acceptable_priority_fee_in_gwei")?,
-            proof_loading_mode: required(&self.proof_loading_mode)
-                .and_then(|x| Ok(proto::ProofLoadingMode::try_from(*x)?))
-                .context("proof_loading_mode")?
-                .parse(),
+
             pubdata_sending_mode: required(&self.pubdata_sending_mode)
                 .and_then(|x| Ok(proto::PubdataSendingMode::try_from(*x)?))
                 .context("pubdata_sending_mode")?
@@ -153,9 +132,9 @@ impl ProtoRepr for proto::Sender {
             timestamp_criteria_max_allowed_lag: Some(
                 this.timestamp_criteria_max_allowed_lag.try_into().unwrap(),
             ),
+            proof_loading_mode: None,
             l1_batch_min_age_before_execute_seconds: this.l1_batch_min_age_before_execute_seconds,
             max_acceptable_priority_fee_in_gwei: Some(this.max_acceptable_priority_fee_in_gwei),
-            proof_loading_mode: Some(proto::ProofLoadingMode::new(&this.proof_loading_mode).into()),
             pubdata_sending_mode: Some(
                 proto::PubdataSendingMode::new(&this.pubdata_sending_mode).into(),
             ),

--- a/core/lib/protobuf_config/src/proto/eth_sender.proto
+++ b/core/lib/protobuf_config/src/proto/eth_sender.proto
@@ -40,7 +40,7 @@ message Sender {
   optional uint64 timestamp_criteria_max_allowed_lag = 14; // required; ?
   optional uint64 l1_batch_min_age_before_execute_seconds = 15; // optional; s
   optional uint64 max_acceptable_priority_fee_in_gwei = 16; // required; gwei
-  optional ProofLoadingMode proof_loading_mode = 17; // required
+  optional ProofLoadingMode proof_loading_mode = 17; // deprecated
   // operator_private_key?
   optional PubdataSendingMode pubdata_sending_mode = 18; // required
 }

--- a/etc/env/base/eth_sender.toml
+++ b/etc/env/base/eth_sender.toml
@@ -46,8 +46,6 @@ max_single_tx_gas=6000000
 # Max acceptable fee for sending tx to L1
 max_acceptable_priority_fee_in_gwei=100000000000
 
-proof_loading_mode="OldProofFromDb"
-
 pubdata_sending_mode="Blobs"
 
 [eth_sender.gas_adjuster]

--- a/infrastructure/zk/src/prover_setup.ts
+++ b/infrastructure/zk/src/prover_setup.ts
@@ -23,7 +23,6 @@ export async function setupProver(proverType: ProverType) {
     if (proverType == ProverType.GPU || proverType == ProverType.CPU) {
         wrapEnvModify('PROVER_TYPE', proverType);
         wrapEnvModify('ETH_SENDER_SENDER_PROOF_SENDING_MODE', 'OnlyRealProofs');
-        wrapEnvModify('ETH_SENDER_SENDER_PROOF_LOADING_MODE', 'FriProofFromGcs');
         wrapEnvModify('FRI_PROVER_GATEWAY_API_POLL_DURATION_SECS', '120');
         await setupArtifactsMode();
         if (!process.env.CI) {

--- a/infrastructure/zk/src/status.ts
+++ b/infrastructure/zk/src/status.ts
@@ -190,11 +190,6 @@ export async function statusProver() {
     main_pool = new Pool({ connectionString: process.env.DATABASE_URL });
     prover_pool = new Pool({ connectionString: process.env.DATABASE_PROVER_URL });
 
-    if (process.env.ETH_SENDER_SENDER_PROOF_LOADING_MODE != 'FriProofFromGcs') {
-        console.log(`${redStart}Can only show status for FRI provers.${resetColor}`);
-        return;
-    }
-
     // Fetch the first and most recent sealed batch numbers
     const stateKeeperStatus = (
         await queryAndReturnRows(main_pool, 'select min(number), max(number) from l1_batches')

--- a/prover/setup.sh
+++ b/prover/setup.sh
@@ -14,7 +14,6 @@ if [[ -z "${ZKSYNC_HOME}" ]]; then
 fi
 
 sed -i.backup 's/^proof_sending_mode=.*$/proof_sending_mode="OnlyRealProofs"/' ../etc/env/base/eth_sender.toml
-sed -i.backup 's/^proof_loading_mode=.*$/proof_loading_mode="FriProofFromGcs"/' ../etc/env/base/eth_sender.toml
 rm ../etc/env/base/eth_sender.toml.backup
 sed -i.backup 's/^setup_data_path=.*$/setup_data_path="vk_setup_data_generator_server_fri\/data\/"/' ../etc/env/base/fri_prover.toml
 rm ../etc/env/base/fri_prover.toml.backup


### PR DESCRIPTION
## What ❔

* Look at the database (`proof_generation_details` table), rather than on GCS contents when selecting proofs to send to l1
* Removed `proof_loading_mode` config option (no longer needed)

## Why ❔

* This helps during emergencies - if we load proofs based on database, we no longer have to worry about clearing the GCS directory - and we can focus only the database, which becomes source of truth.
