### PR TITLE
fix(ci): Do not send Slack webhooks in release-please on no release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,8 +12,6 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    outputs:
-      release_please_output: ${{ toJSON(steps.release.outputs) }}
     steps:
       - name: Run release-please
         id: release
@@ -24,7 +22,7 @@ jobs:
             manifest-file: .github/release-please/manifest.json
 
       - name: Send Release Info
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: matter-labs/format-release-please-for-slack-action@69e6fe9e4ec531b7b5fb0d826f73c190db83cf42 # v2.1.0
         with:
           release-please-output: ${{ toJSON(steps.release.outputs) }}


### PR DESCRIPTION
## What ❔

- Removes obsolete output from release-please workflow
- Swaps to explicit "true" evaluation to ensure it actually works and "Send Release Info" is not executed on empty "releases_created" input

## Why ❔

- To fix workflow, so it does not fail on no releases

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
