### PR TITLE
chore: weakened protobuf compatibility check

### DIFF
--- a/.github/workflows/protobuf.yaml
+++ b/.github/workflows/protobuf.yaml
@@ -54,5 +54,7 @@ jobs:
           `find ./after/target/debug/build/*/output`
           | xargs cat > ./after.binpb
       - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ github.token }}
       - name: buf breaking
         run: buf breaking './after.binpb' --against './before.binpb' --config '{"version":"v1","breaking":{"use":["WIRE_JSON"]}}' --error-format 'github-actions'

--- a/.github/workflows/protobuf.yaml
+++ b/.github/workflows/protobuf.yaml
@@ -54,7 +54,5 @@ jobs:
           `find ./after/target/debug/build/*/output`
           | xargs cat > ./after.binpb
       - uses: bufbuild/buf-setup-action@v1
-      - uses: bufbuild/buf-breaking-action@v1
-        with:
-          input: "./after.binpb"
-          against: "./before.binpb"
+      - name: buf breaking
+        run: buf breaking './after.binpb' --against './before.binpb' --config '{"version":"v1","breaking":{"use":["WIRE_JSON"]}}' --error-format 'github-actions'


### PR DESCRIPTION
Weakened protobuf compatibility check from FILE (backward compatibility of generated code) to WIRE_JSON (backward/forward compatibility of generated JSON and binary messages). This will allow us for removing fields from the schema by [reserving ](https://protobuf.dev/programming-guides/proto3/#fieldreserved) the removed field and number. 