### PR TITLE
fix(kl-factory): first init failing

### DIFF
--- a/infrastructure/zk/src/init.ts
+++ b/infrastructure/zk/src/init.ts
@@ -50,6 +50,12 @@ const initSetup = async ({
     runObservability,
     validiumMode
 }: InitSetupOptions): Promise<void> => {
+    if (!skipSubmodulesCheckout) {
+        await announced('Checkout submodules', submoduleUpdate());
+    }
+    if (validiumMode) {
+        await announced('Checkout era-contracts for Validium mode', validiumSubmoduleCheckout());
+    }
     if (!process.env.CI && !skipEnvSetup) {
         await announced('Pulling images', docker.pull());
         await announced('Checking environment', checkEnv());
@@ -57,15 +63,10 @@ const initSetup = async ({
         await announced('Create volumes', createVolumes());
         await announced('Setting up containers', up(runObservability));
     }
-    if (!skipSubmodulesCheckout) {
-        await announced('Checkout submodules', submoduleUpdate());
-    }
-    if (validiumMode) {
-        await announced('Checkout era-contracts for Validium mode', validiumSubmoduleCheckout());
-    }
+
+    await announced('Compiling JS packages', run.yarn());
 
     await Promise.all([
-        announced('Compiling JS packages', run.yarn()),
         announced('Building L1 L2 contracts', contract.build()),
         announced('Compile L2 system contracts', compiler.compileAll())
     ]);


### PR DESCRIPTION
## What ❔

Alter the order of the commands in the init script.

## Why ❔

The first init ran in the repo was failing because the contracts were being compiled before downloading the dependencies.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
