### PR TITLE
feat(state-keeper): Remove `WitnessBlockState` generation from state keeper

### DIFF
--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -73,7 +73,6 @@ async fn build_state_keeper(
         state_keeper_db_path,
         connection_pool.clone(),
         save_call_traces,
-        false,
         config.optional.enum_index_migration_chunk_size,
         true,
     ));

--- a/core/lib/config/src/configs/chain.rs
+++ b/core/lib/config/src/configs/chain.rs
@@ -110,10 +110,6 @@ pub struct StateKeeperConfig {
     pub virtual_blocks_interval: u32,
     pub virtual_blocks_per_miniblock: u32,
 
-    /// Flag which will enable storage to cache witness_inputs during State Keeper's run.
-    /// NOTE: This will slow down StateKeeper, to be used in non-production environments!
-    pub upload_witness_inputs_to_gcs: bool,
-
     /// Number of keys that is processed by enum_index migration in State Keeper each L1 batch.
     pub enum_index_migration_chunk_size: Option<usize>,
 
@@ -153,7 +149,6 @@ impl StateKeeperConfig {
             save_call_traces: true,
             virtual_blocks_interval: 1,
             virtual_blocks_per_miniblock: 1,
-            upload_witness_inputs_to_gcs: false,
             enum_index_migration_chunk_size: None,
             bootloader_hash: None,
             default_aa_hash: None,

--- a/core/lib/config/src/testonly.rs
+++ b/core/lib/config/src/testonly.rs
@@ -288,7 +288,6 @@ impl RandomConfig for configs::chain::StateKeeperConfig {
             save_call_traces: g.gen(),
             virtual_blocks_interval: g.gen(),
             virtual_blocks_per_miniblock: g.gen(),
-            upload_witness_inputs_to_gcs: g.gen(),
             enum_index_migration_chunk_size: g.gen(),
             bootloader_hash: g.gen(),
             default_aa_hash: g.gen(),

--- a/core/lib/env_config/src/chain.rs
+++ b/core/lib/env_config/src/chain.rs
@@ -92,7 +92,6 @@ mod tests {
             save_call_traces: false,
             virtual_blocks_interval: 1,
             virtual_blocks_per_miniblock: 1,
-            upload_witness_inputs_to_gcs: false,
             enum_index_migration_chunk_size: Some(2_000),
             bootloader_hash: Some(hash(
                 "0x010007ede999d096c84553fb514d3d6ca76fbf39789dda76bfeda9f3ae06236e",
@@ -129,7 +128,6 @@ mod tests {
             CHAIN_STATE_KEEPER_FEE_MODEL_VERSION="V2"
             CHAIN_STATE_KEEPER_VALIDATION_COMPUTATIONAL_GAS_LIMIT="10000000"
             CHAIN_STATE_KEEPER_SAVE_CALL_TRACES="false"
-            CHAIN_STATE_KEEPER_UPLOAD_WITNESS_INPUTS_TO_GCS="false"
             CHAIN_STATE_KEEPER_ENUM_INDEX_MIGRATION_CHUNK_SIZE="2000"
             CHAIN_STATE_KEEPER_VIRTUAL_BLOCKS_PER_MINIBLOCK="1"
             CHAIN_STATE_KEEPER_VIRTUAL_BLOCKS_INTERVAL="1"

--- a/core/lib/protobuf_config/src/chain.rs
+++ b/core/lib/protobuf_config/src/chain.rs
@@ -133,8 +133,6 @@ impl ProtoRepr for proto::StateKeeper {
                 .context("virtual_blocks_interval")?,
             virtual_blocks_per_miniblock: *required(&self.virtual_blocks_per_miniblock)
                 .context("virtual_blocks_per_miniblock")?,
-            upload_witness_inputs_to_gcs: *required(&self.upload_witness_inputs_to_gcs)
-                .context("upload_witness_inputs_to_gcs")?,
             enum_index_migration_chunk_size: self
                 .enum_index_migration_chunk_size
                 .map(|x| x.try_into())
@@ -183,7 +181,6 @@ impl ProtoRepr for proto::StateKeeper {
             save_call_traces: Some(this.save_call_traces),
             virtual_blocks_interval: Some(this.virtual_blocks_interval),
             virtual_blocks_per_miniblock: Some(this.virtual_blocks_per_miniblock),
-            upload_witness_inputs_to_gcs: Some(this.upload_witness_inputs_to_gcs),
             enum_index_migration_chunk_size: this
                 .enum_index_migration_chunk_size
                 .as_ref()

--- a/core/lib/protobuf_config/src/proto/chain.proto
+++ b/core/lib/protobuf_config/src/proto/chain.proto
@@ -49,7 +49,6 @@ message StateKeeper {
   optional bool save_call_traces = 22; // required
   optional uint32 virtual_blocks_interval = 23; // required
   optional uint32 virtual_blocks_per_miniblock = 24; // required
-  optional bool upload_witness_inputs_to_gcs = 25; // required
   optional uint64 enum_index_migration_chunk_size = 26; // optional
   optional bytes bootloader_hash = 27; // required; H256
   optional bytes default_aa_hash = 28; // required; H256

--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -500,7 +500,6 @@ pub async fn initialize_components(
             &db_config,
             &configs.mempool_config.clone().context("mempool_config")?,
             batch_fee_input_provider,
-            store_factory.create_store().await,
             stop_receiver.clone(),
         )
         .await
@@ -744,7 +743,6 @@ async fn add_state_keeper_to_task_futures(
     db_config: &DBConfig,
     mempool_config: &MempoolConfig,
     batch_fee_input_provider: Arc<dyn BatchFeeModelInputProvider>,
-    object_store: Arc<dyn ObjectStore>,
     stop_receiver: watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
     let pool_builder = ConnectionPool::<Core>::singleton(postgres_config.master_url()?);
@@ -771,7 +769,6 @@ async fn add_state_keeper_to_task_futures(
         contracts_config.l2_erc20_bridge_addr,
         state_keeper_config.miniblock_seal_queue_capacity,
     );
-    let persistence = persistence.with_object_store(object_store);
     task_futures.push(tokio::spawn(miniblock_sealer.run()));
 
     let state_keeper = create_state_keeper(

--- a/core/lib/zksync_core/src/state_keeper/batch_executor/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/batch_executor/mod.rs
@@ -8,7 +8,7 @@ use tokio::{
     sync::{mpsc, oneshot, watch},
     task::JoinHandle,
 };
-use zksync_types::{vm_trace::Call, witness_block_state::WitnessBlockState, Transaction};
+use zksync_types::{vm_trace::Call, Transaction};
 use zksync_utils::bytecode::CompressedBytecodeInfo;
 
 use crate::state_keeper::{
@@ -143,8 +143,7 @@ impl BatchExecutorHandle {
         latency.observe();
     }
 
-    // FIXME: remove WitnessBlockState
-    pub(super) async fn finish_batch(self) -> (FinishedL1Batch, Option<WitnessBlockState>) {
+    pub(super) async fn finish_batch(self) -> FinishedL1Batch {
         let (response_sender, response_receiver) = oneshot::channel();
         self.commands
             .send(Command::FinishBatch(response_sender))
@@ -153,10 +152,10 @@ impl BatchExecutorHandle {
         let latency = EXECUTOR_METRICS.batch_executor_command_response_time
             [&ExecutorCommand::FinishBatch]
             .start();
-        let resp = response_receiver.await.unwrap();
+        let finished_batch = response_receiver.await.unwrap();
         self.handle.await.unwrap();
         latency.observe();
-        resp
+        finished_batch
     }
 }
 
@@ -165,5 +164,5 @@ pub(super) enum Command {
     ExecuteTx(Box<Transaction>, oneshot::Sender<TxExecutionResult>),
     StartNextMiniblock(L2BlockEnv, oneshot::Sender<()>),
     RollbackLastTx(oneshot::Sender<()>),
-    FinishBatch(oneshot::Sender<(FinishedL1Batch, Option<WitnessBlockState>)>),
+    FinishBatch(oneshot::Sender<FinishedL1Batch>),
 }

--- a/core/lib/zksync_core/src/state_keeper/batch_executor/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/batch_executor/mod.rs
@@ -143,6 +143,7 @@ impl BatchExecutorHandle {
         latency.observe();
     }
 
+    // FIXME: remove WitnessBlockState
     pub(super) async fn finish_batch(self) -> (FinishedL1Batch, Option<WitnessBlockState>) {
         let (response_sender, response_receiver) = oneshot::channel();
         self.commands

--- a/core/lib/zksync_core/src/state_keeper/batch_executor/tests/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/batch_executor/tests/mod.rs
@@ -375,7 +375,6 @@ async fn bootloader_out_of_gas_for_any_tx() {
             save_call_traces: false,
             vm_gas_limit: Some(10),
             validation_computational_gas_limit: u32::MAX,
-            upload_witness_inputs_to_gcs: false,
         },
     );
 
@@ -403,15 +402,20 @@ async fn bootloader_tip_out_of_gas() {
     let res = executor.execute_tx(alice.execute()).await;
     assert_executed(&res);
 
-    let (vm_block_res, _witness_block_state) = executor.finish_batch().await;
+    let finished_batch = executor.finish_batch().await;
 
     // Just a bit below the gas used for the previous batch execution should be fine to execute the tx
     // but not enough to execute the block tip.
     tester.set_config(TestConfig {
         save_call_traces: false,
-        vm_gas_limit: Some(vm_block_res.block_tip_execution_result.statistics.gas_used - 10),
+        vm_gas_limit: Some(
+            finished_batch
+                .block_tip_execution_result
+                .statistics
+                .gas_used
+                - 10,
+        ),
         validation_computational_gas_limit: u32::MAX,
-        upload_witness_inputs_to_gcs: false,
     });
 
     let second_executor = tester.create_batch_executor().await;

--- a/core/lib/zksync_core/src/state_keeper/batch_executor/tests/tester.rs
+++ b/core/lib/zksync_core/src/state_keeper/batch_executor/tests/tester.rs
@@ -43,7 +43,6 @@ pub(super) struct TestConfig {
     pub(super) save_call_traces: bool,
     pub(super) vm_gas_limit: Option<u32>,
     pub(super) validation_computational_gas_limit: u32,
-    pub(super) upload_witness_inputs_to_gcs: bool,
 }
 
 impl TestConfig {
@@ -54,7 +53,6 @@ impl TestConfig {
             vm_gas_limit: None,
             save_call_traces: false,
             validation_computational_gas_limit: config.validation_computational_gas_limit,
-            upload_witness_inputs_to_gcs: false,
         }
     }
 }
@@ -105,7 +103,6 @@ impl Tester {
             self.db_dir.path().to_str().unwrap().to_owned(),
             self.pool.clone(),
             self.config.save_call_traces,
-            self.config.upload_witness_inputs_to_gcs,
             100,
             false,
         );
@@ -428,7 +425,7 @@ impl StorageSnapshot {
             executor.start_next_miniblock(l2_block_env).await;
         }
 
-        let (finished_batch, _) = executor.finish_batch().await;
+        let finished_batch = executor.finish_batch().await;
         let storage_logs = &finished_batch.block_tip_execution_result.logs.storage_logs;
         storage_writes_deduplicator.apply(storage_logs.iter().filter(|log| log.log_query.rw_flag));
         let modified_entries = storage_writes_deduplicator.into_modified_key_values();

--- a/core/lib/zksync_core/src/state_keeper/io/output_handler.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/output_handler.rs
@@ -4,7 +4,6 @@ use std::fmt;
 
 use anyhow::Context as _;
 use async_trait::async_trait;
-use zksync_types::witness_block_state::WitnessBlockState;
 
 use crate::state_keeper::{io::IoCursor, updates::UpdatesManager};
 
@@ -21,11 +20,7 @@ pub trait StateKeeperOutputHandler: 'static + Send + fmt::Debug {
     async fn handle_miniblock(&mut self, updates_manager: &UpdatesManager) -> anyhow::Result<()>;
 
     /// Handles an L1 batch produced by the state keeper.
-    async fn handle_l1_batch(
-        &mut self,
-        _witness_block_state: Option<&WitnessBlockState>,
-        _updates_manager: &UpdatesManager,
-    ) -> anyhow::Result<()> {
+    async fn handle_l1_batch(&mut self, _updates_manager: &UpdatesManager) -> anyhow::Result<()> {
         Ok(())
     }
 }
@@ -86,12 +81,11 @@ impl OutputHandler {
 
     pub(crate) async fn handle_l1_batch(
         &mut self,
-        witness_block_state: Option<&WitnessBlockState>,
         updates_manager: &UpdatesManager,
     ) -> anyhow::Result<()> {
         for handler in &mut self.inner {
             handler
-                .handle_l1_batch(witness_block_state, updates_manager)
+                .handle_l1_batch(updates_manager)
                 .await
                 .with_context(|| {
                     format!(

--- a/core/lib/zksync_core/src/state_keeper/io/persistence.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/persistence.rs
@@ -1,13 +1,11 @@
 //! State keeper persistence logic.
 
-use std::{sync::Arc, time::Instant};
+use std::time::Instant;
 
-use anyhow::Context as _;
 use async_trait::async_trait;
 use tokio::sync::{mpsc, oneshot};
 use zksync_dal::{ConnectionPool, Core};
-use zksync_object_store::ObjectStore;
-use zksync_types::{witness_block_state::WitnessBlockState, Address};
+use zksync_types::Address;
 
 use crate::{
     metrics::{BlockStage, APP_METRICS},
@@ -29,7 +27,6 @@ struct Completable<T> {
 #[derive(Debug)]
 pub struct StateKeeperPersistence {
     pool: ConnectionPool<Core>,
-    object_store: Option<Arc<dyn ObjectStore>>, // FIXME (PLA-857): remove from the state keeper
     l2_erc20_bridge_addr: Address,
     pre_insert_txs: bool,
     commands_sender: mpsc::Sender<Completable<MiniblockSealCommand>>,
@@ -60,7 +57,6 @@ impl StateKeeperPersistence {
         };
         let this = Self {
             pool,
-            object_store: None,
             l2_erc20_bridge_addr,
             pre_insert_txs: false,
             commands_sender,
@@ -72,11 +68,6 @@ impl StateKeeperPersistence {
 
     pub fn with_tx_insertion(mut self) -> Self {
         self.pre_insert_txs = true;
-        self
-    }
-
-    pub fn with_object_store(mut self, object_store: Arc<dyn ObjectStore>) -> Self {
-        self.object_store = Some(object_store);
         self
     }
 
@@ -156,33 +147,9 @@ impl StateKeeperOutputHandler for StateKeeperPersistence {
         Ok(())
     }
 
-    async fn handle_l1_batch(
-        &mut self,
-        witness_block_state: Option<&WitnessBlockState>,
-        updates_manager: &UpdatesManager,
-    ) -> anyhow::Result<()> {
+    async fn handle_l1_batch(&mut self, updates_manager: &UpdatesManager) -> anyhow::Result<()> {
         // We cannot start sealing an L1 batch until we've sealed all miniblocks included in it.
         self.wait_for_all_commands().await;
-
-        if let Some(witness_block_state) = witness_block_state {
-            let store = self
-                .object_store
-                .as_deref()
-                .context("object store not set when saving `WitnessBlockState`")?;
-            match store
-                .put(updates_manager.l1_batch.number, witness_block_state)
-                .await
-            {
-                Ok(path) => {
-                    tracing::debug!("Successfully uploaded witness block start state to Object Store to path = '{path}'");
-                }
-                Err(e) => {
-                    tracing::error!(
-                        "Failed to upload witness block start state to Object Store: {e:?}"
-                    );
-                }
-            }
-        }
 
         let pool = self.pool.clone();
         let mut storage = pool.connection_tagged("state_keeper").await?;
@@ -323,7 +290,7 @@ mod tests {
         });
 
         updates.finish_batch(default_vm_block_result());
-        persistence.handle_l1_batch(None, &updates).await.unwrap();
+        persistence.handle_l1_batch(&updates).await.unwrap();
 
         // Check that miniblock #1 and L1 batch #1 are persisted.
         let mut storage = pool.connection().await.unwrap();

--- a/core/lib/zksync_core/src/state_keeper/keeper.rs
+++ b/core/lib/zksync_core/src/state_keeper/keeper.rs
@@ -195,11 +195,11 @@ impl ZkSyncStateKeeper {
                 .await;
             }
 
-            let (finished_batch, witness_block_state) = batch_executor.finish_batch().await;
+            let (finished_batch, _) = batch_executor.finish_batch().await;
             let sealed_batch_protocol_version = updates_manager.protocol_version();
             updates_manager.finish_batch(finished_batch);
             self.output_handler
-                .handle_l1_batch(witness_block_state.as_ref(), &updates_manager)
+                .handle_l1_batch(&updates_manager)
                 .await
                 .with_context(|| format!("failed sealing L1 batch {l1_batch_env:?}"))?;
 

--- a/core/lib/zksync_core/src/state_keeper/keeper.rs
+++ b/core/lib/zksync_core/src/state_keeper/keeper.rs
@@ -195,7 +195,7 @@ impl ZkSyncStateKeeper {
                 .await;
             }
 
-            let (finished_batch, _) = batch_executor.finish_batch().await;
+            let finished_batch = batch_executor.finish_batch().await;
             let sealed_batch_protocol_version = updates_manager.protocol_version();
             updates_manager.finish_batch(finished_batch);
             self.output_handler

--- a/core/lib/zksync_core/src/state_keeper/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/mod.rs
@@ -48,7 +48,6 @@ pub(crate) async fn create_state_keeper(
         db_config.state_keeper_db_path.clone(),
         pool.clone(),
         state_keeper_config.save_call_traces,
-        state_keeper_config.upload_witness_inputs_to_gcs,
         state_keeper_config.enum_index_migration_chunk_size(),
         false,
     );

--- a/core/lib/zksync_core/src/state_keeper/tests/tester.rs
+++ b/core/lib/zksync_core/src/state_keeper/tests/tester.rs
@@ -527,7 +527,7 @@ impl TestBatchExecutor {
                 }
                 Command::FinishBatch(resp) => {
                     // Blanket result, it doesn't really matter.
-                    resp.send((default_vm_block_result(), None)).unwrap();
+                    resp.send(default_vm_block_result()).unwrap();
                     return;
                 }
             }
@@ -857,7 +857,7 @@ impl BatchExecutor for MockBatchExecutor {
                     Command::RollbackLastTx(_) => panic!("unexpected rollback"),
                     Command::FinishBatch(resp) => {
                         // Blanket result, it doesn't really matter.
-                        resp.send((default_vm_block_result(), None)).unwrap();
+                        resp.send(default_vm_block_result()).unwrap();
                         return;
                     }
                 }

--- a/core/lib/zksync_core/src/state_keeper/tests/tester.rs
+++ b/core/lib/zksync_core/src/state_keeper/tests/tester.rs
@@ -17,8 +17,7 @@ use tokio::sync::{mpsc, watch};
 use zksync_contracts::BaseSystemContracts;
 use zksync_types::{
     block::MiniblockExecutionData, fee_model::BatchFeeInput, protocol_upgrade::ProtocolUpgradeTx,
-    witness_block_state::WitnessBlockState, Address, L1BatchNumber, L2ChainId, MiniblockNumber,
-    ProtocolVersionId, Transaction, H256,
+    Address, L1BatchNumber, L2ChainId, MiniblockNumber, ProtocolVersionId, Transaction, H256,
 };
 
 use crate::{
@@ -569,11 +568,7 @@ impl StateKeeperOutputHandler for TestPersistence {
         Ok(())
     }
 
-    async fn handle_l1_batch(
-        &mut self,
-        _witness_block_state: Option<&WitnessBlockState>,
-        updates_manager: &UpdatesManager,
-    ) -> anyhow::Result<()> {
+    async fn handle_l1_batch(&mut self, updates_manager: &UpdatesManager) -> anyhow::Result<()> {
         let action = self.pop_next_item("seal_l1_batch");
         let ScenarioItem::BatchSeal(_, check_fn) = action else {
             anyhow::bail!("Unexpected action: {:?}", action);

--- a/core/lib/zksync_core/src/sync_layer/sync_state.rs
+++ b/core/lib/zksync_core/src/sync_layer/sync_state.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use serde::Serialize;
 use zksync_concurrency::{ctx, sync};
 use zksync_health_check::{CheckHealth, Health, HealthStatus};
-use zksync_types::{witness_block_state::WitnessBlockState, MiniblockNumber};
+use zksync_types::MiniblockNumber;
 
 use crate::{
     metrics::EN_METRICS,
@@ -89,11 +89,7 @@ impl StateKeeperOutputHandler for SyncState {
         Ok(())
     }
 
-    async fn handle_l1_batch(
-        &mut self,
-        _witness_block_state: Option<&WitnessBlockState>,
-        updates_manager: &UpdatesManager,
-    ) -> anyhow::Result<()> {
+    async fn handle_l1_batch(&mut self, updates_manager: &UpdatesManager) -> anyhow::Result<()> {
         let sealed_block_number = updates_manager.miniblock.number;
         self.set_local_block(sealed_block_number);
         Ok(())

--- a/core/node/node_framework/src/implementations/layers/state_keeper/main_batch_executor.rs
+++ b/core/node/node_framework/src/implementations/layers/state_keeper/main_batch_executor.rs
@@ -36,7 +36,6 @@ impl WiringLayer for MainBatchExecutorLayer {
             self.db_config.state_keeper_db_path,
             master_pool.get_singleton().await?,
             self.state_keeper_config.save_call_traces,
-            self.state_keeper_config.upload_witness_inputs_to_gcs,
             self.state_keeper_config.enum_index_migration_chunk_size(),
             false,
         );

--- a/core/node/node_framework/src/implementations/layers/state_keeper/mempool_io.rs
+++ b/core/node/node_framework/src/implementations/layers/state_keeper/mempool_io.rs
@@ -13,7 +13,6 @@ use zksync_core::state_keeper::{
 use crate::{
     implementations::resources::{
         fee_input::FeeInputResource,
-        object_store::ObjectStoreResource,
         pools::MasterPoolResource,
         state_keeper::{ConditionalSealerResource, OutputHandlerResource, StateKeeperIOResource},
     },
@@ -73,7 +72,6 @@ impl WiringLayer for MempoolIOLayer {
     async fn wire(self: Box<Self>, mut context: ServiceContext<'_>) -> Result<(), WiringError> {
         // Fetch required resources.
         let batch_fee_input_provider = context.get_resource::<FeeInputResource>().await?.0;
-        let object_store = context.get_resource::<ObjectStoreResource>().await?.0;
         let master_pool = context.get_resource::<MasterPoolResource>().await?;
 
         // Create miniblock sealer task.
@@ -85,7 +83,6 @@ impl WiringLayer for MempoolIOLayer {
             self.contracts_config.l2_erc20_bridge_addr,
             self.state_keeper_config.miniblock_seal_queue_capacity,
         );
-        let persistence = persistence.with_object_store(object_store);
         let output_handler = OutputHandler::new(Box::new(persistence));
         context.insert_resource(OutputHandlerResource(Unique::new(output_handler)))?;
         context.add_task(Box::new(MiniblockSealerTask(miniblock_sealer)));

--- a/etc/env/base/chain.toml
+++ b/etc/env/base/chain.toml
@@ -87,11 +87,6 @@ save_call_traces = true
 virtual_blocks_interval = 1
 virtual_blocks_per_miniblock = 1
 
-# WARNING! This slows down the statekeeper, forcing mempool to upload to GCS
-# It is meant as a validation flag to be used in STAGING only.
-# This variable should not be set to true in any customer facing environment.
-upload_witness_inputs_to_gcs = false
-
 bootloader_hash = "0x010007ede999d096c84553fb514d3d6ca76fbf39789dda76bfeda9f3ae06236e"
 default_aa_hash = "0x0100055b041eb28aff6e3a6e0f37c31fd053fc9ef142683b05e5f0aee6934066"
 


### PR DESCRIPTION
## What ❔

`WitnessBlockState` is only used in the state keeper persistence logic as a temporary measure before the BWIP component is fully implemented.

## Why ❔

Removing this logic simplifies state keeper persistence interfaces.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.