### PR TITLE
feat(node_framework): Only store each wiring layer once

### DIFF
--- a/core/node/node_framework/src/service/mod.rs
+++ b/core/node/node_framework/src/service/mod.rs
@@ -38,8 +38,19 @@ impl ZkStackServiceBuilder {
     /// Adds a wiring layer.
     /// During the [`run`](ZkStackService::run) call the service will invoke
     /// `wire` method of every layer in the order they were added.
+    ///
+    /// This method may be invoked multiple times with the same layer type, but the
+    /// layer will only be stored once (meaning that 2nd attempt to add the same layer will be ignored).
+    /// This may be useful if the same layer is a prerequisite for multiple other layers: it is safe
+    /// to add it multiple times, and it will only be wired once.
     pub fn add_layer<T: WiringLayer>(&mut self, layer: T) -> &mut Self {
-        self.layers.push(Box::new(layer));
+        if !self
+            .layers
+            .iter()
+            .any(|existing_layer| existing_layer.layer_name() == layer.layer_name())
+        {
+            self.layers.push(Box::new(layer));
+        }
         self
     }
 


### PR DESCRIPTION
## What ❔

Changes the logic of the framework so that it's OK to call `add_layer` with the same layer multiple times: the corresponding layer will only be stored once.

## Why ❔

It may be handy if the same layer (e.g. think gas adjuster) is a prerequisite for multiple other layers: we can simply bundle them together without having to worry whether any other layer adds it.

It will be useful for components-based system.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
