### PR TITLE
fix(en): Fix DB pool for Postgres metrics on EN

### DIFF
--- a/core/lib/dal/src/metrics.rs
+++ b/core/lib/dal/src/metrics.rs
@@ -29,7 +29,7 @@ static POSTGRES_METRICS: vise::Global<PostgresMetrics> = vise::Global::new();
 
 impl PostgresMetrics {
     pub async fn run_scraping(pool: ConnectionPool<Core>, scrape_interval: Duration) {
-        let scrape_timeout = Duration::from_secs(1).min(scrape_interval / 2);
+        let scrape_timeout = Duration::from_secs(5).min(scrape_interval / 2);
         loop {
             match tokio::time::timeout(scrape_timeout, Self::scrape(&pool)).await {
                 Err(_) => {

--- a/core/node/node_framework/src/implementations/layers/house_keeper.rs
+++ b/core/node/node_framework/src/implementations/layers/house_keeper.rs
@@ -70,8 +70,8 @@ impl WiringLayer for HouseKeeperLayer {
         let prover_pool = prover_pool_resource.get().await?;
 
         // initialize and add tasks
-        let pool_for_metrics = replica_pool.clone();
-        context.add_task(Box::new(PoolForMetricsTask { pool_for_metrics }));
+        let pool_for_metrics = replica_pool_resource.get_singleton().await?;
+        context.add_task(Box::new(PostgresMetricsScrapingTask { pool_for_metrics }));
 
         let l1_batch_metrics_reporter = L1BatchMetricsReporter::new(
             self.house_keeper_config
@@ -184,18 +184,25 @@ impl WiringLayer for HouseKeeperLayer {
 }
 
 #[derive(Debug)]
-struct PoolForMetricsTask {
+struct PostgresMetricsScrapingTask {
     pool_for_metrics: ConnectionPool<Core>,
 }
 
 #[async_trait::async_trait]
-impl Task for PoolForMetricsTask {
+impl Task for PostgresMetricsScrapingTask {
     fn name(&self) -> &'static str {
-        "pool_for_metrics"
+        "postgres_metrics_scraping"
     }
 
-    async fn run(self: Box<Self>, _stop_receiver: StopReceiver) -> anyhow::Result<()> {
-        PostgresMetrics::run_scraping(self.pool_for_metrics, SCRAPE_INTERVAL).await;
+    async fn run(self: Box<Self>, mut stop_receiver: StopReceiver) -> anyhow::Result<()> {
+        tokio::select! {
+            () = PostgresMetrics::run_scraping(self.pool_for_metrics, SCRAPE_INTERVAL) => {
+                tracing::warn!("Postgres metrics scraping unexpectedly stopped");
+            }
+            _ = stop_receiver.0.changed() => {
+                tracing::info!("Stop signal received, Postgres metrics scraping is shutting down");
+            }
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## What ❔

Uses a singleton DB pool for scraping Postgres metrics instead of sharing the main pool.

## Why ❔

The main pool may be used at capacity (e.g., during snapshot recovery), which leads to timeouts collecting Postgres metrics.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.