### PR TITLE
Escaping the $ in services.postgres.healthcheck.test

### DIFF
--- a/docs/guides/external-node/docker-compose-examples/mainnet-external-node-docker-compose.yml
+++ b/docs/guides/external-node/docker-compose-examples/mainnet-external-node-docker-compose.yml
@@ -41,7 +41,7 @@ services:
     healthcheck:
       interval: 1s
       timeout: 3s
-      test: psql -U postgres -c "select exists (select * from pg_stat_activity where datname = '{{ database_name }}' and application_name = 'pg_restore')" | grep -e ".f$"
+      test: psql -U postgres -c "select exists (select * from pg_stat_activity where datname = '{{ database_name }}' and application_name = 'pg_restore')" | grep -e ".f$$"
     environment:
       - POSTGRES_PASSWORD=notsecurepassword
       - PGPORT=5430


### PR DESCRIPTION
## What ❔

The PR solves an error when starting the container 

**Error:** `invalid interpolation format for services.postgres.healthcheck.test: "psql -U postgres -c \"select exists (select * from pg_stat_activity where datname = '{{ database_name }}' and application_name = 'pg_restore')\" | grep -e \".f$\"". You may need to escape any $ with another $`

