### PR TITLE
test: Fix easy to fix integration tests

### DIFF
--- a/core/tests/revert-test/tests/revert-and-restart-en.test.ts
+++ b/core/tests/revert-test/tests/revert-and-restart-en.test.ts
@@ -329,7 +329,14 @@ describe('Block reverting test', function () {
             amount: depositAmount,
             to: alice.address
         });
-        const l1TxResponse = await alice._providerL1().getTransaction(depositHandle.hash);
+
+        let l1TxResponse = await alice._providerL1().getTransaction(depositHandle.hash);
+        while (!l1TxResponse) {
+            console.log(`Deposit ${depositHandle.hash} is not visible to the L1 network; sleeping`);
+            await utils.sleep(1);
+            l1TxResponse = await alice._providerL1().getTransaction(depositHandle.hash);
+        }
+
         // TODO: it would be nice to know WHY it "doesn't work well with block reversions" and what it actually means.
         console.log(
             "ethers doesn't work well with block reversions, so wait for the receipt before calling `.waitFinalize()`."

--- a/core/tests/revert-test/tests/revert-and-restart.test.ts
+++ b/core/tests/revert-test/tests/revert-and-restart.test.ts
@@ -193,7 +193,14 @@ describe('Block reverting test', function () {
             amount: depositAmount,
             to: alice.address
         });
-        const l1TxResponse = await alice._providerL1().getTransaction(depositHandle.hash);
+
+        let l1TxResponse = await alice._providerL1().getTransaction(depositHandle.hash);
+        while (!l1TxResponse) {
+            console.log(`Deposit ${depositHandle.hash} is not visible to the L1 network; sleeping`);
+            await utils.sleep(1);
+            l1TxResponse = await alice._providerL1().getTransaction(depositHandle.hash);
+        }
+
         // ethers doesn't work well with block reversions, so wait for the receipt before calling `.waitFinalize()`.
         const l2Tx = await alice._providerL2().getL2TransactionFromPriorityOp(l1TxResponse);
         let receipt = null;

--- a/core/tests/ts-integration/src/reporter.ts
+++ b/core/tests/ts-integration/src/reporter.ts
@@ -96,13 +96,13 @@ export class Reporter {
      * Prints a debug message.
      * Debug messages are only shown if `ZKSYNC_DEBUG_LOGS` env variable is set.
      */
-    debug(message: string) {
+    debug(message: string, ...args: any[]) {
         if (process.env.ZKSYNC_DEBUG_LOGS) {
             const testName = 'expect' in globalThis ? expect.getState().currentTestName : undefined;
             // Timestamps only make sense to include in tests.
             const timestampString = testName === undefined ? '' : timestamp(`${new Date().toISOString()} `);
             const testString = testName ? info(` [${testName}]`) : '';
-            console.log(this.indent(`${timestampString}DEBUG${testString}: ${message}`));
+            console.log(this.indent(`${timestampString}DEBUG${testString}: ${message}`), ...args);
         }
     }
 


### PR DESCRIPTION
## What ❔

Fixes a couple of errors in integration tests with known causes.

- Errors in `getFilterChanges` for pending transactions are caused by introducing the mempool cache. The test makes too strict assumptions as to the transaction latency, which can be easily relaxed.
- The revert test somewhat frequently fails because an L1 transaction response for the deposit is null. The exact cause is unknown (maybe, switching to reth?), but it seems to be fixable by retrying the transaction retrieval until it's not null.

## Why ❔

Failing integration tests slow down development.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.