### PR TITLE
chore: remove storage_logs field from ExecutionState

### DIFF
--- a/core/lib/multivm/src/glue/types/vm/vm_block_result.rs
+++ b/core/lib/multivm/src/glue/types/vm/vm_block_result.rs
@@ -51,10 +51,6 @@ impl GlueFrom<crate::vm_m5::vm_instance::VmBlockResult> for crate::interface::Fi
             },
             final_execution_state: CurrentExecutionState {
                 events: value.full_result.events,
-                storage_log_queries: storage_log_queries
-                    .into_iter()
-                    .map(GlueInto::glue_into)
-                    .collect(),
                 deduplicated_storage_log_queries: deduplicated_storage_log_queries
                     .into_iter()
                     .map(GlueInto::glue_into)
@@ -114,10 +110,6 @@ impl GlueFrom<crate::vm_m6::vm_instance::VmBlockResult> for crate::interface::Fi
             },
             final_execution_state: CurrentExecutionState {
                 events: value.full_result.events,
-                storage_log_queries: storage_log_queries
-                    .into_iter()
-                    .map(GlueInto::glue_into)
-                    .collect(),
                 deduplicated_storage_log_queries: deduplicated_storage_log_queries
                     .into_iter()
                     .map(GlueInto::glue_into)
@@ -175,10 +167,6 @@ impl GlueFrom<crate::vm_1_3_2::vm_instance::VmBlockResult> for crate::interface:
             },
             final_execution_state: CurrentExecutionState {
                 events: value.full_result.events,
-                storage_log_queries: storage_log_queries
-                    .into_iter()
-                    .map(GlueInto::glue_into)
-                    .collect(),
                 deduplicated_storage_log_queries: deduplicated_storage_log_queries
                     .into_iter()
                     .map(GlueInto::glue_into)

--- a/core/lib/multivm/src/interface/types/outputs/execution_state.rs
+++ b/core/lib/multivm/src/interface/types/outputs/execution_state.rs
@@ -1,7 +1,7 @@
 use zksync_types::{
     l2_to_l1_log::{SystemL2ToL1Log, UserL2ToL1Log},
     zk_evm_types::LogQuery,
-    StorageLogQuery, VmEvent, U256,
+    VmEvent, U256,
 };
 
 /// State of the VM since the start of the batch execution.
@@ -9,10 +9,7 @@ use zksync_types::{
 pub struct CurrentExecutionState {
     /// Events produced by the VM.
     pub events: Vec<VmEvent>,
-    /// Storage logs produced by the VM.
-    pub storage_log_queries: Vec<StorageLogQuery>,
     /// The deduplicated storage logs produced by the VM.
-    /// It is the deduplicated version of the `storage_log_queries` field.
     pub deduplicated_storage_log_queries: Vec<LogQuery>,
     /// Hashes of the contracts used by the VM.
     pub used_contract_hashes: Vec<U256>,

--- a/core/lib/multivm/src/versions/vm_1_3_2/vm.rs
+++ b/core/lib/multivm/src/versions/vm_1_3_2/vm.rs
@@ -164,10 +164,6 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
 
         CurrentExecutionState {
             events,
-            storage_log_queries: storage_log_queries
-                .into_iter()
-                .map(GlueInto::glue_into)
-                .collect(),
             deduplicated_storage_log_queries: deduped_storage_log_queries
                 .into_iter()
                 .map(GlueInto::glue_into)

--- a/core/lib/multivm/src/versions/vm_1_4_1/vm.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_1/vm.rs
@@ -112,10 +112,6 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
 
         CurrentExecutionState {
             events,
-            storage_log_queries: storage_log_queries
-                .into_iter()
-                .map(GlueInto::glue_into)
-                .collect(),
             deduplicated_storage_log_queries: deduped_storage_log_queries
                 .into_iter()
                 .map(GlueInto::glue_into)

--- a/core/lib/multivm/src/versions/vm_1_4_2/vm.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_2/vm.rs
@@ -112,10 +112,6 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
 
         CurrentExecutionState {
             events,
-            storage_log_queries: storage_log_queries
-                .into_iter()
-                .map(GlueInto::glue_into)
-                .collect(),
             deduplicated_storage_log_queries: deduped_storage_log_queries
                 .into_iter()
                 .map(GlueInto::glue_into)

--- a/core/lib/multivm/src/versions/vm_boojum_integration/vm.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/vm.rs
@@ -112,10 +112,6 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
 
         CurrentExecutionState {
             events,
-            storage_log_queries: storage_log_queries
-                .into_iter()
-                .map(GlueInto::glue_into)
-                .collect(),
             deduplicated_storage_log_queries: deduped_storage_log_queries
                 .into_iter()
                 .map(GlueInto::glue_into)

--- a/core/lib/multivm/src/versions/vm_latest/tests/refunds.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/refunds.rs
@@ -94,8 +94,8 @@ fn test_predetermined_refunded_gas() {
     );
 
     assert_eq!(
-        current_state_with_predefined_refunds.storage_log_queries,
-        current_state_without_predefined_refunds.storage_log_queries
+        current_state_with_predefined_refunds.deduplicated_storage_log_queries,
+        current_state_without_predefined_refunds.deduplicated_storage_log_queries
     );
     assert_eq!(
         current_state_with_predefined_refunds.used_contract_hashes,
@@ -148,16 +148,16 @@ fn test_predetermined_refunded_gas() {
 
     assert_eq!(
         current_state_with_changed_predefined_refunds
-            .storage_log_queries
+            .deduplicated_storage_log_queries
             .len(),
         current_state_without_predefined_refunds
-            .storage_log_queries
+            .deduplicated_storage_log_queries
             .len()
     );
 
     assert_ne!(
-        current_state_with_changed_predefined_refunds.storage_log_queries,
-        current_state_without_predefined_refunds.storage_log_queries
+        current_state_with_changed_predefined_refunds.deduplicated_storage_log_queries,
+        current_state_without_predefined_refunds.deduplicated_storage_log_queries
     );
     assert_eq!(
         current_state_with_changed_predefined_refunds.used_contract_hashes,

--- a/core/lib/multivm/src/versions/vm_latest/vm.rs
+++ b/core/lib/multivm/src/versions/vm_latest/vm.rs
@@ -111,10 +111,6 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
 
         CurrentExecutionState {
             events,
-            storage_log_queries: storage_log_queries
-                .into_iter()
-                .map(GlueInto::glue_into)
-                .collect(),
             deduplicated_storage_log_queries: deduped_storage_log_queries
                 .into_iter()
                 .map(GlueInto::glue_into)

--- a/core/lib/multivm/src/versions/vm_m5/vm.rs
+++ b/core/lib/multivm/src/versions/vm_m5/vm.rs
@@ -175,10 +175,6 @@ impl<S: Storage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
 
         CurrentExecutionState {
             events,
-            storage_log_queries: storage_log_queries
-                .into_iter()
-                .map(GlueInto::glue_into)
-                .collect(),
             deduplicated_storage_log_queries: deduplicated_logs
                 .into_iter()
                 .map(GlueInto::glue_into)

--- a/core/lib/multivm/src/versions/vm_m6/vm.rs
+++ b/core/lib/multivm/src/versions/vm_m6/vm.rs
@@ -191,12 +191,6 @@ impl<S: Storage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
 
         CurrentExecutionState {
             events,
-            storage_log_queries: self
-                .vm
-                .get_final_log_queries()
-                .into_iter()
-                .map(GlueInto::glue_into)
-                .collect(),
             deduplicated_storage_log_queries: deduplicated_logs
                 .into_iter()
                 .map(GlueInto::glue_into)

--- a/core/lib/multivm/src/versions/vm_refunds_enhancement/vm.rs
+++ b/core/lib/multivm/src/versions/vm_refunds_enhancement/vm.rs
@@ -108,10 +108,6 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
 
         CurrentExecutionState {
             events,
-            storage_log_queries: storage_log_queries
-                .into_iter()
-                .map(GlueInto::glue_into)
-                .collect(),
             deduplicated_storage_log_queries: deduped_storage_log_queries
                 .into_iter()
                 .map(GlueInto::glue_into)

--- a/core/lib/multivm/src/versions/vm_virtual_blocks/vm.rs
+++ b/core/lib/multivm/src/versions/vm_virtual_blocks/vm.rs
@@ -108,10 +108,6 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
 
         CurrentExecutionState {
             events,
-            storage_log_queries: storage_log_queries
-                .into_iter()
-                .map(GlueInto::glue_into)
-                .collect(),
             deduplicated_storage_log_queries: deduped_storage_log_queries
                 .into_iter()
                 .map(GlueInto::glue_into)

--- a/core/lib/zksync_core/src/state_keeper/io/persistence.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/persistence.rs
@@ -349,7 +349,6 @@ mod tests {
         });
 
         let mut batch_result = default_vm_batch_result();
-        batch_result.final_execution_state.storage_log_queries = storage_logs.clone();
         batch_result
             .final_execution_state
             .deduplicated_storage_log_queries = storage_logs

--- a/core/lib/zksync_core/src/state_keeper/io/seal_logic.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/seal_logic.rs
@@ -24,7 +24,7 @@ use zksync_types::{
     utils::display_timestamp,
     zk_evm_types::LogQuery,
     AccountTreeId, Address, ExecuteTransactionCommon, L1BlockNumber, ProtocolVersionId, StorageKey,
-    StorageLog, StorageLogQuery, Transaction, VmEvent, H256,
+    StorageLog, Transaction, VmEvent, H256,
 };
 use zksync_utils::u256_to_h256;
 
@@ -76,9 +76,6 @@ impl UpdatesManager {
         );
 
         let (l1_tx_count, l2_tx_count) = l1_l2_tx_count(&self.l1_batch.executed_transactions);
-        let (writes_count, reads_count) = storage_log_query_write_read_counts(
-            &finished_batch.final_execution_state.storage_log_queries,
-        );
         let (dedup_writes_count, dedup_reads_count) = log_query_write_read_counts(
             finished_batch
                 .final_execution_state
@@ -89,8 +86,8 @@ impl UpdatesManager {
         tracing::info!(
             "Sealing L1 batch {current_l1_batch_number} with timestamp {ts}, {total_tx_count} \
              ({l2_tx_count} L2 + {l1_tx_count} L1) txs, {l2_to_l1_log_count} l2_l1_logs, \
-             {event_count} events, {reads_count} reads ({dedup_reads_count} deduped), \
-             {writes_count} writes ({dedup_writes_count} deduped)",
+             {event_count} events, {dedup_reads_count} deduped reads, \
+             {dedup_writes_count} deduped writes",
             ts = display_timestamp(self.batch_timestamp()),
             total_tx_count = l1_tx_count + l2_tx_count,
             l2_to_l1_log_count = finished_batch
@@ -332,12 +329,9 @@ impl L2BlockSealCommand {
         let progress = L2_BLOCK_METRICS.start(L2BlockSealStage::InsertL2BlockHeader, is_fictive);
 
         let (l1_tx_count, l2_tx_count) = l1_l2_tx_count(&self.l2_block.executed_transactions);
-        let (writes_count, reads_count) =
-            storage_log_query_write_read_counts(&self.l2_block.storage_logs);
         tracing::info!(
             "Sealing L2 block {l2_block_number} with timestamp {ts} (L1 batch {l1_batch_number}) \
-             with {total_tx_count} ({l2_tx_count} L2 + {l1_tx_count} L1) txs, {event_count} events, \
-             {reads_count} reads, {writes_count} writes",
+             with {total_tx_count} ({l2_tx_count} L2 + {l1_tx_count} L1) txs, {event_count} events",
             ts = display_timestamp(self.l2_block.timestamp),
             total_tx_count = l1_tx_count + l2_tx_count,
             event_count = self.l2_block.events.len()
@@ -672,8 +666,4 @@ fn log_query_write_read_counts<'a>(logs: impl Iterator<Item = &'a LogQuery>) -> 
         }
     }
     (writes_count, reads_count)
-}
-
-fn storage_log_query_write_read_counts(logs: &[StorageLogQuery]) -> (usize, usize) {
-    log_query_write_read_counts(logs.iter().map(|log| &log.log_query))
 }

--- a/core/lib/zksync_core/src/state_keeper/tests/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/tests/mod.rs
@@ -101,7 +101,6 @@ pub(super) fn default_vm_batch_result() -> FinishedL1Batch {
         },
         final_execution_state: CurrentExecutionState {
             events: vec![],
-            storage_log_queries: vec![],
             deduplicated_storage_log_queries: vec![],
             used_contract_hashes: vec![],
             user_l2_to_l1_logs: vec![],


### PR DESCRIPTION
Before this change CurrentExecutionState contained deduplicated storage logs and the raw storage logs. However, the fast VM cannot produce the raw storage logs, as those are an implementation detail. Luckily it seems that they aren't needed, at least for out-of-circuit use.