### PR TITLE
fix(en): Revert using `liburing` for EN Docker image

### DIFF
--- a/docker/external-node/Dockerfile
+++ b/docker/external-node/Dockerfile
@@ -4,12 +4,11 @@ FROM matterlabs/zksync-build-base:latest as builder
 
 WORKDIR /usr/src/zksync
 COPY . .
-
-RUN cargo build --release --features=rocksdb/io-uring
+RUN cargo build --release
 
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y curl libpq5 ca-certificates liburing-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y curl libpq5 ca-certificates && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/src/zksync/target/release/zksync_external_node /usr/bin
 COPY --from=builder /usr/src/zksync/target/release/block_reverter /usr/bin


### PR DESCRIPTION
## What ❔

Removes `liburing` dependency in the EN image introduced in #1701.

## Why ❔

`liburing` doesn't lead to much performance improvement in practice, and it complicates using the EN executable outside Docker.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).