### PR TITLE
fix(types): Add LegacyMixedCall

### DIFF
--- a/core/lib/dal/src/models/storage_transaction.rs
+++ b/core/lib/dal/src/models/storage_transaction.rs
@@ -9,7 +9,7 @@ use zksync_types::{
     l2::TransactionType,
     protocol_upgrade::ProtocolUpgradeTxCommonData,
     transaction_request::PaymasterParams,
-    vm_trace::{Call, LegacyCall},
+    vm_trace::{Call, LegacyCall, LegacyMixedCall},
     web3::types::U64,
     Address, Bytes, Execute, ExecuteTransactionCommon, L1TxCommonData, L2ChainId, L2TxCommonData,
     Nonce, PackedEthSignature, PriorityOpId, ProtocolVersionId, Transaction, EIP_1559_TX_TYPE,
@@ -546,9 +546,14 @@ pub(crate) struct CallTrace {
 impl CallTrace {
     pub(crate) fn into_call(self, protocol_version: ProtocolVersionId) -> Call {
         if protocol_version.is_pre_1_5_0() {
-            let legacy_call_trace: LegacyCall = bincode::deserialize(&self.call_trace).unwrap();
-
-            legacy_call_trace.into()
+            if let Ok(legacy_call_trace) = bincode::deserialize::<LegacyCall>(&self.call_trace) {
+                legacy_call_trace.into()
+            } else {
+                let legacy_mixed_call_trace =
+                    bincode::deserialize::<LegacyMixedCall>(&self.call_trace)
+                        .expect("Failed to deserialize call trace");
+                legacy_mixed_call_trace.into()
+            }
         } else {
             bincode::deserialize(&self.call_trace).unwrap()
         }


### PR DESCRIPTION
## What ❔

Adds `LegacyMixedCall` struct

## Why ❔

Previous versions of the node saved such call traces, and they should be deserializable

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
