### PR TITLE
fix(api): Fix extra DB connection acquisition during tx submission

### DIFF
--- a/core/lib/zksync_core/src/api_server/tx_sender/mod.rs
+++ b/core/lib/zksync_core/src/api_server/tx_sender/mod.rs
@@ -314,7 +314,7 @@ impl TxSender {
         stage_latency.observe();
 
         let stage_latency = SANDBOX_METRICS.submit_tx[&SubmitTxStage::DryRun].start();
-        let shared_args = self.shared_args().await;
+        let shared_args = self.shared_args().await?;
         let vm_permit = self.0.vm_concurrency_limiter.acquire().await;
         let vm_permit = vm_permit.ok_or(SubmitTxError::ServerShuttingDown)?;
         let block_args = BlockArgs::pending(&mut connection).await?;
@@ -406,10 +406,16 @@ impl TxSender {
         }
     }
 
-    async fn shared_args(&self) -> TxSharedArgs {
-        TxSharedArgs {
+    async fn shared_args(&self) -> anyhow::Result<TxSharedArgs> {
+        let fee_input = self
+            .0
+            .batch_fee_input_provider
+            .get_batch_fee_input()
+            .await
+            .context("cannot get batch fee input")?;
+        Ok(TxSharedArgs {
             operator_account: AccountTreeId::new(self.0.sender_config.fee_account_addr),
-            fee_input: self.0.batch_fee_input_provider.get_batch_fee_input().await,
+            fee_input,
             base_system_contracts: self.0.api_contracts.eth_call.clone(),
             caches: self.storage_caches(),
             validation_computational_gas_limit: self
@@ -418,7 +424,7 @@ impl TxSender {
                 .validation_computational_gas_limit,
             chain_id: self.0.sender_config.chain_id,
             whitelisted_tokens_for_aa: self.read_whitelisted_tokens_for_aa_cache().await,
-        }
+        })
     }
 
     async fn validate_tx(
@@ -439,7 +445,11 @@ impl TxSender {
             return Err(SubmitTxError::GasLimitIsTooBig);
         }
 
-        let fee_input = self.0.batch_fee_input_provider.get_batch_fee_input().await;
+        let fee_input = self
+            .0
+            .batch_fee_input_provider
+            .get_batch_fee_input()
+            .await?;
 
         // TODO (SMA-1715): do not subsidize the overhead for the transaction
 
@@ -676,25 +686,14 @@ impl TxSender {
         let max_gas_limit = get_max_batch_gas_limit(protocol_version.into());
         drop(connection);
 
-        let fee_input = {
-            // For now, both L1 gas price and pubdata price are scaled with the same coefficient
-            let fee_input = self
-                .0
-                .batch_fee_input_provider
-                .get_batch_fee_input_scaled(
-                    self.0.sender_config.gas_price_scale_factor,
-                    self.0.sender_config.gas_price_scale_factor,
-                )
-                .await;
-            adjust_pubdata_price_for_tx(
-                fee_input,
-                tx.gas_per_pubdata_byte_limit(),
-                // We do not have to adjust the params to the `gasPrice` of the transaction, since
-                // its gas price will be amended later on to suit the `fee_input`
-                None,
-                protocol_version.into(),
-            )
-        };
+        let fee_input = adjust_pubdata_price_for_tx(
+            self.scaled_batch_fee_input().await?,
+            tx.gas_per_pubdata_byte_limit(),
+            // We do not have to adjust the params to the `gasPrice` of the transaction, since
+            // its gas price will be amended later on to suit the `fee_input`
+            None,
+            protocol_version.into(),
+        );
 
         let (base_fee, gas_per_pubdata_byte) =
             derive_base_fee_and_gas_per_pubdata(fee_input, protocol_version.into());
@@ -910,6 +909,17 @@ impl TxSender {
         })
     }
 
+    // For now, both L1 gas price and pubdata price are scaled with the same coefficient
+    async fn scaled_batch_fee_input(&self) -> anyhow::Result<BatchFeeInput> {
+        self.0
+            .batch_fee_input_provider
+            .get_batch_fee_input_scaled(
+                self.0.sender_config.gas_price_scale_factor,
+                self.0.sender_config.gas_price_scale_factor,
+            )
+            .await
+    }
+
     pub(super) async fn eth_call(
         &self,
         block_args: BlockArgs,
@@ -923,7 +933,7 @@ impl TxSender {
             .executor
             .execute_tx_eth_call(
                 vm_permit,
-                self.shared_args().await,
+                self.shared_args().await?,
                 self.0.replica_connection_pool.clone(),
                 tx,
                 block_args,
@@ -942,14 +952,7 @@ impl TxSender {
         drop(connection);
 
         let (base_fee, _) = derive_base_fee_and_gas_per_pubdata(
-            // For now, both the L1 gas price and the L1 pubdata price are scaled with the same coefficient
-            self.0
-                .batch_fee_input_provider
-                .get_batch_fee_input_scaled(
-                    self.0.sender_config.gas_price_scale_factor,
-                    self.0.sender_config.gas_price_scale_factor,
-                )
-                .await,
+            self.scaled_batch_fee_input().await?,
             protocol_version.into(),
         );
         Ok(base_fee)

--- a/core/lib/zksync_core/src/api_server/tx_sender/tests.rs
+++ b/core/lib/zksync_core/src/api_server/tx_sender/tests.rs
@@ -1,13 +1,19 @@
 //! Tests for the transaction sender.
 
+use assert_matches::assert_matches;
+use multivm::interface::ExecutionResult;
 use zksync_config::configs::wallets::Wallets;
 use zksync_types::{get_nonce_key, L1BatchNumber, L2BlockNumber, StorageLog};
+use zksync_utils::u256_to_h256;
 
 use super::*;
 use crate::{
     api_server::execution_sandbox::{testonly::MockTransactionExecutor, VmConcurrencyBarrier},
     genesis::{insert_genesis_batch, GenesisParams},
-    utils::testonly::{create_l2_block, prepare_recovery_snapshot, MockBatchFeeParamsProvider},
+    utils::testonly::{
+        create_l2_block, create_l2_transaction, prepare_recovery_snapshot,
+        MockBatchFeeParamsProvider,
+    },
 };
 
 pub(crate) async fn create_test_tx_sender(
@@ -138,4 +144,52 @@ async fn getting_nonce_for_account_after_snapshot_recovery() {
     let missing_address = Address::repeat_byte(0xff);
     let nonce = tx_sender.get_expected_nonce(missing_address).await.unwrap();
     assert_eq!(nonce, Nonce(0));
+}
+
+#[tokio::test]
+async fn submitting_tx_requires_one_connection() {
+    let pool = ConnectionPool::<Core>::constrained_test_pool(1).await;
+    let mut storage = pool.connection().await.unwrap();
+    insert_genesis_batch(&mut storage, &GenesisParams::mock())
+        .await
+        .unwrap();
+
+    let l2_chain_id = L2ChainId::default();
+    let fee_input = MockBatchFeeParamsProvider::default()
+        .get_batch_fee_input_scaled(1.0, 1.0)
+        .await
+        .unwrap();
+    let (base_fee, gas_per_pubdata) =
+        derive_base_fee_and_gas_per_pubdata(fee_input, ProtocolVersionId::latest().into());
+    let tx = create_l2_transaction(base_fee, gas_per_pubdata);
+    let tx_hash = tx.hash();
+
+    // Manually set sufficient balance for the tx initiator.
+    let balance_key = storage_key_for_eth_balance(&tx.initiator_account());
+    let storage_log = StorageLog::new_write_log(balance_key, u256_to_h256(U256::one() << 64));
+    storage
+        .storage_logs_dal()
+        .append_storage_logs(L2BlockNumber(0), &[(H256::zero(), vec![storage_log])])
+        .await
+        .unwrap();
+    drop(storage);
+
+    let mut tx_executor = MockTransactionExecutor::default();
+    tx_executor.set_tx_responses(move |received_tx, _| {
+        assert_eq!(received_tx.hash(), tx_hash);
+        ExecutionResult::Success { output: vec![] }
+    });
+    let tx_executor = tx_executor.into();
+    let (tx_sender, _) = create_test_tx_sender(pool.clone(), l2_chain_id, tx_executor).await;
+
+    let submission_result = tx_sender.submit_tx(tx).await.unwrap();
+    assert_matches!(submission_result, L2TxSubmissionResult::Added);
+
+    let mut storage = pool.connection().await.unwrap();
+    storage
+        .transactions_web3_dal()
+        .get_transaction_by_hash(tx_hash, l2_chain_id)
+        .await
+        .unwrap()
+        .expect("transaction is not persisted");
 }

--- a/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/backend_jsonrpsee/namespaces/zks.rs
@@ -141,7 +141,9 @@ impl ZksNamespaceServer for ZksNamespace {
     }
 
     async fn get_l1_gas_price(&self) -> RpcResult<U64> {
-        Ok(self.get_l1_gas_price_impl().await)
+        self.get_l1_gas_price_impl()
+            .await
+            .map_err(|err| self.current_method().map_err(err))
     }
 
     async fn get_fee_params(&self) -> RpcResult<FeeParams> {

--- a/core/lib/zksync_core/src/api_server/web3/mod.rs
+++ b/core/lib/zksync_core/src/api_server/web3/mod.rs
@@ -367,36 +367,36 @@ impl ApiServer {
         let mut rpc = RpcModule::new(());
         if let Some(pub_sub) = pub_sub {
             rpc.merge(pub_sub.into_rpc())
-                .expect("Can't merge eth pubsub namespace");
+                .context("cannot merge eth pubsub namespace")?;
         }
 
+        if namespaces.contains(&Namespace::Debug) {
+            rpc.merge(DebugNamespace::new(rpc_state.clone()).await?.into_rpc())
+                .context("cannot merge debug namespace")?;
+        }
         if namespaces.contains(&Namespace::Eth) {
             rpc.merge(EthNamespace::new(rpc_state.clone()).into_rpc())
-                .expect("Can't merge eth namespace");
+                .context("cannot merge eth namespace")?;
         }
         if namespaces.contains(&Namespace::Net) {
             rpc.merge(NetNamespace::new(zksync_network_id).into_rpc())
-                .expect("Can't merge net namespace");
+                .context("cannot merge net namespace")?;
         }
         if namespaces.contains(&Namespace::Web3) {
             rpc.merge(Web3Namespace.into_rpc())
-                .expect("Can't merge web3 namespace");
+                .context("cannot merge web3 namespace")?;
         }
         if namespaces.contains(&Namespace::Zks) {
             rpc.merge(ZksNamespace::new(rpc_state.clone()).into_rpc())
-                .expect("Can't merge zks namespace");
+                .context("cannot merge zks namespace")?;
         }
         if namespaces.contains(&Namespace::En) {
             rpc.merge(EnNamespace::new(rpc_state.clone()).into_rpc())
-                .expect("Can't merge en namespace");
-        }
-        if namespaces.contains(&Namespace::Debug) {
-            rpc.merge(DebugNamespace::new(rpc_state.clone()).await.into_rpc())
-                .expect("Can't merge debug namespace");
+                .context("cannot merge en namespace")?;
         }
         if namespaces.contains(&Namespace::Snapshots) {
             rpc.merge(SnapshotsNamespace::new(rpc_state).into_rpc())
-                .expect("Can't merge snapshots namespace");
+                .context("cannot merge snapshots namespace")?;
         }
         Ok(rpc)
     }

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/debug.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/debug.rs
@@ -30,22 +30,23 @@ pub(crate) struct DebugNamespace {
 }
 
 impl DebugNamespace {
-    pub async fn new(state: RpcState) -> Self {
+    pub async fn new(state: RpcState) -> anyhow::Result<Self> {
         let api_contracts = ApiContracts::load_from_disk();
-        Self {
+        let fee_input_provider = &state.tx_sender.0.batch_fee_input_provider;
+        let batch_fee_input = fee_input_provider
+            .get_batch_fee_input_scaled(
+                state.api_config.estimate_gas_scale_factor,
+                state.api_config.estimate_gas_scale_factor,
+            )
+            .await
+            .context("cannot get batch fee input")?;
+
+        Ok(Self {
             // For now, the same scaling is used for both the L1 gas price and the pubdata price
-            batch_fee_input: state
-                .tx_sender
-                .0
-                .batch_fee_input_provider
-                .get_batch_fee_input_scaled(
-                    state.api_config.estimate_gas_scale_factor,
-                    state.api_config.estimate_gas_scale_factor,
-                )
-                .await,
+            batch_fee_input,
             state,
             api_contracts,
-        }
+        })
     }
 
     fn sender_config(&self) -> &TxSenderConfig {

--- a/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
+++ b/core/lib/zksync_core/src/api_server/web3/namespaces/zks.rs
@@ -465,16 +465,10 @@ impl ZksNamespace {
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn get_l1_gas_price_impl(&self) -> U64 {
-        let gas_price = self
-            .state
-            .tx_sender
-            .0
-            .batch_fee_input_provider
-            .get_batch_fee_input()
-            .await
-            .l1_gas_price();
-        gas_price.into()
+    pub async fn get_l1_gas_price_impl(&self) -> Result<U64, Web3Error> {
+        let fee_input_provider = &self.state.tx_sender.0.batch_fee_input_provider;
+        let fee_input = fee_input_provider.get_batch_fee_input().await?;
+        Ok(fee_input.l1_gas_price().into())
     }
 
     #[tracing::instrument(skip(self))]

--- a/core/lib/zksync_core/src/fee_model.rs
+++ b/core/lib/zksync_core/src/fee_model.rs
@@ -1,5 +1,6 @@
 use std::{fmt, sync::Arc};
 
+use anyhow::Context as _;
 use zksync_dal::{ConnectionPool, Core, CoreDal};
 use zksync_types::{
     fee_model::{
@@ -21,10 +22,10 @@ pub trait BatchFeeModelInputProvider: fmt::Debug + 'static + Send + Sync {
         &self,
         l1_gas_price_scale_factor: f64,
         l1_pubdata_price_scale_factor: f64,
-    ) -> BatchFeeInput {
+    ) -> anyhow::Result<BatchFeeInput> {
         let params = self.get_fee_model_params();
 
-        match params {
+        Ok(match params {
             FeeParams::V1(params) => BatchFeeInput::L1Pegged(compute_batch_fee_model_input_v1(
                 params,
                 l1_gas_price_scale_factor,
@@ -36,16 +37,18 @@ pub trait BatchFeeModelInputProvider: fmt::Debug + 'static + Send + Sync {
                     l1_pubdata_price_scale_factor,
                 ))
             }
-        }
-    }
-
-    /// Returns the batch fee input as-is, i.e. without any scaling for the L1 gas and pubdata prices.
-    async fn get_batch_fee_input(&self) -> BatchFeeInput {
-        self.get_batch_fee_input_scaled(1.0, 1.0).await
+        })
     }
 
     /// Returns the fee model parameters.
     fn get_fee_model_params(&self) -> FeeParams;
+}
+
+impl dyn BatchFeeModelInputProvider {
+    /// Returns the batch fee input as-is, i.e. without any scaling for the L1 gas and pubdata prices.
+    pub async fn get_batch_fee_input(&self) -> anyhow::Result<BatchFeeInput> {
+        self.get_batch_fee_input_scaled(1.0, 1.0).await
+    }
 }
 
 /// The struct that represents the batch fee input provider to be used in the main node of the server, i.e.
@@ -79,7 +82,7 @@ impl MainNodeFeeInputProvider {
     }
 }
 
-/// The fee model provider to be used in the API. It returns the maximal batch fee input between the projected main node one and
+/// The fee model provider to be used in the API. It returns the maximum batch fee input between the projected main node one and
 /// the one from the last sealed L2 block.
 #[derive(Debug)]
 pub(crate) struct ApiFeeInputProvider {
@@ -105,24 +108,23 @@ impl BatchFeeModelInputProvider for ApiFeeInputProvider {
         &self,
         l1_gas_price_scale_factor: f64,
         l1_pubdata_price_scale_factor: f64,
-    ) -> BatchFeeInput {
+    ) -> anyhow::Result<BatchFeeInput> {
         let inner_input = self
             .inner
             .get_batch_fee_input_scaled(l1_gas_price_scale_factor, l1_pubdata_price_scale_factor)
-            .await;
+            .await
+            .context("cannot get batch fee input from base provider")?;
         let last_l2_block_params = self
             .connection_pool
             .connection_tagged("api_fee_input_provider")
-            .await
-            .unwrap()
+            .await?
             .blocks_dal()
             .get_last_sealed_l2_block_header()
-            .await
-            .unwrap();
+            .await?;
 
-        last_l2_block_params
+        Ok(last_l2_block_params
             .map(|header| inner_input.stricter(header.batch_fee_input))
-            .unwrap_or(inner_input)
+            .unwrap_or(inner_input))
     }
 
     /// Returns the fee model parameters.

--- a/core/lib/zksync_core/src/state_keeper/io/mempool.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/mempool.rs
@@ -179,7 +179,9 @@ impl StateKeeperIO for MempoolIO {
                 self.batch_fee_input_provider.as_ref(),
                 protocol_version.into(),
             )
-            .await;
+            .await
+            .context("failed creating L2 transaction filter")?;
+
             if !self.mempool.has_next(&self.filter) {
                 tokio::time::sleep(self.delay_interval).await;
                 continue;

--- a/core/lib/zksync_core/src/state_keeper/io/tests/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/tests/mod.rs
@@ -111,7 +111,8 @@ async fn test_filter_with_no_pending_batch(deployment_mode: DeploymentMode) {
         &tester.create_batch_fee_input_provider().await,
         ProtocolVersionId::latest().into(),
     )
-    .await;
+    .await
+    .unwrap();
 
     // Create a mempool without pending batch and ensure that filter is not initialized just yet.
     let (mut mempool, mut guard) = tester.create_test_mempool_io(connection_pool).await;
@@ -160,7 +161,8 @@ async fn test_timestamps_are_distinct(
         &tester.create_batch_fee_input_provider().await,
         ProtocolVersionId::latest().into(),
     )
-    .await;
+    .await
+    .unwrap();
     tester.insert_tx(&mut guard, tx_filter.fee_per_gas, tx_filter.gas_per_pubdata);
 
     let l1_batch_params = mempool
@@ -402,7 +404,8 @@ async fn l2_block_processing_after_snapshot_recovery(deployment_mode: Deployment
         &tester.create_batch_fee_input_provider().await,
         ProtocolVersionId::latest().into(),
     )
-    .await;
+    .await
+    .unwrap();
     let tx = tester.insert_tx(
         &mut mempool_guard,
         tx_filter.fee_per_gas,

--- a/core/lib/zksync_core/src/state_keeper/mempool_actor.rs
+++ b/core/lib/zksync_core/src/state_keeper/mempool_actor.rs
@@ -21,15 +21,14 @@ use crate::{fee_model::BatchFeeModelInputProvider, utils::pending_protocol_versi
 pub async fn l2_tx_filter(
     batch_fee_input_provider: &dyn BatchFeeModelInputProvider,
     vm_version: VmVersion,
-) -> L2TxFilter {
-    let fee_input = batch_fee_input_provider.get_batch_fee_input().await;
-
+) -> anyhow::Result<L2TxFilter> {
+    let fee_input = batch_fee_input_provider.get_batch_fee_input().await?;
     let (base_fee, gas_per_pubdata) = derive_base_fee_and_gas_per_pubdata(fee_input, vm_version);
-    L2TxFilter {
+    Ok(L2TxFilter {
         fee_input,
         fee_per_gas: base_fee,
         gas_per_pubdata: gas_per_pubdata as u32,
-    }
+    })
 }
 
 #[derive(Debug)]
@@ -92,7 +91,8 @@ impl MempoolFetcher {
                 self.batch_fee_input_provider.as_ref(),
                 protocol_version.into(),
             )
-            .await;
+            .await
+            .context("failed creating L2 transaction filter")?;
 
             let transactions = storage
                 .transactions_dal()
@@ -221,8 +221,9 @@ mod tests {
         drop(storage);
 
         let mempool = MempoolGuard::new(PriorityOpId(0), 100);
-        let fee_params_provider = Arc::new(MockBatchFeeParamsProvider::default());
-        let fee_input = fee_params_provider.get_batch_fee_input().await;
+        let fee_params_provider: Arc<dyn BatchFeeModelInputProvider> =
+            Arc::new(MockBatchFeeParamsProvider::default());
+        let fee_input = fee_params_provider.get_batch_fee_input().await.unwrap();
         let (base_fee, gas_per_pubdata) =
             derive_base_fee_and_gas_per_pubdata(fee_input, ProtocolVersionId::latest().into());
 
@@ -279,8 +280,9 @@ mod tests {
         drop(storage);
 
         let mempool = MempoolGuard::new(PriorityOpId(0), 100);
-        let fee_params_provider = Arc::new(MockBatchFeeParamsProvider::default());
-        let fee_input = fee_params_provider.get_batch_fee_input().await;
+        let fee_params_provider: Arc<dyn BatchFeeModelInputProvider> =
+            Arc::new(MockBatchFeeParamsProvider::default());
+        let fee_input = fee_params_provider.get_batch_fee_input().await.unwrap();
         let (base_fee, gas_per_pubdata) =
             derive_base_fee_and_gas_per_pubdata(fee_input, ProtocolVersionId::latest().into());
 
@@ -320,8 +322,9 @@ mod tests {
         drop(storage);
 
         let mempool = MempoolGuard::new(PriorityOpId(0), 100);
-        let fee_params_provider = Arc::new(MockBatchFeeParamsProvider::default());
-        let fee_input = fee_params_provider.get_batch_fee_input().await;
+        let fee_params_provider: Arc<dyn BatchFeeModelInputProvider> =
+            Arc::new(MockBatchFeeParamsProvider::default());
+        let fee_input = fee_params_provider.get_batch_fee_input().await.unwrap();
         let (base_fee, gas_per_pubdata) =
             derive_base_fee_and_gas_per_pubdata(fee_input, ProtocolVersionId::latest().into());
 

--- a/core/lib/zksync_core/src/utils/testonly.rs
+++ b/core/lib/zksync_core/src/utils/testonly.rs
@@ -5,7 +5,7 @@ use multivm::utils::get_max_gas_per_pubdata_byte;
 use zksync_contracts::BaseSystemContractsHashes;
 use zksync_dal::{Connection, Core, CoreDal};
 use zksync_merkle_tree::{domain::ZkSyncTree, TreeInstruction};
-use zksync_system_constants::ZKPORTER_IS_AVAILABLE;
+use zksync_system_constants::{get_intrinsic_constants, ZKPORTER_IS_AVAILABLE};
 use zksync_types::{
     block::{L1BatchHeader, L2BlockHeader},
     commitment::{
@@ -110,7 +110,7 @@ pub(crate) fn l1_batch_metadata_to_commitment_artifacts(
 /// Creates an L2 transaction with randomized parameters.
 pub(crate) fn create_l2_transaction(fee_per_gas: u64, gas_per_pubdata: u64) -> L2Tx {
     let fee = Fee {
-        gas_limit: 1000_u64.into(),
+        gas_limit: (get_intrinsic_constants().l2_tx_intrinsic_gas * 2).into(),
         max_fee_per_gas: fee_per_gas.into(),
         max_priority_fee_per_gas: 0_u64.into(),
         gas_per_pubdata_limit: gas_per_pubdata.into(),


### PR DESCRIPTION
## What ❔

Currently, `TxSender::submit_tx()` on the main node acquires 2 DB connections at the same time: one explicitly, and another in batch fee input provider. This PR eliminates this.

Also, propagates errors in batch fee input provider, so that they don't lead to panics.

## Why ❔

Holding multiple DB connections at the same time can lead to connection starvation, or at worst case (temporary) deadlocks.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.