### PR TITLE
fix(api): increase test timeout

### DIFF
--- a/core/lib/zksync_core/src/api_server/web3/tests/mod.rs
+++ b/core/lib/zksync_core/src/api_server/web3/tests/mod.rs
@@ -57,7 +57,7 @@ mod snapshots;
 mod vm;
 mod ws;
 
-const TEST_TIMEOUT: Duration = Duration::from_secs(20);
+const TEST_TIMEOUT: Duration = Duration::from_secs(90);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 impl ApiServerHandles {

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -175,8 +175,8 @@ To switch dummy prover to real prover, one must change `dummy_verifier` to `fals
 - Running a specific `rust` unit-test:
 
   ```
-  zk test rust --package <package_name> --lib <mod>::tests::<test_fn_name> -- --exact
-  # e.g. zk test rust --package zksync_core --lib eth_sender::tests::resend_each_block -- --exact
+  zk test rust --package <package_name> --lib <mod>::tests::<test_fn_name> --
+  # e.g. zk test rust --package zksync_core --lib eth_sender::tests::resend_each_block --
   ```
 
 - Running the integration test:


### PR DESCRIPTION
## What ❔

I've been playing around with the ZK stack but am not very familiar with it. In order to hack it, it's useful to know all tests run successfully after making any changes.

Hence, this PR does two minor things:
* Increases `TEST_TIMEOUT` in order to successfully run all (Rust) unit tests
* Removes an out-of-date flag from the development guide

Screenshots of the two errors below:

![Screenshot 2024-03-19 at 21 51 47](https://github.com/matter-labs/zksync-era/assets/35889839/3aa7bf2a-6f0a-4a01-9c98-4eaa03e78c95)

![Screenshot 2024-03-19 at 22 12 23](https://github.com/matter-labs/zksync-era/assets/35889839/3be1b20a-96ca-42d2-bbf7-b3fac449db5c)

## Why ❔

I consider my M1 Pro 16 GB (2021) "reasonably" performant but it doesn't manage to run the `api_server` tests without timing out during the complete test suite. I noticed there were several tests that had the `SLOW` warning (> 60s) so I added some margin.