### PR TITLE
fix: Fix CI by ignoring "era-compiler-llvm" and bumping h2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2472,9 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",

--- a/checks-config/links.json
+++ b/checks-config/links.json
@@ -23,6 +23,9 @@
         },
         {
             "pattern": "^https://github\\.com/matter-labs/zksync-era/commit/"
+        },
+        {
+            "pattern": "^https://github\\.com/matter-labs//era-compiler-llvm"
         }
     ],
     "aliveStatusCodes": [0, 200, 206, 304]


### PR DESCRIPTION
## What ❔

The `era-compiler-llvm` will be open sourced soon. For now we'll just ignore it in the CI

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
