### PR TITLE
[EVM-Equivalent-YUL] Add tests for keccak256 opcode

### DIFF
--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -636,7 +636,7 @@ fn test_basic_keccak_vectors() {
             hex::decode("60").unwrap(),
             hex::decode("00").unwrap(),
             // mstore
-            hex::decode("0A").unwrap(),
+            hex::decode("52").unwrap(),
             // push1 4
             hex::decode("60").unwrap(),
             hex::decode("04").unwrap(),

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -627,7 +627,6 @@ fn test_basic_signextend_vectors() {
 #[test]
 fn test_basic_keccak_vectors() {
     // Here we just try to test some small EVM contracts and ensure that they work.
-    println!("KECCAK {:?}", H256(keccak256("FFFFFFFF".as_bytes())));
     let evm_vector = test_evm_vector(
         vec![
             // push32 0xFFFF_FFFF
@@ -655,8 +654,34 @@ fn test_basic_keccak_vectors() {
         .into_iter()
         .concat(),
     );
-    println!("evm_vector: {:?}", H256(evm_vector.into()));
-    assert_eq!(evm_vector, keccak256("FFFFFFFF".as_bytes()).into());
+    assert_eq!(
+        H256(evm_vector.into()),
+        H256(keccak256(&(0xFFFF_FFFFu32.to_le_bytes())))
+    );
+
+    let evm_vector = test_evm_vector(
+        vec![
+            // push1 4
+            hex::decode("60").unwrap(),
+            hex::decode("04").unwrap(),
+            // push1 0
+            hex::decode("60").unwrap(),
+            hex::decode("00").unwrap(),
+            // keccak256
+            hex::decode("20").unwrap(),
+            // push32 0
+            hex::decode("7F").unwrap(),
+            H256::zero().0.to_vec(),
+            // sstore
+            hex::decode("55").unwrap(),
+        ]
+        .into_iter()
+        .concat(),
+    );
+    assert_eq!(
+        H256(evm_vector.into()),
+        H256(keccak256(&(0x00000_00000u32.to_le_bytes())))
+    );
 }
 
 fn assert_deployed_hash<H: HistoryMode>(

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -631,7 +631,8 @@ fn test_basic_keccak_vectors() {
         vec![
             // push32 0xFFFF_FFFF
             hex::decode("7F").unwrap(),
-            u256_to_h256(0xFFFF_FFFFu32.into()).0.to_vec(),
+            hex::decode("FFFFFFFF00000000000000000000000000000000000000000000000000000000")
+                .unwrap(),
             // push1 0
             hex::decode("60").unwrap(),
             hex::decode("00").unwrap(),

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -5,7 +5,6 @@ use std::{
 
 use ethabi::{encode, Contract, Token};
 use itertools::Itertools;
-use tracing::{instrument::WithSubscriber, Instrument};
 // FIXME: 1.4.1 should not be imported from 1.5.0
 use zk_evm_1_4_1::sha2::{self};
 use zk_evm_1_5_0::zkevm_opcode_defs::{BlobSha256Format, VersionedHashLen32};
@@ -111,10 +110,8 @@ fn test_evm_vector(mut bytecode: Vec<u8>) -> U256 {
     );
 
     vm.vm.push_transaction(tx);
-
-    let debug_tracer = EvmDebugTracer::new();
-    let tracer_ptr = debug_tracer.into_tracer_pointer();
-    let tx_result = vm.vm.inspect(tracer_ptr.into(), VmExecutionMode::OneTx);
+    let tx_result: crate::vm_latest::VmExecutionResultAndLogs =
+        vm.vm.execute(VmExecutionMode::OneTx);
 
     assert!(
         !tx_result.result.is_failed(),
@@ -625,6 +622,46 @@ fn test_basic_signextend_vectors() {
         ),
         179_624_556.into()
     );
+}
+
+#[test]
+fn test_basic_keccak_vectors() {
+    // Here we just try to test some small EVM contracts and ensure that they work.
+    println!(
+        "KECCAK {:?}",
+        H256(keccak256(
+            "FFFFFFFF".as_bytes()
+        ))
+    );
+    let evm_vector = test_evm_vector(
+        vec![
+            // push32 0xFFFF_FFFF
+            hex::decode("7F").unwrap(),
+            u256_to_h256(0xFFFF_FFFFu32.into()).0.to_vec(),
+            // push1 0
+            hex::decode("60").unwrap(),
+            hex::decode("00").unwrap(),
+            // mstore
+            hex::decode("0A").unwrap(),
+            // push1 4
+            hex::decode("60").unwrap(),
+            hex::decode("04").unwrap(),
+            // push1 0
+            hex::decode("60").unwrap(),
+            hex::decode("00").unwrap(),
+            // keccak256
+            hex::decode("20").unwrap(),
+            // push32 0
+            hex::decode("7F").unwrap(),
+            H256::zero().0.to_vec(),
+            // sstore
+            hex::decode("55").unwrap(),
+        ]
+        .into_iter()
+        .concat(),
+    );
+    println!("evm_vector: {:?}", H256(evm_vector.into()));
+    assert_eq!(evm_vector, keccak256("FFFFFFFF".as_bytes()).into());
 }
 
 fn assert_deployed_hash<H: HistoryMode>(

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -627,12 +627,7 @@ fn test_basic_signextend_vectors() {
 #[test]
 fn test_basic_keccak_vectors() {
     // Here we just try to test some small EVM contracts and ensure that they work.
-    println!(
-        "KECCAK {:?}",
-        H256(keccak256(
-            "FFFFFFFF".as_bytes()
-        ))
-    );
+    println!("KECCAK {:?}", H256(keccak256("FFFFFFFF".as_bytes())));
     let evm_vector = test_evm_vector(
         vec![
             // push32 0xFFFF_FFFF


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Add tests for `keccak256` opcode.

Note: The `MSTORE` opcode has to be implemented in order to pass the first `assert` of the test. The second `assert` passes because the `keccak256` function is applied to the memory with an offset of 0 and length of 4 bytes, which is equal to 0x0000_0000, since no value was stored in memory.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
