### PR TITLE
fix(ci): Bump `release-please-action` to v4

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -4,6 +4,7 @@
   "bootstrap-sha": "691a7008f6d1f88fb9a5b6b8d92592e1199f37ea",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
+  "include-component-in-tag": true,
   "packages": {
       "core": {
         "release-type": "simple",

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,13 +17,11 @@ jobs:
     steps:
       - name: Run release-please
         id: release
-        uses: google-github-actions/release-please-action@v3
+        uses: google-github-actions/release-please-action@v4
         with:
             token: ${{ secrets.RELEASE_TOKEN }}
-            command: manifest
             config-file: .github/release-please/config.json
             manifest-file: .github/release-please/manifest.json
-            monorepo-tags: true
 
       - name: Send Release Info
         if: ${{ steps.release.outputs.releases_created }}


### PR DESCRIPTION
## What ❔

Fixes release-please config broken after #1584, by bumping the corresponding GitHub action.

## Why ❔

release-please shouldn't be broken.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).