### PR TITLE
chore: Remove initial_writes and repeated_writes from tree metadata

### DIFF
--- a/core/lib/merkle_tree/src/domain.rs
+++ b/core/lib/merkle_tree/src/domain.rs
@@ -3,10 +3,7 @@
 use rayon::{ThreadPool, ThreadPoolBuilder};
 use zksync_crypto::hasher::blake2::Blake2Hasher;
 use zksync_prover_interface::inputs::{PrepareBasicCircuitsJob, StorageLogMetadata};
-use zksync_types::{
-    writes::{InitialStorageWrite, RepeatedStorageWrite},
-    L1BatchNumber, StorageKey,
-};
+use zksync_types::{L1BatchNumber, StorageKey};
 
 use crate::{
     storage::{PatchSet, Patched, RocksDBWrapper},
@@ -24,11 +21,6 @@ pub struct TreeMetadata {
     pub root_hash: ValueHash,
     /// 1-based index of the next leaf to be inserted in the tree.
     pub rollup_last_leaf_index: u64,
-    /// Initial writes performed in the processed L1 batch in the order of provided `StorageLog`s.
-    pub initial_writes: Vec<InitialStorageWrite>,
-    /// Repeated writes performed in the processed L1 batch in the order of provided `StorageLog`s.
-    /// No-op writes (i.e., writing the same value as previously) will be omitted.
-    pub repeated_writes: Vec<RepeatedStorageWrite>,
     /// Witness information. As with `repeated_writes`, no-op updates will be omitted from Merkle paths.
     pub witness: Option<PrepareBasicCircuitsJob>,
 }
@@ -256,68 +248,18 @@ impl ZkSyncTree {
         }
 
         let root_hash = output.root_hash().unwrap_or(starting_root_hash);
-        let logs = output
-            .logs
-            .into_iter()
-            .filter_map(|log| (!log.base.is_read()).then_some(log.base));
-        let kvs = instructions
-            .iter()
-            .filter_map(|instruction| match instruction {
-                TreeInstruction::Write(entry) => Some(*entry),
-                TreeInstruction::Read(_) => None,
-            });
-        let (initial_writes, repeated_writes) = Self::extract_writes(logs, kvs);
 
         tracing::info!(
             "Processed batch #{l1_batch_number}; root hash is {root_hash}, \
-             {leaf_count} leaves in total, \
-             {initial_writes} initial writes, {repeated_writes} repeated writes",
+             {leaf_count} leaves in total",
             leaf_count = output.leaf_count,
-            initial_writes = initial_writes.len(),
-            repeated_writes = repeated_writes.len()
         );
 
         TreeMetadata {
             root_hash,
             rollup_last_leaf_index: output.leaf_count + 1,
-            initial_writes,
-            repeated_writes,
             witness: Some(witness),
         }
-    }
-
-    fn extract_writes(
-        logs: impl Iterator<Item = TreeLogEntry>,
-        entries: impl Iterator<Item = TreeEntry<StorageKey>>,
-    ) -> (Vec<InitialStorageWrite>, Vec<RepeatedStorageWrite>) {
-        let mut initial_writes = vec![];
-        let mut repeated_writes = vec![];
-        for (log_entry, input_entry) in logs.zip(entries) {
-            let key = &input_entry.key;
-            match log_entry {
-                TreeLogEntry::Inserted => {
-                    initial_writes.push(InitialStorageWrite {
-                        index: input_entry.leaf_index,
-                        key: key.hashed_key_u256(),
-                        value: input_entry.value,
-                    });
-                }
-                TreeLogEntry::Updated {
-                    previous_value: prev_value_hash,
-                    ..
-                } => {
-                    if prev_value_hash != input_entry.value {
-                        repeated_writes.push(RepeatedStorageWrite {
-                            index: input_entry.leaf_index,
-                            value: input_entry.value,
-                        });
-                    }
-                    // Else we have a no-op update that must be omitted from `repeated_writes`.
-                }
-                TreeLogEntry::Read { .. } | TreeLogEntry::ReadMissingKey => {}
-            }
-        }
-        (initial_writes, repeated_writes)
     }
 
     fn process_l1_batch_lightweight(
@@ -342,24 +284,17 @@ impl ZkSyncTree {
         } else {
             self.tree.extend(kvs_with_derived_key.clone())
         };
-        let (initial_writes, repeated_writes) =
-            Self::extract_writes(output.logs.into_iter(), kvs.into_iter());
 
         tracing::info!(
             "Processed batch #{l1_batch_number}; root hash is {root_hash}, \
-             {leaf_count} leaves in total, \
-             {initial_writes} initial writes, {repeated_writes} repeated writes",
+             {leaf_count} leaves in total",
             root_hash = output.root_hash,
             leaf_count = output.leaf_count,
-            initial_writes = initial_writes.len(),
-            repeated_writes = repeated_writes.len()
         );
 
         TreeMetadata {
             root_hash: output.root_hash,
             rollup_last_leaf_index: output.leaf_count + 1,
-            initial_writes,
-            repeated_writes,
             witness: None,
         }
     }

