### PR TITLE
chore(types): removes redundant trait method implementations

### DIFF
--- a/core/lib/types/src/storage/writes/compression.rs
+++ b/core/lib/types/src/storage/writes/compression.rs
@@ -62,21 +62,6 @@ impl CompressionMode for CompressionByteAdd {
             Some((diff, size))
         }
     }
-
-    fn output_size(&self) -> Option<usize> {
-        self.get_diff_and_size().map(|(_, size)| size)
-    }
-
-    fn compress_value_only(&self) -> Option<Vec<u8>> {
-        let (diff, size) = self.get_diff_and_size()?;
-
-        let mut buffer = [0u8; 32];
-        diff.to_big_endian(&mut buffer);
-
-        let diff = buffer[(32 - size)..].to_vec();
-
-        Some(diff)
-    }
 }
 
 struct CompressionByteSub {
@@ -100,10 +85,6 @@ impl CompressionMode for CompressionByteSub {
             Some((diff, size))
         }
     }
-
-    fn output_size(&self) -> Option<usize> {
-        self.get_diff_and_size().map(|(_, size)| size)
-    }
 }
 
 struct CompressionByteTransform {
@@ -124,10 +105,6 @@ impl CompressionMode for CompressionByteTransform {
         } else {
             Some((self.new_value, size))
         }
-    }
-
-    fn output_size(&self) -> Option<usize> {
-        self.get_diff_and_size().map(|(_, size)| size)
     }
 }
 


### PR DESCRIPTION
## What ❔

Removes methods that copypaste default implementations on `CompressionMode` trait.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
