### PR TITLE
feat: Support constructor call in protocol upgrade script

### DIFF
--- a/infrastructure/protocol-upgrade/src/l2upgrade/transactions.ts
+++ b/infrastructure/protocol-upgrade/src/l2upgrade/transactions.ts
@@ -56,12 +56,17 @@ export const command = new Command('l2-transaction').description('publish system
 command
     .command('force-deployment-calldata')
     .option('--environment <environment>')
+    .option(
+        '--system-contracts-with-constructor',
+        'Call constructor to the list of the provided system contracts'
+    )
     .action(async (cmd) => {
+        const systemContractsWithConstructor = cmd.systemContractsWithConstructor ? cmd.systemContractsWithConstructor.split(',') as string[] : [];
         const l2upgradeFileName = getL2UpgradeFileName(cmd.environment);
         if (fs.existsSync(l2upgradeFileName)) {
             console.log(`Found l2 upgrade file ${l2upgradeFileName}`);
             let l2Upgrade = JSON.parse(fs.readFileSync(l2upgradeFileName).toString());
-            const forcedDeployments = systemContractsToForceDeployments(l2Upgrade.systemContracts);
+            const forcedDeployments = systemContractsToForceDeployments(l2Upgrade.systemContracts, systemContractsWithConstructor);
             const calldata = forceDeploymentCalldataContractDeployer(forcedDeployments);
             l2Upgrade.forcedDeployments = forcedDeployments;
             l2Upgrade.forcedDeploymentCalldata = calldata;
@@ -72,8 +77,8 @@ command
         }
     });
 
-function systemContractsToForceDeployments(systemContracts): ForceDeployment[] {
-    return systemContracts.map((dependency) => {
+function systemContractsToForceDeployments(systemContracts, systemContractsWithConstructor: string[]): ForceDeployment[] {
+    const forcedDeployments: ForceDeployment[] = systemContracts.map((dependency) => {
         return {
             bytecodeHash: dependency.bytecodeHashes[0],
             newAddress: dependency.address,
@@ -82,6 +87,17 @@ function systemContractsToForceDeployments(systemContracts): ForceDeployment[] {
             callConstructor: false
         };
     });
+
+    for(const contractAddress of systemContractsWithConstructor) {
+        const deploymentInfo = forcedDeployments.find((contract) => contract.newAddress === contractAddress);
+        if (deploymentInfo) {
+            deploymentInfo.callConstructor = true;
+        } else {
+            throw new Error(`Contract ${contractAddress} not found in forced deployments`);
+        }
+    }
+
+    return forcedDeployments;
 }
 
 command
@@ -97,16 +113,21 @@ command
         'Use contract deployer address instead of complex upgrader address. ' +
             "Warning: this shouldn't be a default option, it's only for first upgrade purposes"
     )
+    .option(
+        '--system-contracts-with-constructor <systemContractsWithConstructor>',
+        'Call constructor to the list of the provided system contracts'
+    )
     .action(async (cmd) => {
         const l2upgradeFileName = getL2UpgradeFileName(cmd.environment);
         const l2UpgraderAddress = cmd.l2UpgraderAddress ?? process.env.CONTRACTS_L2_DEFAULT_UPGRADE_ADDR;
+        const systemContractsWithConstructor = cmd.systemContractsWithConstructor ? cmd.systemContractsWithConstructor.split(',') as string[] : [];
         const commonData = JSON.parse(fs.readFileSync(getCommonDataFileName(), { encoding: 'utf-8' }));
         if (fs.existsSync(l2upgradeFileName)) {
             console.log(`Found l2 upgrade file ${l2upgradeFileName}`);
             let l2Upgrade = JSON.parse(fs.readFileSync(l2upgradeFileName).toString());
             let delegatedCalldata = l2Upgrade.delegatedCalldata;
             if (cmd.useForcedDeployments) {
-                l2Upgrade.forcedDeployments = systemContractsToForceDeployments(l2Upgrade.systemContracts);
+                l2Upgrade.forcedDeployments = systemContractsToForceDeployments(l2Upgrade.systemContracts, systemContractsWithConstructor);
                 l2Upgrade.forcedDeploymentCalldata = forceDeploymentCalldataContractDeployer(
                     l2Upgrade.forcedDeployments
                 );

--- a/infrastructure/protocol-upgrade/src/l2upgrade/transactions.ts
+++ b/infrastructure/protocol-upgrade/src/l2upgrade/transactions.ts
@@ -56,17 +56,19 @@ export const command = new Command('l2-transaction').description('publish system
 command
     .command('force-deployment-calldata')
     .option('--environment <environment>')
-    .option(
-        '--system-contracts-with-constructor',
-        'Call constructor to the list of the provided system contracts'
-    )
+    .option('--system-contracts-with-constructor', 'Call constructor to the list of the provided system contracts')
     .action(async (cmd) => {
-        const systemContractsWithConstructor = cmd.systemContractsWithConstructor ? cmd.systemContractsWithConstructor.split(',') as string[] : [];
+        const systemContractsWithConstructor = cmd.systemContractsWithConstructor
+            ? (cmd.systemContractsWithConstructor.split(',') as string[])
+            : [];
         const l2upgradeFileName = getL2UpgradeFileName(cmd.environment);
         if (fs.existsSync(l2upgradeFileName)) {
             console.log(`Found l2 upgrade file ${l2upgradeFileName}`);
             let l2Upgrade = JSON.parse(fs.readFileSync(l2upgradeFileName).toString());
-            const forcedDeployments = systemContractsToForceDeployments(l2Upgrade.systemContracts, systemContractsWithConstructor);
+            const forcedDeployments = systemContractsToForceDeployments(
+                l2Upgrade.systemContracts,
+                systemContractsWithConstructor
+            );
             const calldata = forceDeploymentCalldataContractDeployer(forcedDeployments);
             l2Upgrade.forcedDeployments = forcedDeployments;
             l2Upgrade.forcedDeploymentCalldata = calldata;
@@ -77,7 +79,10 @@ command
         }
     });
 
-function systemContractsToForceDeployments(systemContracts, systemContractsWithConstructor: string[]): ForceDeployment[] {
+function systemContractsToForceDeployments(
+    systemContracts,
+    systemContractsWithConstructor: string[]
+): ForceDeployment[] {
     const forcedDeployments: ForceDeployment[] = systemContracts.map((dependency) => {
         return {
             bytecodeHash: dependency.bytecodeHashes[0],
@@ -88,7 +93,7 @@ function systemContractsToForceDeployments(systemContracts, systemContractsWithC
         };
     });
 
-    for(const contractAddress of systemContractsWithConstructor) {
+    for (const contractAddress of systemContractsWithConstructor) {
         const deploymentInfo = forcedDeployments.find((contract) => contract.newAddress === contractAddress);
         if (deploymentInfo) {
             deploymentInfo.callConstructor = true;
@@ -120,14 +125,19 @@ command
     .action(async (cmd) => {
         const l2upgradeFileName = getL2UpgradeFileName(cmd.environment);
         const l2UpgraderAddress = cmd.l2UpgraderAddress ?? process.env.CONTRACTS_L2_DEFAULT_UPGRADE_ADDR;
-        const systemContractsWithConstructor = cmd.systemContractsWithConstructor ? cmd.systemContractsWithConstructor.split(',') as string[] : [];
+        const systemContractsWithConstructor = cmd.systemContractsWithConstructor
+            ? (cmd.systemContractsWithConstructor.split(',') as string[])
+            : [];
         const commonData = JSON.parse(fs.readFileSync(getCommonDataFileName(), { encoding: 'utf-8' }));
         if (fs.existsSync(l2upgradeFileName)) {
             console.log(`Found l2 upgrade file ${l2upgradeFileName}`);
             let l2Upgrade = JSON.parse(fs.readFileSync(l2upgradeFileName).toString());
             let delegatedCalldata = l2Upgrade.delegatedCalldata;
             if (cmd.useForcedDeployments) {
-                l2Upgrade.forcedDeployments = systemContractsToForceDeployments(l2Upgrade.systemContracts, systemContractsWithConstructor);
+                l2Upgrade.forcedDeployments = systemContractsToForceDeployments(
+                    l2Upgrade.systemContracts,
+                    systemContractsWithConstructor
+                );
                 l2Upgrade.forcedDeploymentCalldata = forceDeploymentCalldataContractDeployer(
                     l2Upgrade.forcedDeployments
                 );


### PR DESCRIPTION
## What ❔

Supporting constructor call for selected system contracts' forced deployments

## Why ❔

In preparation for the v1.5.0 upgrade, where we'll have to override the `blockGasLimit` variable in the `SystemContext` contract

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
