### PR TITLE
[EVM-Equivalent-YUL] Add some logic operators opcodes

### DIFF
--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -570,6 +570,62 @@ fn test_basic_exp_vectors() {
 }
 
 #[test]
+fn test_basic_signextend_vectors() {
+    // Here we just try to test some small EVM contracts and ensure that they work.
+    let mut expected_result: [u8; 32] = [0u8; 32];
+    hex::decode_to_slice(
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffb4da6c",
+        &mut expected_result,
+    )
+    .unwrap();
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push32 179,624,556
+                hex::decode("7F").unwrap(),
+                u256_to_h256(179_624_556.into()).0.to_vec(),
+                // push32 2
+                hex::decode("7F").unwrap(),
+                u256_to_h256(2.into()).0.to_vec(),
+                // signextend
+                hex::decode("0B").unwrap(),
+                // push32 0
+                hex::decode("7F").unwrap(),
+                H256::zero().0.to_vec(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        h256_to_u256(H256::from_slice(&expected_result))
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push32 179,624,556
+                hex::decode("7F").unwrap(),
+                u256_to_h256(179_624_556.into()).0.to_vec(),
+                // push32 3
+                hex::decode("7F").unwrap(),
+                u256_to_h256(3.into()).0.to_vec(),
+                // signextend
+                hex::decode("0B").unwrap(),
+                // push32 0
+                hex::decode("7F").unwrap(),
+                H256::zero().0.to_vec(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        179_624_556.into()
+    );
+}
+
+
+#[test]
 fn test_basic_lt_vectors() {
     // Here we just try to test some small EVM contracts and ensure that they work.
     assert_eq!(
@@ -770,61 +826,6 @@ fn test_basic_slt_vectors() {
             .concat()
         ),
         0.into()
-    );
-}
-
-#[test]
-fn test_basic_signextend_vectors() {
-    // Here we just try to test some small EVM contracts and ensure that they work.
-    let mut expected_result: [u8; 32] = [0u8; 32];
-    hex::decode_to_slice(
-        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffb4da6c",
-        &mut expected_result,
-    )
-    .unwrap();
-    assert_eq!(
-        test_evm_vector(
-            vec![
-                // push32 179,624,556
-                hex::decode("7F").unwrap(),
-                u256_to_h256(179_624_556.into()).0.to_vec(),
-                // push32 2
-                hex::decode("7F").unwrap(),
-                u256_to_h256(2.into()).0.to_vec(),
-                // signextend
-                hex::decode("0B").unwrap(),
-                // push32 0
-                hex::decode("7F").unwrap(),
-                H256::zero().0.to_vec(),
-                // sstore
-                hex::decode("55").unwrap(),
-            ]
-            .into_iter()
-            .concat()
-        ),
-        h256_to_u256(H256::from_slice(&expected_result))
-    );
-    assert_eq!(
-        test_evm_vector(
-            vec![
-                // push32 179,624,556
-                hex::decode("7F").unwrap(),
-                u256_to_h256(179_624_556.into()).0.to_vec(),
-                // push32 3
-                hex::decode("7F").unwrap(),
-                u256_to_h256(3.into()).0.to_vec(),
-                // signextend
-                hex::decode("0B").unwrap(),
-                // push32 0
-                hex::decode("7F").unwrap(),
-                H256::zero().0.to_vec(),
-                // sstore
-                hex::decode("55").unwrap(),
-            ]
-            .into_iter()
-            .concat()
-        ),
-        179_624_556.into()
     );
 }
 

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -570,6 +570,74 @@ fn test_basic_exp_vectors() {
 }
 
 #[test]
+fn test_basic_lt_vectors() {
+    // Here we just try to test some small EVM contracts and ensure that they work.
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 8
+                hex::decode("60").unwrap(),
+                hex::decode("08").unwrap(),
+                // push1 10
+                hex::decode("60").unwrap(),
+                hex::decode("0A").unwrap(),
+                // lt
+                hex::decode("10").unwrap(),
+                // push32 0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        0.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 24
+                hex::decode("60").unwrap(),
+                hex::decode("18").unwrap(),
+                // push1 10
+                hex::decode("60").unwrap(),
+                hex::decode("0A").unwrap(),
+                // lt
+                hex::decode("10").unwrap(),
+                // push32 0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        1.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 10
+                hex::decode("60").unwrap(),
+                hex::decode("0A").unwrap(),
+                // push1 10
+                hex::decode("60").unwrap(),
+                hex::decode("0A").unwrap(),
+                // lt
+                hex::decode("10").unwrap(),
+                // push32 0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        0.into()
+    );
+}
+
+#[test]
 fn test_basic_signextend_vectors() {
     // Here we just try to test some small EVM contracts and ensure that they work.
     let mut expected_result: [u8; 32] = [0u8; 32];

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -829,6 +829,74 @@ fn test_basic_slt_vectors() {
     );
 }
 
