### PR TITLE
feat(Prover CLI): Batch proof compression job status

### DIFF
--- a/core/lib/basic_types/src/prover_dal.rs
+++ b/core/lib/basic_types/src/prover_dal.rs
@@ -1,7 +1,8 @@
 //! Types exposed by the prover DAL for general-purpose use.
 use std::{net::IpAddr, ops::Add, str::FromStr};
 
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Duration, NaiveDateTime, NaiveTime, Utc};
+use strum::{Display, EnumString};
 
 use crate::{basic_fri_types::AggregationRound, L1BatchNumber};
 
@@ -228,4 +229,34 @@ impl FromStr for GpuProverInstanceStatus {
             _ => Err(()),
         }
     }
+}
+
+#[derive(Debug, EnumString, Display)]
+pub enum ProofCompressionJobStatus {
+    #[strum(serialize = "queued")]
+    Queued,
+    #[strum(serialize = "in_progress")]
+    InProgress,
+    #[strum(serialize = "successful")]
+    Successful,
+    #[strum(serialize = "failed")]
+    Failed,
+    #[strum(serialize = "sent_to_server")]
+    SentToServer,
+    #[strum(serialize = "skipped")]
+    Skipped,
+}
+
+pub struct ProofCompressionJobInfo {
+    pub l1_batch_number: L1BatchNumber,
+    pub attempts: u32,
+    pub status: ProofCompressionJobStatus,
+    pub fri_proof_blob_url: Option<String>,
+    pub l1_proof_blob_url: Option<String>,
+    pub error: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+    pub processing_started_at: Option<NaiveDateTime>,
+    pub time_taken: Option<NaiveTime>,
+    pub picked_by: Option<String>,
 }

