### PR TITLE
fix: ensure two connections for both executor and async catchup

### DIFF
--- a/core/lib/zksync_core/src/state_keeper/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/mod.rs
@@ -1,12 +1,9 @@
 use std::sync::Arc;
 
 use tokio::sync::watch;
-use zksync_config::{
-    configs::{
-        chain::{MempoolConfig, StateKeeperConfig},
-        wallets,
-    },
-    DBConfig,
+use zksync_config::configs::{
+    chain::{MempoolConfig, StateKeeperConfig},
+    wallets,
 };
 use zksync_dal::{ConnectionPool, Core};
 use zksync_types::L2ChainId;


### PR DESCRIPTION
## What ❔

Fixes recently discovered bug in v22.1.0 where executor and fee migration logic get starved out by async catch up task that holds a long-term connection.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
