### PR TITLE
feat(en): metric scraping and grafana for docker compose image

### DIFF
--- a/docs/guides/external-node/00_quick_start.md
+++ b/docs/guides/external-node/00_quick_start.md
@@ -34,6 +34,9 @@ cd docker-compose-examples
 docker compose --file testnet-external-node-docker-compose.yml down --volumes
 ```
 
+You can see the status of the node (after recovery) in
+[local grafana dashboard](http://localhost:3000/d/0/external-node).
+
 Those commands start external node locally inside docker.
 
 The HTTP JSON-RPC API can be accessed on port `3060` and WebSocket API can be accessed on port `3061`.

--- a/docs/guides/external-node/docker-compose-examples/grafana/provisioning/dashboards/General.json
+++ b/docs/guides/external-node/docker-compose-examples/grafana/provisioning/dashboards/General.json
@@ -1,0 +1,412 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "sum by (stage) (rate(server_processed_txs{stage=~\"mempool_added\"}[$__rate_interval]))",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "TPS",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "sum by (stage) (external_node_fetcher_l1_batch)",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Last processed batch by status",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 33,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "sum by (stage) (external_node_sync_lag)",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Sync lag (blocks)",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "sum by (job) (rocksdb_total_sst_size)",
+          "interval": "",
+          "legendFormat": "RocksDB",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "sum by (job) (postgres_table_total_size_bytes)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "PostgresSQL",
+          "refId": "B"
+        }
+      ],
+      "title": "Total disk space usage",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "External Node",
+  "uid": "0",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/guides/external-node/docker-compose-examples/grafana/provisioning/dashboards/default.yml
+++ b/docs/guides/external-node/docker-compose-examples/grafana/provisioning/dashboards/default.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: 'Default'  # Name of the dashboard provider
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10  # How often Grafana will scan for changed dashboards
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/docs/guides/external-node/docker-compose-examples/grafana/provisioning/datasources/prometheus.yml
+++ b/docs/guides/external-node/docker-compose-examples/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/docs/guides/external-node/docker-compose-examples/mainnet-external-node-docker-compose.yml
+++ b/docs/guides/external-node/docker-compose-examples/mainnet-external-node-docker-compose.yml
@@ -1,12 +1,32 @@
 version: '3.2'
 services:
+  prometheus:
+    image: prom/prometheus:v2.35.0
+    volumes:
+      - mainnet-prometheus-data:/prometheus
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+  grafana:
+    image: grafana/grafana:9.3.6
+    volumes:
+      - mainnet-grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+    environment:
+      GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+    ports:
+      - "3000:3000"
+    expose:
+      - 3000
   postgres:
     image: "postgres:14"
     command: postgres -c 'max_connections=200'
     ports:
-      - 127.0.0.1:5432:5432
+      - "5432:5432"
     volumes:
-      - postgres:/var/lib/postgresql/data
+      - mainnet-postgres:/var/lib/postgresql/data
     healthcheck:
       interval: 1s
       timeout: 3s
@@ -19,8 +39,10 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    ports:
+      - "3322:3322"
     volumes:
-      - rocksdb:/db
+      - mainnet-rocksdb:/db
     expose:
       - 3060
       - 3061
@@ -32,6 +54,7 @@ services:
       EN_HTTP_PORT: 3060
       EN_WS_PORT: 3061
       EN_HEALTHCHECK_PORT: 3081
+      EN_PROMETHEUS_PORT: 3322
       EN_ETH_CLIENT_URL: https://ethereum-rpc.publicnode.com
       EN_MAIN_NODE_URL: https://zksync2-mainnet.zksync.io
       EN_L1_CHAIN_ID: 1
@@ -46,5 +69,7 @@ services:
       - --enable-snapshots-recovery
 
 volumes:
-  postgres: {}
-  rocksdb: {}
+  mainnet-postgres: {}
+  mainnet-rocksdb: {}
+  mainnet-prometheus-data: { }
+  mainnet-grafana-data: { }

--- a/docs/guides/external-node/docker-compose-examples/prometheus/prometheus.yml
+++ b/docs/guides/external-node/docker-compose-examples/prometheus/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 3s  # By default, scrape targets every 15 seconds.
+
+scrape_configs:
+  - job_name: 'external-node'
+    static_configs:
+      - targets: ['external-node:3322']

--- a/docs/guides/external-node/docker-compose-examples/testnet-external-node-docker-compose.yml
+++ b/docs/guides/external-node/docker-compose-examples/testnet-external-node-docker-compose.yml
@@ -1,12 +1,32 @@
 version: '3.2'
 services:
+  prometheus:
+    image: prom/prometheus:v2.35.0
+    volumes:
+      - testnet-prometheus-data:/prometheus
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+  grafana:
+    image: grafana/grafana:9.3.6
+    volumes:
+      - testnet-grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+    environment:
+      GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+    ports:
+      - "3000:3000"
+    expose:
+      - 3000
   postgres:
     image: "postgres:14"
     command: postgres -c 'max_connections=200'
     ports:
-      - 127.0.0.1:5432:5432
+      - "5432:5432"
     volumes:
-      - postgres:/var/lib/postgresql/data
+      - testnet-postgres:/var/lib/postgresql/data
     healthcheck:
       interval: 1s
       timeout: 3s
@@ -19,8 +39,10 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    ports:
+      - "3322:3322"
     volumes:
-      - rocksdb:/db
+      - testnet-rocksdb:/db
     expose:
       - 3060
       - 3061
@@ -32,6 +54,7 @@ services:
       EN_HTTP_PORT: 3060
       EN_WS_PORT: 3061
       EN_HEALTHCHECK_PORT: 3081
+      EN_PROMETHEUS_PORT: 3322
       EN_ETH_CLIENT_URL: https://ethereum-sepolia-rpc.publicnode.com
       EN_MAIN_NODE_URL: https://sepolia.era.zksync.dev
       EN_L1_CHAIN_ID: 11155111
@@ -46,5 +69,7 @@ services:
       - --enable-snapshots-recovery
 
 volumes:
-  postgres: {}
-  rocksdb: {}
+  testnet-postgres: {}
+  testnet-rocksdb: {}
+  testnet-prometheus-data: {}
+  testnet-grafana-data: {}


### PR DESCRIPTION
I've added prometheus and grafana do EN docker compose with a simple dashboard like this:
![image](https://github.com/matter-labs/zksync-era/assets/18558509/d1778855-cd0f-4b6d-b8a8-19a57a0f564d)
