### PR TITLE
refactor(state-keeper): L1 batches seal timeout to use miniblocks timestamp instead of local time (BFT-340)

### DIFF
--- a/core/lib/config/src/configs/chain.rs
+++ b/core/lib/config/src/configs/chain.rs
@@ -92,7 +92,7 @@ pub struct StateKeeperConfig {
     /// The max number of slots for txs in a block before it should be sealed by the slots sealer.
     pub transaction_slots: usize,
 
-    /// Number of ms after which an L1 batch is going to be unconditionally sealed.
+    /// Number of ms after which an L1 batch is going to be sealed, checked against latest miniblock's timestamp.
     pub block_commit_deadline_ms: u64,
     /// Number of ms after which a miniblock should be sealed by the timeout sealer.
     pub miniblock_commit_deadline_ms: u64,

--- a/core/lib/zksync_core/src/state_keeper/io/mempool.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/mempool.rs
@@ -58,9 +58,8 @@ pub struct MempoolIO {
 }
 
 impl IoSealCriteria for MempoolIO {
-    fn should_seal_l1_batch_unconditionally(&mut self, manager: &UpdatesManager) -> bool {
-        self.timeout_sealer
-            .should_seal_l1_batch_unconditionally(manager)
+    fn should_seal_l1_batch(&mut self, manager: &UpdatesManager) -> bool {
+        self.timeout_sealer.should_seal_l1_batch(manager)
     }
 
     fn should_seal_miniblock(&mut self, manager: &UpdatesManager) -> bool {

--- a/core/lib/zksync_core/src/state_keeper/tests/tester.rs
+++ b/core/lib/zksync_core/src/state_keeper/tests/tester.rs
@@ -685,7 +685,7 @@ impl TestIO {
 }
 
 impl IoSealCriteria for TestIO {
-    fn should_seal_l1_batch_unconditionally(&mut self, manager: &UpdatesManager) -> bool {
+    fn should_seal_l1_batch(&mut self, manager: &UpdatesManager) -> bool {
         (self.l1_batch_seal_fn)(manager)
     }
 

--- a/core/lib/zksync_core/src/sync_layer/external_io.rs
+++ b/core/lib/zksync_core/src/sync_layer/external_io.rs
@@ -111,7 +111,7 @@ impl ExternalIO {
 }
 
 impl IoSealCriteria for ExternalIO {
-    fn should_seal_l1_batch_unconditionally(&mut self, _manager: &UpdatesManager) -> bool {
+    fn should_seal_l1_batch(&mut self, _manager: &UpdatesManager) -> bool {
         if !matches!(self.actions.peek_action(), Some(SyncAction::SealBatch)) {
             return false;
         }


### PR DESCRIPTION
## What ❔

Current L1 batches unconditional sealing are non-deterministic because it relies on timing-random checks of timeout against local time. 

This change tries to improve it a bit, by checking for timeout against latest miniblock's timestamp, instead of the local time, and so is conditional to the creation of new miniblocks.

## Why ❔

Reduce randomness in L1 batches sealing. 

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
