### PR TITLE
Add commitment_generator option to zk server command

### DIFF
--- a/prover/prover_fri/README.md
+++ b/prover/prover_fri/README.md
@@ -54,7 +54,7 @@ installation as a pre-requisite, alongside these machine specs:
 2. Run the server. In the root of the repository:
 
    ```console
-   zk server --components=api,eth,tree,state_keeper,housekeeper,proof_data_handler
+   zk server --components=api,eth,tree,state_keeper,housekeeper,commitment_generator,proof_data_handler
    ```
 
    Note that it will produce a first l1 batch that can be proven (should be batch 0).
@@ -139,7 +139,7 @@ Machine specs:
 4. Run the sequencer/operator. In the root of the repository:
 
    ```console
-   zk server --components=api,eth,tree,state_keeper,housekeeper,proof_data_handler
+   zk server --components=api,eth,tree,state_keeper,housekeeper,commitment_generator,proof_data_handler
    ```
 
    to produce blocks to be proven


### PR DESCRIPTION
## What ❔

Fix `zk server` command in the README of the `prover_fri` instructions.

## Why ❔

Without the `commitment_generator` option, the server will crash in `submit_proof` requests, e.g., `http://127.0.0.1:3320/submit_proof/1`, and the witness generator will also crash for any batch greater than batch `1` when querying the metadata of the previous batch.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.

__Note:__ no code change.