### PR TITLE
fix(vm): Increase log demuxer cycles on far calls

### DIFF
--- a/core/lib/multivm/src/versions/vm_1_4_2/tests/circuits.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_2/tests/circuits.rs
@@ -33,7 +33,7 @@ fn test_circuits() {
     let s = res.statistics.circuit_statistic;
     // Check `circuit_statistic`.
     const EXPECTED: [f32; 11] = [
-        1.1979, 0.1390, 1.5455, 0.0031, 1.0573, 0.00059, 0.00226, 0.00077, 0.1195, 0.1429, 0.0,
+        1.1979, 0.1390, 1.5455, 0.0031, 1.0573, 0.00059, 0.003438, 0.00077, 0.1195, 0.1429, 0.0,
     ];
     let actual = [
         (s.main_vm, "main_vm"),

--- a/core/lib/multivm/src/versions/vm_1_4_2/tracers/circuits_capacity.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_2/tracers/circuits_capacity.rs
@@ -26,6 +26,7 @@ pub(crate) const STORAGE_WRITE_STORAGE_APPLICATION_CYCLES: u32 = 2;
 pub(crate) const FAR_CALL_RAM_CYCLES: u32 = 1;
 pub(crate) const FAR_CALL_STORAGE_SORTER_CYCLES: u32 = 1;
 pub(crate) const FAR_CALL_CODE_DECOMMITTER_SORTER_CYCLES: u32 = 1;
+pub(crate) const FAR_CALL_LOG_DEMUXER_CYCLES: u32 = 1;
 
 // 5 RAM permutations, because: 1 to read opcode + 2 reads + 2 writes.
 // 2 reads and 2 writes are needed because unaligned access is implemented with

--- a/core/lib/multivm/src/versions/vm_1_4_2/tracers/circuits_tracer.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_2/tracers/circuits_tracer.rs
@@ -79,6 +79,7 @@ impl<S: WriteStorage, H: HistoryMode> DynTracer<S, SimpleMemory<H>> for Circuits
                 self.statistics.code_decommitter_sorter_cycles +=
                     FAR_CALL_CODE_DECOMMITTER_SORTER_CYCLES;
                 self.statistics.storage_sorter_cycles += FAR_CALL_STORAGE_SORTER_CYCLES;
+                self.statistics.log_demuxer_cycles += FAR_CALL_LOG_DEMUXER_CYCLES;
             }
             Opcode::UMA(UMAOpcode::AuxHeapWrite | UMAOpcode::HeapWrite) => {
                 self.statistics.ram_permutation_cycles += UMA_WRITE_RAM_CYCLES;

--- a/core/lib/multivm/src/versions/vm_latest/tests/circuits.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/circuits.rs
@@ -35,7 +35,7 @@ fn test_circuits() {
     let s = res.statistics.circuit_statistic;
     // Check `circuit_statistic`.
     const EXPECTED: [f32; 11] = [
-        1.1979, 0.1390, 1.5455, 0.0031, 1.0573, 0.00059, 0.00226, 0.00077, 0.1195, 0.1429, 0.0,
+        1.1979, 0.1390, 1.5455, 0.0031, 1.0573, 0.00059, 0.003438, 0.00077, 0.1195, 0.1429, 0.0,
     ];
     let actual = [
         (s.main_vm, "main_vm"),

--- a/core/lib/multivm/src/versions/vm_latest/tracers/circuits_capacity.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tracers/circuits_capacity.rs
@@ -26,6 +26,7 @@ pub(crate) const STORAGE_WRITE_STORAGE_APPLICATION_CYCLES: u32 = 2;
 pub(crate) const FAR_CALL_RAM_CYCLES: u32 = 1;
 pub(crate) const FAR_CALL_STORAGE_SORTER_CYCLES: u32 = 1;
 pub(crate) const FAR_CALL_CODE_DECOMMITTER_SORTER_CYCLES: u32 = 1;
+pub(crate) const FAR_CALL_LOG_DEMUXER_CYCLES: u32 = 1;
 
 // 5 RAM permutations, because: 1 to read opcode + 2 reads + 2 writes.
 // 2 reads and 2 writes are needed because unaligned access is implemented with

--- a/core/lib/multivm/src/versions/vm_latest/tracers/circuits_tracer.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tracers/circuits_tracer.rs
@@ -79,6 +79,7 @@ impl<S: WriteStorage, H: HistoryMode> DynTracer<S, SimpleMemory<H>> for Circuits
                 self.statistics.code_decommitter_sorter_cycles +=
                     FAR_CALL_CODE_DECOMMITTER_SORTER_CYCLES;
                 self.statistics.storage_sorter_cycles += FAR_CALL_STORAGE_SORTER_CYCLES;
+                self.statistics.log_demuxer_cycles += FAR_CALL_LOG_DEMUXER_CYCLES;
             }
             Opcode::UMA(UMAOpcode::AuxHeapWrite | UMAOpcode::HeapWrite) => {
                 self.statistics.ram_permutation_cycles += UMA_WRITE_RAM_CYCLES;


### PR DESCRIPTION
## What ❔

Increases log demuxer cycles on far calls

## Why ❔

Storage is read when applying far call: https://github.com/matter-labs/era-zk_evm/blob/v1.5.0/src/opcodes/execution/far_call.rs#L159, this adds one query to a log query queue

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
