### PR TITLE
fix(api): Change error code for Web3Error::NotImplemented

### DIFF
--- a/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/mod.rs
+++ b/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/mod.rs
@@ -29,9 +29,8 @@ impl MethodTracer {
             _ => None,
         };
         let code = match err {
-            Web3Error::InternalError(_) | Web3Error::NotImplemented => {
-                ErrorCode::InternalError.code()
-            }
+            Web3Error::NotImplemented => ErrorCode::MethodNotFound.code(),
+            Web3Error::InternalError(_) => ErrorCode::InternalError.code(),
             Web3Error::NoBlock
             | Web3Error::PrunedBlock(_)
             | Web3Error::PrunedL1Batch(_)

--- a/core/lib/zksync_core/src/api_server/web3/tests/filters.rs
+++ b/core/lib/zksync_core/src/api_server/web3/tests/filters.rs
@@ -269,7 +269,7 @@ async fn log_filter_changes_with_block_boundaries() {
 
 fn assert_not_implemented<T: Debug>(result: Result<T, Error>) {
     assert_matches!(result, Err(Error::Call(e)) => {
-        assert_eq!(e.code(), ErrorCode::InternalError.code());
+        assert_eq!(e.code(), ErrorCode::MethodNotFound.code());
         assert_eq!(e.message(), "Not implemented");
     });
 }


### PR DESCRIPTION
## What ❔

Changes the error code for `Web3Error::NotImplemented` from `InternalError` to `MethodNotFound`.

## Why ❔

Better representation of the nature of an error. Useful for better error-handling on the client side.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
