### PR TITLE
fix(api): `filters_disabled` should only affect HTTP endpoints

### DIFF
--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -156,7 +156,8 @@ pub struct OptionalENConfig {
     latest_values_cache_size_mb: usize,
     /// Enabled JSON RPC API namespaces.
     api_namespaces: Option<Vec<Namespace>>,
-    /// Whether to support methods installing filters and querying filter changes.
+    /// Whether to support HTTP methods that install filters and query filter changes.
+    /// WS methods are unaffected.
     ///
     /// When to set this value to `true`:
     /// Filters are local to the specific node they were created at. Meaning if

--- a/core/lib/config/src/configs/api.rs
+++ b/core/lib/config/src/configs/api.rs
@@ -32,7 +32,8 @@ pub struct Web3JsonRpcConfig {
     pub ws_url: String,
     /// Max possible limit of entities to be requested once.
     pub req_entities_limit: Option<u32>,
-    /// Whether to support methods installing filters and querying filter changes.
+    /// Whether to support HTTP methods that install filters and query filter changes.
+    /// WS methods are unaffected.
     ///
     /// When to set this value to `true`:
     /// Filters are local to the specific node they were created at. Meaning if

--- a/core/lib/zksync_core/src/api_server/web3/mod.rs
+++ b/core/lib/zksync_core/src/api_server/web3/mod.rs
@@ -314,13 +314,15 @@ impl ApiServer {
         let start_info = BlockStartInfo::new(&mut storage).await?;
         drop(storage);
 
-        let installed_filters = if self.config.filters_disabled {
-            None
-        } else {
-            Some(Arc::new(Mutex::new(Filters::new(
-                self.optional.filters_limit,
-            ))))
-        };
+        // Disable filter API for HTTP endpoints, WS endpoints are unaffected by the `filters_disabled` flag
+        let installed_filters =
+            if matches!(self.transport, ApiTransport::Http(_)) && self.config.filters_disabled {
+                None
+            } else {
+                Some(Arc::new(Mutex::new(Filters::new(
+                    self.optional.filters_limit,
+                ))))
+            };
 
         Ok(RpcState {
             current_method: self.method_tracer,


### PR DESCRIPTION
## What ❔

Follow-up on #1078 

## Why ❔

Websocket API does not suffer from the issues described in the original PR, hence it can and should be used by users.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.
