### PR TITLE
chore(docs): Update url for zksync-lite-docs

### DIFF
--- a/docs/guides/repositories.md
+++ b/docs/guides/repositories.md
@@ -76,5 +76,5 @@
 | Public repository                                                           | Description                      |
 | --------------------------------------------------------------------------- | -------------------------------- |
 | [zksync](https://github.com/matter-labs/zksync)                             | zkSync Lite implementation       |
-| [zksync-docs](https://github.com/matter-labs/zksync-docs)                   | Public zkSync Lite documentation |
+| [zksync-lite-docs](https://github.com/matter-labs/zksync-lite-docs)         | Public zkSync Lite documentation |
 | [zksync-dapp-checkout](https://github.com/matter-labs/zksync-dapp-checkout) | Batch payments DApp              |


### PR DESCRIPTION
## What ❔

Update url for `zksync-lite-docs` repo

## Why ❔

Previous URL was incorrect and causing 404 errors for link checker

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.
