### PR TITLE
refactor(prover): Remove is_blob_cleaned

### DIFF
--- a/prover/prover_dal/.sqlx/query-75f6eaa518e7840374c4e44b0788bf92c7f2c55386c8208e3a82b30456abd5b4.json
+++ b/prover/prover_dal/.sqlx/query-75f6eaa518e7840374c4e44b0788bf92c7f2c55386c8208e3a82b30456abd5b4.json
@@ -50,21 +50,16 @@
       },
       {
         "ordinal": 9,
-        "name": "is_blob_cleaned",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 10,
         "name": "protocol_version",
         "type_info": "Int4"
       },
       {
-        "ordinal": 11,
+        "ordinal": 10,
         "name": "picked_by",
         "type_info": "Text"
       },
       {
-        "ordinal": 12,
+        "ordinal": 11,
         "name": "eip_4844_blobs",
         "type_info": "Bytea"
       }
@@ -84,7 +79,6 @@
       true,
       false,
       false,
-      true,
       true,
       true,
       true,

--- a/prover/prover_dal/.sqlx/query-7a8fffe8d4e3085e00c98f770d250d625f057acf1440b6550375ce5509a816a6.json
+++ b/prover/prover_dal/.sqlx/query-7a8fffe8d4e3085e00c98f770d250d625f057acf1440b6550375ce5509a816a6.json
@@ -60,21 +60,16 @@
       },
       {
         "ordinal": 11,
-        "name": "is_blob_cleaned",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 12,
         "name": "number_of_basic_circuits",
         "type_info": "Int4"
       },
       {
-        "ordinal": 13,
+        "ordinal": 12,
         "name": "protocol_version",
         "type_info": "Int4"
       },
       {
-        "ordinal": 14,
+        "ordinal": 13,
         "name": "picked_by",
         "type_info": "Text"
       }
@@ -95,7 +90,6 @@
       true,
       false,
       false,
-      true,
       true,
       true,
       true,

--- a/prover/prover_dal/migrations/20240331091147_remove_is_blob_cleaned.down.sql
+++ b/prover/prover_dal/migrations/20240331091147_remove_is_blob_cleaned.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE IF EXISTS witness_inputs_fri ADD COLUMN is_blob_cleaned BOOLEAN;
+ALTER TABLE IF EXISTS leaf_aggregation_witness_jobs_fri ADD COLUMN is_blob_cleaned BOOLEAN;
+
+ALTER TABLE IF EXISTS prover_jobs_fri ADD COLUMN is_blob_cleaned BOOLEAN;
+ALTER TABLE IF EXISTS prover_jobs_fri_archive ADD COLUMN is_blob_cleaned BOOLEAN;

--- a/prover/prover_dal/migrations/20240331091147_remove_is_blob_cleaned.up.sql
+++ b/prover/prover_dal/migrations/20240331091147_remove_is_blob_cleaned.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE IF EXISTS witness_inputs_fri DROP COLUMN IF EXISTS is_blob_cleaned;
+ALTER TABLE IF EXISTS leaf_aggregation_witness_jobs_fri DROP COLUMN IF EXISTS is_blob_cleaned;
+
+ALTER TABLE IF EXISTS prover_jobs_fri DROP COLUMN IF EXISTS is_blob_cleaned;
+ALTER TABLE IF EXISTS prover_jobs_fri_archive DROP COLUMN IF EXISTS is_blob_cleaned;


### PR DESCRIPTION
The entire codebase for this change was merged a long time again. See [321](https://github.com/matter-labs/zksync-era/pull/321). This PR cleans up the database leftovers. This logic is moved to GCS.
