### PR TITLE
chore(ci): Increase block_commit_deadline_ms

### DIFF
--- a/etc/env/base/chain.toml
+++ b/etc/env/base/chain.toml
@@ -18,7 +18,7 @@ transaction_slots = 250
 
 # 2^50, the maximal allowed gas limit in a batch.
 max_allowed_l2_tx_gas_limit = 1125899906842624
-block_commit_deadline_ms = 2500
+block_commit_deadline_ms = 5000
 miniblock_commit_deadline_ms = 1000
 miniblock_seal_queue_capacity = 10
 # Max gas that can used to include single block in aggregated operation


### PR DESCRIPTION
## What ❔

 Increases block_commit_deadline_ms.

## Why ❔

Commitment generation time is almost constant and doesn't depend on how many transactions are in batch, currently it takes 5-7s. So batches are sealed faster than commitment can be generated for them. Note, that increasing batch timeout much is also not good because some tests require waiting for batch to be sealed, so increasing batch timeout also increases time needed for tests.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
