### PR TITLE
docs: fix the markdown link

### DIFF
--- a/docker/local-node/README.md
+++ b/docker/local-node/README.md
@@ -3,7 +3,8 @@
 This docker container is used for 'local-node' - the fast way to bring up the fully working system (similar to what you
 get by running `zk init`).
 
-You can find more instructions (and docker compose files) in [https://github.com/matter-labs/local-setup]
+You can find more instructions (and docker compose files) in the
+[zkSync local development setup repo](https://github.com/matter-labs/local-setup)
 
 This directory is more focused on 'creating' the image rather than using it.
 


### PR DESCRIPTION
## What ❔

fix a markdown link in documentation

## Why ❔

to make the linkchecker happy and nicely display the link

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
