### PR TITLE
ci: Remove prover workspace hack in CI

### DIFF
--- a/.github/workflows/build-prover-template.yml
+++ b/.github/workflows/build-prover-template.yml
@@ -137,38 +137,9 @@ jobs:
         env:
           DOCKER_ACTION: ${{ inputs.action }}
           COMPONENT: ${{ matrix.component }}
-          RUST_NIGHTLY_COMPONENTS: |
-            (
-              "witness-generator"
-              "prover-v2"
-              "circuit-synthesizer"
-              "prover-fri"
-              "prover-gpu-fri"
-              "witness-vector-generator"
-              "prover-fri-gateway"
-              "proof-fri-compressor"
-            )
-        run: |
-          nightly_components=${{ env.RUST_NIGHTLY_COMPONENTS }}
-
-          if [[ " ${nightly_components[*]} " =~ " ${COMPONENT} " ]]; then
-            underscored_name=$(echo "$COMPONENT" | tr '-' '_')
-            # Hack: prover-v2 codebase located in prover directory instead of prover_v2
-            if [ "$underscored_name" == "prover_v2" ]; then
-              underscored_name="prover"
-            fi
-            # prover-gpu-fri codebase located in prover_fri directory instead of prover_gpu_fri
-            if [ "$underscored_name" == "prover_gpu_fri" ]; then
-              underscored_name="prover_fri"
-            fi
-            ci_run echo [workspace] > Cargo.toml
-            ci_run echo members = [\"prover/${underscored_name}\"] >> Cargo.toml
-            ci_run cp prover/Cargo.lock Cargo.lock
-            PASSED_ENV_VARS="ERA_BELLMAN_CUDA_RELEASE,CUDA_ARCH" \
-            ci_run zk docker $DOCKER_ACTION $COMPONENT
-          else
-            ci_run zk docker $DOCKER_ACTION $COMPONENT
-          fi
+        run: |          
+          PASSED_ENV_VARS="ERA_BELLMAN_CUDA_RELEASE,CUDA_ARCH" \
+          ci_run zk docker $DOCKER_ACTION $COMPONENT
 
       - name: Show sccache stats
         if: always()

--- a/docker/proof-fri-compressor/Dockerfile
+++ b/docker/proof-fri-compressor/Dockerfile
@@ -7,7 +7,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /usr/src/zksync
 COPY . .
 
-RUN cargo build --release --bin zksync_proof_fri_compressor
+RUN cd prover && cargo build --release --bin zksync_proof_fri_compressor
 
 FROM debian:bookworm-slim
 
@@ -19,6 +19,6 @@ COPY prover/vk_setup_data_generator_server_fri/data/ /prover/vk_setup_data_gener
 # copy universal setup key required for proof compression
 COPY setup_2\^26.key /setup_2\^26.key
 
-COPY --from=builder /usr/src/zksync/target/release/zksync_proof_fri_compressor /usr/bin/
+COPY --from=builder /usr/src/zksync/prover/target/release/zksync_proof_fri_compressor /usr/bin/
 
 ENTRYPOINT ["zksync_proof_fri_compressor"]

--- a/docker/prover-fri-gateway/Dockerfile
+++ b/docker/prover-fri-gateway/Dockerfile
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /usr/src/zksync
 COPY . .
 
-RUN cargo build --release --bin zksync_prover_fri_gateway
+RUN cd prover && cargo build --release --bin zksync_prover_fri_gateway
 
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y curl libpq5 ca-certificates && rm -rf /var/lib/apt/lists/*
@@ -13,6 +13,6 @@ RUN apt-get update && apt-get install -y curl libpq5 ca-certificates && rm -rf /
 # copy VK required for proof wrapping
 COPY prover/vk_setup_data_generator_server_fri/data/ /prover/vk_setup_data_generator_server_fri/data/
 
-COPY --from=builder /usr/src/zksync/target/release/zksync_prover_fri_gateway /usr/bin/
+COPY --from=builder /usr/src/zksync/prover/target/release/zksync_prover_fri_gateway /usr/bin/
 
 ENTRYPOINT ["zksync_prover_fri_gateway"]

--- a/docker/prover-fri/Dockerfile
+++ b/docker/prover-fri/Dockerfile
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /usr/src/zksync
 COPY . .
 
-RUN cargo build --release --bin zksync_prover_fri
+RUN cd prover && cargo build --release --bin zksync_prover_fri
 
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y curl libpq5 ca-certificates && rm -rf /var/lib/apt/lists/*
@@ -13,6 +13,6 @@ RUN apt-get update && apt-get install -y curl libpq5 ca-certificates && rm -rf /
 # copy VK required for protocol version
 COPY prover/vk_setup_data_generator_server_fri/data/ /prover/vk_setup_data_generator_server_fri/data/
 
-COPY --from=builder /usr/src/zksync/target/release/zksync_prover_fri /usr/bin/
+COPY --from=builder /usr/src/zksync/prover/target/release/zksync_prover_fri /usr/bin/
 
 ENTRYPOINT ["zksync_prover_fri"]

--- a/docker/prover-gpu-fri/Dockerfile
+++ b/docker/prover-gpu-fri/Dockerfile
@@ -24,7 +24,7 @@ RUN curl -Lo cmake-3.24.2-linux-x86_64.sh https://github.com/Kitware/CMake/relea
 WORKDIR /usr/src/zksync
 COPY . .
 
-RUN cargo build --release --features "gpu" --bin zksync_prover_fri
+RUN cd prover && cargo build --release --features "gpu" --bin zksync_prover_fri
 
 FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
 
@@ -33,6 +33,6 @@ RUN apt-get update && apt-get install -y curl libpq5 ca-certificates && rm -rf /
 # copy finalization hints required for assembly generation
 COPY prover/vk_setup_data_generator_server_fri/data/ /prover/vk_setup_data_generator_server_fri/data/
 
-COPY --from=builder /usr/src/zksync/target/release/zksync_prover_fri /usr/bin/
+COPY --from=builder /usr/src/zksync/prover/target/release/zksync_prover_fri /usr/bin/
 
 ENTRYPOINT ["zksync_prover_fri"]

--- a/docker/witness-generator/Dockerfile
+++ b/docker/witness-generator/Dockerfile
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /usr/src/zksync
 COPY . .
 
-RUN cargo build --release --bin zksync_witness_generator
+RUN cd prover && cargo build --release --bin zksync_witness_generator
 
 FROM debian:bookworm-slim
 
@@ -13,6 +13,6 @@ RUN apt-get update && apt-get install -y curl libpq5 ca-certificates && rm -rf /
 
 COPY prover/vk_setup_data_generator_server_fri/data/ /prover/vk_setup_data_generator_server_fri/data/
 
-COPY --from=builder /usr/src/zksync/target/release/zksync_witness_generator /usr/bin/
+COPY --from=builder /usr/src/zksync/prover/target/release/zksync_witness_generator /usr/bin/
 
 ENTRYPOINT ["zksync_witness_generator"]

--- a/docker/witness-vector-generator/Dockerfile
+++ b/docker/witness-vector-generator/Dockerfile
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /usr/src/zksync
 COPY . .
 
-RUN cargo build --release --bin zksync_witness_vector_generator
+RUN cd prover && cargo build --release --bin zksync_witness_vector_generator
 
 FROM debian:bookworm-slim
 
@@ -14,6 +14,6 @@ RUN apt-get update && apt-get install -y curl libpq5 ca-certificates && rm -rf /
 # copy finalization hints required for witness vector generation
 COPY prover/vk_setup_data_generator_server_fri/data/ /prover/vk_setup_data_generator_server_fri/data/
 
-COPY --from=builder /usr/src/zksync/target/release/zksync_witness_vector_generator /usr/bin/
+COPY --from=builder /usr/src/zksync/prover/target/release/zksync_witness_vector_generator /usr/bin/
 
 ENTRYPOINT ["zksync_witness_vector_generator"]


### PR DESCRIPTION
## What ❔

WIP ⚠️ 

Removes a hack that generated a temporary `Cargo.toml` for prover workspace.

## Why ❔

Supposedly not needed anymore.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
