### PR TITLE
fix(prover): Fix prover allocation on 1.4.2

### DIFF
--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -5387,7 +5387,7 @@ dependencies = [
 [[package]]
 name = "shivini"
 version = "0.2.0"
-source = "git+https://github.com/matter-labs/era-shivini.git?branch=v1.4.2#f29d5be4afa890647fd42c913e30186819ff774a"
+source = "git+https://github.com/matter-labs/era-shivini.git?branch=v1.4.2#86c2564f69a709d1a8f0a109bd2f92f02d4a4f65"
 dependencies = [
  "bincode",
  "blake2 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
This is a special purpose built branch to hotfix 1.4.2.
1.4.2 has problems on T4 allocations which are fixed in 1.5.0.
This commit/tag will expedite the change to 1.4.2, without releasing 1.5.0 prematurely.

