### PR TITLE
fix(dal): correct `tx_index_in_l1_batch` in `get_vm_events_for_l1_batch`

### DIFF
--- a/core/lib/dal/.sqlx/query-26bc9b315c4c57bcff1f46da956727233a36e018fe5c0651995b876053a6a054.json
+++ b/core/lib/dal/.sqlx/query-26bc9b315c4c57bcff1f46da956727233a36e018fe5c0651995b876053a6a054.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                address,\n                topic1,\n                topic2,\n                topic3,\n                topic4,\n                value\n            FROM\n                events\n            WHERE\n                miniblock_number BETWEEN $1 AND $2\n            ORDER BY\n                miniblock_number ASC,\n                event_index_in_block ASC\n            ",
+  "query": "\n            SELECT\n                address,\n                topic1,\n                topic2,\n                topic3,\n                topic4,\n                value,\n                event_index_in_tx\n            FROM\n                events\n            WHERE\n                miniblock_number BETWEEN $1 AND $2\n            ORDER BY\n                miniblock_number ASC,\n                event_index_in_block ASC\n            ",
   "describe": {
     "columns": [
       {
@@ -32,6 +32,11 @@
         "ordinal": 5,
         "name": "value",
         "type_info": "Bytea"
+      },
+      {
+        "ordinal": 6,
+        "name": "event_index_in_tx",
+        "type_info": "Int4"
       }
     ],
     "parameters": {
@@ -46,8 +51,9 @@
       false,
       false,
       false,
+      false,
       false
     ]
   },
-  "hash": "de55102189196905a7dadb5a8b599acee63cae615e16007cccb0ed0cbe903467"
+  "hash": "26bc9b315c4c57bcff1f46da956727233a36e018fe5c0651995b876053a6a054"
 }

--- a/core/lib/dal/src/events_dal.rs
+++ b/core/lib/dal/src/events_dal.rs
@@ -341,6 +341,7 @@ impl EventsDal<'_, '_> {
         else {
             return Ok(None);
         };
+        let mut tx_index_in_l1_batch = -1;
         let events = sqlx::query!(
             r#"
             SELECT
@@ -349,7 +350,8 @@ impl EventsDal<'_, '_> {
                 topic2,
                 topic3,
                 topic4,
-                value
+                value,
+                event_index_in_tx
             FROM
                 events
             WHERE
@@ -366,8 +368,7 @@ impl EventsDal<'_, '_> {
         .fetch_all(self.storage)
         .await?
         .into_iter()
-        .enumerate()
-        .map(|(index_in_l1_batch, row)| {
+        .map(|row| {
             let indexed_topics = vec![row.topic1, row.topic2, row.topic3, row.topic4]
                 .into_iter()
                 .filter_map(|topic| {
@@ -378,8 +379,11 @@ impl EventsDal<'_, '_> {
                     }
                 })
                 .collect();
+            if row.event_index_in_tx == 0 {
+                tx_index_in_l1_batch += 1;
+            }
             VmEvent {
-                location: (l1_batch_number, index_in_l1_batch as u32),
+                location: (l1_batch_number, tx_index_in_l1_batch as u32),
                 address: Address::from_slice(&row.address),
                 indexed_topics,
                 value: row.value,


### PR DESCRIPTION
## What ❔

Fix calculation for `tx_index_in_l1_batch` in `get_vm_events_for_l1_batch` method.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
