### PR TITLE
feat: soft removal of `events_queue` table 

### DIFF
--- a/core/lib/dal/src/blocks_dal.rs
+++ b/core/lib/dal/src/blocks_dal.rs
@@ -15,7 +15,6 @@ use zksync_types::{
     block::{BlockGasCount, L1BatchHeader, L1BatchTreeData, MiniblockHeader},
     circuit::CircuitStatistic,
     commitment::{L1BatchCommitmentArtifacts, L1BatchWithMetadata},
-    zk_evm_types::LogQuery,
     Address, L1BatchNumber, MiniblockNumber, ProtocolVersionId, H256, U256,
 };
 
@@ -397,42 +396,6 @@ impl BlocksDal<'_, '_> {
         Ok(Some(storage_refunds))
     }
 
-    pub async fn get_events_queue(
-        &mut self,
-        number: L1BatchNumber,
-    ) -> anyhow::Result<Option<Vec<LogQuery>>> {
-        let Some(row) = sqlx::query!(
-            r#"
-            SELECT
-                serialized_events_queue_bytea,
-                serialized_events_queue
-            FROM
-                events_queue
-            WHERE
-                l1_batch_number = $1
-            "#,
-            i64::from(number.0)
-        )
-        .instrument("get_events_queue")
-        .report_latency()
-        .with_arg("number", &number)
-        .fetch_optional(self.storage)
-        .await?
-        else {
-            return Ok(None);
-        };
-
-        let events = if let Some(serialized_events_queue_bytea) = row.serialized_events_queue_bytea
-        {
-            bincode::deserialize(&serialized_events_queue_bytea)
-                .context("invalid value for serialized_events_queue_bytea in the DB")?
-        } else {
-            serde_json::from_value(row.serialized_events_queue)
-                .context("invalid value for serialized_events_queue in the DB")?
-        };
-        Ok(Some(events))
-    }
-
     pub async fn set_eth_tx_id(
         &mut self,
         number_range: ops::RangeInclusive<L1BatchNumber>,
@@ -500,7 +463,6 @@ impl BlocksDal<'_, '_> {
         header: &L1BatchHeader,
         initial_bootloader_contents: &[(usize, U256)],
         predicted_block_gas: BlockGasCount,
-        events_queue: &[LogQuery],
         storage_refunds: &[u32],
         predicted_circuits_by_type: CircuitStatistic, // predicted number of circuits for each circuit type
     ) -> anyhow::Result<()> {
@@ -607,20 +569,6 @@ impl BlocksDal<'_, '_> {
         .execute(transaction.conn())
         .await?;
 
-        let events_queue =
-            bincode::serialize(events_queue).expect("failed to serialize events_queue to bytes");
-        sqlx::query!(
-            r#"
-            INSERT INTO
-                events_queue (l1_batch_number, serialized_events_queue, serialized_events_queue_bytea)
-            VALUES
-                ($1, '{}', $2)
-            "#,
-            i64::from(header.number.0),
-            &events_queue
-        )
-        .execute(transaction.conn())
-        .await?;
         transaction.commit().await?;
 
         Ok(())
@@ -2420,15 +2368,8 @@ impl BlocksDal<'_, '_> {
     }
 
     pub async fn insert_mock_l1_batch(&mut self, header: &L1BatchHeader) -> anyhow::Result<()> {
-        self.insert_l1_batch(
-            header,
-            &[],
-            Default::default(),
-            &[],
-            &[],
-            Default::default(),
-        )
-        .await
+        self.insert_l1_batch(header, &[], Default::default(), &[], Default::default())
+            .await
     }
 
     /// Deletes all miniblocks and L1 batches, including the genesis ones. Should only be used in tests.
@@ -2532,7 +2473,7 @@ mod tests {
             execute: 10,
         };
         conn.blocks_dal()
-            .insert_l1_batch(&header, &[], predicted_gas, &[], &[], Default::default())
+            .insert_l1_batch(&header, &[], predicted_gas, &[], Default::default())
             .await
             .unwrap();
 
@@ -2540,7 +2481,7 @@ mod tests {
         header.timestamp += 100;
         predicted_gas += predicted_gas;
         conn.blocks_dal()
-            .insert_l1_batch(&header, &[], predicted_gas, &[], &[], Default::default())
+            .insert_l1_batch(&header, &[], predicted_gas, &[], Default::default())
             .await
             .unwrap();
 

--- a/core/lib/zksync_core/src/commitment_generator/mod.rs
+++ b/core/lib/zksync_core/src/commitment_generator/mod.rs
@@ -48,16 +48,9 @@ impl CommitmentGenerator {
             .connection_pool
             .connection_tagged("commitment_generator")
             .await?;
-        let events_queue_from_db = connection
-            .blocks_dal()
-            .get_events_queue(l1_batch_number)
-            .await?
-            .with_context(|| format!("Events queue is missing for L1 batch #{l1_batch_number}"))?;
 
         // Calculate events queue using VM events.
-        // For now we only check that it results in the same set of events that are saved in `events_queue` DB table.
-        // Later, `events_queue` table will be removed and this will be the only way to get events queue.
-        let events_queue_calculated = {
+        let events_queue = {
             let events = connection
                 .events_dal()
                 .get_vm_events_for_l1_batch(l1_batch_number)
@@ -65,10 +58,6 @@ impl CommitmentGenerator {
                 .with_context(|| format!("Events are missing for L1 batch #{l1_batch_number}"))?;
             convert_vm_events_to_log_queries(&events)
         };
-
-        if events_queue_from_db != events_queue_calculated {
-            tracing::error!("Events queue mismatch for L1 batch #{l1_batch_number}");
-        }
 
         let initial_bootloader_contents = connection
             .blocks_dal()
@@ -83,7 +72,7 @@ impl CommitmentGenerator {
             tokio::task::spawn_blocking(move || {
                 let latency = METRICS.events_queue_commitment_latency.start();
                 let events_queue_commitment =
-                    events_queue_commitment(&events_queue_from_db, protocol_version)
+                    events_queue_commitment(&events_queue, protocol_version)
                         .context("Events queue commitment is required for post-boojum batch")?;
                 latency.observe();
 

--- a/core/lib/zksync_core/src/genesis.rs
+++ b/core/lib/zksync_core/src/genesis.rs
@@ -467,7 +467,6 @@ pub(crate) async fn create_genesis_l1_batch(
             &[],
             BlockGasCount::default(),
             &[],
-            &[],
             Default::default(),
         )
         .await?;

--- a/core/lib/zksync_core/src/state_keeper/io/seal_logic.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/seal_logic.rs
@@ -122,10 +122,6 @@ impl UpdatesManager {
             pubdata_input: finished_batch.pubdata_input.clone(),
         };
 
-        let events_queue = &finished_batch
-            .final_execution_state
-            .deduplicated_events_logs;
-
         let final_bootloader_memory = finished_batch
             .final_bootloader_memory
             .clone()
@@ -136,7 +132,6 @@ impl UpdatesManager {
                 &l1_batch,
                 &final_bootloader_memory,
                 self.pending_l1_gas_count(),
-                events_queue,
                 &finished_batch.final_execution_state.storage_refunds,
                 self.pending_execution_metrics().circuit_statistic,
             )


### PR DESCRIPTION
## What ❔

`events_queue` is not read from and data is no longer inserted there.

## Why ❔

`events` table is sufficient.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