--- a/prover/prover_cli/src/commands/status/batch.rs
+++ b/prover/prover_cli/src/commands/status/batch.rs
@@ -61,7 +61,7 @@ async fn get_proof_compression_job_status_for_batch<'a>(
     conn: ConnectionPool<'a, Prover>,
 ) -> anyhow::Result<TaskStatus> {
     conn.fri_proof_compressor_dal()
-        .get_proof_compression_job_for_batch(L1BatchNumber(0))
+        .get_proof_compression_job_for_batch(batch_number)
         .await
         .map(|job| TaskStatus::from(job.status))
         .unwrap_or(TaskStatus::Custom("Compressor job not found 🚫".to_owned()))

--- a/prover/prover_cli/src/commands/status/utils.rs
+++ b/prover/prover_cli/src/commands/status/utils.rs
@@ -1,12 +1,11 @@
 use std::{collections::HashMap, fmt::Debug};
 
 use colored::*;
-use prover_dal::fri_proof_compressor_dal::ProofCompressionJobStatus;
 use strum::{Display, EnumString};
 use zksync_basic_types::{basic_fri_types::AggregationRound, prover_dal::JobCountStatistics};
 use zksync_config::PostgresConfig;
 use zksync_env_config::FromEnv;
-use zksync_types::L1BatchNumber;
+use zksync_types::{prover_dal::ProofCompressionJobStatus, L1BatchNumber};
 
 pub fn postgres_config() -> anyhow::Result<PostgresConfig> {
     Ok(PostgresConfig::from_env()?)

--- a/prover/prover_cli/src/commands/status/utils.rs
+++ b/prover/prover_cli/src/commands/status/utils.rs
@@ -184,7 +184,6 @@ impl Default for BatchData {
 pub enum TaskStatus {
     /// A custom status that can be set manually.
     /// Mostly used when a task has singular status.
-    #[strum(to_string = "{0}")]
     Custom(String),
     /// A task is considered queued when all of its jobs is queued.
     #[strum(to_string = "Queued 📥")]
@@ -273,6 +272,10 @@ impl Task {
 impl Debug for Task {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "-- {} --", self.to_string().bold())?;
-        writeln!(f, "> {}", self.status().to_string())
+        if let TaskStatus::Custom(msg) = self.status() {
+            writeln!(f, "> {msg}")
+        } else {
+            writeln!(f, "> {}", self.status().to_string())
+        }
     }
 }

--- a/prover/prover_cli/src/commands/status/utils.rs
+++ b/prover/prover_cli/src/commands/status/utils.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, fmt::Debug};
 
 use anyhow::ensure;
 use colored::*;
+use prover_dal::fri_proof_compressor_dal::ProofCompressionJobStatus;
 use strum::{Display, EnumString};
 use zksync_basic_types::{basic_fri_types::AggregationRound, prover_dal::JobCountStatistics};
 use zksync_config::PostgresConfig;
@@ -205,6 +206,21 @@ pub enum TaskStatus {
 impl Default for TaskStatus {
     fn default() -> Self {
         TaskStatus::WaitingForProofs
+    }
+}
+
+impl From<ProofCompressionJobStatus> for TaskStatus {
+    fn from(status: ProofCompressionJobStatus) -> Self {
+        match status {
+            ProofCompressionJobStatus::Queued => TaskStatus::Queued,
+            ProofCompressionJobStatus::InProgress => TaskStatus::InProgress,
+            ProofCompressionJobStatus::Successful => TaskStatus::Successful,
+            ProofCompressionJobStatus::Failed => TaskStatus::InProgress,
+            ProofCompressionJobStatus::SentToServer => {
+                TaskStatus::Custom("Sent to server 📤".to_owned())
+            }
+            ProofCompressionJobStatus::Skipped => TaskStatus::Custom("Skipped ⏩".to_owned()),
+        }
     }
 }
 

--- a/prover/prover_dal/.sqlx/query-2ab2f83b273c5aa88c1eefc8f70a8ea23052f714cd74c1d28ae1203ce8f0eaa9.json
+++ b/prover/prover_dal/.sqlx/query-2ab2f83b273c5aa88c1eefc8f70a8ea23052f714cd74c1d28ae1203ce8f0eaa9.json
@@ -1,0 +1,82 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                *\n            FROM\n                proof_compression_jobs_fri\n            WHERE\n                l1_batch_number = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "l1_batch_number",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "attempts",
+        "type_info": "Int2"
+      },
+      {
+        "ordinal": 2,
+        "name": "status",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "fri_proof_blob_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "l1_proof_blob_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "error",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 8,
+        "name": "processing_started_at",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 9,
+        "name": "time_taken",
+        "type_info": "Time"
+      },
+      {
+        "ordinal": 10,
+        "name": "picked_by",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "2ab2f83b273c5aa88c1eefc8f70a8ea23052f714cd74c1d28ae1203ce8f0eaa9"
+}

--- a/prover/prover_dal/src/fri_proof_compressor_dal.rs
+++ b/prover/prover_dal/src/fri_proof_compressor_dal.rs
@@ -318,7 +318,7 @@ impl FriProofCompressorDal<'_, '_> {
         &mut self,
         block_number: L1BatchNumber,
     ) -> Option<ProofCompressionJobInfo> {
-        let row = sqlx::query!(
+        sqlx::query!(
             r#"
             SELECT
                 *
@@ -331,24 +331,19 @@ impl FriProofCompressorDal<'_, '_> {
         )
         .fetch_optional(self.storage.conn())
         .await
-        .unwrap();
-
-        if let Some(row) = row {
-            Some(ProofCompressionJobInfo {
-                l1_batch_number: block_number,
-                attempts: row.attempts as u32,
-                status: ProofCompressionJobStatus::from_str(&row.status).unwrap(),
-                fri_proof_blob_url: row.fri_proof_blob_url,
-                l1_proof_blob_url: row.l1_proof_blob_url,
-                error: row.error,
-                created_at: row.created_at,
-                updated_at: row.updated_at,
-                processing_started_at: row.processing_started_at,
-                time_taken: row.time_taken,
-                picked_by: row.picked_by,
-            })
-        } else {
-            None
-        }
+        .unwrap()
+        .map(|row| ProofCompressionJobInfo {
+            l1_batch_number: block_number,
+            attempts: row.attempts as u32,
+            status: ProofCompressionJobStatus::from_str(&row.status).unwrap(),
+            fri_proof_blob_url: row.fri_proof_blob_url,
+            l1_proof_blob_url: row.l1_proof_blob_url,
+            error: row.error,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            processing_started_at: row.processing_started_at,
+            time_taken: row.time_taken,
+            picked_by: row.picked_by,
+        })
     }
 }

--- a/prover/prover_dal/src/fri_proof_compressor_dal.rs
+++ b/prover/prover_dal/src/fri_proof_compressor_dal.rs
@@ -1,7 +1,10 @@
 #![doc = include_str!("../doc/FriProofCompressorDal.md")]
 use std::{collections::HashMap, str::FromStr, time::Duration};
 
-use sqlx::Row;
+use sqlx::{
+    types::chrono::{NaiveDateTime, NaiveTime},
+    Row,
+};
 use strum::{Display, EnumString};
 use zksync_basic_types::{
     prover_dal::{JobCountStatistics, StuckJobs},
@@ -30,6 +33,20 @@ pub enum ProofCompressionJobStatus {
     SentToServer,
     #[strum(serialize = "skipped")]
     Skipped,
+}
+
+pub struct ProofCompressionJobInfo {
+    pub l1_batch_number: L1BatchNumber,
+    pub attempts: u32,
+    pub status: ProofCompressionJobStatus,
+    pub fri_proof_blob_url: Option<String>,
+    pub l1_proof_blob_url: Option<String>,
+    pub error: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+    pub processing_started_at: Option<NaiveDateTime>,
+    pub time_taken: Option<NaiveTime>,
+    pub picked_by: Option<String>,
 }
 
 impl FriProofCompressorDal<'_, '_> {
@@ -326,6 +343,44 @@ impl FriProofCompressorDal<'_, '_> {
                 attempts: row.attempts as u64,
             })
             .collect()
+        }
+    }
+
+    pub async fn get_proof_compression_job_for_batch(
+        &mut self,
+        block_number: L1BatchNumber,
+    ) -> Option<ProofCompressionJobInfo> {
+        let row = sqlx::query!(
+            r#"
+            SELECT
+                *
+            FROM
+                proof_compression_jobs_fri
+            WHERE
+                l1_batch_number = $1
+            "#,
+            i64::from(block_number.0)
+        )
+        .fetch_optional(self.storage.conn())
+        .await
+        .unwrap();
+
+        if let Some(row) = row {
+            Some(ProofCompressionJobInfo {
+                l1_batch_number: block_number,
+                attempts: row.attempts as u32,
+                status: ProofCompressionJobStatus::from_str(&row.status).unwrap(),
+                fri_proof_blob_url: row.fri_proof_blob_url,
+                l1_proof_blob_url: row.l1_proof_blob_url,
+                error: row.error,
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+                processing_started_at: row.processing_started_at,
+                time_taken: row.time_taken,
+                picked_by: row.picked_by,
+            })
+        } else {
+            None
         }
     }
 }

--- a/prover/prover_dal/src/fri_proof_compressor_dal.rs
+++ b/prover/prover_dal/src/fri_proof_compressor_dal.rs
@@ -1,13 +1,11 @@
 #![doc = include_str!("../doc/FriProofCompressorDal.md")]
 use std::{collections::HashMap, str::FromStr, time::Duration};
 
-use sqlx::{
-    types::chrono::{NaiveDateTime, NaiveTime},
-    Row,
-};
-use strum::{Display, EnumString};
+use sqlx::Row;
 use zksync_basic_types::{
-    prover_dal::{JobCountStatistics, StuckJobs},
+    prover_dal::{
+        JobCountStatistics, ProofCompressionJobInfo, ProofCompressionJobStatus, StuckJobs,
+    },
     L1BatchNumber,
 };
 use zksync_db_connection::connection::Connection;
@@ -17,36 +15,6 @@ use crate::{duration_to_naive_time, pg_interval_from_duration, Prover};
 #[derive(Debug)]
 pub struct FriProofCompressorDal<'a, 'c> {
     pub(crate) storage: &'a mut Connection<'c, Prover>,
-}
-
-#[derive(Debug, EnumString, Display)]
-pub enum ProofCompressionJobStatus {
-    #[strum(serialize = "queued")]
-    Queued,
-    #[strum(serialize = "in_progress")]
-    InProgress,
-    #[strum(serialize = "successful")]
-    Successful,
-    #[strum(serialize = "failed")]
-    Failed,
-    #[strum(serialize = "sent_to_server")]
-    SentToServer,
-    #[strum(serialize = "skipped")]
-    Skipped,
-}
-
-pub struct ProofCompressionJobInfo {
-    pub l1_batch_number: L1BatchNumber,
-    pub attempts: u32,
-    pub status: ProofCompressionJobStatus,
-    pub fri_proof_blob_url: Option<String>,
-    pub l1_proof_blob_url: Option<String>,
-    pub error: Option<String>,
-    pub created_at: NaiveDateTime,
-    pub updated_at: NaiveDateTime,
-    pub processing_started_at: Option<NaiveDateTime>,
-    pub time_taken: Option<NaiveTime>,
-    pub picked_by: Option<String>,
 }
 
 impl FriProofCompressorDal<'_, '_> {


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Handles the batch proof compression status for the `status batch` command.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

A user that will do maintenance on the prover could find useful to see the batch proof compression job status.

## Example

```
cd prover/prover_cli
zk f cargo run --release  status batch -n 1
```

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.
