### PR TITLE
fix: Improve error handling in ObservabilityBuilder::with_opentelemetry

### DIFF
--- a/core/lib/vlog/src/lib.rs
+++ b/core/lib/vlog/src/lib.rs
@@ -177,8 +177,9 @@ impl ObservabilityBuilder {
         otlp_endpoint: String,
         service_name: String,
     ) -> Result<Self, OpenTelemetryLevelFormatError> {
+        let opentelemetry_level = opentelemetry_level.parse()?;
         self.opentelemetry_options = Some(OpenTelemetryOptions {
-            opentelemetry_level: opentelemetry_level.parse()?,
+            opentelemetry_level,
             otlp_endpoint,
             service_name,
         });


### PR DESCRIPTION
## What ❔

This PR improves error handling in the ObservabilityBuilder::with_opentelemetry method by making it return a Result type. This change ensures consistent error handling throughout the builder methods, allowing callers to handle parsing errors explicitly when configuring the observability subsystem.

## Why ❔

Consistent error handling is essential for robust code, especially in a builder pattern where various configurations may involve parsing user input or external data. By returning a Result type from ObservabilityBuilder::with_opentelemetry, we provide a clear indication of potential parsing errors, helping users of the API to handle such errors appropriately.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via zk fmt and zk lint.
- [x] Spellcheck has been run via zk spellcheck.
- [x] Linkcheck has been run via zk linkcheck.