### PR TITLE
[EVM-Equivalent-Yul] Add mload, mstore and mstore8

### DIFF
--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -3,7 +3,7 @@ use std::{
     str::FromStr,
 };
 
-use ethabi::{encode, Contract, Token};
+use ethabi::{encode, ethereum_types::H264, Contract, Token};
 use itertools::Itertools;
 use tracing::{instrument::WithSubscriber, Instrument};
 // FIXME: 1.4.1 should not be imported from 1.5.0
@@ -754,6 +754,107 @@ fn test_basic_memory_vectors() {
             .concat()
         ),
         0.into()
+    );
+}
+
+#[test]
+fn test_basic_mstore8_vectors() {
+    // Here we just try to test some small EVM contracts and ensure that they work.
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push2 0xFFFF
+                hex::decode("61").unwrap(),
+                hex::decode("FFFF").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // mstore8
+                hex::decode("53").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // mload
+                hex::decode("51").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        h256_to_u256(
+            H256::from_str("FF00000000000000000000000000000000000000000000000000000000000000")
+                .unwrap()
+        )
+        .into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push2 0xAAFF
+                hex::decode("61").unwrap(),
+                hex::decode("AAFF").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // mstore8
+                hex::decode("53").unwrap(),
+                // push1 0xBB
+                hex::decode("60").unwrap(),
+                hex::decode("BB").unwrap(),
+                // push1 1
+                hex::decode("60").unwrap(),
+                hex::decode("01").unwrap(),
+                // mstore8
+                hex::decode("53").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // mload
+                hex::decode("51").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        h256_to_u256(
+            H256::from_str("FFBB000000000000000000000000000000000000000000000000000000000000")
+                .unwrap()
+        )
+        .into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push0
+                hex::decode("5F").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // mstore
+                hex::decode("52").unwrap(),
+                // push2 0xAABB
+                hex::decode("61").unwrap(),
+                hex::decode("AABB").unwrap(),
+                // push1 32
+                hex::decode("60").unwrap(),
+                hex::decode("20").unwrap(),
+                // mstore8
+                hex::decode("53").unwrap(),
+                // push1 1
+                hex::decode("60").unwrap(),
+                hex::decode("01").unwrap(),
+                // mload
+                hex::decode("51").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        187.into() // 0xBB
     );
 }
 

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -730,6 +730,31 @@ fn test_basic_memory_vectors() {
         ),
         0.into()
     );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 255
+                hex::decode("60").unwrap(),
+                hex::decode("FF").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // mstore
+                hex::decode("52").unwrap(),
+                // push1 64
+                hex::decode("60").unwrap(),
+                hex::decode("40").unwrap(),
+                // mload
+                hex::decode("51").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        0.into()
+    );
 }
 
 fn assert_deployed_hash<H: HistoryMode>(

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -653,6 +653,85 @@ fn test_basic_pop_vectors() {
     );
 }
 
+#[test]
+fn test_basic_memory_vectors() {
+    // Here we just try to test some small EVM contracts and ensure that they work.
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 255
+                hex::decode("60").unwrap(),
+                hex::decode("FF").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // mstore
+                hex::decode("52").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // mload
+                hex::decode("51").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        255.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 255
+                hex::decode("60").unwrap(),
+                hex::decode("FF").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // mstore
+                hex::decode("52").unwrap(),
+                // push1 2
+                hex::decode("60").unwrap(),
+                hex::decode("02").unwrap(),
+                // mload
+                hex::decode("51").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        16_711_680.into()
+    );
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 255
+                hex::decode("60").unwrap(),
+                hex::decode("FF").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // mstore
+                hex::decode("52").unwrap(),
+                // push1 32
+                hex::decode("60").unwrap(),
+                hex::decode("20").unwrap(),
+                // mload
+                hex::decode("51").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        0.into()
+    );
+}
+
 fn assert_deployed_hash<H: HistoryMode>(
     tester: &mut VmTester<H>,
     address: Address,

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -643,6 +643,32 @@ fn test_basic_signextend_vectors() {
     );
 }
 
+#[test]
+fn test_basic_pop_vectors() {
+    // Here we just try to test some small EVM contracts and ensure that they work.
+    assert_eq!(
+        test_evm_vector(
+            vec![
+                // push1 160
+                hex::decode("60").unwrap(),
+                hex::decode("A0").unwrap(),
+                // push1 31
+                hex::decode("60").unwrap(),
+                hex::decode("1F").unwrap(),
+                // pop
+                hex::decode("50").unwrap(),
+                // push0
+                hex::decode("5F").unwrap(),
+                // sstore
+                hex::decode("55").unwrap(),
+            ]
+            .into_iter()
+            .concat()
+        ),
+        160.into()
+    );
+}
+
 fn assert_deployed_hash<H: HistoryMode>(
     tester: &mut VmTester<H>,
     address: Address,


### PR DESCRIPTION
## What ❔

This PR adds `mload`, `mstore` and `mstore8` tests.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