+#[test]
+fn test_basic_sgt_vectors() {
+    // Here we just try to test some small EVM contracts and ensure that they work.
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push32 -3
+                hex::decode("7F").unwrap(),
+                hex::decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD").unwrap(),
+                // push1 13
+                hex::decode("60").unwrap(),
+                hex::decode("0D").unwrap(),
+                // sgt
+                hex::decode("13").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        1.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 7
+                hex::decode("60").unwrap(),
+                hex::decode("07").unwrap(),
+                // push32 -8
+                hex::decode("7F").unwrap(),
+                hex::decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF8").unwrap(),
+                // sgt
+                hex::decode("13").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        0.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 50
+                hex::decode("60").unwrap(),
+                hex::decode("3C").unwrap(),
+                // push1 50
+                hex::decode("60").unwrap(),
+                hex::decode("3C").unwrap(),
+                // sgt
+                hex::decode("13").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        0.into()
+    );
+}
+
 fn assert_deployed_hash<H: HistoryMode>(
     tester: &mut VmTester<H>,
     address: Address,

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -624,7 +624,6 @@ fn test_basic_signextend_vectors() {
     );
 }
 
-
 #[test]
 fn test_basic_lt_vectors() {
     // Here we just try to test some small EVM contracts and ensure that they work.
@@ -769,7 +768,8 @@ fn test_basic_slt_vectors() {
             vec![
                 // push32 -3
                 hex::decode("7F").unwrap(),
-                hex::decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD").unwrap(),
+                hex::decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD")
+                    .unwrap(),
                 // push1 13
                 hex::decode("60").unwrap(),
                 hex::decode("0D").unwrap(),
@@ -793,7 +793,8 @@ fn test_basic_slt_vectors() {
                 hex::decode("07").unwrap(),
                 // push32 -8
                 hex::decode("7F").unwrap(),
-                hex::decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF8").unwrap(),
+                hex::decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF8")
+                    .unwrap(),
                 // slt
                 hex::decode("12").unwrap(),
                 // push0
@@ -837,7 +838,8 @@ fn test_basic_sgt_vectors() {
             vec![
                 // push32 -3
                 hex::decode("7F").unwrap(),
-                hex::decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD").unwrap(),
+                hex::decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD")
+                    .unwrap(),
                 // push1 13
                 hex::decode("60").unwrap(),
                 hex::decode("0D").unwrap(),
@@ -861,7 +863,8 @@ fn test_basic_sgt_vectors() {
                 hex::decode("07").unwrap(),
                 // push32 -8
                 hex::decode("7F").unwrap(),
-                hex::decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF8").unwrap(),
+                hex::decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF8")
+                    .unwrap(),
                 // sgt
                 hex::decode("13").unwrap(),
                 // push0
@@ -1002,6 +1005,53 @@ fn test_basic_iszero_vectors() {
             .concat()
         ),
         1.into()
+    );
+}
+
+#[test]
+fn test_basic_xor_vectors() {
+    // Here we just try to test some small EVM contracts and ensure that they work.
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 51
+                hex::decode("60").unwrap(),
+                hex::decode("33").unwrap(),
+                // push1 18
+                hex::decode("60").unwrap(),
+                hex::decode("12").unwrap(),
+                // xor
+                hex::decode("18").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        33.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 3
+                hex::decode("60").unwrap(),
+                hex::decode("03").unwrap(),
+                // push1 12
+                hex::decode("60").unwrap(),
+                hex::decode("0C").unwrap(),
+                // xor
+                hex::decode("18").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        15.into()
     );
 }
 

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -583,7 +583,7 @@ fn test_basic_lt_vectors() {
                 hex::decode("0A").unwrap(),
                 // lt
                 hex::decode("10").unwrap(),
-                // push32 0
+                // push0
                 hex::decode("5F").unwrap(),
                 // sstore
                 hex::decode("55").unwrap(),
@@ -604,7 +604,7 @@ fn test_basic_lt_vectors() {
                 hex::decode("0A").unwrap(),
                 // lt
                 hex::decode("10").unwrap(),
-                // push32 0
+                // push0
                 hex::decode("5F").unwrap(),
                 // sstore
                 hex::decode("55").unwrap(),
@@ -625,7 +625,75 @@ fn test_basic_lt_vectors() {
                 hex::decode("0A").unwrap(),
                 // lt
                 hex::decode("10").unwrap(),
-                // push32 0
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        0.into()
+    );
+}
+
+#[test]
+fn test_basic_gt_vectors() {
+    // Here we just try to test some small EVM contracts and ensure that they work.
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 4
+                hex::decode("60").unwrap(),
+                hex::decode("04").unwrap(),
+                // push1 13
+                hex::decode("60").unwrap(),
+                hex::decode("0D").unwrap(),
+                // gt
+                hex::decode("11").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        1.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 25
+                hex::decode("60").unwrap(),
+                hex::decode("19").unwrap(),
+                // push1 9
+                hex::decode("60").unwrap(),
+                hex::decode("09").unwrap(),
+                // gt
+                hex::decode("11").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        0.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 12
+                hex::decode("60").unwrap(),
+                hex::decode("0C").unwrap(),
+                // push1 12
+                hex::decode("60").unwrap(),
+                hex::decode("0C").unwrap(),
+                // lt
+                hex::decode("11").unwrap(),
+                // push0
                 hex::decode("5F").unwrap(),
                 // sstore
                 hex::decode("55").unwrap(),

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -1098,6 +1098,96 @@ fn test_basic_not_vectors() {
     );
 }
 
+#[test]
+fn test_basic_byte_vectors() {
+    // Here we just try to test some small EVM contracts and ensure that they work.
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 255
+                hex::decode("60").unwrap(),
+                hex::decode("FF").unwrap(),
+                // push1 31
+                hex::decode("60").unwrap(),
+                hex::decode("1F").unwrap(),
+                // byte
+                hex::decode("1A").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        255.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push2 A1FF
+                hex::decode("61").unwrap(),
+                hex::decode("A1FF").unwrap(),
+                // push1 30
+                hex::decode("60").unwrap(),
+                hex::decode("1E").unwrap(),
+                // byte
+                hex::decode("1A").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        161.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push32
+                hex::decode("7F").unwrap(),
+                hex::decode("B2FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
+                    .unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // byte
+                hex::decode("1A").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        178.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push32
+                hex::decode("7F").unwrap(),
+                hex::decode("B2FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
+                    .unwrap(),
+                // push1 32
+                hex::decode("60").unwrap(),
+                hex::decode("20").unwrap(),
+                // byte
+                hex::decode("1A").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        0.into()
+    );
+}
+
 fn assert_deployed_hash<H: HistoryMode>(
     tester: &mut VmTester<H>,
     address: Address,

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -1055,6 +1055,49 @@ fn test_basic_xor_vectors() {
     );
 }
 
+#[test]
+fn test_basic_not_vectors() {
+    // Here we just try to test some small EVM contracts and ensure that they work.
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push32 MAX
+                hex::decode("7F").unwrap(),
+                hex::decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
+                    .unwrap(),
+                // not
+                hex::decode("19").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        0.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push32
+                hex::decode("7F").unwrap(),
+                hex::decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFAA")
+                    .unwrap(),
+                // not
+                hex::decode("19").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        85.into()
+    );
+}
+
 fn assert_deployed_hash<H: HistoryMode>(
     tester: &mut VmTester<H>,
     address: Address,

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -965,6 +965,46 @@ fn test_basic_eq_vectors() {
     );
 }
 
+#[test]
+fn test_basic_iszero_vectors() {
+    // Here we just try to test some small EVM contracts and ensure that they work.
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 3
+                hex::decode("60").unwrap(),
+                hex::decode("03").unwrap(),
+                // iszero
+                hex::decode("15").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        0.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push0
+                hex::decode("5F").unwrap(),
+                // iszero
+                hex::decode("15").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        1.into()
+    );
+}
+
 fn assert_deployed_hash<H: HistoryMode>(
     tester: &mut VmTester<H>,
     address: Address,

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -691,8 +691,76 @@ fn test_basic_gt_vectors() {
                 // push1 12
                 hex::decode("60").unwrap(),
                 hex::decode("0C").unwrap(),
-                // lt
+                // gt
                 hex::decode("11").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        0.into()
+    );
+}
+
+#[test]
+fn test_basic_slt_vectors() {
+    // Here we just try to test some small EVM contracts and ensure that they work.
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push32 -3
+                hex::decode("7F").unwrap(),
+                hex::decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFD").unwrap(),
+                // push1 13
+                hex::decode("60").unwrap(),
+                hex::decode("0D").unwrap(),
+                // slt
+                hex::decode("12").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        0.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 7
+                hex::decode("60").unwrap(),
+                hex::decode("07").unwrap(),
+                // push32 -8
+                hex::decode("7F").unwrap(),
+                hex::decode("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF8").unwrap(),
+                // slt
+                hex::decode("12").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        1.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 50
+                hex::decode("60").unwrap(),
+                hex::decode("3C").unwrap(),
+                // push1 50
+                hex::decode("60").unwrap(),
+                hex::decode("3C").unwrap(),
+                // slt
+                hex::decode("12").unwrap(),
                 // push0
                 hex::decode("5F").unwrap(),
                 // sstore

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -897,6 +897,74 @@ fn test_basic_sgt_vectors() {
     );
 }
 
+#[test]
+fn test_basic_eq_vectors() {
+    // Here we just try to test some small EVM contracts and ensure that they work.
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 3
+                hex::decode("60").unwrap(),
+                hex::decode("03").unwrap(),
+                // push1 13
+                hex::decode("60").unwrap(),
+                hex::decode("0D").unwrap(),
+                // eq
+                hex::decode("14").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        0.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 7
+                hex::decode("60").unwrap(),
+                hex::decode("07").unwrap(),
+                // push1 8
+                hex::decode("60").unwrap(),
+                hex::decode("08").unwrap(),
+                // eq
+                hex::decode("14").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        0.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 50
+                hex::decode("60").unwrap(),
+                hex::decode("3C").unwrap(),
+                // push1 50
+                hex::decode("60").unwrap(),
+                hex::decode("3C").unwrap(),
+                // eq
+                hex::decode("14").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        1.into()
+    );
+}
+
 fn assert_deployed_hash<H: HistoryMode>(
     tester: &mut VmTester<H>,
     address: Address,


### PR DESCRIPTION
## What ❔

This PR adds `lt`, `gt`, `slt`, `sgt`, `eq`, `iszero`, `xor`, `not` and `byte` opcodes tests.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
