### PR TITLE
fix(contract-verifier-api): permissive cors for contract verifier api server

### DIFF
--- a/core/lib/zksync_core/src/api_server/contract_verification/api_decl.rs
+++ b/core/lib/zksync_core/src/api_server/contract_verification/api_decl.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use tower_http::cors::CorsLayer;
 use zksync_dal::{ConnectionPool, Core};
 
 #[derive(Debug, Clone)]
@@ -49,6 +50,7 @@ impl RestApi {
                 "/contract_verification/info/:address",
                 axum::routing::get(Self::verification_info),
             )
+            .layer(CorsLayer::permissive())
             .with_state(Arc::new(self))
     }
 }


### PR DESCRIPTION
## What ❔

Sets permissive CORS for contract verifier api server

## Why ❔

To have same cors as we had with actix

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
