### PR TITLE
fix(CI): Less flaky CI

### DIFF
--- a/core/lib/zksync_core/src/block_reverter/mod.rs
+++ b/core/lib/zksync_core/src/block_reverter/mod.rs
@@ -351,9 +351,19 @@ impl BlockReverter {
             .block(BlockId::Number(BlockNumber::Pending))
             .await
             .unwrap()
-            .unwrap()
-            .base_fee_per_gas
-            .unwrap();
+            .map(|block| block.base_fee_per_gas.unwrap());
+        let base_fee = if let Some(base_fee) = base_fee {
+            base_fee
+        } else {
+            // Pending block doesn't exist, use the latest one.
+            web3.eth()
+                .block(BlockId::Number(BlockNumber::Latest))
+                .await
+                .unwrap()
+                .unwrap()
+                .base_fee_per_gas
+                .unwrap()
+        };
 
         let tx = TransactionParameters {
             to: eth_config.validator_timelock_addr.into(),

--- a/infrastructure/zk/src/init.ts
+++ b/infrastructure/zk/src/init.ts
@@ -147,7 +147,7 @@ export async function announced(fn: string, promise: Promise<void> | void) {
 
 export async function submoduleUpdate() {
     await utils.exec('git submodule init');
-    await utils.exec('git submodule update --remote');
+    await utils.exec('git submodule update');
 }
 
 export async function validiumSubmoduleCheckout() {


### PR DESCRIPTION
## What ❔

Fixes a few problems:

- Removes `--remote` flag added to submodule update in https://github.com/matter-labs/zksync-era/pull/1461. This flag would override the currently used submodule version, which is incorrect.
- Adds a fallback to latest block in the block reverter (it seems, in `reth` pending block doesn't always exist).

There are other problems with CI that are to be solved, but it's better to fix something ASAP.

## Why ❔

Flaky CI bad

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
