### PR TITLE
fix(Prover): Create directory for setup data if its not present when saving the setup

### DIFF
--- a/prover/vk_setup_data_generator_server_fri/src/keystore.rs
+++ b/prover/vk_setup_data_generator_server_fri/src/keystore.rs
@@ -297,6 +297,24 @@ impl Keystore {
         })
     }
 
+    fn create_setup_data_directory(&self) -> anyhow::Result<()> {
+        let setup_data_path = Path::new(
+            self.setup_data_path
+                .as_ref()
+                .expect("Setup data path not set"),
+        );
+        std::fs::create_dir(setup_data_path).context("create_setup_data_directory()")
+    }
+
+    fn is_setup_data_directory_present(&self) -> bool {
+        Path::new(
+            self.setup_data_path
+                .as_ref()
+                .expect("Setup data path not set"),
+        )
+        .exists()
+    }
+
     pub fn is_setup_data_present(&self, key: &ProverServiceDataKey) -> bool {
         Path::new(&self.get_file_path(key.clone(), ProverServiceDataType::SetupData)).exists()
     }
@@ -306,6 +324,9 @@ impl Keystore {
         key: ProverServiceDataKey,
         serialized_setup_data: &Vec<u8>,
     ) -> anyhow::Result<()> {
+        if !self.is_setup_data_directory_present() {
+            self.create_setup_data_directory()?;
+        }
         let filepath = self.get_file_path(key.clone(), ProverServiceDataType::SetupData);
         tracing::info!("saving {:?} setup data to: {}", key, filepath);
         std::fs::write(filepath.clone(), serialized_setup_data)


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

This PR adds the functionality for creating a directory for the setup data if it isn't present when saving the setup.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

If you run the `./setup.sh` step with the default config (without changing the `setup_data_path` config from the `fri_prover`) and the setup data directory does not exist, the following error shows up

```
Caused by:
0: save_setup_data()
1: Failed saving setup-data at path: "/usr/src/setup-data/setup_basic_1_data.bin"
2: No such file or directory (os error 2)
```

If you search for the `/usr/src/setup-data/` dir you can confirm that it does not exist.

I think it would be better to handle this case automatically instead of delegating the user the responsibility for creating said directory.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.