--- a/core/lib/merkle_tree/tests/integration/domain.rs
+++ b/core/lib/merkle_tree/tests/integration/domain.rs
@@ -166,7 +166,7 @@ fn revert_blocks() {
 
     let mirror_logs = logs.clone();
     let tree_metadata: Vec<_> = {
-        let mut tree = ZkSyncTree::new_lightweight(storage.into());
+        let mut tree = ZkSyncTree::new(storage.into());
         let metadata = logs.chunks(block_size).map(|chunk| {
             let metadata = tree.process_l1_batch(chunk);
             tree.save();

--- a/core/lib/merkle_tree/tests/integration/domain.rs
+++ b/core/lib/merkle_tree/tests/integration/domain.rs
@@ -54,15 +54,6 @@ fn basic_workflow() {
 
     assert_eq!(metadata.root_hash, expected_root_hash);
     assert_eq!(metadata.rollup_last_leaf_index, 101);
-    assert_eq!(metadata.initial_writes.len(), logs.len());
-    for (write, log) in metadata.initial_writes.iter().zip(&logs) {
-        let expected_value = match log {
-            TreeInstruction::Write(entry) => entry.value,
-            TreeInstruction::Read(_) => unreachable!(),
-        };
-        assert_eq!(write.value, expected_value);
-    }
-    assert!(metadata.repeated_writes.is_empty());
 
     assert_eq!(
         expected_root_hash,
@@ -122,8 +113,6 @@ fn filtering_out_no_op_writes() {
     // All writes are no-op updates and thus must be filtered out.
     let new_metadata = tree.process_l1_batch(&logs);
     assert_eq!(new_metadata.root_hash, root_hash);
-    assert!(new_metadata.initial_writes.is_empty());
-    assert!(new_metadata.repeated_writes.is_empty());
     let merkle_paths = new_metadata.witness.unwrap().into_merkle_paths();
     assert_eq!(merkle_paths.len(), 0);
 
@@ -138,8 +127,6 @@ fn filtering_out_no_op_writes() {
     }
     let new_metadata = tree.process_l1_batch(&logs);
     assert_ne!(new_metadata.root_hash, root_hash);
-    assert!(new_metadata.initial_writes.is_empty());
-    assert_eq!(new_metadata.repeated_writes.len(), expected_writes_count);
     let merkle_paths = new_metadata.witness.unwrap().into_merkle_paths();
     assert_eq!(merkle_paths.len(), expected_writes_count);
     for merkle_path in merkle_paths {
@@ -192,17 +179,20 @@ fn revert_blocks() {
     // 4 first blocks must contain only insert ops, while the last one must contain
     // only the update ops.
     for (i, metadata) in tree_metadata.iter().enumerate() {
+        let merkle_paths = metadata.witness.clone().unwrap().into_merkle_paths();
         let expected_leaf_index = if i == 4 {
-            assert!(metadata.initial_writes.is_empty());
-            assert_eq!(metadata.repeated_writes.len(), block_size);
-            for (write, idx) in metadata.repeated_writes.iter().zip(1_u64..) {
-                assert_eq!(write.index, idx);
-                assert_eq!(write.value, H256::from_low_u64_be(idx));
+            assert_eq!(merkle_paths.len(), block_size);
+            for (merkle_path, idx) in merkle_paths.into_iter().zip(1_u64..) {
+                assert!(!merkle_path.first_write);
+                assert_eq!(merkle_path.leaf_enumeration_index, idx);
+                assert_eq!(merkle_path.value_written, H256::from_low_u64_be(idx).0);
             }
             block_size * 4 + 1
         } else {
-            assert!(metadata.repeated_writes.is_empty());
-            assert_eq!(metadata.initial_writes.len(), block_size);
+            assert_eq!(merkle_paths.len(), block_size);
+            for merkle_path in merkle_paths {
+                assert!(merkle_path.first_write);
+            }
             block_size * (i + 1) + 1
         };
         assert_eq!(metadata.rollup_last_leaf_index, expected_leaf_index as u64);
@@ -381,12 +371,8 @@ fn process_block_idempotency_check() {
     let repeated_tree_metadata = tree.process_l1_batch(&logs);
     assert_eq!(repeated_tree_metadata.root_hash, tree_metadata.root_hash);
     assert_eq!(
-        repeated_tree_metadata.initial_writes,
-        tree_metadata.initial_writes
-    );
-    assert_eq!(
-        repeated_tree_metadata.repeated_writes,
-        tree_metadata.repeated_writes
+        repeated_tree_metadata.rollup_last_leaf_index,
+        tree_metadata.rollup_last_leaf_index
     );
 }
 

--- a/core/lib/zksync_core/src/metadata_calculator/helpers.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/helpers.rs
@@ -706,9 +706,6 @@ mod tests {
             actual.rollup_last_leaf_index,
             expected.rollup_last_leaf_index
         );
-        assert_eq!(actual.initial_writes, expected.initial_writes);
-        assert_eq!(actual.initial_writes, expected.initial_writes);
-        assert_eq!(actual.repeated_writes, expected.repeated_writes);
     }
 
     fn assert_equivalent_witnesses(lhs: PrepareBasicCircuitsJob, rhs: PrepareBasicCircuitsJob) {

--- a/core/lib/zksync_core/src/metadata_calculator/metrics.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/metrics.rs
@@ -17,7 +17,6 @@ use super::MetadataCalculator;
 pub(super) enum TreeUpdateStage {
     LoadChanges,
     Compute,
-    CheckConsistency,
     SavePostgres,
     SaveRocksdb,
     SaveGcs,


### PR DESCRIPTION
## What ❔

Removes initial_writes and repeated_writes from tree metadata. Witness object is used in tests to perform needed checks.

## Why ❔

initial_writes and repeated_writes weren't used except for testing and consistency check purposes


## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
