### PR TITLE
[EVM-Equivalent-YUL] Benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ go_to_env.sh
 server_logs.txt
 
 core/lib/storage/.env
+/core/lib/multivm/benchmarks
 
 .zcli-config.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ go_to_env.sh
 server_logs.txt
 
 core/lib/storage/.env
-/core/lib/multivm/benchmarks
+/core/lib/multivm/benchmarks/*.csv
 
 .zcli-config.json
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,6 +1734,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,10 +3901,12 @@ dependencies = [
  "circuit_sequencer_api 0.1.40",
  "circuit_sequencer_api 0.1.41",
  "circuit_sequencer_api 0.1.42",
+ "csv",
  "ethabi",
  "hex",
  "itertools 0.10.5",
  "once_cell",
+ "serde",
  "thiserror",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3897,6 +3897,7 @@ name = "multivm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "circuit_sequencer_api 0.1.0",
  "circuit_sequencer_api 0.1.40",
  "circuit_sequencer_api 0.1.41",

--- a/core/lib/contracts/src/lib.rs
+++ b/core/lib/contracts/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
 use std::{
+    env,
     fs::{self, File},
     path::{Path, PathBuf},
 };
@@ -15,7 +16,6 @@ use ethabi::{
 };
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use std::env;
 use zksync_utils::{bytecode::hash_bytecode, bytes_to_be_words};
 
 pub mod test_contracts;

--- a/core/lib/contracts/src/lib.rs
+++ b/core/lib/contracts/src/lib.rs
@@ -15,6 +15,7 @@ use ethabi::{
 };
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use std::env;
 use zksync_utils::{bytecode::hash_bytecode, bytes_to_be_words};
 
 pub mod test_contracts;
@@ -299,9 +300,16 @@ impl BaseSystemContracts {
 
         // FIXME: this part can get changed in API more often than e.g. default account especially when optimizations are used, etc.
         // so it is better to rely on more dynamic value instead of disk value
-        let evm_simulator_bytecode =
-            // read_sys_contract_bytecode("", "EvmInterpreter", ContractLanguage::Sol);
-            read_sys_contract_bytecode("", "EvmInterpreterPreprocessed", ContractLanguage::Yul);
+
+        let evm_simulator_bytecode;
+        let evm_simulator_version = env::var("EVM_SIMULATOR").unwrap_or_else(|_| "yul".to_string());
+        if evm_simulator_version.to_lowercase() == "yul" {
+            evm_simulator_bytecode =
+                read_sys_contract_bytecode("", "EvmInterpreterPreprocessed", ContractLanguage::Yul);
+        } else {
+            evm_simulator_bytecode =
+                read_sys_contract_bytecode("", "EvmInterpreter", ContractLanguage::Sol);
+        }
         let evm_simulator_hash = hash_bytecode(&evm_simulator_bytecode);
         let evm_simulator = SystemContractCode {
             code: bytes_to_be_words(evm_simulator_bytecode),

--- a/core/lib/multivm/Cargo.toml
+++ b/core/lib/multivm/Cargo.toml
@@ -44,3 +44,4 @@ ethabi = "18.0.0"
 zksync_eth_signer = { path = "../eth_signer" }
 serde = { version = "1.0", features = ["derive"] }
 csv = "1.3.0"
+chrono = "0.4"

--- a/core/lib/multivm/Cargo.toml
+++ b/core/lib/multivm/Cargo.toml
@@ -42,3 +42,5 @@ tokio = { version = "1", features = ["time"] }
 zksync_test_account = { path = "../../tests/test_account" }
 ethabi = "18.0.0"
 zksync_eth_signer = { path = "../eth_signer" }
+serde = { version = "1.0", features = ["derive"] }
+csv = "1.3.0"

--- a/core/lib/multivm/benchmarks/compare_benchmarks.py
+++ b/core/lib/multivm/benchmarks/compare_benchmarks.py
@@ -1,0 +1,62 @@
+import csv
+import sys
+
+# ANSI color codes
+COLOR_RED = '\033[91m'
+COLOR_GREEN = '\033[92m'
+COLOR_YELLOW = '\033[93m'
+COLOR_BLUE = '\033[94m'
+COLOR_MAGENTA = '\033[95m'
+COLOR_CYAN = '\033[96m'
+COLOR_RESET = '\033[0m'  # Reset to default color
+
+def print_colored(text, color):
+    # Print text in the specified color
+    print(color + text + COLOR_RESET)
+
+def compare_benchmarks(filename1,filename2):
+    file1_data = get_file_data(filename1)
+    file2_data = get_file_data(filename2)
+
+    for name in file1_data:
+        if name in file2_data:
+            print_colored(f'{name}', COLOR_CYAN)
+            print(f'Used zkevm ergs: {file1_data[name][0]}, {file2_data[name][0]}, ',end='') 
+            print_colored(f'{(file1_data[name][0] - file2_data[name][0]) / file1_data[name][0] * 100} %', COLOR_RED if file1_data[name][0] < file2_data[name][0] else COLOR_GREEN)
+            print(f'Used evm gas: {file1_data[name][1]}, {file2_data[name][1]}, ',end='') 
+            print_colored(f'{(file1_data[name][1] - file2_data[name][1]) / file1_data[name][1] * 100} %', COLOR_RED if file1_data[name][1] < file2_data[name][1] else COLOR_GREEN)
+            print(f'Used circuits: {file1_data[name][2]}, {file2_data[name][2]}, ',end='') 
+            print_colored(f'{(file1_data[name][2] - file2_data[name][2]) / file1_data[name][2] * 100} %', COLOR_RED if file1_data[name][2] < file2_data[name][2] else COLOR_GREEN)
+            print()
+        else:
+            print_colored(f'{name} is not in {filename2}', COLOR_RED)
+            print()
+
+    for name in file2_data:
+        if name not in file1_data:
+            print_colored(f'{name} is not in {filename1}', COLOR_RED)
+            print()
+
+def get_file_data(filename):
+    with open(filename, newline='') as file:
+        file_data = {}
+        reader = csv.DictReader(file)
+        for row in reader:
+            # Access the values of each column using the column names
+            name = row['name']
+            used_zkevm_ergs = int(row['used_zkevm_ergs'])
+            used_evm_gas = int(row['used_evm_gas'])
+            used_circuits = float(row['used_circuits'])
+            file_data[name] = (used_zkevm_ergs, used_evm_gas, used_circuits)
+    return file_data
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: python compare_benchmarks.py <file1.csv> <file2.csv>")
+        return
+    compare_benchmarks(sys.argv[1],sys.argv[2])
+
+main()
+    
+
+

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -7,11 +7,12 @@ use std::{
     str::FromStr,
 };
 
+// FIXME: 1.4.1 should not be imported from 1.5.0
+use chrono::{Datelike, Timelike, Utc};
 use csv::{ReaderBuilder, Writer, WriterBuilder};
 use ethabi::{encode, ethereum_types::H264, Contract, Token};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-// FIXME: 1.4.1 should not be imported from 1.5.0
 use zk_evm_1_4_1::sha2::{self};
 use zk_evm_1_5_0::zkevm_opcode_defs::{BlobSha256Format, VersionedHashLen32};
 use zksync_contracts::{load_contract, read_bytecode, read_evm_bytecode};
@@ -4301,22 +4302,16 @@ fn perform_opcode_benchmark(params: EVMOpcodeBenchmarkParams) -> EVMOpcodeBenchm
 
 fn start_benchmark() -> Result<String, Box<dyn std::error::Error>> {
     let evm_version = env::var("EVM_SIMULATOR").unwrap_or_else(|_| "yul".to_string());
-    let seconds_since_epoch = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-    let days = seconds_since_epoch / (24 * 3600);
-    let hours = (seconds_since_epoch % (24 * 3600)) / 3600;
-    let minutes = (seconds_since_epoch % 3600) / 60;
-    let seconds = seconds_since_epoch % 60;
+    let now = Utc::now();
+    let year = now.year();
+    let month = now.month();
+    let day = now.day();
+    let hour = now.hour();
+    let minute = now.minute();
+    let second = now.second();
     let formatted_time = format!(
         "{:04}-{:02}-{:02}-{:02}-{:02}-{:02}",
-        1970 + days as i32 / 365,
-        1 + (days as i32 % 365) / 30,
-        1 + (days as i32 % 365) % 30,
-        hours,
-        minutes,
-        seconds
+        year, month, day, hour, minute, second
     );
     let directory_path = format!("benchmarks");
     if !std::fs::metadata(&directory_path).is_ok() {

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -1,10 +1,16 @@
 use std::{
+    env,
+    error::Error,
+    fs::{File, OpenOptions},
+    io::{prelude::*, Seek, SeekFrom},
     ops::{Div, Sub},
     str::FromStr,
 };
 
+use csv::{ReaderBuilder, Writer, WriterBuilder};
 use ethabi::{encode, ethereum_types::H264, Contract, Token};
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 // FIXME: 1.4.1 should not be imported from 1.5.0
 use zk_evm_1_4_1::sha2::{self};
 use zk_evm_1_5_0::zkevm_opcode_defs::{BlobSha256Format, VersionedHashLen32};
@@ -42,12 +48,6 @@ use crate::{
     vm_m5::storage::Storage,
     HistoryMode,
 };
-use csv::{ReaderBuilder, Writer, WriterBuilder};
-use serde::{Deserialize, Serialize};
-use std::env;
-use std::error::Error;
-use std::fs::{File, OpenOptions};
-use std::io::{prelude::*, Seek, SeekFrom};
 const CONTRACT_ADDRESS: &str = "0xde03a0B5963f75f1C8485B355fF6D30f3093BDE7";
 
 fn insert_evm_contract(storage: &mut InMemoryStorage, mut bytecode: Vec<u8>) -> Address {

--- a/core/lib/types/src/system_contracts.rs
+++ b/core/lib/types/src/system_contracts.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 use once_cell::sync::Lazy;
 use zksync_basic_types::{AccountTreeId, Address, H256, U256};
@@ -17,8 +17,6 @@ use crate::{
     L2_ETH_TOKEN_ADDRESS, MSG_VALUE_SIMULATOR_ADDRESS, NONCE_HOLDER_ADDRESS,
     SHA256_PRECOMPILE_ADDRESS, SYSTEM_CONTEXT_ADDRESS,
 };
-
-use std::env;
 
 // Note, that in the `NONCE_HOLDER_ADDRESS` storage the nonces of accounts
 // are stored in the following form:

--- a/core/lib/types/src/system_contracts.rs
+++ b/core/lib/types/src/system_contracts.rs
@@ -18,6 +18,8 @@ use crate::{
     SHA256_PRECOMPILE_ADDRESS, SYSTEM_CONTEXT_ADDRESS,
 };
 
+use std::env;
+
 // Note, that in the `NONCE_HOLDER_ADDRESS` storage the nonces of accounts
 // are stored in the following form:
 // `2^128 * deployment_nonce + tx_nonce`,
@@ -176,12 +178,20 @@ static SYSTEM_CONTRACTS: Lazy<Vec<DeployedContract>> = Lazy::new(|| {
 });
 
 static EVM_INTERPRETER_HASH: Lazy<H256> = Lazy::new(|| {
-    hash_bytecode(&read_sys_contract_bytecode(
-        "",
-        "EvmInterpreterPreprocessed",
-        // ContractLanguage::Sol,
-        ContractLanguage::Yul,
-    ))
+    let evm_simulator_version = env::var("EVM_SIMULATOR").unwrap_or_else(|_| "yul".to_string());
+    if evm_simulator_version.to_lowercase() == "yul" {
+        hash_bytecode(&read_sys_contract_bytecode(
+            "",
+            "EvmInterpreterPreprocessed",
+            ContractLanguage::Yul,
+        ))
+    } else {
+        hash_bytecode(&read_sys_contract_bytecode(
+            "",
+            "EvmInterpreter",
+            ContractLanguage::Sol,
+        ))
+    }
 });
 
 /// Gets default set of system contracts, based on ZKSYNC_HOME environment variable.

--- a/core/lib/zksync_core/src/genesis.rs
+++ b/core/lib/zksync_core/src/genesis.rs
@@ -2,6 +2,8 @@
 //! It initializes the Merkle tree with the basic setup (such as fields of special service accounts),
 //! setups the required databases, and outputs the data required to initialize a smart contract.
 
+use std::env;
+
 use anyhow::Context as _;
 use multivm::{
     circuit_sequencer_api_latest::sort_storage_access::sort_storage_access_queries,
@@ -10,7 +12,6 @@ use multivm::{
         LogQuery as MultiVmLogQuery, Timestamp as MultiVMTimestamp,
     },
 };
-use std::env;
 use zksync_contracts::{
     read_sys_contract_bytecode, BaseSystemContracts, ContractLanguage, SET_CHAIN_ID_EVENT,
 };


### PR DESCRIPTION
## What ❔

This PR adds the possibility of running benchmarks with the YUL evm

A new environment variable was added for this purpose

Right now there a 3 benchmarks, you can add your own adding a new function following the same structure as `benchmark_basic`

How to run benchmarks:

`EVM_SIMULATOR=YUL cargo test test_emv_benchmark`

or

`EVM_SIMULATOR=SOLIDITY cargo test test_emv_benchmark`

This will generate a csv file under `zksync-era/core/lib/multivm/benchmarks`, with the following name: `benchmark_<yul/solidity>_<date>.csv` for example: `benchmark_yul_2024-04-25-18-09-53.csv`

The csv has the following headers:
`name,used_zkevm_ergs,used_evm_gas,used_circuits`

A python script was added in `zksync-era/core/lib/multivm/benchmarks` to facilitate comparing two benchmarks, it can be run as:

`python3 compare_benchmarks.py <file1.csv> <file2.csv>`

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
