### PR TITLE
refactor: Switch core workspace to using workspace deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,45 +358,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core 0.3.4",
+ "axum-core",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http 0.2.9",
- "http-body 0.4.5",
- "hyper 0.14.27",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1236b4b292f6c4d6dc34604bb5120d85c3fe1d1aa596bd5cc52ca054d13e7b9e"
-dependencies = [
- "async-trait",
- "axum-core 0.4.3",
- "bytes",
- "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
- "http-body-util",
- "hyper 1.2.0",
- "hyper-util",
+ "http",
+ "http-body",
+ "hyper",
  "itoa",
  "matchit",
  "memchr",
@@ -413,7 +381,6 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -425,33 +392,12 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 0.2.9",
- "http-body 0.4.5",
+ "http",
+ "http-body",
  "mime",
  "rustversion",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -540,7 +486,6 @@ dependencies = [
  "num-bigint 0.4.4",
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -2377,7 +2322,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http 0.2.9",
+ "http",
  "js-sys",
  "pin-project",
  "serde",
@@ -2536,26 +2481,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.9",
- "indexmap 2.1.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d030e59af851932b72ceebadf4a2b5986dba4c3b99dd2493f8273a0f151943"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 1.1.0",
+ "http",
  "indexmap 2.1.0",
  "slab",
  "tokio",
@@ -2639,7 +2565,7 @@ dependencies = [
  "base64 0.21.5",
  "bytes",
  "headers-core",
- "http 0.2.9",
+ "http",
  "httpdate",
  "mime",
  "sha1",
@@ -2651,7 +2577,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http 0.2.9",
+ "http",
 ]
 
 [[package]]
@@ -2743,47 +2669,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http 0.2.9",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
-dependencies = [
- "bytes",
- "http 1.1.0",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
-dependencies = [
- "bytes",
- "futures-core",
- "http 1.1.0",
- "http-body 1.0.0",
+ "http",
  "pin-project-lite",
 ]
 
@@ -2815,9 +2707,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.24",
- "http 0.2.9",
- "http-body 0.4.5",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -2830,34 +2722,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "h2 0.4.2",
- "http 1.1.0",
- "http-body 1.0.0",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
-]
-
-[[package]]
 name = "hyper-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
  "futures-util",
- "http 0.2.9",
- "hyper 0.14.27",
+ "http",
+ "hyper",
  "log",
  "rustls 0.21.7",
  "rustls-native-certs 0.6.3",
@@ -2872,26 +2744,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.27",
+ "hyper",
  "native-tls",
  "tokio",
  "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
-dependencies = [
- "bytes",
- "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
- "hyper 1.2.0",
- "pin-project-lite",
- "socket2 0.5.5",
- "tokio",
 ]
 
 [[package]]
@@ -3143,7 +2999,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "gloo-net",
- "http 0.2.9",
+ "http",
  "jsonrpsee-core",
  "pin-project",
  "rustls-native-certs 0.7.0",
@@ -3170,7 +3026,7 @@ dependencies = [
  "beef",
  "futures-timer",
  "futures-util",
- "hyper 0.14.27",
+ "hyper",
  "jsonrpsee-types",
  "parking_lot",
  "pin-project",
@@ -3192,7 +3048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b7de9f3219d95985eb77fd03194d7c1b56c19bce1abfcc9d07462574b15572"
 dependencies = [
  "async-trait",
- "hyper 0.14.27",
+ "hyper",
  "hyper-rustls",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -3225,8 +3081,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc7c6d1a2c58f6135810284a390d9f823d0f508db74cd914d8237802de80f98"
 dependencies = [
  "futures-util",
- "http 0.2.9",
- "hyper 0.14.27",
+ "http",
+ "hyper",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "pin-project",
@@ -3272,7 +3128,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "073c077471e89c4b511fa88b3df9a0f0abdf4a0a2e6683dd2ab36893af87bb2d"
 dependencies = [
- "http 0.2.9",
+ "http",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -3396,6 +3252,8 @@ dependencies = [
  "glob",
  "libc",
  "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -3462,7 +3320,7 @@ dependencies = [
  "futures 0.3.28",
  "hex",
  "metrics",
- "num 0.3.1",
+ "num",
  "once_cell",
  "prometheus_exporter",
  "rand 0.8.5",
@@ -3539,6 +3397,16 @@ name = "lru"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2994eeba8ed550fd9b47a0b38f0242bc3344e496483c6180b69139cc2fa5d1d7"
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "mach"
@@ -3652,7 +3520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a4964177ddfdab1e3a2b37aec7cf320e14169abb0ed73999f558136409178d5"
 dependencies = [
  "base64 0.21.5",
- "hyper 0.14.27",
+ "hyper",
  "indexmap 1.9.3",
  "ipnet",
  "metrics",
@@ -3874,29 +3742,15 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
-dependencies = [
- "num-bigint 0.3.3",
- "num-complex 0.3.1",
- "num-integer",
- "num-iter",
- "num-rational 0.3.2",
- "num-traits",
-]
-
-[[package]]
-name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
  "num-bigint 0.4.4",
- "num-complex 0.4.4",
+ "num-complex",
  "num-integer",
  "num-iter",
- "num-rational 0.4.1",
+ "num-rational",
  "num-traits",
 ]
 
@@ -3909,7 +3763,6 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -3939,16 +3792,6 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "zeroize",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
-dependencies = [
- "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -4001,19 +3844,6 @@ checksum = "64a5fe11d4135c3bcdf3a95b18b194afa9608a5f6ff034f5d857bc9a27fb0119"
 dependencies = [
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
-dependencies = [
- "autocfg",
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -5066,10 +4896,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.24",
- "http 0.2.9",
- "http-body 0.4.5",
- "hyper 0.14.27",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
  "hyper-rustls",
  "hyper-tls",
  "ipnet",
@@ -6019,7 +5849,7 @@ dependencies = [
  "base64 0.13.1",
  "bytes",
  "futures 0.3.28",
- "http 0.2.9",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -6812,8 +6642,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 0.2.9",
- "http-body 0.4.5",
+ "http",
+ "http-body",
  "http-range-header",
  "httpdate",
  "iri-string",
@@ -7163,7 +6993,7 @@ name = "vise-exporter"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/vise.git?rev=1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1#1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1"
 dependencies = [
- "hyper 0.14.27",
+ "hyper",
  "metrics-exporter-prometheus",
  "once_cell",
  "tokio",
@@ -7386,7 +7216,24 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
+ "soketto",
  "tiny-keccak 2.0.2",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+ "web3-async-native-tls",
+]
+
+[[package]]
+name = "web3-async-native-tls"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6d8d1636b2627fe63518d5a9b38a569405d9c9bc665c43c9c341de57227ebb"
+dependencies = [
+ "native-tls",
+ "thiserror",
+ "tokio",
  "url",
 ]
 
@@ -7690,7 +7537,7 @@ dependencies = [
  "blake2 0.10.6 (git+https://github.com/RustCrypto/hashes.git?rev=1f727ce37ff40fa0cce84eb8543a45bdd3ca4a4e)",
  "k256 0.11.6",
  "lazy_static",
- "num 0.4.1",
+ "num",
  "serde",
  "serde_json",
  "sha2 0.10.6",
@@ -7706,7 +7553,7 @@ source = "git+https://github.com/matter-labs/era-zk_evm.git?tag=v1.3.3-rc2#fbee2
 dependencies = [
  "anyhow",
  "lazy_static",
- "num 0.4.1",
+ "num",
  "serde",
  "serde_json",
  "static_assertions",
@@ -7721,7 +7568,7 @@ source = "git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.3.3#fbee20
 dependencies = [
  "anyhow",
  "lazy_static",
- "num 0.4.1",
+ "num",
  "serde",
  "serde_json",
  "static_assertions",
@@ -7736,7 +7583,7 @@ source = "git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.4.0#dd76fc
 dependencies = [
  "anyhow",
  "lazy_static",
- "num 0.4.1",
+ "num",
  "serde",
  "serde_json",
  "static_assertions",
@@ -7751,7 +7598,7 @@ source = "git+https://github.com/matter-labs/era-zk_evm.git?branch=v1.4.1#6250db
 dependencies = [
  "anyhow",
  "lazy_static",
- "num 0.4.1",
+ "num",
  "serde",
  "serde_json",
  "static_assertions",
@@ -7870,7 +7717,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "hex",
- "num 0.3.1",
+ "num",
  "serde_json",
  "thiserror",
  "tokio",
@@ -8152,7 +7999,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
- "axum 0.6.20",
+ "axum",
  "bitflags 1.3.2",
  "chrono",
  "ctrlc",
@@ -8231,7 +8078,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "thiserror",
  "zksync_basic_types",
 ]
@@ -8323,7 +8170,7 @@ name = "zksync_eth_signer"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "axum 0.7.4",
+ "axum",
  "futures 0.3.28",
  "hex",
  "jsonrpc-core",
@@ -8493,7 +8340,7 @@ dependencies = [
  "flate2",
  "google-cloud-auth",
  "google-cloud-storage",
- "http 0.2.9",
+ "http",
  "prost",
  "serde_json",
  "tempdir",
@@ -8692,8 +8539,8 @@ dependencies = [
  "chrono",
  "hex",
  "itertools 0.10.5",
- "num 0.4.1",
- "num_enum 0.6.1",
+ "num",
+ "num_enum 0.7.2",
  "once_cell",
  "prost",
  "rlp",
@@ -8724,7 +8571,7 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "metrics",
- "num 0.4.1",
+ "num",
  "rand 0.8.5",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,153 @@ exclude = []
 [profile.perf]
 inherits = "release"
 debug = true
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
+homepage = "https://zksync.io/"
+repository = "https://github.com/matter-labs/zksync-era"
+license = "MIT OR Apache-2.0"
+keywords = ["blockchain", "zksync"]
+categories = ["cryptography"]
+
+[workspace.dependencies]
+# "External" dependencies
+anyhow = "1"
+assert_matches = "1.5"
+async-trait = "0.1"
+axum = "0.6.19"
+bigdecimal = "0.3.0"
+bincode = "1"
+bitflags = "1.3.2"
+blake2 = "0.10"
+chrono = "0.4"
+clap = "4.2.2"
+codegen = "0.2.0"
+criterion = "0.4.0"
+ctrlc = "3.1"
+envy = "0.4"
+ethabi = "18.0.0"
+flate2 = "1.0.28"
+futures = "0.3"
+google-cloud-auth = "0.13.0"
+google-cloud-storage = "0.15.0"
+governor = "0.4.2"
+hex = "0.4"
+http = "0.2.9"
+iai = "0.1"
+insta = "1.29.0"
+itertools = "0.10"
+jsonrpc-core = "18"
+jsonrpsee = { version = "0.21.0", default-features = false }
+lazy_static = "1.4"
+leb128 = "0.2.5"
+lru = { version = "0.12.1", default-features = false }
+metrics = "0.21"
+metrics-exporter-prometheus = "0.12"
+mini-moka = "0.10.0"
+num = "0.4.0"
+num_cpus = "1.13"
+num_enum = "0.7.2"
+once_cell = "1"
+pin-project-lite = "0.2.13"
+pretty_assertions = "1"
+prost = "0.12.1"
+rand = "0.8"
+rayon = "1.3.1"
+regex = "1"
+reqwest = "0.11"
+rlp = "0.5"
+rocksdb = "0.21.0"
+secp256k1 = "0.27.0"
+semver = "1"
+sentry = "0.31"
+serde = "1"
+serde_derive = "1.0.90"
+serde_json = "1"
+serde_with = "1"
+serde_yaml = "0.9"
+sha2 = "0.10.8"
+sha3 = "0.10.8"
+sqlx = "0.7.3"
+static_assertions = "1.1"
+structopt = "0.3.20"
+strum = "0.24"
+tempdir = "0.3.7"
+tempfile = "3.0.2"
+test-casing = "0.1.2"
+thiserror = "1"
+thread_local = "1.1"
+tikv-jemallocator = "0.5"
+tokio = "1"
+tower = "0.4.13"
+tower-http = "0.4.1"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+url = "2"
+web3 = "0.19.0"
+
+# "Internal" dependencies
+circuit_sequencer_api = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
+circuit_sequencer_api_1_3_3 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3" }
+circuit_sequencer_api_1_4_0 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.0" }
+circuit_sequencer_api_1_4_1 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.1" }
+circuit_sequencer_api_1_4_2 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
+crypto_codegen = { package = "codegen", git = "https://github.com/matter-labs/solidity_plonk_verifier.git", branch = "dev" }
+kzg = { package = "kzg", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
+vise = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
+vise-exporter = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
+zk_evm = { git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.3-rc2" }
+zk_evm_1_3_1 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.1-rc2" }
+zk_evm_1_3_3 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.3-rc2" }
+zk_evm_1_4_0 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.4.0" }
+zk_evm_1_4_1 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.4.1" }
+zksync_concurrency = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
+zksync_consensus_bft = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
+zksync_consensus_crypto = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
+zksync_consensus_executor = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
+zksync_consensus_network = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
+zksync_consensus_roles = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
+zksync_consensus_storage = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
+zksync_consensus_utils = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
+zksync_protobuf = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
+zksync_protobuf_build = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
+
+# "Local" dependencies
+multivm = { path = "core/lib/multivm" }
+prometheus_exporter = { path = "core/lib/prometheus_exporter" }
+prover_dal = { path = "prover/prover_dal" }
+vlog = { path = "core/lib/vlog" }
+vm_utils = { path = "core/lib/vm_utils" }
+vm-benchmark-harness = { path = "core/tests/vm-benchmark/harness" }
+zksync = { path = "sdk/zksync-rs" }
+zksync_basic_types = { path = "core/lib/basic_types" }
+zksync_circuit_breaker = { path = "core/lib/circuit_breaker" }
+zksync_commitment_utils = { path = "core/lib/commitment_utils" }
+zksync_config = { path = "core/lib/config" }
+zksync_contracts = { path = "core/lib/contracts" }
+zksync_core = { path = "core/lib/zksync_core" }
+zksync_crypto = { path = "core/lib/crypto" }
+zksync_dal = { path = "core/lib/dal" }
+zksync_db_connection = { path = "core/lib/db_connection" }
+zksync_env_config = { path = "core/lib/env_config" }
+zksync_eth_client = { path = "core/lib/eth_client" }
+zksync_eth_signer = { path = "core/lib/eth_signer" }
+zksync_health_check = { path = "core/lib/health_check" }
+zksync_l1_contract_interface = { path = "core/lib/l1_contract_interface" }
+zksync_mempool = { path = "core/lib/mempool" }
+zksync_merkle_tree = { path = "core/lib/merkle_tree" }
+zksync_mini_merkle_tree = { path = "core/lib/mini_merkle_tree" }
+zksync_object_store = { path = "core/lib/object_store" }
+zksync_protobuf_config = { path = "core/lib/protobuf_config" }
+zksync_prover_interface = { path = "core/lib/prover_interface" }
+zksync_queued_job_processor = { path = "core/lib/queued_job_processor" }
+zksync_snapshots_applier = { path = "core/lib/snapshots_applier" }
+zksync_state = { path = "core/lib/state" }
+zksync_storage = { path = "core/lib/storage" }
+zksync_system_constants = { path = "core/lib/constants" }
+zksync_test_account = { path = "core/tests/test_account" }
+zksync_types = { path = "core/lib/types" }
+zksync_utils = { path = "core/lib/utils" }
+zksync_web3_decl = { path = "core/lib/web3_decl" }

--- a/core/bin/block_reverter/Cargo.toml
+++ b/core/bin/block_reverter/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
 name = "block_reverter"
-version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
-publish = false # We don't want to publish our binaries.
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish = false
 
 [dependencies]
-zksync_config = { path = "../../lib/config" }
-zksync_env_config = { path = "../../lib/env_config" }
-zksync_dal = { path = "../../lib/dal" }
-zksync_types = { path = "../../lib/types" }
-zksync_core = { path = "../../lib/zksync_core" }
-vlog = { path = "../../lib/vlog" }
+zksync_config.workspace = true
+zksync_env_config.workspace = true
+zksync_dal.workspace = true
+zksync_types.workspace = true
+zksync_core.workspace = true
+vlog.workspace = true
 
-anyhow = "1.0"
-clap = { version = "4.2.4", features = ["derive"] }
-tokio = { version = "1", features = ["full"] }
-serde_json = "1.0"
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["full"] }
+serde_json.workspace = true

--- a/core/bin/contract-verifier/Cargo.toml
+++ b/core/bin/contract-verifier/Cargo.toml
@@ -1,39 +1,39 @@
 [package]
 name = "zksync_contract_verifier"
-version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
 description = "The zkEVM contract verifier"
-publish = false # We don't want to publish our binaries.
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish = false
 
 [dependencies]
-zksync_types = { path = "../../lib/types" }
-zksync_dal = { path = "../../lib/dal" }
-zksync_env_config = { path = "../../lib/env_config" }
-zksync_config = { path = "../../lib/config" }
-zksync_contracts = { path = "../../lib/contracts" }
-zksync_queued_job_processor = { path = "../../lib/queued_job_processor" }
-zksync_utils = { path = "../../lib/utils" }
-prometheus_exporter = { path = "../../lib/prometheus_exporter" }
-vlog = { path = "../../lib/vlog" }
+zksync_types.workspace = true
+zksync_dal.workspace = true
+zksync_env_config.workspace = true
+zksync_config.workspace = true
+zksync_contracts.workspace = true
+zksync_queued_job_processor.workspace = true
+zksync_utils.workspace = true
+prometheus_exporter.workspace = true
+vlog.workspace = true
 
-anyhow = "1.0"
-tokio = { version = "1", features = ["full"] }
-futures = { version = "0.3", features = ["compat"] }
-ctrlc = { version = "3.1", features = ["termination"] }
-thiserror = "1.0"
-chrono = "0.4"
-serde_json = "1.0"
-ethabi = "18.0.0"
-metrics = "0.21"
-hex = "0.4"
-serde = { version = "1.0", features = ["derive"] }
-structopt = "0.3.20"
-lazy_static = "1.4"
-tempfile = "3.0.2"
-regex = "1"
-tracing = "0.1"
+anyhow.workspace = true
+tokio = { workspace = true, features = ["full"] }
+futures.workspace = true
+ctrlc.workspace = true
+thiserror.workspace = true
+chrono.workspace = true
+serde_json.workspace = true
+ethabi.workspace = true
+metrics.workspace = true
+hex.workspace = true
+serde = { workspace = true, features = ["derive"] }
+structopt.workspace = true
+lazy_static.workspace = true
+tempfile.workspace = true
+regex.workspace = true
+tracing.workspace = true

--- a/core/bin/external_node/Cargo.toml
+++ b/core/bin/external_node/Cargo.toml
@@ -1,45 +1,45 @@
 [package]
 name = "zksync_external_node"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
-publish = false # We don't want to publish our binaries.
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish = false
 
 [dependencies]
-zksync_core = { path = "../../lib/zksync_core" }
-zksync_dal = { path = "../../lib/dal" }
-zksync_db_connection = { path = "../../lib/db_connection" }
-zksync_config = { path = "../../lib/config" }
-zksync_storage = { path = "../../lib/storage" }
-zksync_utils = { path = "../../lib/utils" }
-zksync_state = { path = "../../lib/state" }
-zksync_basic_types = { path = "../../lib/basic_types" }
-zksync_contracts = { path = "../../lib/contracts" }
-zksync_l1_contract_interface = { path = "../../lib/l1_contract_interface" }
-zksync_snapshots_applier = { path = "../../lib/snapshots_applier" }
-zksync_object_store = { path = "../../lib/object_store" }
-prometheus_exporter = { path = "../../lib/prometheus_exporter" }
-zksync_health_check = { path = "../../lib/health_check" }
-zksync_web3_decl = { path = "../../lib/web3_decl" }
-zksync_types = { path = "../../lib/types" }
-vlog = { path = "../../lib/vlog" }
+zksync_core.workspace = true
+zksync_dal.workspace = true
+zksync_db_connection.workspace = true
+zksync_config.workspace = true
+zksync_storage.workspace = true
+zksync_utils.workspace = true
+zksync_state.workspace = true
+zksync_basic_types.workspace = true
+zksync_contracts.workspace = true
+zksync_l1_contract_interface.workspace = true
+zksync_snapshots_applier.workspace = true
+zksync_object_store.workspace = true
+prometheus_exporter.workspace = true
+zksync_health_check.workspace = true
+zksync_web3_decl.workspace = true
+zksync_types.workspace = true
+vlog.workspace = true
 
-zksync_concurrency = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-zksync_consensus_roles = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-vise = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
+zksync_concurrency.workspace = true
+zksync_consensus_roles.workspace = true
+vise.workspace = true
 
-anyhow = "1.0"
-tokio = { version = "1", features = ["full"] }
-futures = "0.3"
-serde = { version = "1.0", features = ["derive"] }
-envy = "0.4"
-url = "2.4"
-clap = { version = "4.2.4", features = ["derive"] }
-serde_json = "1"
-semver = "1"
-tracing = "0.1"
+anyhow.workspace = true
+tokio = { workspace = true, features = ["full"] }
+futures.workspace = true
+serde = { workspace = true, features = ["derive"] }
+envy.workspace = true
+url.workspace = true
+clap = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+semver.workspace = true
+tracing.workspace = true

--- a/core/bin/merkle_tree_consistency_checker/Cargo.toml
+++ b/core/bin/merkle_tree_consistency_checker/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "merkle_tree_consistency_checker"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
-publish = false # We don't want to publish our binaries.
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish = false
 
 [dependencies]
-zksync_config = { path = "../../lib/config" }
-zksync_env_config = { path = "../../lib/env_config" }
-zksync_merkle_tree = { path = "../../lib/merkle_tree" }
-zksync_types = { path = "../../lib/types" }
-zksync_storage = { path = "../../lib/storage" }
-vlog = { path = "../../lib/vlog" }
+zksync_config.workspace = true
+zksync_env_config.workspace = true
+zksync_merkle_tree.workspace = true
+zksync_types.workspace = true
+zksync_storage.workspace = true
+vlog.workspace = true
 
-anyhow = "1.0"
-clap = { version = "4.2.4", features = ["derive"] }
-tracing = "0.1"
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+tracing.workspace = true

--- a/core/bin/snapshots_creator/Cargo.toml
+++ b/core/bin/snapshots_creator/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
 name = "snapshots_creator"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
-publish = false # We don't want to publish our binaries.
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish = false
 
 [dependencies]
-vise = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
-prometheus_exporter = { path = "../../lib/prometheus_exporter" }
-zksync_config = { path = "../../lib/config" }
-zksync_dal = { path = "../../lib/dal" }
-zksync_env_config = { path = "../../lib/env_config" }
-zksync_types = { path = "../../lib/types" }
-zksync_object_store = { path = "../../lib/object_store" }
-vlog = { path = "../../lib/vlog" }
+vise.workspace = true
+prometheus_exporter.workspace = true
+zksync_config.workspace = true
+zksync_dal.workspace = true
+zksync_env_config.workspace = true
+zksync_types.workspace = true
+zksync_object_store.workspace = true
+vlog.workspace = true
 
-anyhow = "1.0"
-tokio = { version = "1", features = ["full"] }
-tracing = "0.1"
-futures = "0.3"
+anyhow.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
+futures.workspace = true
 
 [dev-dependencies]
-rand = "0.8"
+rand.workspace = true

--- a/core/bin/system-constants-generator/Cargo.toml
+++ b/core/bin/system-constants-generator/Cargo.toml
@@ -1,24 +1,23 @@
 [package]
 name = "system-constants-generator"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "Tool for generating JSON files with the system constants for L1/L2 contracts"
-publish = false # We don't want to publish our binaries.
+publish = false
 
 [dependencies]
-zksync_state = { path = "../../lib/state" }
-zksync_types = { path = "../../lib/types" }
-zksync_utils = { path = "../../lib/utils" }
-zksync_contracts = { path = "../../lib/contracts" }
-multivm = { path = "../../lib/multivm" }
+zksync_state.workspace = true
+zksync_types.workspace = true
+zksync_utils.workspace = true
+zksync_contracts.workspace = true
+multivm.workspace = true
 
-codegen = "0.2.0"
-
-serde = "1.0"
-serde_json = "1.0"
-once_cell = "1.7"
+codegen.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+once_cell.workspace = true

--- a/core/bin/verified_sources_fetcher/Cargo.toml
+++ b/core/bin/verified_sources_fetcher/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "verified_sources_fetcher"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
-publish = false # We don't want to publish our binaries.
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish = false
 
 [dependencies]
-zksync_dal = { path = "../../lib/dal" }
-zksync_types = { path = "../../lib/types" }
-zksync_config = { path = "../../lib/config" }
-zksync_env_config = { path = "../../lib/env_config" }
+zksync_dal.workspace = true
+zksync_types.workspace = true
+zksync_config.workspace = true
+zksync_env_config.workspace = true
 
-anyhow = "1.0"
-tokio = { version = "1", features = ["full"] }
-serde_json = "1.0"
+anyhow.workspace = true
+tokio = { workspace = true, features = ["full"] }
+serde_json.workspace = true

--- a/core/bin/zksync_server/Cargo.toml
+++ b/core/bin/zksync_server/Cargo.toml
@@ -1,36 +1,36 @@
 [package]
 name = "zksync_server"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
-publish = false # We don't want to publish our binaries.
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish = false
 
 [dependencies]
-zksync_config = { path = "../../lib/config" }
-zksync_env_config = { path = "../../lib/env_config" }
-zksync_storage = { path = "../../lib/storage" }
-zksync_utils = { path = "../../lib/utils" }
-zksync_types = { path = "../../lib/types" }
-zksync_core = { path = "../../lib/zksync_core" }
+zksync_config.workspace = true
+zksync_env_config.workspace = true
+zksync_storage.workspace = true
+zksync_utils.workspace = true
+zksync_types.workspace = true
+zksync_core.workspace = true
 
 # Consensus dependenices
-zksync_consensus_crypto = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-zksync_consensus_roles = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-zksync_consensus_executor = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-zksync_concurrency = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-vlog = { path = "../../lib/vlog" }
+zksync_consensus_crypto.workspace = true
+zksync_consensus_roles.workspace = true
+zksync_consensus_executor.workspace = true
+zksync_concurrency.workspace = true
+vlog.workspace = true
 
-anyhow = "1.0"
-clap = { version = "4.2.4", features = ["derive"] }
-serde_json = "1.0"
-tokio = { version = "1", features = ["full"] }
-tracing = "0.1"
-futures = "0.3"
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
+futures.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = "0.5"
+tikv-jemallocator.workspace = true

--- a/core/lib/basic_types/Cargo.toml
+++ b/core/lib/basic_types/Cargo.toml
@@ -1,18 +1,22 @@
 [package]
 name = "zksync_basic_types"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-web3 = { version = "0.19.0", default-features = false, features = ["http-rustls-tls", "test", "signing"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-chrono = "0.4"
-strum = { version = "0.24", features = ["derive"] }
-num_enum = "0.7.2"
+web3 = { workspace = true, features = [
+    "http-rustls-tls",
+    "test",
+    "signing",
+] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+chrono.workspace = true
+strum = { workspace = true, features = ["derive"] }
+num_enum.workspace = true

--- a/core/lib/circuit_breaker/Cargo.toml
+++ b/core/lib/circuit_breaker/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
 name = "zksync_circuit_breaker"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-zksync_types = { path = "../types" }
-zksync_config = { path = "../config" }
-zksync_contracts = { path = "../contracts" }
-zksync_dal = { path = "../dal" }
-thiserror = "1.0"
-serde_json = "1.0"
-futures = { version = "0.3", features = ["compat"] }
-tokio = { version = "1", features = ["time"] }
-anyhow = "1.0"
-async-trait = "0.1"
-hex = "0.4"
-metrics = "0.21"
-tracing = "0.1.26"
+zksync_types.workspace = true
+zksync_config.workspace = true
+zksync_contracts.workspace = true
+zksync_dal.workspace = true
+thiserror.workspace = true
+serde_json.workspace = true
+futures.workspace = true
+tokio = { workspace = true, features = ["time"] }
+anyhow.workspace = true
+async-trait.workspace = true
+hex.workspace = true
+metrics.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-assert_matches = "1.5.0"
+assert_matches.workspace = true

--- a/core/lib/commitment_utils/Cargo.toml
+++ b/core/lib/commitment_utils/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "zksync_commitment_utils"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-zksync_types = { path = "../../lib/types" }
-zksync_utils = { path = "../../lib/utils" }
-circuit_sequencer_api_1_4_0 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.0" }
-circuit_sequencer_api_1_4_1 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.1" }
+zksync_types.workspace = true
+zksync_utils.workspace = true
+circuit_sequencer_api_1_4_0.workspace = true
+circuit_sequencer_api_1_4_1.workspace = true
 
-zk_evm_1_4_1 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.4.1" }
-zk_evm_1_3_3 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.3-rc2" }
-multivm = { path = "../../lib/multivm" }
+zk_evm_1_4_1.workspace = true
+zk_evm_1_3_3.workspace = true
+multivm.workspace = true

--- a/core/lib/config/Cargo.toml
+++ b/core/lib/config/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "zksync_config"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-zksync_basic_types = { path = "../../lib/basic_types" }
+zksync_basic_types.workspace = true
 
-anyhow = "1.0"
-rand = "0.8"
-serde = { version = "1.0", features = ["derive"] }
+anyhow.workspace = true
+rand.workspace = true
+serde = { workspace = true, features = ["derive"] }

--- a/core/lib/constants/Cargo.toml
+++ b/core/lib/constants/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "zksync_system_constants"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-zksync_basic_types = { path = "../../lib/basic_types" }
-zksync_utils = { path = "../../lib/utils" }
+zksync_basic_types.workspace = true
+zksync_utils.workspace = true
 
-once_cell = "1.13.0"
+once_cell.workspace = true

--- a/core/lib/contracts/Cargo.toml
+++ b/core/lib/contracts/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "zksync_contracts"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-zksync_utils = { path = "../utils" }
+zksync_utils.workspace = true
 
-ethabi = "18.0.0"
-serde_json = "1.0"
-serde = "1.0"
-once_cell = "1.7"
-hex = "0.4"
-envy = "0.4"
+ethabi.workspace = true
+serde_json.workspace = true
+serde.workspace = true
+once_cell.workspace = true
+hex.workspace = true
+envy.workspace = true

--- a/core/lib/crypto/Cargo.toml
+++ b/core/lib/crypto/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "zksync_crypto"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 readme = "README.md"
 
 [dependencies]
-zksync_basic_types = { path = "../basic_types" }
-serde = "1.0"
-thiserror = "1.0"
-once_cell = "1.7"
-hex = "0.4"
-sha2 = "0.9"
-blake2 = "0.10"
+zksync_basic_types.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+once_cell.workspace = true
+hex.workspace = true
+sha2.workspace = true
+blake2.workspace = true
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json.workspace = true

--- a/core/lib/dal/Cargo.toml
+++ b/core/lib/dal/Cargo.toml
@@ -1,34 +1,34 @@
 [package]
 name = "zksync_dal"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 links = "zksync_dal_proto"
 
 [dependencies]
-vise = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
-zksync_utils = { path = "../utils" }
-zksync_system_constants = { path = "../constants" }
-zksync_contracts = { path = "../contracts" }
-zksync_types = { path = "../types" }
-zksync_consensus_roles = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-zksync_consensus_storage = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-zksync_protobuf = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-zksync_db_connection = { path = "../db_connection" }
+vise.workspace = true
+zksync_utils.workspace = true
+zksync_system_constants.workspace = true
+zksync_contracts.workspace = true
+zksync_types.workspace = true
+zksync_consensus_roles.workspace = true
+zksync_consensus_storage.workspace = true
+zksync_protobuf.workspace = true
+zksync_db_connection.workspace = true
 
-itertools = "0.10.1"
-thiserror = "1.0"
-anyhow = "1.0"
-prost = "0.12.1"
-rand = "0.8"
-tokio = { version = "1", features = ["full"] }
-sqlx = { version = "0.7.3", default-features = false, features = [
+itertools.workspace = true
+thiserror.workspace = true
+anyhow.workspace = true
+prost.workspace = true
+rand.workspace = true
+tokio = { workspace = true, features = ["full"] }
+sqlx = { workspace = true, features = [
     "runtime-tokio",
     "tls-native-tls",
     "macros",
@@ -40,14 +40,14 @@ sqlx = { version = "0.7.3", default-features = false, features = [
     "migrate",
     "ipnetwork",
 ] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-bigdecimal = "0.3.0"
-bincode = "1"
-hex = "0.4"
-strum = { version = "0.24", features = ["derive"] }
-tracing = "0.1"
-chrono = { version = "0.4", features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+bigdecimal.workspace = true
+bincode.workspace = true
+hex.workspace = true
+strum = { workspace = true, features = ["derive"] }
+tracing.workspace = true
+chrono = { workspace = true, features = ["serde"] }
 
 [build-dependencies]
-zksync_protobuf_build = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
+zksync_protobuf_build.workspace = true

--- a/core/lib/db_connection/Cargo.toml
+++ b/core/lib/db_connection/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "zksync_db_connection"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-zksync_health_check = { path = "../health_check" }
+zksync_health_check.workspace = true
 
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-sqlx = { version = "0.7.3", default-features = false, features = [
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sqlx = { workspace = true, features = [
     "runtime-tokio",
     "tls-native-tls",
     "macros",
@@ -26,13 +26,13 @@ sqlx = { version = "0.7.3", default-features = false, features = [
     "migrate",
     "ipnetwork",
 ] }
-vise = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
-tokio = { version = "1", features = ["full"] }
-anyhow = "1.0"
-url = "2"
-rand = "0.8"
-tracing = "0.1"
+vise.workspace = true
+tokio = { workspace = true, features = ["full"] }
+anyhow.workspace = true
+url.workspace = true
+rand.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-assert_matches = "1.5.0"
-zksync_basic_types = { path = "../basic_types" }
+assert_matches.workspace = true
+zksync_basic_types.workspace = true

--- a/core/lib/env_config/Cargo.toml
+++ b/core/lib/env_config/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "zksync_env_config"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-zksync_basic_types = { path = "../../lib/basic_types" }
-zksync_config = { path = "../../lib/config" }
+zksync_basic_types.workspace = true
+zksync_config.workspace = true
 
-anyhow = "1.0"
-serde = "1.0"
-envy = "0.4"
+anyhow.workspace = true
+serde.workspace = true
+envy.workspace = true

--- a/core/lib/eth_client/Cargo.toml
+++ b/core/lib/eth_client/Cargo.toml
@@ -1,31 +1,31 @@
 [package]
 name = "zksync_eth_client"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-vise = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
-zksync_types = { path = "../types" }
-zksync_eth_signer = { path = "../eth_signer" }
-zksync_config = { path = "../config" }
-zksync_contracts = { path = "../contracts" }
+vise.workspace = true
+zksync_types.workspace = true
+zksync_eth_signer.workspace = true
+zksync_config.workspace = true
+zksync_contracts.workspace = true
 
-jsonrpc-core = "18"
-serde = "1.0.90"
-thiserror = "1"
-async-trait = "0.1"
-tracing = "0.1"
-rlp = "0.5"
+jsonrpc-core.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+async-trait.workspace = true
+tracing.workspace = true
+rlp.workspace = true
 
 [dev-dependencies]
-static_assertions = "1.1.0"
-tokio = { version = "1", features = ["full"] }
-pretty_assertions = "1"
-hex = "0.4.2"
-serde_json = "1.0"
+static_assertions.workspace = true
+tokio = { workspace = true, features = ["full"] }
+pretty_assertions.workspace = true
+hex.workspace = true
+serde_json.workspace = true

--- a/core/lib/eth_signer/Cargo.toml
+++ b/core/lib/eth_signer/Cargo.toml
@@ -1,32 +1,32 @@
 [package]
 name = "zksync_eth_signer"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 zksync_types = { path = "../types" }
 
-serde = "1.0.90"
-serde_derive = "1.0.90"
-serde_json = "1.0.0"
-hex = "0.4.2"
-secp256k1 = "0.27.0"
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
+hex.workspace = true
+secp256k1.workspace = true
 
-rlp = "0.5"
+rlp.workspace = true
 
-reqwest = { version = "0.11", features = ["json", "blocking"] }
-thiserror = "1.0"
+reqwest = { workspace = true, features = ["json", "blocking"] }
+thiserror.workspace = true
 
-jsonrpc-core = "18.0.0"
-async-trait = "0.1"
+jsonrpc-core.workspace = true
+async-trait.workspace = true
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"] }
-axum = "0.7"
-futures = "0.3"
+tokio = { workspace = true, features = ["full"] }
+axum.workspace = true
+futures.workspace = true

--- a/core/lib/eth_signer/src/json_rpc_signer.rs
+++ b/core/lib/eth_signer/src/json_rpc_signer.rs
@@ -396,9 +396,9 @@ mod tests {
             .with_state(Arc::new(state));
 
         for i in 9000..9999 {
-            let new_url = format!("127.0.0.1:{}", i);
-            if let Ok(listener) = tokio::net::TcpListener::bind(&new_url).await {
-                server = Some(axum::serve(listener, app));
+            let new_url = format!("127.0.0.1:{}", i).parse().unwrap();
+            if let Ok(axum_server) = axum::Server::try_bind(&new_url) {
+                server = Some(axum_server.serve(app.into_make_service()));
                 url = Some(new_url);
                 break;
             }

--- a/core/lib/health_check/Cargo.toml
+++ b/core/lib/health_check/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
 name = "zksync_health_check"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-vise = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
+vise.workspace = true
 
-async-trait = "0.1"
-futures = "0.3"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tokio = { version = "1", features = ["sync", "time"] }
-tracing = "0.1"
+async-trait.workspace = true
+futures.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["sync", "time"] }
+tracing.workspace = true
 
 [dev-dependencies]
-assert_matches = "1.5.0"
-tokio = { version = "1", features = ["macros", "rt"] }
+assert_matches.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/core/lib/l1_contract_interface/Cargo.toml
+++ b/core/lib/l1_contract_interface/Cargo.toml
@@ -1,33 +1,32 @@
 [package]
 name = "zksync_l1_contract_interface"
-version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
-readme = "README.md"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+readme.workspace = true
 
 [dependencies]
-zksync_types = { path = "../types" }
-zksync_prover_interface = { path = "../prover_interface" }
+zksync_types.workspace = true
+zksync_prover_interface.workspace = true
 
 # Used to serialize proof data
-codegen = { git = "https://github.com/matter-labs/solidity_plonk_verifier.git", branch = "dev" }
+crypto_codegen.workspace = true
 # Used to calculate commitment for vk from the old L1 verifier contract (backward comatibility needs)
-
-circuit_sequencer_api_1_3_3 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3" }
+circuit_sequencer_api_1_3_3.workspace = true
 # Used to calculate the kzg commitment and proofs
-kzg = { package = "kzg", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
+kzg.workspace = true
 
-sha2 = "0.10.8"
-sha3 = "0.10.8"
-hex = "0.4"
-once_cell = "1"
+sha2.workspace = true
+sha3.workspace = true
+hex.workspace = true
+once_cell.workspace = true
 
 [dev-dependencies]
-serde = "1.0.90"
-serde_json = "1.0.0"
-serde_with = { version = "1", features = ["base64", "hex"] }
+serde.workspace = true
+serde_json.workspace = true
+serde_with = { workspace = true, features = ["base64", "hex"] }

--- a/core/lib/l1_contract_interface/Cargo.toml
+++ b/core/lib/l1_contract_interface/Cargo.toml
@@ -8,7 +8,6 @@ repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
-readme.workspace = true
 
 [dependencies]
 zksync_types.workspace = true

--- a/core/lib/l1_contract_interface/src/i_executor/methods/prove_batches.rs
+++ b/core/lib/l1_contract_interface/src/i_executor/methods/prove_batches.rs
@@ -1,4 +1,4 @@
-use codegen::serialize_proof;
+use crypto_codegen::serialize_proof;
 use zksync_prover_interface::outputs::L1BatchProofForL1;
 use zksync_types::{
     commitment::L1BatchWithMetadata, ethabi::Token, web3::contract::tokens::Tokenizable, U256,

--- a/core/lib/mempool/Cargo.toml
+++ b/core/lib/mempool/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "zksync_mempool"
-version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-zksync_types = { path = "../types" }
-tracing = "0.1"
+zksync_types.workspace = true
+tracing.workspace = true

--- a/core/lib/merkle_tree/Cargo.toml
+++ b/core/lib/merkle_tree/Cargo.toml
@@ -1,38 +1,38 @@
 [package]
 name = "zksync_merkle_tree"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-vise = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
-zksync_types = { path = "../types" }
-zksync_crypto = { path = "../crypto" }
-zksync_storage = { path = "../storage" }
-zksync_prover_interface = { path = "../prover_interface" }
-zksync_utils = { path = "../utils" }
+vise.workspace = true
+zksync_types.workspace = true
+zksync_crypto.workspace = true
+zksync_storage.workspace = true
+zksync_prover_interface.workspace = true
+zksync_utils.workspace = true
 
-leb128 = "0.2.5"
-once_cell = "1.17.1"
-rayon = "1.3.1"
-thiserror = "1.0"
-tracing = "0.1"
+leb128.workspace = true
+once_cell.workspace = true
+rayon.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-zksync_system_constants = { path = "../constants" }
+zksync_system_constants.workspace = true
 
-assert_matches = "1.5.0"
-clap = { version = "4.2.2", features = ["derive"] }
-insta = { version = "1.29.0", features = ["yaml"] }
-rand = "0.8.5"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_with = { version = "1", features = ["hex"] }
-tempfile = "3.0.2"
-test-casing = "0.1.2"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+assert_matches.workspace = true
+clap = { workspace = true, features = ["derive"] }
+insta = { workspace = true, features = ["yaml"] }
+rand.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_with = { workspace = true, features = ["hex"] }
+tempfile.workspace = true
+test-casing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/core/lib/mini_merkle_tree/Cargo.toml
+++ b/core/lib/mini_merkle_tree/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "zksync_mini_merkle_tree"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-zksync_crypto = { path = "../../lib/crypto" }
-zksync_basic_types = { path = "../basic_types" }
+zksync_crypto.workspace = true
+zksync_basic_types.workspace = true
 
-once_cell = "1.7"
+once_cell.workspace = true
 
 [dev-dependencies]
-criterion = "0.4.0"
+criterion.workspace = true
 
 [[bench]]
 name = "tree"

--- a/core/lib/multivm/Cargo.toml
+++ b/core/lib/multivm/Cargo.toml
@@ -1,42 +1,42 @@
 [package]
 name = "multivm"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-zk_evm_1_4_1 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.4.1" }
-zk_evm_1_4_0 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.4.0" }
-zk_evm_1_3_3 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", tag= "v1.3.3-rc2" }
-zk_evm_1_3_1 = { package = "zk_evm", git = "https://github.com/matter-labs/era-zk_evm.git", tag= "v1.3.1-rc2" }
+zk_evm_1_4_1.workspace = true
+zk_evm_1_4_0.workspace = true
+zk_evm_1_3_3.workspace = true
+zk_evm_1_3_1.workspace = true
 
-circuit_sequencer_api_1_3_3 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3" }
-circuit_sequencer_api_1_4_0 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.0" }
-circuit_sequencer_api_1_4_1 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.1" }
-circuit_sequencer_api_1_4_2 = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
+circuit_sequencer_api_1_3_3.workspace = true
+circuit_sequencer_api_1_4_0.workspace = true
+circuit_sequencer_api_1_4_1.workspace = true
+circuit_sequencer_api_1_4_2.workspace = true
 
-zksync_types = { path = "../types" }
-zksync_state = { path = "../state" }
-zksync_contracts = { path = "../contracts" }
-zksync_utils = { path = "../utils" }
-zksync_system_constants = { path = "../constants" }
+zksync_types.workspace = true
+zksync_state.workspace = true
+zksync_contracts.workspace = true
+zksync_utils.workspace = true
+zksync_system_constants.workspace = true
 
 
-anyhow = "1.0"
-hex = "0.4"
-itertools = "0.10"
-once_cell = "1.7"
-thiserror = "1.0"
-tracing = "0.1"
-vise = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
+anyhow.workspace = true
+hex.workspace = true
+itertools.workspace = true
+once_cell.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+vise.workspace = true
 
 [dev-dependencies]
-tokio = { version = "1", features = ["time"] }
-zksync_test_account = { path = "../../tests/test_account" }
-ethabi = "18.0.0"
-zksync_eth_signer = { path = "../eth_signer" }
+tokio = { workspace = true, features = ["time"] }
+zksync_test_account.workspace = true
+ethabi.workspace = true
+zksync_eth_signer.workspace = true

--- a/core/lib/multivm/src/versions/vm_m6/fuzz/Cargo.toml
+++ b/core/lib/multivm/src/versions/vm_m6/fuzz/Cargo.toml
@@ -2,15 +2,15 @@
 name = "vm-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2018"
+edition.workspace = true
 
 [package.metadata]
 cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-vm-benchmark = {path = "../../../../../../tests/vm-benchmark"}
-zksync_types = {path = "../../../../../types"}
+vm-benchmark = { path = "../../../../../../tests/vm-benchmark" }
+zksync_types = { path = "../../../../../types" }
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/core/lib/object_store/Cargo.toml
+++ b/core/lib/object_store/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
 name = "zksync_object_store"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-vise = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
-zksync_config = { path = "../config" }
-zksync_types = { path = "../types" }
-zksync_protobuf = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-anyhow = "1.0"
-async-trait = "0.1"
-bincode = "1"
-google-cloud-storage = "0.15.0"
-google-cloud-auth = "0.13.0"
-http = "0.2.9"
-serde_json = "1.0"
-flate2 = "1.0.28"
-tokio = { version = "1.21.2", features = ["full"] }
-tracing = "0.1"
-prost = "0.12.1"
+vise.workspace = true
+zksync_config.workspace = true
+zksync_types.workspace = true
+zksync_protobuf.workspace = true
+anyhow.workspace = true
+async-trait.workspace = true
+bincode.workspace = true
+google-cloud-storage.workspace = true
+google-cloud-auth.workspace = true
+http.workspace = true
+serde_json.workspace = true
+flate2.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
+prost.workspace = true
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempdir.workspace = true

--- a/core/lib/prometheus_exporter/Cargo.toml
+++ b/core/lib/prometheus_exporter/Cargo.toml
@@ -1,23 +1,19 @@
 [package]
 name = "prometheus_exporter"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-anyhow = "1.0"
-metrics = "0.21"
-metrics-exporter-prometheus = "0.12"
-tokio = "1"
-vise = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
+anyhow.workspace = true
+metrics.workspace = true
+metrics-exporter-prometheus.workspace = true
+tokio.workspace = true
+vise.workspace = true
 
-[dependencies.vise-exporter]
-git = "https://github.com/matter-labs/vise.git"
-version = "0.1.0"
-rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1"
-features = ["legacy"]
+vise-exporter = { workspace = true, features = ["legacy"] }

--- a/core/lib/protobuf_config/Cargo.toml
+++ b/core/lib/protobuf_config/Cargo.toml
@@ -1,29 +1,28 @@
 [package]
 name = "zksync_protobuf_config"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 links = "zksync_protobuf_config_proto"
 
 [dependencies]
-serde_json = "1.0"
-serde_yaml = "0.9"
-zksync_basic_types = { path = "../basic_types" }
-zksync_config = { path = "../config" }
-zksync_protobuf = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-zksync_types = { path = "../types" }
+serde_json.workspace = true
+serde_yaml.workspace = true
+zksync_basic_types.workspace = true
+zksync_config.workspace = true
+zksync_protobuf.workspace = true
+zksync_types.workspace = true
 
-anyhow = "1.0"
-pretty_assertions = "1.4.0"
-prost = "0.12.1"
-rand = "0.8"
+anyhow.workspace = true
+pretty_assertions.workspace = true
+prost.workspace = true
+rand.workspace = true
 
 [build-dependencies]
-zksync_protobuf_build = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-
+zksync_protobuf_build.workspace = true

--- a/core/lib/prover_interface/Cargo.toml
+++ b/core/lib/prover_interface/Cargo.toml
@@ -8,7 +8,6 @@ repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
-readme = "README.md"
 
 [dependencies]
 zksync_types.workspace = true

--- a/core/lib/prover_interface/Cargo.toml
+++ b/core/lib/prover_interface/Cargo.toml
@@ -1,27 +1,27 @@
 [package]
 name = "zksync_prover_interface"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 readme = "README.md"
 
 [dependencies]
-zksync_types = { path = "../types" }
-zksync_object_store = { path = "../object_store" }
+zksync_types.workspace = true
+zksync_object_store.workspace = true
 
 # We can use the newest api to send proofs to L1.
-circuit_sequencer_api = { package = "circuit_sequencer_api", git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.4.2" }
+circuit_sequencer_api.workspace = true
 
-serde = "1.0.90"
-strum = { version = "0.24", features = ["derive"] }
-serde_with = { version = "1", features = ["base64"] }
-chrono = { version = "0.4", features = ["serde"] }
+serde.workspace = true
+strum = { workspace = true, features = ["derive"] }
+serde_with = { workspace = true, features = ["base64"] }
+chrono = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
-tokio = { version = "1.21.2", features = ["full"] }
-bincode = "1"
+tokio = { workspace = true, features = ["full"] }
+bincode.workspace = true

--- a/core/lib/queued_job_processor/Cargo.toml
+++ b/core/lib/queued_job_processor/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "zksync_queued_job_processor"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
-tokio = { version = "1", features = ["time"] }
-tracing = "0.1"
+anyhow.workspace = true
+async-trait.workspace = true
+tokio = { workspace = true, features = ["time"] }
+tracing.workspace = true
 
-zksync_utils = { path = "../../lib/utils" }
-vise = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
+zksync_utils.workspace = true
+vise.workspace = true

--- a/core/lib/snapshots_applier/Cargo.toml
+++ b/core/lib/snapshots_applier/Cargo.toml
@@ -1,31 +1,31 @@
 [package]
 name = "zksync_snapshots_applier"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-zksync_db_connection = { path = "../../lib/db_connection" }
-zksync_dal = { path = "../../lib/dal" }
-zksync_health_check = { path = "../../lib/health_check" }
-zksync_types = { path = "../../lib/types" }
-zksync_object_store = { path = "../../lib/object_store" }
-zksync_web3_decl = { path = "../../lib/web3_decl" }
-zksync_utils = { path = "../../lib/utils" }
+zksync_db_connection.workspace = true
+zksync_dal.workspace = true
+zksync_health_check.workspace = true
+zksync_types.workspace = true
+zksync_object_store.workspace = true
+zksync_web3_decl.workspace = true
+zksync_utils.workspace = true
 
-vise = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
+vise.workspace = true
 
-anyhow = "1.0"
-async-trait = "0.1"
-tokio = { version = "1", features = ["time"] }
-tracing = "0.1"
-thiserror = "1.0"
-serde = { version = "1.0.189", features = ["derive"] }
+anyhow.workspace = true
+async-trait.workspace = true
+tokio = { workspace = true, features = ["time"] }
+tracing.workspace = true
+thiserror.workspace = true
+serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-test-casing = "0.1.2"
+test-casing.workspace = true

--- a/core/lib/state/Cargo.toml
+++ b/core/lib/state/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
 name = "zksync_state"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-vise = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
-zksync_dal = { path = "../dal" }
-zksync_types = { path = "../types" }
-zksync_utils = { path = "../utils" }
-zksync_storage = { path = "../storage" }
+vise.workspace = true
+zksync_dal.workspace = true
+zksync_types.workspace = true
+zksync_utils.workspace = true
+zksync_storage.workspace = true
 
-anyhow = "1.0"
-mini-moka = "0.10.0"
-tokio = { version = "1", features = ["rt"] }
-tracing = "0.1"
-itertools = "0.10.3"
-chrono = "0.4.31"
+anyhow.workspace = true
+mini-moka.workspace = true
+tokio = { workspace = true, features = ["rt"] }
+tracing.workspace = true
+itertools.workspace = true
+chrono.workspace = true
 
 [dev-dependencies]
-assert_matches = "1.5.0"
-rand = "0.8.5"
-tempfile = "3.0.2"
-test-casing = "0.1.2"
+assert_matches.workspace = true
+rand.workspace = true
+tempfile.workspace = true
+test-casing.workspace = true

--- a/core/lib/storage/Cargo.toml
+++ b/core/lib/storage/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "zksync_storage"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-vise = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
+vise.workspace = true
 
-num_cpus = "1.13"
-once_cell = "1.18.0"
-rocksdb = { version = "0.21.0", default-features = false, features = [
+num_cpus.workspace = true
+once_cell.workspace = true
+rocksdb = { workspace = true, features = [
     "snappy",
 ] }
-tracing = "0.1"
+tracing.workspace = true
 
 [dev-dependencies]
-tempfile = "3.0.2"
+tempfile.workspace = true

--- a/core/lib/types/Cargo.toml
+++ b/core/lib/types/Cargo.toml
@@ -1,46 +1,46 @@
 [package]
 name = "zksync_types"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 readme = "README.md"
 
 [dependencies]
-zksync_system_constants = { path = "../constants" }
-zksync_utils = { path = "../utils" }
-zksync_basic_types = { path = "../basic_types" }
-zksync_contracts = { path = "../contracts" }
-zksync_mini_merkle_tree = { path = "../mini_merkle_tree" }
-zksync_config = { path = "../config" }
-zksync_protobuf = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
+zksync_system_constants.workspace = true
+zksync_utils.workspace = true
+zksync_basic_types.workspace = true
+zksync_contracts.workspace = true
+zksync_mini_merkle_tree.workspace = true
+zksync_config.workspace = true
+zksync_protobuf.workspace = true
 
-anyhow = "1.0.75"
-chrono = { version = "0.4", features = ["serde"] }
-num = { version = "0.4.0", features = ["serde"] }
-once_cell = "1.7"
-rlp = "0.5"
-serde = "1.0.90"
-serde_json = "1.0.0"
-serde_with = { version = "1", features = ["base64"] }
-strum = { version = "0.24", features = ["derive"] }
-thiserror = "1.0"
-num_enum = "0.6"
-hex = "0.4"
-prost = "0.12.1"
-itertools = "0.10.3"
+anyhow.workspace = true
+chrono = { workspace = true, features = ["serde"] }
+num = { workspace = true, features = ["serde"] }
+once_cell.workspace = true
+rlp.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_with = { workspace = true, features = ["base64"] }
+strum = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
+num_enum.workspace = true
+hex.workspace = true
+prost.workspace = true
+itertools.workspace = true
 
 # Crypto stuff
-secp256k1 = { version = "0.27", features = ["recovery", "global-context"] }
-blake2 = "0.10"
+secp256k1 = { workspace = true, features = ["recovery", "global-context"] }
+blake2.workspace = true
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt", "macros"] }
-serde_with = { version = "1", features = ["hex"] }
+tokio = { workspace = true, features = ["rt", "macros"] }
+serde_with = { workspace = true, features = ["hex"] }
 
 [build-dependencies]
-zksync_protobuf_build = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
+zksync_protobuf_build.workspace = true

--- a/core/lib/types/Cargo.toml
+++ b/core/lib/types/Cargo.toml
@@ -8,7 +8,6 @@ repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
-readme = "README.md"
 
 [dependencies]
 zksync_system_constants.workspace = true

--- a/core/lib/utils/Cargo.toml
+++ b/core/lib/utils/Cargo.toml
@@ -1,32 +1,32 @@
 [package]
 name = "zksync_utils"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-zksync_basic_types = { path = "../../lib/basic_types" }
-zk_evm = { git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.3-rc2" }
-vlog = { path = "../../lib/vlog" }
+zksync_basic_types.workspace = true
+zk_evm.workspace = true
+vlog.workspace = true
 
-bigdecimal = { version = "0.3.0", features = ["serde"] }
-num = { version = "0.4.0", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1", features = ["time"] }
-tracing = "0.1"
-anyhow = "1.0"
-thiserror = "1.0"
-futures = "0.3"
-hex = "0.4"
-reqwest = { version = "0.11", features = ["blocking"] }
-itertools = "0.10.5"
-metrics = "0.21"
+bigdecimal.workspace = true
+num = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["time"] }
+tracing.workspace = true
+anyhow.workspace = true
+thiserror.workspace = true
+futures.workspace = true
+hex.workspace = true
+reqwest = { workspace = true, features = ["blocking"] }
+itertools.workspace = true
+metrics.workspace = true
 
 [dev-dependencies]
-serde_json = "1.0.0"
-rand = "0.8"
+serde_json.workspace = true
+rand.workspace = true

--- a/core/lib/vlog/Cargo.toml
+++ b/core/lib/vlog/Cargo.toml
@@ -1,18 +1,23 @@
 [package]
 name = "vlog"
-version="0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
-publish = false # This is an utility crate, not to be used by libraries.
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish = false
 
 [dependencies]
-chrono = "0.4"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "time", "json"] }
-sentry = "0.31"
-serde_json = "1.0"
+chrono.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = [
+    "fmt",
+    "env-filter",
+    "time",
+    "json",
+] }
+sentry.workspace = true
+serde_json.workspace = true

--- a/core/lib/vm_utils/Cargo.toml
+++ b/core/lib/vm_utils/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "vm_utils"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-multivm = { path = "../multivm" }
-zksync_types = { path = "../types" }
-zksync_dal = { path = "../dal" }
-zksync_state = { path = "../state" }
-tokio = { version = "1" }
-anyhow = "1.0"
-tracing = "0.1"
-zksync_utils = { path = "../utils" }
-zksync_contracts = { path = "../contracts" }
+multivm.workspace = true
+zksync_types.workspace = true
+zksync_dal.workspace = true
+zksync_state.workspace = true
+tokio.workspace = true
+anyhow.workspace = true
+tracing.workspace = true
+zksync_utils.workspace = true
+zksync_contracts.workspace = true

--- a/core/lib/web3_decl/Cargo.toml
+++ b/core/lib/web3_decl/Cargo.toml
@@ -1,27 +1,27 @@
 [package]
 name = "zksync_web3_decl"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-anyhow = "1.0"
-serde = "1.0"
-rlp = "0.5.0"
-thiserror = "1.0"
-jsonrpsee = { version = "0.21.0", default-features = false, features = [
+anyhow.workspace = true
+serde.workspace = true
+rlp.workspace = true
+thiserror.workspace = true
+jsonrpsee = { workspace = true, features = [
     "macros",
 ] }
-pin-project-lite = "0.2.13"
-zksync_types = { path = "../../lib/types" }
+pin-project-lite.workspace = true
+zksync_types.workspace = true
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json.workspace = true
 
 [features]
 default = ["server", "client"]

--- a/core/lib/zksync_core/Cargo.toml
+++ b/core/lib/zksync_core/Cargo.toml
@@ -1,104 +1,104 @@
 [package]
 name = "zksync_core"
 version = "0.1.0"
-edition = "2021"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 links = "zksync_core_proto"
 
 [dependencies]
-vise = { git = "https://github.com/matter-labs/vise.git", version = "0.1.0", rev = "1c9cc500e92cf9ea052b230e114a6f9cce4fb2c1" }
-zksync_state = { path = "../state" }
-vm_utils = { path = "../vm_utils" }
-zksync_types = { path = "../types" }
-zksync_dal = { path = "../dal" }
-prover_dal = { path = "../../../prover/prover_dal" }
-zksync_db_connection = { path = "../db_connection" }
-zksync_config = { path = "../config" }
-zksync_env_config = { path = "../env_config" }
-zksync_protobuf_config = { path = "../protobuf_config" }
-zksync_utils = { path = "../utils" }
-zksync_contracts = { path = "../contracts" }
-zksync_system_constants = { path = "../../lib/constants" }
-zksync_commitment_utils = { path = "../commitment_utils" }
-zksync_eth_client = { path = "../eth_client" }
-zksync_eth_signer = { path = "../eth_signer" }
-zksync_l1_contract_interface = { path = "../l1_contract_interface" }
-zksync_mempool = { path = "../mempool" }
-zksync_queued_job_processor = { path = "../queued_job_processor" }
-zksync_circuit_breaker = { path = "../circuit_breaker" }
-zksync_storage = { path = "../storage" }
-zksync_merkle_tree = { path = "../merkle_tree" }
-zksync_mini_merkle_tree = { path = "../mini_merkle_tree" }
-prometheus_exporter = { path = "../prometheus_exporter" }
-zksync_prover_interface = { path = "../prover_interface" }
-zksync_web3_decl = { path = "../web3_decl", default-features = false, features = [
+vise.workspace = true
+zksync_state.workspace = true
+vm_utils.workspace = true
+zksync_types.workspace = true
+zksync_dal.workspace = true
+prover_dal.workspace = true
+zksync_db_connection.workspace = true
+zksync_config.workspace = true
+zksync_env_config.workspace = true
+zksync_protobuf_config.workspace = true
+zksync_utils.workspace = true
+zksync_contracts.workspace = true
+zksync_system_constants.workspace = true
+zksync_commitment_utils.workspace = true
+zksync_eth_client.workspace = true
+zksync_eth_signer.workspace = true
+zksync_l1_contract_interface.workspace = true
+zksync_mempool.workspace = true
+zksync_queued_job_processor.workspace = true
+zksync_circuit_breaker.workspace = true
+zksync_storage.workspace = true
+zksync_merkle_tree.workspace = true
+zksync_mini_merkle_tree.workspace = true
+prometheus_exporter.workspace = true
+zksync_prover_interface.workspace = true
+zksync_web3_decl = { workspace = true, features = [
     "server",
     "client",
 ] }
-zksync_object_store = { path = "../object_store" }
-zksync_health_check = { path = "../health_check" }
-vlog = { path = "../vlog" }
+zksync_object_store.workspace = true
+zksync_health_check.workspace = true
+vlog.workspace = true
 
-multivm = { path = "../multivm" }
+multivm.workspace = true
 
 # Consensus dependenices
-zksync_concurrency = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-zksync_consensus_crypto = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-zksync_consensus_network = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-zksync_consensus_roles = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-zksync_consensus_storage = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-zksync_consensus_executor = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-zksync_consensus_bft = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-zksync_consensus_utils = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
-zksync_protobuf = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
+zksync_concurrency.workspace = true
+zksync_consensus_crypto.workspace = true
+zksync_consensus_network.workspace = true
+zksync_consensus_roles.workspace = true
+zksync_consensus_storage.workspace = true
+zksync_consensus_executor.workspace = true
+zksync_consensus_bft.workspace = true
+zksync_consensus_utils.workspace = true
+zksync_protobuf.workspace = true
 
-prost = "0.12.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-serde_yaml = "0.9"
-itertools = "0.10.3"
-metrics = "0.21"
-ctrlc = { version = "3.1", features = ["termination"] }
-rand = "0.8"
+prost.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_yaml.workspace = true
+itertools.workspace = true
+metrics.workspace = true
+ctrlc.workspace = true
+rand.workspace = true
 
-tokio = { version = "1", features = ["time"] }
-futures = { version = "0.3", features = ["compat"] }
-pin-project-lite = "0.2.13"
-chrono = { version = "0.4", features = ["serde"] }
-anyhow = "1.0"
-thiserror = "1.0"
-async-trait = "0.1"
-bitflags = "1.3.2"
-thread_local = "1.1"
+tokio = { workspace = true, features = ["time"] }
+futures = { workspace = true, features = ["compat"] }
+pin-project-lite.workspace = true
+chrono = { workspace = true, features = ["serde"] }
+anyhow.workspace = true
+thiserror.workspace = true
+async-trait.workspace = true
+bitflags.workspace = true
+thread_local.workspace = true
 
-reqwest = { version = "0.11", features = ["blocking", "json"] }
-hex = "0.4"
-lru = { version = "0.12.1", default-features = false }
-governor = "0.4.2"
-tower-http = { version = "0.4.1", features = ["full"] }
-tower = { version = "0.4.13", features = ["full"] }
-axum = { version = "0.6.19", default-features = false, features = [
+reqwest = { workspace = true, features = ["blocking", "json"] }
+hex.workspace = true
+lru.workspace = true
+governor.workspace = true
+tower-http = { workspace = true, features = ["full"] }
+tower = { workspace = true, features = ["full"] }
+axum = { workspace = true,features = [
     "http1",
     "json",
     "tokio",
 ] }
-once_cell = "1.7"
+once_cell.workspace = true
 
-tracing = "0.1.26"
+tracing.workspace = true
 
 [dev-dependencies]
-zksync_test_account = { path = "../../tests/test_account" }
+zksync_test_account.workspace = true
 
-assert_matches = "1.5"
-jsonrpsee = "0.21.0"
-tempfile = "3.0.2"
-test-casing = "0.1.2"
+assert_matches.workspace = true
+jsonrpsee.workspace = true
+tempfile.workspace = true
+test-casing.workspace = true
 
 [build-dependencies]
-zksync_protobuf_build = { version = "0.1.0", git = "https://github.com/matter-labs/era-consensus.git", rev = "5329a809cfc06d4939fb5ece26c9ad1e1741c50a" }
+zksync_protobuf_build.workspace = true

--- a/core/node/node_framework/Cargo.toml
+++ b/core/node/node_framework/Cargo.toml
@@ -1,40 +1,40 @@
 [package]
 name = "zksync_node_framework"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-prometheus_exporter = { path = "../../lib/prometheus_exporter" }
-zksync_types = { path = "../../lib/types" }
-zksync_health_check = { path = "../../lib/health_check" }
-zksync_dal = { path = "../../lib/dal" }
-prover_dal = { path = "../../../prover/prover_dal" }
-zksync_db_connection = { path = "../../lib/db_connection" }
-zksync_config = { path = "../../lib/config" }
-zksync_state = { path = "../../lib/state" }
-zksync_object_store = { path = "../../lib/object_store" }
-zksync_core = { path = "../../lib/zksync_core" }
-zksync_storage = { path = "../../lib/storage" }
-zksync_eth_client = { path = "../../lib/eth_client" }
-zksync_contracts = { path = "../../lib/contracts" }
-zksync_web3_decl = { path = "../../lib/web3_decl" }
-zksync_utils = { path = "../../lib/utils" }
+prometheus_exporter.workspace = true
+zksync_types.workspace = true
+zksync_health_check.workspace = true
+zksync_dal.workspace = true
+prover_dal.workspace = true
+zksync_db_connection.workspace = true
+zksync_config.workspace = true
+zksync_state.workspace = true
+zksync_object_store.workspace = true
+zksync_core.workspace = true
+zksync_storage.workspace = true
+zksync_eth_client.workspace = true
+zksync_contracts.workspace = true
+zksync_web3_decl.workspace = true
+zksync_utils.workspace = true
 
-tracing = "0.1"
-thiserror = "1"
-async-trait = "0.1"
-futures = "0.3"
-anyhow = "1"
-tokio = { version = "1", features = ["rt"] }
-ctrlc = { version = "3.1", features = ["termination"] }
+tracing.workspace = true
+thiserror.workspace = true
+async-trait.workspace = true
+futures.workspace = true
+anyhow.workspace = true
+tokio = { workspace = true, features = ["rt"] }
+ctrlc.workspace = true
 
 [dev-dependencies]
-zksync_env_config = { path = "../../lib/env_config" }
-vlog = { path = "../../lib/vlog" }
-assert_matches = "1.5.0"
+zksync_env_config.workspace = true
+vlog.workspace = true
+assert_matches.workspace = true

--- a/core/tests/loadnext/Cargo.toml
+++ b/core/tests/loadnext/Cargo.toml
@@ -1,42 +1,42 @@
 [package]
 name = "loadnext"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
-publish = false                                           # We don't want to publish our tests.
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish = false
 
 [dependencies]
-zksync = { path = "../../../sdk/zksync-rs", features = ["mint"] }
-zksync_types = { path = "../../lib/types" }
-zksync_utils = { path = "../../lib/utils" }
-zksync_eth_signer = { path = "../../lib/eth_signer" }
-zksync_web3_decl = { path = "../../lib/web3_decl" }
-zksync_eth_client = { path = "../../lib/eth_client" }
-zksync_config = { path = "../../lib/config" }
-zksync_contracts = { path = "../../lib/contracts" }
-zksync_system_constants = { path = "../../lib/constants" }
-vlog = { path = "../../lib/vlog" }
-prometheus_exporter = { path = "../../lib/prometheus_exporter" }
+zksync = { workspace = true, features = ["mint"] }
+zksync_types.workspace = true
+zksync_utils.workspace = true
+zksync_eth_signer.workspace = true
+zksync_web3_decl.workspace = true
+zksync_eth_client.workspace = true
+zksync_config.workspace = true
+zksync_contracts.workspace = true
+zksync_system_constants.workspace = true
+vlog.workspace = true
+prometheus_exporter.workspace = true
 
-async-trait = "0.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-num = { version = "0.3.1", features = ["serde"] }
-tokio = { version = "1", features = ["full"] }
-futures = "0.3"
-anyhow = "1.0"
-rand = { version = "0.8", features = ["small_rng"] }
-envy = "0.4"
-hex = "0.4"
-static_assertions = "1.1"
-once_cell = "1.7"
-thiserror = "1"
-reqwest = { version = "0.11", features = ["blocking", "json"] }
-regex = "1.7"
-metrics = "0.21"
-tracing = "0.1"
+async-trait.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+num = { workspace = true, features = ["serde"] }
+tokio = { workspace = true, features = ["full"] }
+futures.workspace = true
+anyhow.workspace = true
+rand = { workspace = true, features = ["small_rng"] }
+envy.workspace = true
+hex.workspace = true
+static_assertions.workspace = true
+once_cell.workspace = true
+thiserror.workspace = true
+reqwest = { workspace = true, features = ["blocking", "json"] }
+regex.workspace = true
+metrics.workspace = true
+tracing.workspace = true

--- a/core/tests/test_account/Cargo.toml
+++ b/core/tests/test_account/Cargo.toml
@@ -8,7 +8,6 @@ repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
-readme = "README.md"
 publish = false
 
 [dependencies]

--- a/core/tests/test_account/Cargo.toml
+++ b/core/tests/test_account/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "zksync_test_account"
 version = "0.1.0"
-edition = "2018"
-authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
-homepage = "https://zksync.io/"
-repository = "https://github.com/matter-labs/zksync-era"
-license = "MIT OR Apache-2.0"
-keywords = ["blockchain", "zksync"]
-categories = ["cryptography"]
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 readme = "README.md"
 publish = false
 
 [dependencies]
-zksync_types = { path = "../../lib/types" }
-zksync_system_constants = { path = "../../lib/constants" }
-zksync_utils = { path = "../../lib/utils" }
-zksync_eth_signer = { path = "../../lib/eth_signer" }
-zksync_contracts = { path = "../../lib/contracts" }
+zksync_types.workspace = true
+zksync_system_constants.workspace = true
+zksync_utils.workspace = true
+zksync_eth_signer.workspace = true
+zksync_contracts.workspace = true
 
-hex = "0.4"
-ethabi = "18.0.0"
+hex.workspace = true
+ethabi.workspace = true

--- a/core/tests/vm-benchmark/Cargo.toml
+++ b/core/tests/vm-benchmark/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "vm-benchmark"
 version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
-vm-benchmark-harness = {path = "harness"}
-metrics-exporter-prometheus = "0.12"
-metrics = "0.21"
-tokio = "1"
+vm-benchmark-harness.workspace = true
+metrics-exporter-prometheus.workspace = true
+metrics.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
-criterion = "0.4"
-iai = "0.1"
+criterion.workspace = true
+iai.workspace = true
 
 [[bench]]
 name = "criterion"

--- a/core/tests/vm-benchmark/harness/Cargo.toml
+++ b/core/tests/vm-benchmark/harness/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "vm-benchmark-harness"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
-multivm = { path = "../../../lib/multivm" }
-zksync_types = { path = "../../../lib/types" }
-zksync_state = { path = "../../../lib/state" }
-zksync_utils = { path = "../../../lib/utils" }
-zksync_system_constants = { path = "../../../lib/constants" }
-zksync_contracts = { path = "../../../lib/contracts" }
-zk_evm = { git = "https://github.com/matter-labs/era-zk_evm.git", tag = "v1.3.3-rc2" }
-once_cell = "1.17"
+multivm.workspace = true
+zksync_types.workspace = true
+zksync_state.workspace = true
+zksync_utils.workspace = true
+zksync_system_constants.workspace = true
+zksync_contracts.workspace = true
+zk_evm.workspace = true
+once_cell.workspace = true

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -368,7 +368,6 @@ dependencies = [
  "num-bigint 0.4.4",
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -2857,6 +2856,8 @@ dependencies = [
  "glob",
  "libc",
  "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -2966,6 +2967,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbfc0d229f1f42d790440136d941afd806bc9e949e2bcb8faa813b0f00d1267e"
 dependencies = [
  "logos-codegen",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -4949,6 +4960,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5163,6 +5187,21 @@ checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "soketto"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
+dependencies = [
+ "base64 0.13.1",
+ "bytes",
+ "futures 0.3.30",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha-1",
 ]
 
 [[package]]
@@ -5845,6 +5884,7 @@ checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -6428,7 +6468,24 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
+ "soketto",
  "tiny-keccak 2.0.2",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+ "web3-async-native-tls",
+]
+
+[[package]]
+name = "web3-async-native-tls"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6d8d1636b2627fe63518d5a9b38a569405d9c9bc665c43c9c341de57227ebb"
+dependencies = [
+ "native-tls",
+ "thiserror",
+ "tokio",
  "url",
 ]
 
@@ -7101,7 +7158,7 @@ dependencies = [
  "hex",
  "once_cell",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "thiserror",
  "zksync_basic_types",
 ]
@@ -7431,7 +7488,7 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "num",
- "num_enum 0.6.1",
+ "num_enum 0.7.2",
  "once_cell",
  "prost",
  "rlp",
@@ -7540,4 +7597,14 @@ dependencies = [
  "zksync_queued_job_processor",
  "zksync_types",
  "zksync_utils",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.9+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/sdk/zksync-rs/Cargo.toml
+++ b/sdk/zksync-rs/Cargo.toml
@@ -6,25 +6,25 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-zksync_types = { path = "../../core/lib/types" }
-zksync_utils = { path = "../../core/lib/utils" }
-zksync_eth_client = { path = "../../core/lib/eth_client" }
-zksync_eth_signer = { path = "../../core/lib/eth_signer" }
-zksync_web3_decl = { path = "../../core/lib/web3_decl", default-features = false, features = [
+zksync_types.workspace = true
+zksync_utils.workspace = true
+zksync_eth_client.workspace = true
+zksync_eth_signer.workspace = true
+zksync_web3_decl = { workspace = true, features = [
     "client",
 ] }
 
-tokio = { version = "1", features = ["time"] }
+tokio = { workspace = true, features = ["time"] }
 
-serde_json = "1.0"
-num = { version = "0.3.1", features = ["serde"] }
-thiserror = "1.0"
+serde_json.workspace = true
+num = { workspace = true, features = ["serde"] }
+thiserror.workspace = true
 
 [dev-dependencies]
-zksync_config = { path = "../../core/lib/config" }
-tokio = { version = "1", features = ["full"] }
-anyhow = "1.0"
-hex = "0.4"
+zksync_config.workspace = true
+tokio = { workspace = true, features = ["full"] }
+anyhow.workspace = true
+hex.workspace = true
 
 [features]
 integration-tests = []


### PR DESCRIPTION
## What ❔

Switches core workspace to using workspace deps.

⚠️ No-nitpick-territory ⚠️ 
During review, please focus on the fact that this should be an incremental improvement. This PR was _**painful**_ to prepare, and I would like to merge it ASAP, since it's also likely to get merge conflicts. If there are non-critical comments, I'll try to address them in follow-up PRs. I've touched a lot of code that was in imperfect state before, and now it's in the diff (for example, incorrectly set features for crates), and maybe some things I've done aren't as pretty as they can be -- but IMHO the switch to using workspace deps has enough value to merge it without addressing all and every minor thing beforehand.

Feel free to leave as many comments as you have to, but it'd be great if they will still come with a ✅ unless I really broke something here.

## Why ❔

- Soft prerequisite for publishing on crates.io.
- More convenient.
- More modern.
- No need to worry that some dependency has multiple versions across different crates.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
