### PR TITLE
chore: fix local-setup link

### DIFF
--- a/docker/local-node/README.md
+++ b/docker/local-node/README.md
@@ -3,7 +3,7 @@
 This docker container is used for 'local-node' - the fast way to bring up the fully working system (similar to what you
 get by running `zk init`).
 
-You can find more instructions (and docker compose files) in [https://github.com/matter-labs/local-setup]
+You can find more instructions (and docker compose files) [here](https://github.com/matter-labs/local-setup)
 
 This directory is more focused on 'creating' the image rather than using it.
 


### PR DESCRIPTION
## What ❔

Makes local-setup link properly formatted

## Why ❔

Link checker has been failing with below for the last couple of days, e.g. [here](https://github.com/matter-labs/zksync-era/actions/runs/8749278699/job/24010671980?pr=1734)
```
FILE: ./docker/local-node/README.md
  [✖] https://github.com/matter-labs/local-setup%5D

  ERROR: 1 dead links found!

  1 links checked.
  [✖] https://github.com/matter-labs/local-setup%5D → Status: 404
```

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
