### PR TITLE
Add preprocessor for evm interpreter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ cobertura.xml
 tags
 *.orig
 .direnv
+.envrc
 
 # Yarn files
 .yarn/

--- a/recompile_interpreter.sh
+++ b/recompile_interpreter.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -e
 
-zksolc contracts/system-contracts/contracts/EvmInterpreter.yul --optimization 3 --yul --bin --overwrite -o contracts/system-contracts/contracts-preprocessed/artifacts/
+preprocess -f contracts/system-contracts/contracts/EvmInterpreter.yul -d contracts/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+zksolc contracts/system-contracts/contracts/EvmInterpreterPreprocessed.yul --optimization 3 --yul --bin --overwrite -o contracts/system-contracts/contracts-preprocessed/artifacts/


### PR DESCRIPTION
## What ❔

Adds a preprocessor step in recompile_interpreter.sh in order to be able to use include on the EvmInterpreter.yul

Remember to run `npm install -g preprocess-cli-tool`

Related to the following PR: https://github.com/matter-labs/era-contracts/pull/377
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
