### PR TITLE
fix(kl-factory): fix init and zk test i server

### DIFF
--- a/core/tests/ts-integration/src/env.ts
+++ b/core/tests/ts-integration/src/env.ts
@@ -29,7 +29,7 @@ export async function waitForServer() {
     for (let i = 0; i < maxAttempts; ++i) {
         try {
             await l2Provider.getNetwork(); // Will throw if the server is not ready yet.
-            const bridgeAddress = (await l2Provider.getDefaultBridgeAddresses()).erc20L2;
+            const bridgeAddress = (await l2Provider.getDefaultBridgeAddresses()).sharedL2;
             const code = await l2Provider.getCode(bridgeAddress);
             if (code == '0x') {
                 throw Error('L2 ERC20 bridge is not deployed yet, server is not ready');

--- a/infrastructure/zk/src/init.ts
+++ b/infrastructure/zk/src/init.ts
@@ -11,7 +11,7 @@ import * as env from './env';
 import * as config from './config';
 import * as run from './run';
 import * as server from './server';
-import { up } from './up';
+import { createVolumes, up } from './up';
 import { announced } from './utils';
 
 // Checks if all required tools are installed with the correct versions
@@ -43,6 +43,7 @@ const initSetup = async ({ skipSubmodulesCheckout, skipEnvSetup }: InitSetupOpti
         await announced('Pulling images', docker.pull());
         await announced('Checking environment', checkEnv());
         await announced('Checking git hooks', env.gitHooks());
+        await announced('Create volumes', createVolumes());
         await announced('Setting up containers', up());
     }
     if (!skipSubmodulesCheckout) {


### PR DESCRIPTION
## What ❔

Re-add `createVolumes()` function to make `zk init` work and `bridgeAddress` so the `zk test i server` runs.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
