### PR TITLE
refactor: remove unnecessary clone in ComponentsToRun

### DIFF
--- a/core/bin/zksync_server/src/main.rs
+++ b/core/bin/zksync_server/src/main.rs
@@ -66,11 +66,12 @@ impl FromStr for ComponentsToRun {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let components = s.split(',').try_fold(vec![], |mut acc, component_str| {
-            let components = Components::from_str(component_str.trim())?;
-            acc.extend(components.0);
-            Ok::<_, String>(acc)
-        })?;
+        let components = s
+            .split(',')
+            .try_fold(Vec::new(), |mut acc, component_str| {
+                acc.extend(Components::from_str(component_str.trim())?);
+                Ok(acc)
+            })?;
         Ok(Self(components))
     }
 }


### PR DESCRIPTION
## What ❔
This PR removes an unnecessary clone operation in the implementation of the ComponentsToRun struct. The Components vector was being cloned when converting from a string, which was unnecessary and could potentially impact performance.

## Why ❔
Cloning data structures can be a relatively expensive operation, especially for larger data structures. Avoiding unnecessary clones can help improve performance and reduce memory usage, which is particularly important in performance-critical applications or systems with limited resources.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).

- [ ] Tests for the changes have been added / updated.

- [ ] Documentation comments have been added / updated.

- [x] Code has been formatted via zk fmt and zk lint.

- [x] Spellcheck has been run via zk spellcheck.

- [x] Linkcheck has been run via zk linkcheck.

