### PR TITLE
chore: remove unused imports

### DIFF
--- a/core/lib/zksync_core/src/state_keeper/mempool_actor.rs
+++ b/core/lib/zksync_core/src/state_keeper/mempool_actor.rs
@@ -2,14 +2,10 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use anyhow::Context as _;
 use multivm::utils::derive_base_fee_and_gas_per_pubdata;
-#[cfg(test)]
-use tokio::sync::mpsc;
 use tokio::sync::watch;
 use zksync_config::configs::chain::MempoolConfig;
 use zksync_dal::{Connection, ConnectionPool, Core, CoreDal};
 use zksync_mempool::L2TxFilter;
-#[cfg(test)]
-use zksync_types::H256;
 use zksync_types::{get_nonce_key, Address, Nonce, Transaction, VmVersion};
 
 use super::{metrics::KEEPER_METRICS, types::MempoolGuard};


### PR DESCRIPTION
## What ❔

This PR removes unused imports from the code to improve code readability and maintainability.

## Why ❔

Removing unused imports is a good practice in software development. It helps to keep the codebase clean and organized, making it easier to understand and maintain. Additionally, it can improve build times by reducing the amount of code that needs to be compiled.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via zk fmt and zk lint.
- [x] Spellcheck has been run via zk spellcheck.
- [x] Linkcheck has been run via zk linkcheck.