### PR TITLE
dont merge: use big default value

### DIFF
--- a/core/lib/constants/src/ethereum.rs
+++ b/core/lib/constants/src/ethereum.rs
@@ -14,4 +14,4 @@ pub const REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE: u64 = 800;
 // The default gas per pubdata byte for L2 transactions, that is used, for instance, when we need to
 // insert some default value for type 2 transactions.
 // It is a realistic value, but it is large enough to fill into any batch regardless of the pubdata price.
-pub const DEFAULT_L2_TX_GAS_PER_PUBDATA_BYTE: u64 = 50_000;
+pub const DEFAULT_L2_TX_GAS_PER_PUBDATA_BYTE: u64 = 1 << 20;


### PR DESCRIPTION
## What ❔

This PR is intended solely to check [this](https://github.com/matter-labs/zksync-era/pull/1508#discussion_r1543077219) question by using a large default gas per pubdata in the CI

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
