### PR TITLE
fix: contract verifier config test

### DIFF
--- a/core/lib/env_config/src/contract_verifier.rs
+++ b/core/lib/env_config/src/contract_verifier.rs
@@ -35,7 +35,7 @@ mod tests {
             CONTRACT_VERIFIER_PROMETHEUS_PORT=3314
             CONTRACT_VERIFIER_PORT=3070
             CONTRACT_VERIFIER_URL=127.0.0.1:3070
-            CONTRACT_THREADS_PER_SERVER=128
+            CONTRACT_VERIFIER_THREADS_PER_SERVER=128
 
         "#;
         lock.set_env(config);


### PR DESCRIPTION
## What ❔

Makes contract verifier config test use the correct env var name

## Why ❔

Test is failing for me locally, no idea how it works on CI though

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
