### PR TITLE
feat: create `VmVersion::Local` aid in bootloader development

### DIFF
--- a/core/lib/commitment_utils/src/lib.rs
+++ b/core/lib/commitment_utils/src/lib.rs
@@ -24,7 +24,7 @@ pub fn events_queue_commitment(
                     .collect(),
             ),
         )),
-        VmVersion::Vm1_4_1 | VmVersion::Vm1_4_2 => Some(H256(
+        VmVersion::Vm1_4_1 | VmVersion::Vm1_4_2 | VmVersion::Local => Some(H256(
             circuit_sequencer_api_1_4_1::commitments::events_queue_commitment_fixed(
                 &events_queue
                     .iter()
@@ -55,7 +55,7 @@ pub fn bootloader_initial_content_commitment(
                 &full_bootloader_memory,
             ),
         )),
-        VmVersion::Vm1_4_1 | VmVersion::Vm1_4_2 => Some(H256(
+        VmVersion::Vm1_4_1 | VmVersion::Vm1_4_2 | VmVersion::Local => Some(H256(
             circuit_sequencer_api_1_4_1::commitments::initial_heap_content_commitment_fixed(
                 &full_bootloader_memory,
             ),

--- a/core/lib/contracts/src/lib.rs
+++ b/core/lib/contracts/src/lib.rs
@@ -206,6 +206,10 @@ fn read_playground_batch_bootloader_bytecode() -> Vec<u8> {
     read_bootloader_code("playground_batch")
 }
 
+fn read_estimate_gas_bootloader_bytecode() -> Vec<u8> {
+    read_bootloader_code("fee_estimate")
+}
+
 /// Reads zbin bytecode from a given path, relative to ZKSYNC_HOME.
 pub fn read_zbin_bytecode(relative_zbin_path: impl AsRef<Path>) -> Vec<u8> {
     let zksync_home = std::env::var("ZKSYNC_HOME").unwrap_or_else(|_| ".".into());
@@ -316,6 +320,11 @@ impl BaseSystemContracts {
         let bootloader_bytecode = read_zbin_bytecode(
             "etc/multivm_bootloaders/vm_1_4_2/playground_batch.yul/playground_batch.yul.zbin",
         );
+        BaseSystemContracts::load_with_bootloader(bootloader_bytecode)
+    }
+
+    pub fn estimate_gas() -> Self {
+        let bootloader_bytecode = read_estimate_gas_bootloader_bytecode();
         BaseSystemContracts::load_with_bootloader(bootloader_bytecode)
     }
 

--- a/core/lib/multivm/src/utils.rs
+++ b/core/lib/multivm/src/utils.rs
@@ -44,9 +44,11 @@ pub fn derive_base_fee_and_gas_per_pubdata(
         VmVersion::Vm1_4_1 => crate::vm_1_4_1::utils::fee::derive_base_fee_and_gas_per_pubdata(
             batch_fee_input.into_pubdata_independent(),
         ),
-        VmVersion::Vm1_4_2 => crate::vm_latest::utils::fee::derive_base_fee_and_gas_per_pubdata(
-            batch_fee_input.into_pubdata_independent(),
-        ),
+        VmVersion::Vm1_4_2 | VmVersion::Local => {
+            crate::vm_latest::utils::fee::derive_base_fee_and_gas_per_pubdata(
+                batch_fee_input.into_pubdata_independent(),
+            )
+        }
     }
 }
 
@@ -69,7 +71,9 @@ pub fn get_batch_base_fee(l1_batch_env: &L1BatchEnv, vm_version: VmVersion) -> u
             crate::vm_boojum_integration::utils::fee::get_batch_base_fee(l1_batch_env)
         }
         VmVersion::Vm1_4_1 => crate::vm_1_4_1::utils::fee::get_batch_base_fee(l1_batch_env),
-        VmVersion::Vm1_4_2 => crate::vm_latest::utils::fee::get_batch_base_fee(l1_batch_env),
+        VmVersion::Vm1_4_2 | VmVersion::Local => {
+            crate::vm_latest::utils::fee::get_batch_base_fee(l1_batch_env)
+        }
     }
 }
 
@@ -194,7 +198,9 @@ pub fn derive_overhead(
             )
         }
         VmVersion::Vm1_4_1 => crate::vm_1_4_1::utils::overhead::derive_overhead(encoded_len),
-        VmVersion::Vm1_4_2 => crate::vm_latest::utils::overhead::derive_overhead(encoded_len),
+        VmVersion::Vm1_4_2 | VmVersion::Local => {
+            crate::vm_latest::utils::overhead::derive_overhead(encoded_len)
+        }
     }
 }
 
@@ -217,7 +223,9 @@ pub fn get_bootloader_encoding_space(version: VmVersion) -> u32 {
             crate::vm_boojum_integration::constants::BOOTLOADER_TX_ENCODING_SPACE
         }
         VmVersion::Vm1_4_1 => crate::vm_1_4_1::constants::BOOTLOADER_TX_ENCODING_SPACE,
-        VmVersion::Vm1_4_2 => crate::vm_latest::constants::BOOTLOADER_TX_ENCODING_SPACE,
+        VmVersion::Vm1_4_2 | VmVersion::Local => {
+            crate::vm_latest::constants::BOOTLOADER_TX_ENCODING_SPACE
+        }
     }
 }
 
