### PR TITLE
fix(merkle_tree): don't panic in `BlockOutputWithProofs::verify_proofs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8720,6 +8720,7 @@ dependencies = [
 name = "zksync_merkle_tree"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "clap 4.4.6",
  "insta",

--- a/core/lib/merkle_tree/Cargo.toml
+++ b/core/lib/merkle_tree/Cargo.toml
@@ -17,6 +17,7 @@ zksync_storage.workspace = true
 zksync_prover_interface.workspace = true
 zksync_utils.workspace = true
 
+anyhow.workspace = true
 leb128.workspace = true
 once_cell.workspace = true
 rayon.workspace = true

--- a/core/lib/merkle_tree/tests/integration/merkle_tree.rs
+++ b/core/lib/merkle_tree/tests/integration/merkle_tree.rs
@@ -55,7 +55,9 @@ fn output_proofs_are_computed_correctly_on_empty_tree(kv_count: u64) {
 
     assert_eq!(output.root_hash(), Some(expected_hash));
     assert_eq!(output.logs.len(), instructions.len());
-    output.verify_proofs(&Blake2Hasher, empty_tree_hash, &instructions);
+    output
+        .verify_proofs(&Blake2Hasher, empty_tree_hash, &instructions)
+        .unwrap();
     let root_hash = output.root_hash().unwrap();
 
     let reads = instructions
@@ -64,7 +66,9 @@ fn output_proofs_are_computed_correctly_on_empty_tree(kv_count: u64) {
     let mut reads: Vec<_> = reads.collect();
     reads.shuffle(&mut rng);
     let output = tree.extend_with_proofs(reads.clone());
-    output.verify_proofs(&Blake2Hasher, root_hash, &reads);
+    output
+        .verify_proofs(&Blake2Hasher, root_hash, &reads)
+        .unwrap();
     assert_eq!(output.root_hash(), Some(root_hash));
 }
 
@@ -138,7 +142,9 @@ fn proofs_are_computed_correctly_for_mixed_instructions() {
         .iter()
         .any(|op| matches!(op.base, TreeLogEntry::Read { .. })));
 
-    output.verify_proofs(&Blake2Hasher, old_root_hash, &instructions);
+    output
+        .verify_proofs(&Blake2Hasher, old_root_hash, &instructions)
+        .unwrap();
     assert_eq!(output.root_hash(), Some(expected_hash));
 }
 
@@ -163,7 +169,9 @@ fn proofs_are_computed_correctly_for_missing_keys() {
         .filter(|op| matches!(op.base, TreeLogEntry::ReadMissingKey));
     assert_eq!(read_misses.count(), 30);
     let empty_tree_hash = Blake2Hasher.empty_subtree_hash(256);
-    output.verify_proofs(&Blake2Hasher, empty_tree_hash, &instructions);
+    output
+        .verify_proofs(&Blake2Hasher, empty_tree_hash, &instructions)
+        .unwrap();
 }
 
 fn test_intermediate_commits(db: &mut impl Database, chunk_size: usize) {
@@ -196,7 +204,9 @@ fn output_proofs_are_computed_correctly_with_intermediate_commits(chunk_size: us
     for chunk in kvs.chunks(chunk_size) {
         let instructions = convert_to_writes(chunk);
         let output = tree.extend_with_proofs(instructions.clone());
-        output.verify_proofs(&Blake2Hasher, root_hash, &instructions);
+        output
+            .verify_proofs(&Blake2Hasher, root_hash, &instructions)
+            .unwrap();
         root_hash = output.root_hash().unwrap();
     }
     assert_eq!(root_hash, *expected_hash);
@@ -390,12 +400,16 @@ fn proofs_are_computed_correctly_with_key_updates(updated_keys: usize) {
     let mut tree = MerkleTree::new(PatchSet::default());
     let output = tree.extend_with_proofs(old_instructions.clone());
     let empty_tree_hash = Blake2Hasher.empty_subtree_hash(256);
-    output.verify_proofs(&Blake2Hasher, empty_tree_hash, &old_instructions);
+    output
+        .verify_proofs(&Blake2Hasher, empty_tree_hash, &old_instructions)
+        .unwrap();
 
     let root_hash = output.root_hash().unwrap();
     let output = tree.extend_with_proofs(instructions.clone());
     assert_eq!(output.root_hash(), Some(*expected_hash));
-    output.verify_proofs(&Blake2Hasher, root_hash, &instructions);
+    output
+        .verify_proofs(&Blake2Hasher, root_hash, &instructions)
+        .unwrap();
 
     let keys: Vec<_> = kvs.iter().map(|entry| entry.key).collect();
     let proofs = tree.entries_with_proofs(1, &keys).unwrap();

--- a/core/lib/merkle_tree/tests/integration/recovery.rs
+++ b/core/lib/merkle_tree/tests/integration/recovery.rs
@@ -106,7 +106,9 @@ fn test_tree_after_recovery<DB: Database>(
         } else {
             let instructions = convert_to_writes(chunk);
             let output = tree.extend_with_proofs(instructions.clone());
-            output.verify_proofs(&Blake2Hasher, prev_root_hash, &instructions);
+            output
+                .verify_proofs(&Blake2Hasher, prev_root_hash, &instructions)
+                .unwrap();
             output.root_hash().unwrap()
         };
 


### PR DESCRIPTION
## What ❔

don't panic in `BlockOutputWithProofs::verify_proofs` and rather return a `Result`

## Why ❔

So  `BlockOutputWithProofs::verify_proofs` can be used by other components.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
