### PR TITLE
refactor(prover): Idiomatic Eip4844 conversions

### DIFF
--- a/core/lib/zksync_core/src/proof_data_handler/request_processor.rs
+++ b/core/lib/zksync_core/src/proof_data_handler/request_processor.rs
@@ -132,12 +132,9 @@ impl RequestProcessor {
             .unwrap()
             .unwrap();
 
-        let eip_4844_blobs: Eip4844Blobs = storage_batch
-            .pubdata_input
-            .expect(&format!(
-                "expected pubdata, but it is not available for batch {l1_batch_number:?}"
-            ))
-            .into();
+        let eip_4844_blobs = Eip4844Blobs::decode(storage_batch.pubdata_input.expect(&format!(
+            "expected pubdata, but it is not available for batch {l1_batch_number:?}"
+        )));
 
         let proof_gen_data = ProofGenerationData {
             l1_batch_number,

--- a/prover/prover_dal/src/fri_witness_generator_dal.rs
+++ b/prover/prover_dal/src/fri_witness_generator_dal.rs
@@ -41,7 +41,7 @@ impl FriWitnessGeneratorDal<'_, '_> {
         protocol_version_id: ProtocolVersionId,
         eip_4844_blobs: Eip4844Blobs,
     ) {
-        let blobs_raw: Vec<u8> = eip_4844_blobs.into();
+        let blobs_raw: Vec<u8> = eip_4844_blobs.encode();
         sqlx::query!(
             r#"
             INSERT INTO
@@ -116,9 +116,10 @@ impl FriWitnessGeneratorDal<'_, '_> {
         .map(|row| {
             (
                 L1BatchNumber(row.l1_batch_number as u32),
-                row.eip_4844_blobs
-                    .expect("missing eip 4844 blobs from the database")
-                    .into(),
+                Eip4844Blobs::decode(
+                    row.eip_4844_blobs
+                        .expect("missing eip 4844 blobs from the database"),
+                ),
             )
         })
     }


### PR DESCRIPTION
This PR introduces  idiomatic conversion for `Eip4844Blobs`. During the first implementation, `From` traits were used. `From` is not the right fit, given there are multiple not obvious conversions between blobs and vectors. Furthermore, the conversion can panic, which is against [guidelines](https://doc.rust-lang.org/std/convert/trait.From.html#when-to-implement-from).

This change moves to a more idiomatic function usage to avoid future confusion.