@@ -236,7 +244,7 @@ pub fn get_bootloader_max_txs_in_batch(version: VmVersion) -> usize {
         }
         VmVersion::VmBoojumIntegration => crate::vm_boojum_integration::constants::MAX_TXS_IN_BLOCK,
         VmVersion::Vm1_4_1 => crate::vm_1_4_1::constants::MAX_TXS_IN_BATCH,
-        VmVersion::Vm1_4_2 => crate::vm_latest::constants::MAX_TXS_IN_BATCH,
+        VmVersion::Vm1_4_2 | VmVersion::Local => crate::vm_latest::constants::MAX_TXS_IN_BATCH,
     }
 }
 
@@ -256,7 +264,9 @@ pub fn gas_bootloader_batch_tip_overhead(version: VmVersion) -> u32 {
             crate::vm_boojum_integration::constants::BOOTLOADER_BATCH_TIP_OVERHEAD
         }
         VmVersion::Vm1_4_1 => crate::vm_1_4_1::constants::BOOTLOADER_BATCH_TIP_OVERHEAD,
-        VmVersion::Vm1_4_2 => crate::vm_latest::constants::BOOTLOADER_BATCH_TIP_OVERHEAD,
+        VmVersion::Vm1_4_2 | VmVersion::Local => {
+            crate::vm_latest::constants::BOOTLOADER_BATCH_TIP_OVERHEAD
+        }
     }
 }
 
@@ -277,7 +287,9 @@ pub fn get_max_gas_per_pubdata_byte(version: VmVersion) -> u64 {
             crate::vm_boojum_integration::constants::MAX_GAS_PER_PUBDATA_BYTE
         }
         VmVersion::Vm1_4_1 => crate::vm_1_4_1::constants::MAX_GAS_PER_PUBDATA_BYTE,
-        VmVersion::Vm1_4_2 => crate::vm_latest::constants::MAX_GAS_PER_PUBDATA_BYTE,
+        VmVersion::Vm1_4_2 | VmVersion::Local => {
+            crate::vm_latest::constants::MAX_GAS_PER_PUBDATA_BYTE
+        }
     }
 }
 
@@ -300,7 +312,9 @@ pub fn get_used_bootloader_memory_bytes(version: VmVersion) -> usize {
             crate::vm_boojum_integration::constants::USED_BOOTLOADER_MEMORY_BYTES
         }
         VmVersion::Vm1_4_1 => crate::vm_1_4_1::constants::USED_BOOTLOADER_MEMORY_BYTES,
-        VmVersion::Vm1_4_2 => crate::vm_latest::constants::USED_BOOTLOADER_MEMORY_BYTES,
+        VmVersion::Vm1_4_2 | VmVersion::Local => {
+            crate::vm_latest::constants::USED_BOOTLOADER_MEMORY_BYTES
+        }
     }
 }
 
@@ -323,6 +337,8 @@ pub fn get_used_bootloader_memory_words(version: VmVersion) -> usize {
             crate::vm_boojum_integration::constants::USED_BOOTLOADER_MEMORY_WORDS
         }
         VmVersion::Vm1_4_1 => crate::vm_1_4_1::constants::USED_BOOTLOADER_MEMORY_WORDS,
-        VmVersion::Vm1_4_2 => crate::vm_latest::constants::USED_BOOTLOADER_MEMORY_WORDS,
+        VmVersion::Vm1_4_2 | VmVersion::Local => {
+            crate::vm_latest::constants::USED_BOOTLOADER_MEMORY_WORDS
+        }
     }
 }

--- a/core/lib/multivm/src/vm_instance.rs
+++ b/core/lib/multivm/src/vm_instance.rs
@@ -210,7 +210,7 @@ impl<S: WriteStorage, H: HistoryMode> VmInstance<S, H> {
                 let vm = crate::vm_1_4_1::Vm::new(l1_batch_env, system_env, storage_view);
                 VmInstance::Vm1_4_1(vm)
             }
