### PR TITLE
chore(docs): Dedup system requirements in EN docs

### DIFF
--- a/checks-config/era.dic
+++ b/checks-config/era.dic
@@ -47,6 +47,7 @@ f64
 k
 M
 kb
+Gbps
 50M
 2M
 130µs

--- a/docs/guides/external-node/00_quick_start.md
+++ b/docs/guides/external-node/00_quick_start.md
@@ -57,11 +57,12 @@ This configuration is approximate and should be considered as **minimal** requir
 - 32-core CPU
 - 64GB RAM
 - SSD storage (NVME recommended):
-  - Sepolia Testnet - 10GB EN + 50GB PostgreSQL (at the time of writing, will grow over time, so should be constantly monitored)
+  - Sepolia Testnet - 10GB EN + 50GB PostgreSQL (at the time of writing, will grow over time, so should be constantly
+    monitored)
   - Mainnet - 3TB EN + 7TB PostgreSQL (at the time of writing, will grow over time, so should be constantly monitored)
 - 100 Mbps connection (1 Gbps+ recommended)
 
 ## Advanced setup
 
-If you need monitoring, backups, to recover from DB dump/snapshot or a more customized PostgreSQL settings, etc, please see:
-[ansible-en-role repo](https://github.com/matter-labs/ansible-en-role)
+If you need monitoring, backups, to recover from DB dump/snapshot or a more customized PostgreSQL settings, etc, please
+see: [ansible-en-role repo](https://github.com/matter-labs/ansible-en-role)

--- a/docs/guides/external-node/00_quick_start.md
+++ b/docs/guides/external-node/00_quick_start.md
@@ -52,11 +52,16 @@ The HTTP JSON-RPC API can be accessed on port `3060` and WebSocket API can be ac
 
 ### System Requirements
 
-- 32 GB of RAM and a relatively modern CPU
-- 50GB of storage for testnet instance
-- 700GB of storage for mainnet instance
+This configuration is approximate and should be considered as *minimal* requirements.
+
+- 32-core CPU
+- 64GB RAM
+- SSD storage (NVME recommended):
+  - Sepolia Testnet - 10GB EN + 50GB PostgreSQL (at the time of writing, will grow over time, so should be constantly monitored)
+  - Mainnet - 3TB EN + 7TB PostgreSQL (at the time of writing, will grow over time, so should be constantly monitored)
+- 100 Mbps connection (1 Gbps+ recommended)
 
 ## Advanced setup
 
-If you need monitoring, backups, to recover from DB dump or a more customized postgres settings, etc, please see:
+If you need monitoring, backups, to recover from DB dump/snapshot or a more customized PostgreSQL settings, etc, please see:
 [ansible-en-role repo](https://github.com/matter-labs/ansible-en-role)

--- a/docs/guides/external-node/00_quick_start.md
+++ b/docs/guides/external-node/00_quick_start.md
@@ -52,7 +52,7 @@ The HTTP JSON-RPC API can be accessed on port `3060` and WebSocket API can be ac
 
 ### System Requirements
 
-This configuration is approximate and should be considered as *minimal* requirements.
+This configuration is approximate and should be considered as **minimal** requirements.
 
 - 32-core CPU
 - 64GB RAM

--- a/docs/guides/external-node/03_running.md
+++ b/docs/guides/external-node/03_running.md
@@ -9,7 +9,7 @@ This section assumes that you have prepared a configuration file as described on
 
 [**Minimal system requirements**](https://github.com/matter-labs/zksync-era/blob/main/docs/guides/external-node/00_quick_start.md#system-requirements)
 
-### A note about PostgreSQL storage
+## A note about PostgreSQL storage
 
 By far, the heaviest table to maintain is the `call_traces` table. This table is only required for the `debug`
 namespace. If you want to clear some space and aren't using the `debug` namespace, you can

--- a/docs/guides/external-node/03_running.md
+++ b/docs/guides/external-node/03_running.md
@@ -20,8 +20,7 @@ namespace. If you want to clear some space and aren't using the `debug` namespac
 
 ## Infrastructure
 
-Setting up Postgres is out of the scope of these docs, but the popular choice is to run it in Docker. There are many of
-guides on that, [here's one example](https://www.docker.com/blog/how-to-use-the-postgres-docker-official-image/).
+You need to set up a PostgreSQL server, however it is out of the scope of these docs, but the popular choice is to run it in Docker. There are many of guides on that, [here's one example](https://www.docker.com/blog/how-to-use-the-postgres-docker-official-image/). You can also refer to [configuration management blueprint](https://github.com/matter-labs/zksync-era/blob/main/docs/guides/external-node/00_quick_start.md#advanced-setup).
 
 Note however that if you run Postgres as a stand-alone Docker image (e.g. not in Docker-compose with a network shared
 between EN and Postgres), EN won't be able to access Postgres via `localhost` or `127.0.0.1` URLs. To make it work,

--- a/docs/guides/external-node/03_running.md
+++ b/docs/guides/external-node/03_running.md
@@ -20,15 +20,17 @@ namespace. If you want to clear some space and aren't using the `debug` namespac
 
 ## Infrastructure
 
-You need to set up a PostgreSQL server, however it is out of the scope of these docs, but the popular choice is to run it in Docker. There are many of guides on that, [here's one example](https://www.docker.com/blog/how-to-use-the-postgres-docker-official-image/). You can also refer to [configuration management blueprint](https://github.com/matter-labs/zksync-era/blob/main/docs/guides/external-node/00_quick_start.md#advanced-setup).
+You need to set up a PostgreSQL server, however it is out of the scope of these docs, but the popular choice is to run it in Docker. There are many of guides on that, [here's one example](https://www.docker.com/blog/how-to-use-the-postgres-docker-official-image/).
 
-Note however that if you run Postgres as a stand-alone Docker image (e.g. not in Docker-compose with a network shared
+Note however that if you run PostgresSQL as a stand-alone Docker image (e.g. not in Docker-compose with a network shared
 between EN and Postgres), EN won't be able to access Postgres via `localhost` or `127.0.0.1` URLs. To make it work,
 you'll have to either run it with a `--network host` (on Linux) or use `host.docker.internal` instead of `localhost` in
 the EN configuration ([official docs][host_docker_internal]).
 
 Besides running Postgres, you are expected to have a DB dump from a corresponding env. You can restore it using
 `pg_restore -O -C <DUMP_PATH> --dbname=<DB_URL>`.
+
+You can also refer to [configuration management blueprint](https://github.com/matter-labs/zksync-era/blob/main/docs/guides/external-node/00_quick_start.md#advanced-setup) for advanced DB instance configurations.
 
 [host_docker_internal](https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host)
 

--- a/docs/guides/external-node/03_running.md
+++ b/docs/guides/external-node/03_running.md
@@ -30,7 +30,7 @@ the EN configuration ([official docs][host_docker_internal]).
 Besides running Postgres, you are expected to have a DB dump from a corresponding env. You can restore it using
 `pg_restore -O -C <DUMP_PATH> --dbname=<DB_URL>`.
 
-You can also refer to [configuration management blueprint](https://github.com/matter-labs/zksync-era/blob/main/docs/guides/external-node/00_quick_start.md#advanced-setup) for advanced DB instance configurations.
+You can also refer to [External Node configuration management blueprint](https://github.com/matter-labs/zksync-era/blob/main/docs/guides/external-node/00_quick_start.md#advanced-setup) for advanced DB instance configurations.
 
 [host_docker_internal](https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host)
 

--- a/docs/guides/external-node/03_running.md
+++ b/docs/guides/external-node/03_running.md
@@ -7,17 +7,7 @@
 This section assumes that you have prepared a configuration file as described on the
 [previous page](./02_configuration.md).
 
-## Preferred hardware configuration
-
-This configuration is approximate, expect updates to these specs.
-
-- 32-core CPU
-- 64GB RAM
-- SSD storage:
-  - Testnet - ~800 GB (at the time of writing) and will grow over time, so should be constantly monitored
-  - Mainnet - ~400 GB (at the time of writing) and will grow over time, so should be constantly monitored
-  - NVMe recommended
-- 100 Mbps network connection.
+[**Minimal system requirements**](https://github.com/matter-labs/zksync-era/blob/main/docs/guides/external-node/00_quick_start.md#system-requirements)
 
 ### A note about PostgreSQL storage
 
@@ -29,11 +19,6 @@ namespace. If you want to clear some space and aren't using the `debug` namespac
   [example config](prepared_configs/mainnet-config.env).
 
 ## Infrastructure
-
-You need to set up a PostgreSQL server with SSD storage:
-
-- Testnet - ~1TB (at the time of writing) and will grow over time, so should be constantly monitored
-- Mainnet - ~2TB (at the time of writing) and will grow over time, so should be constantly monitored
 
 Setting up Postgres is out of the scope of these docs, but the popular choice is to run it in Docker. There are many of
 guides on that, [here's one example](https://www.docker.com/blog/how-to-use-the-postgres-docker-official-image/).

--- a/docs/guides/external-node/03_running.md
+++ b/docs/guides/external-node/03_running.md
@@ -20,7 +20,9 @@ namespace. If you want to clear some space and aren't using the `debug` namespac
 
 ## Infrastructure
 
-You need to set up a PostgreSQL server, however it is out of the scope of these docs, but the popular choice is to run it in Docker. There are many of guides on that, [here's one example](https://www.docker.com/blog/how-to-use-the-postgres-docker-official-image/).
+You need to set up a PostgreSQL server, however it is out of the scope of these docs, but the popular choice is to run
+it in Docker. There are many of guides on that,
+[here's one example](https://www.docker.com/blog/how-to-use-the-postgres-docker-official-image/).
 
 Note however that if you run PostgresSQL as a stand-alone Docker image (e.g. not in Docker-compose with a network shared
 between EN and Postgres), EN won't be able to access Postgres via `localhost` or `127.0.0.1` URLs. To make it work,
@@ -30,7 +32,9 @@ the EN configuration ([official docs][host_docker_internal]).
 Besides running Postgres, you are expected to have a DB dump from a corresponding env. You can restore it using
 `pg_restore -O -C <DUMP_PATH> --dbname=<DB_URL>`.
 
-You can also refer to [External Node configuration management blueprint](https://github.com/matter-labs/zksync-era/blob/main/docs/guides/external-node/00_quick_start.md#advanced-setup) for advanced DB instance configurations.
+You can also refer to
+[External Node configuration management blueprint](https://github.com/matter-labs/zksync-era/blob/main/docs/guides/external-node/00_quick_start.md#advanced-setup)
+for advanced DB instance configurations.
 
 [host_docker_internal](https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5404,7 +5404,7 @@ enhanced-resolve@^5.12.0:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
-enquirer@^2.3.0, enquirer@^2.3.5:
+enquirer@^2.3.0, enquirer@^2.3.5, enquirer@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.4.1.tgz#93334b3fbd74fc7097b224ab4a8fb7e40bf4ae56"
   integrity sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==


### PR DESCRIPTION
## What ❔

Dedups system requirements in External Node docs and makes them (hopefully) more clear

## Why ❔

Users are being confused by unclear system requirements mentioned in two different places in docs.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.
