### PR TITLE
feat: Docker file with compilers for CI

### DIFF
--- a/.github/workflows/build-compiler-docker.yml
+++ b/.github/workflows/build-compiler-docker.yml
@@ -1,0 +1,41 @@
+name: Compilers - Build docker image with compiler binary
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Tag of a built image to deploy (latest2.0 by default)"
+        type: string
+        required: false
+        default: "latest2.0"
+
+jobs:
+  build-images:
+    name: Compilers - Build and Push Docker Image
+    runs-on: [matterlabs-ci-runner]
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
+        with:
+          submodules: "recursive"
+
+      - name: setup-env
+        run: |
+          echo ZKSYNC_HOME=$(pwd) >> $GITHUB_ENV
+          echo CI=1 >> $GITHUB_ENV
+          echo $(pwd)/bin >> $GITHUB_PATH
+          echo CI=1 >> .env
+          echo IN_DOCKER=1 >> .env
+
+      - name: init
+        run: |
+          ci_run git config --global --add safe.directory /usr/src/zksync
+          ci_run git config --global --add safe.directory /usr/src/zksync/contracts/system-contracts
+          ci_run git config --global --add safe.directory /usr/src/zksync/contracts
+
+          ci_run zk
+
+
+      - name: update-image
+        run: |
+          ci_run docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+          ci_run gcloud auth configure-docker us-docker.pkg.dev -q
+          ci_run zk docker push compilers --custom-tag ${{ inputs.image_tag }}

--- a/docker/compilers/Dockerfile
+++ b/docker/compilers/Dockerfile
@@ -24,6 +24,11 @@ RUN wget -nv -O $COMPILER_DIR/zksolc/compilerVersionInfo.json  "https://raw.gith
 # In the future, we should make it more automatic.
 RUN (for ver in v1.3.18 v1.3.21 v1.4.0 v1.4.1; do wget -nv -O $COMPILER_DIR/zksolc/zksolc-$ver  https://raw.githubusercontent.com/matter-labs/zksolc-bin/main/linux-amd64/zksolc-linux-amd64-musl-$ver; done) 
 
+# Special pre-release 1.5.0 compiler.
+# It can be removed once system-contracts/hardhatconfig.ts stops using it.
+RUN wget -nv -O $COMPILER_DIR/zksolc/zksolc-remote-4cad2deaa6801d7a419f1ed6503c999948b0d6d8.0 https://github.com/matter-labs/era-compiler-solidity/releases/download/prerelease-a167aa3-code4rena/zksolc-linux-amd64-musl-v1.5.0
+
+
 RUN wget -nv -O $COMPILER_DIR/zkvyper/compilerVersionInfo.json  "https://raw.githubusercontent.com/matter-labs/zkvyper-bin/main/version.json" 
 
 RUN (for ver in v1.3.13; do wget -nv -O $COMPILER_DIR/zkvyper/zkvyper-$ver  https://raw.githubusercontent.com/matter-labs/zkvyper-bin/main/linux-amd64/zkvyper-linux-amd64-musl-$ver; done) 

--- a/docker/compilers/Dockerfile
+++ b/docker/compilers/Dockerfile
@@ -1,0 +1,44 @@
+# This docker file contains all the compilers (zksolc, solc, zkvyper and vyper), that are used by our contracts.
+# Normally, hardhat would download them in the background, but this is causing CI issues, due to github traffic limiting.
+# So we put them all into the docker file instead.
+# In the current version, this docker file is managed manually (so if we decide to use a new compiler version, we have to add it below).
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y wget
+
+# This ./cache/hardhat-nodejs is coming from the env-paths module
+# that hardhat is using.
+ENV COMPILER_DIR=./.cache/hardhat-nodejs/compilers-v2
+RUN  mkdir -p $COMPILER_DIR/linux-amd64
+RUN  mkdir -p $COMPILER_DIR/vyper/linux
+RUN  mkdir -p $COMPILER_DIR/zksolc
+RUN  mkdir -p $COMPILER_DIR/zkvyper
+
+
+# Fetch latest compiler version
+RUN wget -nv -O $COMPILER_DIR/zksolc/compilerVersionInfo.json  "https://raw.githubusercontent.com/matter-labs/zksolc-bin/main/version.json" 
+
+
+# These are the versions that we currently have in hardhat.config.ts in zksync-era and era-contracts.
+# For now, if there is a new version of compiler, we'd have to modify this file.
+# In the future, we should make it more automatic.
+RUN (for ver in v1.3.18 v1.3.21 v1.4.0 v1.4.1; do wget -nv -O $COMPILER_DIR/zksolc/zksolc-$ver  https://raw.githubusercontent.com/matter-labs/zksolc-bin/main/linux-amd64/zksolc-linux-amd64-musl-$ver; done) 
+
+RUN wget -nv -O $COMPILER_DIR/zkvyper/compilerVersionInfo.json  "https://raw.githubusercontent.com/matter-labs/zkvyper-bin/main/version.json" 
+
+RUN (for ver in v1.3.13; do wget -nv -O $COMPILER_DIR/zkvyper/zkvyper-$ver  https://raw.githubusercontent.com/matter-labs/zkvyper-bin/main/linux-amd64/zkvyper-linux-amd64-musl-$ver; done) 
+
+
+# This matches VYPER_RELEASES_MIRROR_URL from hardhat-vyper
+RUN wget -nv -O $COMPILER_DIR/vyper/linux/list.json https://vyper-releases-mirror.hardhat.org/list.json
+
+# Currently we only use 0.3.10 release of vyper compiler (path taken from the list.json above)
+RUN wget -nv -O $COMPILER_DIR/vyper/linux/0.3.10 https://github.com/vyperlang/vyper/releases/download/v0.3.10/vyper.0.3.10%2Bcommit.91361694.linux
+
+
+# This matches COMPILER_REPOSITORY_URL from hardhat-core.
+RUN wget -nv -O $COMPILER_DIR/linux-amd64/list.json https://binaries.soliditylang.org/linux-amd64/list.json
+
+RUN (for ver in solc-linux-amd64-v0.8.20+commit.a1b79de6 solc-linux-amd64-v0.8.23+commit.f704f362 solc-linux-amd64-v0.8.24+commit.e11b9ed9; do \
+    wget -nv -O $COMPILER_DIR/linux-amd64/$ver https://binaries.soliditylang.org/linux-amd64/$ver; \
+    done)

--- a/infrastructure/zk/src/docker.ts
+++ b/infrastructure/zk/src/docker.ts
@@ -15,7 +15,8 @@ const IMAGES = [
     'witness-vector-generator',
     'prover-fri-gateway',
     'proof-fri-compressor',
-    'snapshots-creator'
+    'snapshots-creator',
+    'compilers'
 ];
 
 const DOCKER_REGISTRIES = ['us-docker.pkg.dev/matterlabs-infra/matterlabs-docker', 'matterlabs'];


### PR DESCRIPTION
## What ❔

* Docker file that contains all the current compilers that we use, so it can be used for CI.

## Why ❔

* Without it, CI sometimes tries to download images from github, which is flaky.
* in the next PRs, I'll start moving CI to use this docker image.

## Caveats
* For now, the list of versions is manually written in the Docker image. 