-            VmVersion::Vm1_4_2 => {
+            VmVersion::Vm1_4_2 | VmVersion::Local => {
                 let vm = crate::vm_latest::Vm::new(l1_batch_env, system_env, storage_view);
                 VmInstance::Vm1_4_2(vm)
             }

--- a/core/lib/types/src/protocol_version.rs
+++ b/core/lib/types/src/protocol_version.rs
@@ -42,11 +42,18 @@ pub enum ProtocolVersionId {
     Version19,
     Version20,
     Version21,
+    // Local version has to be after the `latest` version and
+    // before the `next` version in this enum, otherwise some tests will fail.
+    Local,
     Version22,
 }
 
 impl ProtocolVersionId {
     pub fn latest() -> Self {
+        // During development of system contracts, one can replace this value with `Self::Local` to
+        // see the system contract changes take effect without the hassle of moving the artifacts
+        // into etc/multivm_bootloaders each time.
+        // Don't forget to do the same change in VmVersion::latest()
         Self::Version21
     }
 
@@ -81,6 +88,7 @@ impl ProtocolVersionId {
             ProtocolVersionId::Version20 => VmVersion::Vm1_4_1,
             ProtocolVersionId::Version21 => VmVersion::Vm1_4_2,
             ProtocolVersionId::Version22 => VmVersion::Vm1_4_2,
+            ProtocolVersionId::Local => VmVersion::Local,
         }
     }
 
@@ -212,6 +220,7 @@ impl From<ProtocolVersionId> for FriProtocolVersionId {
             ProtocolVersionId::Version20 => FriProtocolVersionId::Version20,
             ProtocolVersionId::Version21 => FriProtocolVersionId::Version21,
             ProtocolVersionId::Version22 => FriProtocolVersionId::Version22,
+            ProtocolVersionId::Local => FriProtocolVersionId::Version22,
         }
     }
 }
@@ -828,6 +837,7 @@ impl From<ProtocolVersionId> for VmVersion {
             ProtocolVersionId::Version20 => VmVersion::Vm1_4_1,
             ProtocolVersionId::Version21 => VmVersion::Vm1_4_2,
             ProtocolVersionId::Version22 => VmVersion::Vm1_4_2,
+            ProtocolVersionId::Local => VmVersion::Local,
         }
     }
 }

--- a/core/lib/types/src/vm_version.rs
+++ b/core/lib/types/src/vm_version.rs
@@ -10,11 +10,16 @@ pub enum VmVersion {
     VmBoojumIntegration,
     Vm1_4_1,
     Vm1_4_2,
+    Local,
 }
 
 impl VmVersion {
     /// Returns the latest supported VM version.
     pub const fn latest() -> VmVersion {
+        // During development of system contracts, one can replace this value with `Self::Local` to
+        // see the system contract changes take effect without the hassle of moving the artifacts
+        // into etc/multivm_bootloaders each time.
+        // Don't forget to do the same change in ProtocolVersionId::latest()
         Self::Vm1_4_2
     }
 }

--- a/core/lib/zksync_core/src/api_server/tx_sender/mod.rs
+++ b/core/lib/zksync_core/src/api_server/tx_sender/mod.rs
@@ -64,6 +64,8 @@ pub struct MultiVMBaseSystemContracts {
     pub(crate) post_1_4_1: BaseSystemContracts,
     /// Contracts to be used after the 1.4.2 upgrade
     pub(crate) post_1_4_2: BaseSystemContracts,
+    /// Contracts to be used for local requests.
+    pub(crate) local: BaseSystemContracts,
 }
 
 impl MultiVMBaseSystemContracts {
@@ -91,6 +93,7 @@ impl MultiVMBaseSystemContracts {
             ProtocolVersionId::Version19 => self.post_allowlist_removal,
             ProtocolVersionId::Version20 => self.post_1_4_1,
             ProtocolVersionId::Version21 | ProtocolVersionId::Version22 => self.post_1_4_2,
+            ProtocolVersionId::Local => self.local,
         }
     }
 }
@@ -124,6 +127,7 @@ impl ApiContracts {
                 post_allowlist_removal: BaseSystemContracts::estimate_gas_post_allowlist_removal(),
                 post_1_4_1: BaseSystemContracts::estimate_gas_post_1_4_1(),
                 post_1_4_2: BaseSystemContracts::estimate_gas_post_1_4_2(),
+                local: BaseSystemContracts::estimate_gas(),
             },
             eth_call: MultiVMBaseSystemContracts {
                 pre_virtual_blocks: BaseSystemContracts::playground_pre_virtual_blocks(),
@@ -134,6 +138,7 @@ impl ApiContracts {
                 post_allowlist_removal: BaseSystemContracts::playground_post_allowlist_removal(),
                 post_1_4_1: BaseSystemContracts::playground_post_1_4_1(),
                 post_1_4_2: BaseSystemContracts::playground_post_1_4_2(),
+                local: BaseSystemContracts::playground(),
             },
         }
     }


### PR DESCRIPTION
## What ❔

This PR creates `VmVersion::Local` and `ProtocolVersionId::Local` that would use bootloader code directly from the artifacts folder in `contracts/system-contracts/bootloader/build/artifacts/` instead of from `etc/multivm_bootloaders/`

## Why ❔

Currently, after modifying the bootloader, to see the changes take effect when running the server, you have to manually move the compiled artifacts to `etc/multivm_bootloaders/` each time something has changed.

This PR lets developers simply use the `Local` VM version that would use locally compiled artifacts.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
