### PR TITLE
[EVM-Equivalent-Yul] Add gas charge to lacking opcodes

### DIFF
--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -2193,7 +2193,6 @@ fn test_basic_pc_vectors() {
 
 #[test]
 fn test_basic_gas_vectors() {
-    // This test will fail when push1 charge gas. Reduce expected value by 3 units.
     assert_eq!(
         test_evm_vector(
             vec![
@@ -2211,13 +2210,12 @@ fn test_basic_gas_vectors() {
             .concat()
         ),
         U256::from_dec_str(
-            "115792089237316195423570985008687907853269984665640564039457584007913129639933"
+            "115792089237316195423570985008687907853269984665640564039457584007913129639930"
         )
         .unwrap()
         .into()
     );
 
-    // This test will fail when push1 charge gas. Reduce expected value by 12 units.
     assert_eq!(
         test_evm_vector(
             vec![
@@ -2246,7 +2244,7 @@ fn test_basic_gas_vectors() {
             .concat()
         ),
         U256::from_dec_str(
-            "115792089237316195423570985008687907853269984665640564039457584007913129639931"
+            "115792089237316195423570985008687907853269984665640564039457584007913129639919"
         )
         .unwrap()
         .into()


### PR DESCRIPTION
## What ❔

Fix tests about gas consumption as now `PUSH`n opcodes consume gas.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
