### PR TITLE
refactor(types): Use dedicated type for secp256k1 private keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8505,6 +8505,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "hex",
+ "rand 0.8.5",
  "secp256k1",
  "serde",
  "serde_json",

--- a/core/bin/system-constants-generator/src/utils.rs
+++ b/core/bin/system-constants-generator/src/utils.rs
@@ -20,9 +20,9 @@ use zksync_contracts::{
 use zksync_state::{InMemoryStorage, StorageView, WriteStorage};
 use zksync_types::{
     block::L2BlockHasher, ethabi::Token, fee::Fee, fee_model::BatchFeeInput, l1::L1Tx, l2::L2Tx,
-    utils::storage_key_for_eth_balance, AccountTreeId, Address, Execute, L1BatchNumber,
-    L1TxCommonData, L2BlockNumber, L2ChainId, Nonce, ProtocolVersionId, StorageKey, Transaction,
-    BOOTLOADER_ADDRESS, H256, SYSTEM_CONTEXT_ADDRESS, SYSTEM_CONTEXT_GAS_PRICE_POSITION,
+    utils::storage_key_for_eth_balance, AccountTreeId, Address, Execute, K256PrivateKey,
+    L1BatchNumber, L1TxCommonData, L2BlockNumber, L2ChainId, Nonce, ProtocolVersionId, StorageKey,
+    Transaction, BOOTLOADER_ADDRESS, SYSTEM_CONTEXT_ADDRESS, SYSTEM_CONTEXT_GAS_PRICE_POSITION,
     SYSTEM_CONTEXT_TX_ORIGIN_POSITION, U256, ZKPORTER_IS_AVAILABLE,
 };
 use zksync_utils::{bytecode::hash_bytecode, bytes_to_be_words, u256_to_h256};
@@ -81,7 +81,11 @@ pub static GAS_TEST_SYSTEM_CONTRACTS: Lazy<BaseSystemContracts> = Lazy::new(|| {
 // 100 gwei is base fee large enough for almost any L1 gas price
 const BIG_BASE_FEE: u64 = 100_000_000_000;
 
-pub(super) fn get_l2_tx(contract_address: Address, signer: &H256, pubdata_price: u32) -> L2Tx {
+pub(super) fn get_l2_tx(
+    contract_address: Address,
+    signer: &K256PrivateKey,
+    pubdata_price: u32,
+) -> L2Tx {
     L2Tx::new_signed(
         contract_address,
         vec![],
@@ -106,7 +110,7 @@ pub(super) fn get_l2_txs(number_of_txs: usize) -> (Vec<Transaction>, Vec<Transac
     let mut txs_without_pubdata_price = vec![];
 
     for _ in 0..number_of_txs {
-        let signer = H256::random();
+        let signer = K256PrivateKey::random();
         let contract_address = Address::random();
 
         txs_without_pubdata_price.push(get_l2_tx(contract_address, &signer, 0).into());

--- a/core/lib/config/src/configs/eth_sender.rs
+++ b/core/lib/config/src/configs/eth_sender.rs
@@ -1,7 +1,9 @@
 use std::time::Duration;
 
+use anyhow::Context as _;
 use serde::Deserialize;
 use zksync_basic_types::H256;
+use zksync_crypto_primitives::K256PrivateKey;
 
 use crate::EthWatchConfig;
 
@@ -135,10 +137,16 @@ impl SenderConfig {
 
     // Don't load private key, if it's not required.
     #[deprecated]
-    pub fn private_key(&self) -> Option<H256> {
+    pub fn private_key(&self) -> anyhow::Result<Option<K256PrivateKey>> {
         std::env::var("ETH_SENDER_SENDER_OPERATOR_PRIVATE_KEY")
             .ok()
-            .map(|pk| pk.parse().unwrap())
+            .map(|pk| {
+                let private_key_bytes: H256 =
+                    pk.parse().context("failed parsing private key bytes")?;
+                K256PrivateKey::from_bytes(private_key_bytes)
+                    .context("private key bytes are invalid")
+            })
+            .transpose()
     }
 
     // Don't load blobs private key, if it's not required

--- a/core/lib/crypto_primitives/Cargo.toml
+++ b/core/lib/crypto_primitives/Cargo.toml
@@ -20,3 +20,4 @@ serde_json.workspace = true
 serde.workspace = true
 hex.workspace = true
 anyhow.workspace = true
+rand.workspace = true

--- a/core/lib/crypto_primitives/src/ecdsa_signature.rs
+++ b/core/lib/crypto_primitives/src/ecdsa_signature.rs
@@ -295,7 +295,10 @@ mod tests {
         let private_key = K256PrivateKey::from_bytes(private_key_bytes).unwrap();
         assert_eq!(
             private_key.public(),
-            "8ce0db0b0359ffc5866ba61903cc2518c3675ef2cf380a7e54bde7ea20e6fa1ab45b7617346cd11b7610001ee6ae5b0155c41cad9527cbcdff44ec67848943a4".parse().unwrap()
+            "8ce0db0b0359ffc5866ba61903cc2518c3675ef2cf380a7e54bde7ea20e6fa1a\
+             b45b7617346cd11b7610001ee6ae5b0155c41cad9527cbcdff44ec67848943a4"
+                .parse()
+                .unwrap()
         );
         assert_eq!(
             private_key.address(),

--- a/core/lib/crypto_primitives/src/ecdsa_signature.rs
+++ b/core/lib/crypto_primitives/src/ecdsa_signature.rs
@@ -39,7 +39,58 @@ use web3::{
 
 type Message = H256;
 type Public = H512;
-type Secret = H256;
+
+/// secp256k1 private key wrapper.
+#[derive(Clone)]
+pub struct K256PrivateKey(SecretKey);
+
+impl fmt::Debug for K256PrivateKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Secret")
+            .field("address", &self.address())
+            .finish()
+    }
+}
+
+impl K256PrivateKey {
+    pub fn from_bytes(bytes: H256) -> Result<Self, Error> {
+        Ok(Self(SecretKey::from_slice(bytes.as_bytes())?))
+    }
+
+    pub fn random() -> Self {
+        Self::random_using(&mut rand::rngs::OsRng)
+    }
+
+    pub fn random_using(rng: &mut impl rand::Rng) -> Self {
+        loop {
+            if let Ok(this) = Self::from_bytes(H256::random_using(rng)) {
+                return this;
+            }
+        }
+    }
+
+    pub fn expose_secret(&self) -> &SecretKey {
+        &self.0
+    }
+
+    pub fn public(&self) -> Public {
+        let pub_key = PublicKey::from_secret_key(SECP256K1, &self.0);
+        let mut public = Public::zero();
+        public
+            .as_bytes_mut()
+            .copy_from_slice(&pub_key.serialize_uncompressed()[1..]);
+        public
+    }
+
+    pub fn address(&self) -> Address {
+        let pub_key = PublicKey::from_secret_key(SECP256K1, &self.0);
+        let hash = keccak256(&pub_key.serialize_uncompressed()[1..]);
+        let mut result = Address::zero();
+        result.as_bytes_mut().copy_from_slice(&hash[12..]);
+        result
+    }
+}
 
 /// Convert public key into the address
 pub(super) fn public_to_address(public: &Public) -> Address {
@@ -47,43 +98,6 @@ pub(super) fn public_to_address(public: &Public) -> Address {
     let mut result = Address::zero();
     result.as_bytes_mut().copy_from_slice(&hash[12..]);
     result
-}
-
-#[derive(Debug, Clone, PartialEq)]
-/// secp256k1 key pair
-pub(super) struct KeyPair {
-    secret: Secret,
-    public: Public,
-}
-
-impl fmt::Display for KeyPair {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        writeln!(f, "secret:  {:x}", self.secret)?;
-        writeln!(f, "public:  {:x}", self.public)?;
-        write!(f, "address: {:x}", self.address())
-    }
-}
-
-impl KeyPair {
-    /// Create a pair from secret key
-    pub(super) fn from_secret(secret: Secret) -> Result<KeyPair, Error> {
-        let context = &SECP256K1;
-        let s: SecretKey = SecretKey::from_slice(secret.as_bytes())?;
-        let pub_key = PublicKey::from_secret_key(context, &s);
-        let serialized = pub_key.serialize_uncompressed();
-
-        let mut public = Public::default();
-        public.as_bytes_mut().copy_from_slice(&serialized[1..65]);
-
-        let keypair = KeyPair { secret, public };
-
-        Ok(keypair)
-    }
-
-    /// Returns public part of the keypair converted into Address
-    pub(super) fn address(&self) -> Address {
-        public_to_address(&self.public)
-    }
 }
 
 // Copied from parity-crypto 0.9.0 `src/publickey/ecdsa_signature.rs`
@@ -243,10 +257,9 @@ impl DerefMut for Signature {
 
 /// Signs message with the given secret key.
 /// Returns the corresponding signature.
-pub(super) fn sign(secret: &Secret, message: &Message) -> Result<Signature, Error> {
+pub(super) fn sign(secret: &K256PrivateKey, message: &Message) -> Result<Signature, Error> {
     let context = &SECP256K1;
-    let sec = SecretKey::from_slice(secret.as_ref())?;
-    let s = context.sign_ecdsa_recoverable(&SecpMessage::from_slice(&message[..])?, &sec);
+    let s = context.sign_ecdsa_recoverable(&SecpMessage::from_slice(&message[..])?, &secret.0);
     let (rec_id, data) = s.serialize_compact();
     let mut data_arr = [0; 65];
 
@@ -271,37 +284,45 @@ pub(super) fn recover(signature: &Signature, message: &Message) -> Result<Public
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
-    use super::{recover, sign, KeyPair, Message, Secret, Signature};
+    use super::*;
 
     #[test]
-    fn from_secret() {
-        let secret = Secret::from_slice(
-            &hex::decode("a100df7a048e50ed308ea696dc600215098141cb391e9527329df289f9383f65")
-                .unwrap(),
+    fn key_conversions() {
+        let private_key_bytes: H256 =
+            "a100df7a048e50ed308ea696dc600215098141cb391e9527329df289f9383f65"
+                .parse()
+                .unwrap();
+        let private_key = K256PrivateKey::from_bytes(private_key_bytes).unwrap();
+        assert_eq!(
+            private_key.public(),
+            "8ce0db0b0359ffc5866ba61903cc2518c3675ef2cf380a7e54bde7ea20e6fa1ab45b7617346cd11b7610001ee6ae5b0155c41cad9527cbcdff44ec67848943a4".parse().unwrap()
         );
-        let _ = KeyPair::from_secret(secret).unwrap();
+        assert_eq!(
+            private_key.address(),
+            "5b073e9233944b5e729e46d618f0d8edf3d9c34a".parse().unwrap()
+        );
     }
 
     #[test]
-    fn keypair_display() {
-        let expected =
-"secret:  a100df7a048e50ed308ea696dc600215098141cb391e9527329df289f9383f65
-public:  8ce0db0b0359ffc5866ba61903cc2518c3675ef2cf380a7e54bde7ea20e6fa1ab45b7617346cd11b7610001ee6ae5b0155c41cad9527cbcdff44ec67848943a4
-address: 5b073e9233944b5e729e46d618f0d8edf3d9c34a".to_owned();
-        let secret = Secret::from_slice(
-            &hex::decode("a100df7a048e50ed308ea696dc600215098141cb391e9527329df289f9383f65")
-                .unwrap(),
+    fn key_is_not_exposed_in_debug_impl() {
+        let private_key_str = "a100df7a048e50ed308ea696dc600215098141cb391e9527329df289f9383f65";
+        let private_key_bytes: H256 = private_key_str.parse().unwrap();
+        let private_key = K256PrivateKey::from_bytes(private_key_bytes).unwrap();
+        let private_key_debug = format!("{private_key:?}");
+        assert!(
+            !private_key_debug.contains(private_key_str),
+            "{private_key_debug}"
         );
-        let kp = KeyPair::from_secret(secret).unwrap();
-        assert_eq!(format!("{}", kp), expected);
+        assert!(
+            private_key_debug.contains("5b073e9233944b5e729e46d618f0d8edf3d9c34a"),
+            "{private_key_debug}"
+        );
     }
 
     #[test]
     fn vrs_conversion() {
         // given
-        let secret = Secret::from_slice(&[1u8; 32]);
+        let secret = K256PrivateKey::from_bytes(H256::repeat_byte(1)).unwrap();
         let message =
             Message::from_str("0000000000000000000000000000000000000000000000000000000000000001")
                 .unwrap();
@@ -317,7 +338,7 @@ address: 5b073e9233944b5e729e46d618f0d8edf3d9c34a".to_owned();
 
     #[test]
     fn signature_to_and_from_str() {
-        let secret = Secret::from_slice(&[1u8; 32]);
+        let secret = K256PrivateKey::from_bytes(H256::repeat_byte(1)).unwrap();
         let message =
             Message::from_str("0000000000000000000000000000000000000000000000000000000000000001")
                 .unwrap();
@@ -329,36 +350,27 @@ address: 5b073e9233944b5e729e46d618f0d8edf3d9c34a".to_owned();
 
     #[test]
     fn sign_and_recover_public() {
-        let secret = Secret::from_slice(&[1u8; 32]);
-        let keypair = KeyPair::from_secret(secret).unwrap();
+        let secret = K256PrivateKey::from_bytes(H256::repeat_byte(1)).unwrap();
         let message =
             Message::from_str("0000000000000000000000000000000000000000000000000000000000000001")
                 .unwrap();
-        let signature = sign(&keypair.secret, &message).unwrap();
-        assert_eq!(&keypair.public, &recover(&signature, &message).unwrap());
+        let signature = sign(&secret, &message).unwrap();
+        assert_eq!(secret.public(), recover(&signature, &message).unwrap());
     }
 
     #[test]
     fn sign_and_recover_public_works_with_zeroed_messages() {
-        let secret = Secret::from_slice(&[1u8; 32]);
-        let keypair = KeyPair::from_secret(secret).unwrap();
-        let signature = sign(&keypair.secret, &Message::zero()).unwrap();
+        let secret = K256PrivateKey::from_bytes(H256::repeat_byte(1)).unwrap();
+        let signature = sign(&secret, &Message::zero()).unwrap();
         let zero_message = Message::zero();
-        assert_eq!(
-            &keypair.public,
-            &recover(&signature, &zero_message).unwrap()
-        );
+        assert_eq!(secret.public(), recover(&signature, &zero_message).unwrap());
     }
 
     #[test]
     fn recover_allowing_all_zero_message_can_recover_from_all_zero_messages() {
-        let secret = Secret::from_slice(&[1u8; 32]);
-        let keypair = KeyPair::from_secret(secret).unwrap();
-        let signature = sign(&keypair.secret, &Message::zero()).unwrap();
+        let secret = K256PrivateKey::from_bytes(H256::repeat_byte(1)).unwrap();
+        let signature = sign(&secret, &Message::zero()).unwrap();
         let zero_message = Message::zero();
-        assert_eq!(
-            &keypair.public,
-            &recover(&signature, &zero_message).unwrap()
-        )
+        assert_eq!(secret.public(), recover(&signature, &zero_message).unwrap())
     }
 }

--- a/core/lib/crypto_primitives/src/eip712_signature/tests.rs
+++ b/core/lib/crypto_primitives/src/eip712_signature/tests.rs
@@ -5,6 +5,7 @@ use web3::signing::keccak256;
 use zksync_basic_types::{Address, H256, U256};
 
 use crate::{
+    ecdsa_signature::K256PrivateKey,
     eip712_signature::{
         struct_builder::StructBuilder,
         typed_structure::{EIP712TypedStructure, Eip712Domain},
@@ -108,8 +109,8 @@ fn test_encode_eip712_typed_struct() {
         H256::from_str("3b98b16ad068d9d8854a6a416bd476de44a4933ec5104d7c786a422ab262ed14").unwrap()
     );
 
-    let private_key = keccak256(b"cow").into();
-    let address_owner = PackedEthSignature::address_from_private_key(&private_key).unwrap();
+    let private_key = K256PrivateKey::from_bytes(H256(keccak256(b"cow"))).unwrap();
+    let address_owner = private_key.address();
 
     let signature = PackedEthSignature::sign_typed_data(&private_key, &domain, &message).unwrap();
     let signed_bytes = PackedEthSignature::typed_data_to_signed_bytes(&domain, &message);

--- a/core/lib/crypto_primitives/src/lib.rs
+++ b/core/lib/crypto_primitives/src/lib.rs
@@ -1,6 +1,5 @@
+pub use self::{ecdsa_signature::K256PrivateKey, eip712_signature::*, packed_eth_signature::*};
+
 pub(crate) mod ecdsa_signature;
 pub mod eip712_signature;
 pub mod packed_eth_signature;
-
-pub use eip712_signature::*;
-pub use packed_eth_signature::*;

--- a/core/lib/crypto_primitives/src/packed_eth_signature.rs
+++ b/core/lib/crypto_primitives/src/packed_eth_signature.rs
@@ -6,7 +6,7 @@ use zksync_utils::ZeroPrefixHexSerde;
 
 use crate::{
     ecdsa_signature::{
-        public_to_address, recover, sign, Error as ParityCryptoError, KeyPair,
+        public_to_address, recover, sign, Error as ParityCryptoError, K256PrivateKey,
         Signature as ETHSignature,
     },
     eip712_signature::typed_structure::{EIP712TypedStructure, Eip712Domain},
@@ -65,7 +65,7 @@ impl PackedEthSignature {
     }
 
     pub fn sign_raw(
-        private_key: &H256,
+        private_key: &K256PrivateKey,
         signed_bytes: &H256,
     ) -> Result<PackedEthSignature, ParityCryptoError> {
         let signature = sign(private_key, signed_bytes)?;
@@ -75,7 +75,7 @@ impl PackedEthSignature {
     /// Signs typed struct using Ethereum private key by EIP-712 signature standard.
     /// Result of this function is the equivalent of RPC calling `eth_signTypedData`.
     pub fn sign_typed_data(
-        private_key: &H256,
+        private_key: &K256PrivateKey,
         domain: &Eip712Domain,
         typed_struct: &impl EIP712TypedStructure,
     ) -> Result<PackedEthSignature, ParityCryptoError> {
@@ -109,13 +109,6 @@ impl PackedEthSignature {
         let signed_bytes = H256::from_slice(&signed_bytes.0);
         let public_key = recover(&self.0, &signed_bytes)?;
         let address = public_to_address(&public_key);
-        Ok(Address::from(address.0))
-    }
-
-    /// Get Ethereum address from private key.
-    pub fn address_from_private_key(private_key: &H256) -> Result<Address, ParityCryptoError> {
-        let private_key = H256::from_slice(&private_key.0);
-        let address = KeyPair::from_secret(private_key)?.address();
         Ok(Address::from(address.0))
     }
 

--- a/core/lib/dal/src/tests/mod.rs
+++ b/core/lib/dal/src/tests/mod.rs
@@ -13,8 +13,8 @@ use zksync_types::{
     protocol_upgrade::{ProtocolUpgradeTx, ProtocolUpgradeTxCommonData},
     snapshots::SnapshotRecoveryStatus,
     tx::{tx_execution_info::TxExecutionStatus, ExecutionMetrics, TransactionExecutionResult},
-    Address, Execute, L1BatchNumber, L1BlockNumber, L1TxCommonData, L2BlockNumber, L2ChainId,
-    PriorityOpId, ProtocolVersion, ProtocolVersionId, VmEvent, H160, H256, U256,
+    Address, Execute, K256PrivateKey, L1BatchNumber, L1BlockNumber, L1TxCommonData, L2BlockNumber,
+    L2ChainId, PriorityOpId, ProtocolVersion, ProtocolVersionId, VmEvent, H160, H256, U256,
 };
 
 use crate::{
@@ -65,7 +65,7 @@ pub(crate) fn mock_l2_transaction() -> L2Tx {
         fee,
         Default::default(),
         L2ChainId::from(270),
-        &H256::random(),
+        &K256PrivateKey::random(),
         None,
         Default::default(),
     )

--- a/core/lib/env_config/src/eth_sender.rs
+++ b/core/lib/env_config/src/eth_sender.rs
@@ -127,9 +127,15 @@ mod tests {
 
         let actual = EthConfig::from_env().unwrap();
         assert_eq!(actual, expected_config());
+        let private_key = actual
+            .sender
+            .unwrap()
+            .private_key()
+            .unwrap()
+            .expect("no private key");
         assert_eq!(
-            actual.sender.unwrap().private_key().unwrap(),
-            hash("27593fea79697e947890ecbecce7901b0008345e5d7259710d0dd5e500d040be")
+            private_key.expose_secret().secret_bytes(),
+            hash("27593fea79697e947890ecbecce7901b0008345e5d7259710d0dd5e500d040be").as_bytes()
         );
     }
 }

--- a/core/lib/env_config/src/wallets.rs
+++ b/core/lib/env_config/src/wallets.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use anyhow::Context;
-use zksync_basic_types::Address;
+use zksync_basic_types::{Address, H256};
 use zksync_config::configs::wallets::{AddressWallet, EthSender, StateKeeper, Wallet, Wallets};
 
 use crate::FromEnv;
@@ -10,18 +10,17 @@ impl FromEnv for Wallets {
     fn from_env() -> anyhow::Result<Self> {
         let operator = std::env::var("ETH_SENDER_SENDER_OPERATOR_PRIVATE_KEY")
             .ok()
-            .map(|pk| pk.parse().context("Malformed pk"))
+            .map(|pk| pk.parse::<H256>().context("Malformed pk"))
             .transpose()?;
-
         let blob_operator = std::env::var("ETH_SENDER_SENDER_OPERATOR_BLOBS_PRIVATE_KEY")
             .ok()
-            .map(|pk| pk.parse().context("Malformed pk"))
+            .map(|pk| pk.parse::<H256>().context("Malformed pk"))
             .transpose()?;
 
         let eth_sender = if let Some(operator) = operator {
-            let operator = Wallet::from_private_key(operator, None)?;
+            let operator = Wallet::from_private_key_bytes(operator, None)?;
             let blob_operator = if let Some(blob_operator) = blob_operator {
-                Some(Wallet::from_private_key(blob_operator, None)?)
+                Some(Wallet::from_private_key_bytes(blob_operator, None)?)
             } else {
                 None
             };

--- a/core/lib/eth_client/src/clients/http/signing.rs
+++ b/core/lib/eth_client/src/clients/http/signing.rs
@@ -15,7 +15,7 @@ use zksync_types::{
             H256, U256, U64,
         },
     },
-    L1ChainId, PackedEthSignature, EIP_4844_TX_TYPE,
+    K256PrivateKey, L1ChainId, EIP_4844_TX_TYPE,
 };
 
 use super::{query::QueryClient, Method, LATENCIES};
@@ -33,7 +33,7 @@ impl PKSigningClient {
         eth_sender: &EthConfig,
         contracts_config: &ContractsConfig,
         l1_chain_id: L1ChainId,
-        operator_private_key: H256,
+        operator_private_key: K256PrivateKey,
     ) -> Self {
         Self::from_config_inner(
             eth_sender,
@@ -44,16 +44,14 @@ impl PKSigningClient {
     }
 
     pub fn new_raw(
-        operator_private_key: H256,
+        operator_private_key: K256PrivateKey,
         diamond_proxy_addr: Address,
         default_priority_fee_per_gas: u64,
         l1_chain_id: L1ChainId,
         web3_url: &str,
     ) -> Self {
         let transport = Http::new(web3_url).expect("Failed to create transport");
-        let operator_address = PackedEthSignature::address_from_private_key(&operator_private_key)
-            .expect("Failed to get address from private key");
-
+        let operator_address = operator_private_key.address();
         let signer = PrivateKeySigner::new(operator_private_key);
         tracing::info!("Operator address: {:?}", operator_address);
         SigningClient::new(
@@ -71,7 +69,7 @@ impl PKSigningClient {
         eth_sender: &EthConfig,
         contracts_config: &ContractsConfig,
         l1_chain_id: L1ChainId,
-        operator_private_key: H256,
+        operator_private_key: K256PrivateKey,
     ) -> Self {
         let diamond_proxy_addr = contracts_config.diamond_proxy_addr;
         let default_priority_fee_per_gas = eth_sender

--- a/core/lib/eth_client/src/types.rs
+++ b/core/lib/eth_client/src/types.rs
@@ -366,7 +366,7 @@ mod tests {
     use zksync_types::{
         eth_sender::{EthTxBlobSidecarV1, SidecarBlobV1},
         web3::{self},
-        EIP_4844_TX_TYPE, H160, H256, U256, U64,
+        K256PrivateKey, EIP_4844_TX_TYPE, H160, H256, U256, U64,
     };
 
     use super::*;
@@ -389,9 +389,10 @@ mod tests {
     // network format defined by the `EIP`. That is, a signed transaction
     // itself and the sidecar containing the blobs.
     async fn test_generating_signed_raw_transaction_with_4844_sidecar() {
-        let private_key =
-            H256::from_str("27593fea79697e947890ecbecce7901b0008345e5d7259710d0dd5e500d040be")
-                .unwrap();
+        let private_key: H256 = "27593fea79697e947890ecbecce7901b0008345e5d7259710d0dd5e500d040be"
+            .parse()
+            .unwrap();
+        let private_key = K256PrivateKey::from_bytes(private_key).unwrap();
         let commitment = hex::decode(
             "b5022d2a994ebd05f42c2f8e9b227185bf5963fcd1d412e17e97a026698d9670c0139872a400740d25835b5eaade22ad"
         ).unwrap();
@@ -479,6 +480,7 @@ mod tests {
         let private_key =
             H256::from_str("27593fea79697e947890ecbecce7901b0008345e5d7259710d0dd5e500d040be")
                 .unwrap();
+        let private_key = K256PrivateKey::from_bytes(private_key).unwrap();
 
         let commitment_1 = hex::decode(
 "b5022d2a994ebd05f42c2f8e9b227185bf5963fcd1d412e17e97a026698d9670c0139872a400740d25835b5eaade22ad"

--- a/core/lib/eth_signer/src/pk_signer.rs
+++ b/core/lib/eth_signer/src/pk_signer.rs
@@ -1,24 +1,19 @@
-use secp256k1::SecretKey;
-use zksync_types::{Address, EIP712TypedStructure, Eip712Domain, PackedEthSignature, H256};
+use zksync_types::{
+    Address, EIP712TypedStructure, Eip712Domain, K256PrivateKey, PackedEthSignature,
+};
 
 use crate::{
     raw_ethereum_tx::{Transaction, TransactionParameters},
     EthereumSigner, SignerError,
 };
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct PrivateKeySigner {
-    private_key: H256,
-}
-
-impl std::fmt::Debug for PrivateKeySigner {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "PrivateKeySigner")
-    }
+    private_key: K256PrivateKey,
 }
 
 impl PrivateKeySigner {
-    pub fn new(private_key: H256) -> Self {
+    pub fn new(private_key: K256PrivateKey) -> Self {
         Self { private_key }
     }
 }
@@ -27,8 +22,7 @@ impl PrivateKeySigner {
 impl EthereumSigner for PrivateKeySigner {
     /// Get Ethereum address that matches the private key.
     async fn get_address(&self) -> Result<Address, SignerError> {
-        PackedEthSignature::address_from_private_key(&self.private_key)
-            .map_err(|_| SignerError::DefineAddress)
+        Ok(self.private_key.address())
     }
 
     /// Signs typed struct using Ethereum private key by EIP-712 signature standard.
@@ -49,8 +43,6 @@ impl EthereumSigner for PrivateKeySigner {
         &self,
         raw_tx: TransactionParameters,
     ) -> Result<Vec<u8>, SignerError> {
-        let key = SecretKey::from_slice(self.private_key.as_bytes()).unwrap();
-
         // According to the code in web3 <https://docs.rs/web3/latest/src/web3/api/accounts.rs.html#86>
         // We should use `max_fee_per_gas` as `gas_price` if we use EIP1559
         let gas_price = raw_tx.max_fee_per_gas;
@@ -71,21 +63,21 @@ impl EthereumSigner for PrivateKeySigner {
             blob_versioned_hashes: raw_tx.blob_versioned_hashes,
         };
 
-        let signed = tx.sign(&key, raw_tx.chain_id);
+        let signed = tx.sign(self.private_key.expose_secret(), raw_tx.chain_id);
         Ok(signed.raw_transaction.0)
     }
 }
 
 #[cfg(test)]
 mod test {
-    use zksync_types::{H160, H256, U256, U64};
+    use zksync_types::{K256PrivateKey, H160, H256, U256, U64};
 
     use super::PrivateKeySigner;
     use crate::{raw_ethereum_tx::TransactionParameters, EthereumSigner};
 
     #[tokio::test]
     async fn test_generating_signed_raw_transaction() {
-        let private_key = H256::from([5; 32]);
+        let private_key = K256PrivateKey::from_bytes(H256::from([5; 32])).unwrap();
         let signer = PrivateKeySigner::new(private_key);
         let raw_transaction = TransactionParameters {
             nonce: U256::from(1u32),

--- a/core/lib/multivm/src/versions/vm_1_3_2/test_utils.rs
+++ b/core/lib/multivm/src/versions/vm_1_3_2/test_utils.rs
@@ -10,17 +10,12 @@ use std::collections::HashMap;
 
 use itertools::Itertools;
 use zk_evm_1_3_3::{aux_structures::Timestamp, vm_state::VmLocalState};
-use zksync_contracts::{
-    deployer_contract, get_loadnext_contract, load_contract,
-    test_contracts::LoadnextContractExecutionParams,
-};
+use zksync_contracts::deployer_contract;
 use zksync_state::WriteStorage;
 use zksync_types::{
     ethabi::{Address, Token},
-    fee::Fee,
-    l2::L2Tx,
     web3::signing::keccak256,
-    Execute, L2ChainId, Nonce, StorageKey, StorageValue, CONTRACT_DEPLOYER_ADDRESS, H256, U256,
+    Execute, Nonce, StorageKey, StorageValue, CONTRACT_DEPLOYER_ADDRESS, H256, U256,
 };
 use zksync_utils::{
     address_to_h256, bytecode::hash_bytecode, h256_to_account_address, u256_to_h256,
@@ -143,87 +138,6 @@ impl<H: HistoryMode, S: WriteStorage> VmInstance<S, H> {
     }
 }
 
-// This one is used only for tests, but it is in this folder to
-// be able to share it among crates
-pub fn mock_loadnext_test_call(
-    eth_private_key: H256,
-    nonce: Nonce,
-    contract_address: Address,
-    fee: Fee,
-    execution_params: LoadnextContractExecutionParams,
-) -> L2Tx {
-    let loadnext_contract = get_loadnext_contract();
-
-    let contract_function = loadnext_contract.contract.function("execute").unwrap();
-
-    let params = vec![
-        Token::Uint(U256::from(execution_params.reads)),
-        Token::Uint(U256::from(execution_params.writes)),
-        Token::Uint(U256::from(execution_params.hashes)),
-        Token::Uint(U256::from(execution_params.events)),
-        Token::Uint(U256::from(execution_params.recursive_calls)),
-        Token::Uint(U256::from(execution_params.deploys)),
-    ];
-    let calldata = contract_function
-        .encode_input(&params)
-        .expect("failed to encode parameters");
-
-    let mut l2_tx = L2Tx::new_signed(
-        contract_address,
-        calldata,
-        nonce,
-        fee,
-        Default::default(),
-        L2ChainId::from(270),
-        &eth_private_key,
-        None,
-        Default::default(),
-    )
-    .unwrap();
-    // Input means all transaction data (NOT calldata, but all tx fields) that came from the API.
-    // This input will be used for the derivation of the tx hash, so put some random to it to be sure
-    // that the transaction hash is unique.
-    l2_tx.set_input(H256::random().0.to_vec(), H256::random());
-    l2_tx
-}
-
-// This one is used only for tests, but it is in this folder to
-// be able to share it among crates
-pub fn mock_loadnext_gas_burn_call(
-    eth_private_key: H256,
-    nonce: Nonce,
-    contract_address: Address,
-    fee: Fee,
-    gas: u32,
-) -> L2Tx {
-    let loadnext_contract = get_loadnext_contract();
-
-    let contract_function = loadnext_contract.contract.function("burnGas").unwrap();
-
-    let params = vec![Token::Uint(U256::from(gas))];
-    let calldata = contract_function
-        .encode_input(&params)
-        .expect("failed to encode parameters");
-
-    let mut l2_tx = L2Tx::new_signed(
-        contract_address,
-        calldata,
-        nonce,
-        fee,
-        Default::default(),
-        L2ChainId::from(270),
-        &eth_private_key,
-        None,
-        Default::default(),
-    )
-    .unwrap();
-    // Input means all transaction data (NOT calldata, but all tx fields) that came from the API.
-    // This input will be used for the derivation of the tx hash, so put some random to it to be sure
-    // that the transaction hash is unique.
-    l2_tx.set_input(H256::random().0.to_vec(), H256::random());
-    l2_tx
-}
-
 pub fn get_create_execute(code: &[u8], calldata: &[u8]) -> Execute {
     let deployer = deployer_contract();
 
@@ -244,77 +158,6 @@ pub fn get_create_execute(code: &[u8], calldata: &[u8]) -> Execute {
         factory_deps: Some(vec![code.to_vec()]),
         value: U256::zero(),
     }
-}
-
-fn get_execute_error_calldata() -> Vec<u8> {
-    let test_contract = load_contract(
-        "etc/contracts-test-data/artifacts-zk/contracts/error/error.sol/SimpleRequire.json",
-    );
-
-    let function = test_contract.function("require_short").unwrap();
-
-    function
-        .encode_input(&[])
-        .expect("failed to encode parameters")
-}
-
-pub fn get_deploy_tx(
-    account_private_key: H256,
-    nonce: Nonce,
-    code: &[u8],
-    factory_deps: Vec<Vec<u8>>,
-    calldata: &[u8],
-    fee: Fee,
-) -> L2Tx {
-    let factory_deps = factory_deps
-        .into_iter()
-        .chain(vec![code.to_vec()])
-        .collect();
-    let execute = get_create_execute(code, calldata);
-
-    let mut signed = L2Tx::new_signed(
-        CONTRACT_DEPLOYER_ADDRESS,
-        execute.calldata,
-        nonce,
-        fee,
-        U256::zero(),
-        L2ChainId::from(270),
-        &account_private_key,
-        Some(factory_deps),
-        Default::default(),
-    )
-    .expect("should create a signed execute transaction");
-
-    signed.set_input(H256::random().as_bytes().to_vec(), H256::random());
-
-    signed
-}
-
-pub fn get_error_tx(
-    account_private_key: H256,
-    nonce: Nonce,
-    contract_address: Address,
-    fee: Fee,
-) -> L2Tx {
-    let factory_deps = vec![];
-    let calldata = get_execute_error_calldata();
-
-    let mut signed = L2Tx::new_signed(
-        contract_address,
-        calldata,
-        nonce,
-        fee,
-        U256::zero(),
-        L2ChainId::from(270),
-        &account_private_key,
-        Some(factory_deps),
-        Default::default(),
-    )
-    .expect("should create a signed execute transaction");
-
-    signed.set_input(H256::random().as_bytes().to_vec(), H256::random());
-
-    signed
 }
 
 pub fn get_create_zksync_address(sender_address: Address, sender_nonce: Nonce) -> Address {

--- a/core/lib/multivm/src/versions/vm_m5/test_utils.rs
+++ b/core/lib/multivm/src/versions/vm_m5/test_utils.rs
@@ -12,16 +12,11 @@ use itertools::Itertools;
 use zk_evm_1_3_1::{
     aux_structures::Timestamp, reference_impls::event_sink::ApplicationData, vm_state::VmLocalState,
 };
-use zksync_contracts::{
-    deployer_contract, get_loadnext_contract, load_contract,
-    test_contracts::LoadnextContractExecutionParams,
-};
+use zksync_contracts::deployer_contract;
 use zksync_types::{
     ethabi::{Address, Token},
-    fee::Fee,
-    l2::L2Tx,
     web3::signing::keccak256,
-    Execute, L2ChainId, Nonce, StorageKey, StorageValue, CONTRACT_DEPLOYER_ADDRESS, H256, U256,
+    Execute, Nonce, StorageKey, StorageValue, CONTRACT_DEPLOYER_ADDRESS, H256, U256,
 };
 use zksync_utils::{
     address_to_h256, bytecode::hash_bytecode, h256_to_account_address, u256_to_h256,
@@ -141,87 +136,6 @@ impl<S: Storage> VmInstance<S> {
     }
 }
 
-// This one is used only for tests, but it is in this folder to
-// be able to share it among crates
-pub fn mock_loadnext_test_call(
-    eth_private_key: H256,
-    nonce: Nonce,
-    contract_address: Address,
-    fee: Fee,
-    execution_params: LoadnextContractExecutionParams,
-) -> L2Tx {
-    let loadnext_contract = get_loadnext_contract();
-
-    let contract_function = loadnext_contract.contract.function("execute").unwrap();
-
-    let params = vec![
-        Token::Uint(U256::from(execution_params.reads)),
-        Token::Uint(U256::from(execution_params.writes)),
-        Token::Uint(U256::from(execution_params.hashes)),
-        Token::Uint(U256::from(execution_params.events)),
-        Token::Uint(U256::from(execution_params.recursive_calls)),
-        Token::Uint(U256::from(execution_params.deploys)),
-    ];
-    let calldata = contract_function
-        .encode_input(&params)
-        .expect("failed to encode parameters");
-
-    let mut l2_tx = L2Tx::new_signed(
-        contract_address,
-        calldata,
-        nonce,
-        fee,
-        Default::default(),
-        L2ChainId::from(270),
-        &eth_private_key,
-        None,
-        Default::default(),
-    )
-    .unwrap();
-    // Input means all transaction data (NOT calldata, but all tx fields) that came from the API.
-    // This input will be used for the derivation of the tx hash, so put some random to it to be sure
-    // that the transaction hash is unique.
-    l2_tx.set_input(H256::random().0.to_vec(), H256::random());
-    l2_tx
-}
-
-// This one is used only for tests, but it is in this folder to
-// be able to share it among crates
-pub fn mock_loadnext_gas_burn_call(
-    eth_private_key: H256,
-    nonce: Nonce,
-    contract_address: Address,
-    fee: Fee,
-    gas: u32,
-) -> L2Tx {
-    let loadnext_contract = get_loadnext_contract();
-
-    let contract_function = loadnext_contract.contract.function("burnGas").unwrap();
-
-    let params = vec![Token::Uint(U256::from(gas))];
-    let calldata = contract_function
-        .encode_input(&params)
-        .expect("failed to encode parameters");
-
-    let mut l2_tx = L2Tx::new_signed(
-        contract_address,
-        calldata,
-        nonce,
-        fee,
-        Default::default(),
-        L2ChainId::from(270),
-        &eth_private_key,
-        None,
-        Default::default(),
-    )
-    .unwrap();
-    // Input means all transaction data (NOT calldata, but all tx fields) that came from the API.
-    // This input will be used for the derivation of the tx hash, so put some random to it to be sure
-    // that the transaction hash is unique.
-    l2_tx.set_input(H256::random().0.to_vec(), H256::random());
-    l2_tx
-}
-
 pub fn get_create_execute(code: &[u8], calldata: &[u8]) -> Execute {
     let deployer = deployer_contract();
 
@@ -242,77 +156,6 @@ pub fn get_create_execute(code: &[u8], calldata: &[u8]) -> Execute {
         factory_deps: Some(vec![code.to_vec()]),
         value: U256::zero(),
     }
-}
-
-fn get_execute_error_calldata() -> Vec<u8> {
-    let test_contract = load_contract(
-        "etc/contracts-test-data/artifacts-zk/contracts/error/error.sol/SimpleRequire.json",
-    );
-
-    let function = test_contract.function("require_short").unwrap();
-
-    function
-        .encode_input(&[])
-        .expect("failed to encode parameters")
-}
-
-pub fn get_deploy_tx(
-    account_private_key: H256,
-    nonce: Nonce,
-    code: &[u8],
-    factory_deps: Vec<Vec<u8>>,
-    calldata: &[u8],
-    fee: Fee,
-) -> L2Tx {
-    let factory_deps = factory_deps
-        .into_iter()
-        .chain(vec![code.to_vec()])
-        .collect();
-    let execute = get_create_execute(code, calldata);
-
-    let mut signed = L2Tx::new_signed(
-        CONTRACT_DEPLOYER_ADDRESS,
-        execute.calldata,
-        nonce,
-        fee,
-        U256::zero(),
-        L2ChainId::from(270),
-        &account_private_key,
-        Some(factory_deps),
-        Default::default(),
-    )
-    .expect("should create a signed execute transaction");
-
-    signed.set_input(H256::random().as_bytes().to_vec(), H256::random());
-
-    signed
-}
-
-pub fn get_error_tx(
-    account_private_key: H256,
-    nonce: Nonce,
-    contract_address: Address,
-    fee: Fee,
-) -> L2Tx {
-    let factory_deps = vec![];
-    let calldata = get_execute_error_calldata();
-
-    let mut signed = L2Tx::new_signed(
-        contract_address,
-        calldata,
-        nonce,
-        fee,
-        U256::zero(),
-        L2ChainId::from(270),
-        &account_private_key,
-        Some(factory_deps),
-        Default::default(),
-    )
-    .expect("should create a signed execute transaction");
-
-    signed.set_input(H256::random().as_bytes().to_vec(), H256::random());
-
-    signed
 }
 
 pub fn get_create_zksync_address(sender_address: Address, sender_nonce: Nonce) -> Address {

--- a/core/lib/protobuf_config/src/wallets.rs
+++ b/core/lib/protobuf_config/src/wallets.rs
@@ -12,7 +12,7 @@ impl ProtoRepr for proto::Wallets {
     fn read(&self) -> anyhow::Result<Self::Type> {
         let eth_sender = if self.operator.is_some() && self.blob_operator.is_some() {
             let blob_operator = if let Some(blob_operator) = &self.blob_operator {
-                Some(Wallet::from_private_key(
+                Some(Wallet::from_private_key_bytes(
                     parse_h256(required(&blob_operator.private_key).context("blob operator")?)?,
                     blob_operator
                         .address
@@ -25,7 +25,7 @@ impl ProtoRepr for proto::Wallets {
 
             let operator_wallet = &self.operator.clone().context("Operator private key")?;
 
-            let operator = Wallet::from_private_key(
+            let operator = Wallet::from_private_key_bytes(
                 parse_h256(required(&operator_wallet.private_key).context("operator")?)?,
                 operator_wallet
                     .address

--- a/core/lib/types/src/l2/mod.rs
+++ b/core/lib/types/src/l2/mod.rs
@@ -4,6 +4,7 @@ use anyhow::Context as _;
 use num_enum::TryFromPrimitive;
 use rlp::{Rlp, RlpStream};
 use serde::{Deserialize, Serialize};
+use zksync_crypto_primitives::K256PrivateKey;
 
 use self::error::SignError;
 use crate::{
@@ -190,11 +191,11 @@ impl L2Tx {
         fee: Fee,
         value: U256,
         chain_id: L2ChainId,
-        private_key: &H256,
+        private_key: &K256PrivateKey,
         factory_deps: Option<Vec<Vec<u8>>>,
         paymaster_params: PaymasterParams,
     ) -> Result<Self, SignError> {
-        let initiator_address = PackedEthSignature::address_from_private_key(private_key).unwrap();
+        let initiator_address = private_key.address();
         let mut res = Self::new(
             contract_address,
             calldata,

--- a/core/lib/types/src/transaction_request.rs
+++ b/core/lib/types/src/transaction_request.rs
@@ -953,7 +953,7 @@ pub fn validate_factory_deps(
 
 #[cfg(test)]
 mod tests {
-    use secp256k1::SecretKey;
+    use zksync_crypto_primitives::K256PrivateKey;
 
     use super::*;
     use crate::web3::{
@@ -966,10 +966,12 @@ mod tests {
     async fn decode_real_tx() {
         let accounts = crate::web3::api::Accounts::new(TestTransport::default());
 
-        let pk = hex::decode("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318")
-            .unwrap();
-        let address = PackedEthSignature::address_from_private_key(&H256::from_slice(&pk)).unwrap();
-        let key = SecretKey::from_slice(&pk).unwrap();
+        let private_key_bytes: H256 =
+            "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318"
+                .parse()
+                .unwrap();
+        let private_key = K256PrivateKey::from_bytes(private_key_bytes).unwrap();
+        let address = private_key.address();
 
         let tx = TransactionParameters {
             nonce: Some(U256::from(1u32)),
@@ -984,7 +986,10 @@ mod tests {
             transaction_type: None,
             access_list: None,
         };
-        let signed_tx = accounts.sign_transaction(tx.clone(), &key).await.unwrap();
+        let signed_tx = accounts
+            .sign_transaction(tx.clone(), private_key.expose_secret())
+            .await
+            .unwrap();
         let (tx2, _) = TransactionRequest::from_bytes(
             signed_tx.raw_transaction.0.as_slice(),
             L2ChainId::from(270),
@@ -1000,8 +1005,8 @@ mod tests {
 
     #[test]
     fn decode_rlp() {
-        let private_key = H256::random();
-        let address = PackedEthSignature::address_from_private_key(&private_key).unwrap();
+        let private_key = K256PrivateKey::random();
+        let address = private_key.address();
 
         let mut tx = TransactionRequest {
             nonce: U256::from(1u32),
@@ -1036,8 +1041,8 @@ mod tests {
 
     #[test]
     fn decode_eip712_with_meta() {
-        let private_key = H256::random();
-        let address = PackedEthSignature::address_from_private_key(&private_key).unwrap();
+        let private_key = K256PrivateKey::random();
+        let address = private_key.address();
 
         let mut tx = TransactionRequest {
             nonce: U256::from(1u32),
@@ -1084,8 +1089,8 @@ mod tests {
 
     #[test]
     fn check_recovered_public_key_eip712() {
-        let private_key = H256::random();
-        let address = PackedEthSignature::address_from_private_key(&private_key).unwrap();
+        let private_key = K256PrivateKey::random();
+        let address = private_key.address();
 
         let transaction_request = TransactionRequest {
             nonce: U256::from(1u32),
@@ -1121,8 +1126,8 @@ mod tests {
 
     #[test]
     fn check_recovered_public_key_eip712_with_wrong_chain_id() {
-        let private_key = H256::random();
-        let address = PackedEthSignature::address_from_private_key(&private_key).unwrap();
+        let private_key = K256PrivateKey::random();
+        let address = private_key.address();
 
         let transaction_request = TransactionRequest {
             nonce: U256::from(1u32),
@@ -1163,8 +1168,8 @@ mod tests {
 
     #[test]
     fn check_recovered_public_key_eip1559() {
-        let private_key = H256::random();
-        let address = PackedEthSignature::address_from_private_key(&private_key).unwrap();
+        let private_key = K256PrivateKey::random();
+        let address = private_key.address();
 
         let mut transaction_request = TransactionRequest {
             max_priority_fee_per_gas: Some(U256::from(1u32)),
@@ -1202,8 +1207,8 @@ mod tests {
 
     #[test]
     fn check_recovered_public_key_eip1559_with_wrong_chain_id() {
-        let private_key = H256::random();
-        let address = PackedEthSignature::address_from_private_key(&private_key).unwrap();
+        let private_key = K256PrivateKey::random();
+        let address = private_key.address();
 
         let mut transaction_request = TransactionRequest {
             max_priority_fee_per_gas: Some(U256::from(1u32)),
@@ -1241,8 +1246,8 @@ mod tests {
 
     #[test]
     fn check_decode_eip1559_with_access_list() {
-        let private_key = H256::random();
-        let address = PackedEthSignature::address_from_private_key(&private_key).unwrap();
+        let private_key = K256PrivateKey::random();
+        let address = private_key.address();
 
         let mut transaction_request = TransactionRequest {
             max_priority_fee_per_gas: Some(U256::from(1u32)),
@@ -1281,8 +1286,8 @@ mod tests {
 
     #[test]
     fn check_failed_to_decode_eip2930() {
-        let private_key = H256::random();
-        let address = PackedEthSignature::address_from_private_key(&private_key).unwrap();
+        let private_key = K256PrivateKey::random();
+        let address = private_key.address();
 
         let mut transaction_request = TransactionRequest {
             transaction_type: Some(EIP_2930_TX_TYPE.into()),
@@ -1402,9 +1407,10 @@ mod tests {
     #[test]
     fn transaction_request_with_oversize_data() {
         let random_tx_max_size = 1_000_000; // bytes
-        let private_key = H256::random();
-        let address = PackedEthSignature::address_from_private_key(&private_key).unwrap();
-        // choose some number that divides on 8 and is `> 1_000_000`
+        let private_key = K256PrivateKey::random();
+        let address = private_key.address();
+
+        // Choose some number that divides on 8 and is `> 1_000_000`
         let factory_dep = vec![2u8; 1600000];
         let factory_deps: Vec<Vec<u8>> = factory_dep.chunks(32).map(|s| s.into()).collect();
         let mut tx = TransactionRequest {

--- a/core/lib/zksync_core/src/api_server/web3/tests/vm.rs
+++ b/core/lib/zksync_core/src/api_server/web3/tests/vm.rs
@@ -4,7 +4,8 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use multivm::interface::{ExecutionResult, VmRevertReason};
 use zksync_types::{
-    get_intrinsic_constants, transaction_request::CallRequest, L2ChainId, PackedEthSignature, U256,
+    get_intrinsic_constants, transaction_request::CallRequest, K256PrivateKey, L2ChainId,
+    PackedEthSignature, U256,
 };
 use zksync_utils::u256_to_h256;
 use zksync_web3_decl::namespaces::DebugNamespaceClient;
@@ -151,10 +152,10 @@ struct SendRawTransactionTest {
 
 impl SendRawTransactionTest {
     fn transaction_bytes_and_hash() -> (Vec<u8>, H256) {
-        let (private_key, address) = Self::private_key_and_address();
+        let private_key = Self::private_key();
         let tx_request = api::TransactionRequest {
             chain_id: Some(L2ChainId::default().as_u64()),
-            from: Some(address),
+            from: Some(private_key.address()),
             to: Some(Address::repeat_byte(2)),
             value: 123_456.into(),
             gas: (get_intrinsic_constants().l2_tx_intrinsic_gas * 2).into(),
@@ -176,15 +177,12 @@ impl SendRawTransactionTest {
         (data.into(), tx_hash)
     }
 
-    fn private_key_and_address() -> (H256, Address) {
-        let private_key = H256::repeat_byte(11);
-        let address = PackedEthSignature::address_from_private_key(&private_key).unwrap();
-        (private_key, address)
+    fn private_key() -> K256PrivateKey {
+        K256PrivateKey::from_bytes(H256::repeat_byte(11)).unwrap()
     }
 
     fn balance_storage_log() -> StorageLog {
-        let (_, address) = Self::private_key_and_address();
-        let balance_key = storage_key_for_eth_balance(&address);
+        let balance_key = storage_key_for_eth_balance(&Self::private_key().address());
         StorageLog::new_write_log(balance_key, u256_to_h256(U256::one() << 64))
     }
 }
@@ -459,7 +457,7 @@ impl HttpTest for EstimateGasTest {
                 .await?;
         }
         let mut call_request = CallRequest::from(l2_transaction);
-        call_request.from = Some(SendRawTransactionTest::private_key_and_address().1);
+        call_request.from = Some(SendRawTransactionTest::private_key().address());
         call_request.value = Some(1_000_000.into());
         client.estimate_gas(call_request.clone(), None).await?;
 

--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -636,7 +636,7 @@ pub async fn initialize_components(
         let web3_url = &eth.web3_url;
 
         let eth_client = PKSigningClient::new_raw(
-            operator_private_key,
+            operator_private_key.clone(),
             diamond_proxy_addr,
             default_priority_fee_per_gas,
             l1_chain_id,
@@ -711,7 +711,7 @@ pub async fn initialize_components(
         let web3_url = &eth.web3_url;
 
         let eth_client = PKSigningClient::new_raw(
-            operator_private_key,
+            operator_private_key.clone(),
             diamond_proxy_addr,
             default_priority_fee_per_gas,
             l1_chain_id,
@@ -719,7 +719,7 @@ pub async fn initialize_components(
         );
 
         let eth_client_blobs = if let Some(blob_operator) = eth_sender_wallets.blob_operator {
-            let operator_blob_private_key = blob_operator.private_key();
+            let operator_blob_private_key = blob_operator.private_key().clone();
             Some(PKSigningClient::new_raw(
                 operator_blob_private_key,
                 diamond_proxy_addr,

--- a/core/lib/zksync_core/src/temp_config_store/mod.rs
+++ b/core/lib/zksync_core/src/temp_config_store/mod.rs
@@ -116,18 +116,16 @@ impl TempConfigStore {
 
     #[allow(deprecated)]
     pub fn wallets(&self) -> Wallets {
-        let eth_sender = self.eth_sender_config.as_ref().and_then(|x| {
-            x.sender.as_ref().and_then(|sender| {
-                let operator = sender
-                    .private_key()
-                    .and_then(|operator| Wallet::from_private_key(operator, None).ok());
-                let blob_operator = sender
-                    .private_key_blobs()
-                    .and_then(|operator| Wallet::from_private_key(operator, None).ok());
-                operator.map(|operator| EthSender {
-                    operator,
-                    blob_operator,
-                })
+        let eth_sender = self.eth_sender_config.as_ref().and_then(|config| {
+            let sender = config.sender.as_ref()?;
+            let operator_private_key = sender.private_key().ok()??;
+            let operator = Wallet::new(operator_private_key);
+            let blob_operator = sender
+                .private_key_blobs()
+                .and_then(|operator| Wallet::from_private_key_bytes(operator, None).ok());
+            Some(EthSender {
+                operator,
+                blob_operator,
             })
         });
         let state_keeper = self

--- a/core/lib/zksync_core/src/utils/testonly.rs
+++ b/core/lib/zksync_core/src/utils/testonly.rs
@@ -18,8 +18,8 @@ use zksync_types::{
     snapshots::SnapshotRecoveryStatus,
     transaction_request::PaymasterParams,
     tx::{tx_execution_info::TxExecutionStatus, ExecutionMetrics, TransactionExecutionResult},
-    Address, L1BatchNumber, L2BlockNumber, L2ChainId, Nonce, ProtocolVersion, ProtocolVersionId,
-    StorageLog, H256, U256,
+    Address, K256PrivateKey, L1BatchNumber, L2BlockNumber, L2ChainId, Nonce, ProtocolVersion,
+    ProtocolVersionId, StorageLog, H256, U256,
 };
 
 use crate::{fee_model::BatchFeeModelInputProvider, genesis::GenesisParams};
@@ -122,7 +122,7 @@ pub(crate) fn create_l2_transaction(fee_per_gas: u64, gas_per_pubdata: u64) -> L
         fee,
         U256::zero(),
         L2ChainId::from(271),
-        &H256::random(),
+        &K256PrivateKey::random(),
         None,
         PaymasterParams::default(),
     )

--- a/core/node/block_reverter/src/lib.rs
+++ b/core/node/block_reverter/src/lib.rs
@@ -24,7 +24,7 @@ use zksync_types::{
         types::{BlockId, BlockNumber},
         Web3,
     },
-    Address, L1BatchNumber, L2ChainId, H160, H256, U256,
+    Address, K256PrivateKey, L1BatchNumber, L2ChainId, H160, H256, U256,
 };
 
 #[cfg(test)]
@@ -33,7 +33,7 @@ mod tests;
 #[derive(Debug)]
 pub struct BlockReverterEthConfig {
     eth_client_url: String,
-    reverter_private_key: Option<H256>,
+    reverter_private_key: Option<K256PrivateKey>,
     diamond_proxy_addr: H160,
     validator_timelock_addr: H160,
     default_priority_fee_per_gas: u64,
@@ -50,14 +50,15 @@ impl BlockReverterEthConfig {
     ) -> anyhow::Result<Self> {
         #[allow(deprecated)]
         // `BlockReverter` doesn't support non env configs yet
-        let pk = eth_config
+        let reverter_private_key = eth_config
             .sender
             .context("eth_sender_config")?
-            .private_key();
+            .private_key()
+            .context("eth_sender_config.private_key")?;
 
         Ok(Self {
             eth_client_url: eth_config.web3_url,
-            reverter_private_key: pk,
+            reverter_private_key,
             diamond_proxy_addr: contract.diamond_proxy_addr,
             validator_timelock_addr: contract.validator_timelock_addr,
             default_priority_fee_per_gas: eth_config
@@ -461,6 +462,7 @@ impl BlockReverter {
         let signer = PrivateKeySigner::new(
             eth_config
                 .reverter_private_key
+                .clone()
                 .context("private key is required to send revert transaction")?,
         );
         let chain_id = web3

--- a/core/node/node_framework/src/implementations/layers/eth_sender.rs
+++ b/core/node/node_framework/src/implementations/layers/eth_sender.rs
@@ -85,7 +85,7 @@ impl WiringLayer for EthSenderLayer {
                 &self.eth_sender_config,
                 &self.contracts_config,
                 self.l1chain_id,
-                wallet.private_key(),
+                wallet.private_key().clone(),
             )
         });
         let eth_client_blobs_addr = eth_client_blobs.clone().map(|k| k.sender_account());

--- a/core/node/node_framework/src/implementations/layers/pk_signing_eth_client.rs
+++ b/core/node/node_framework/src/implementations/layers/pk_signing_eth_client.rs
@@ -50,7 +50,7 @@ impl WiringLayer for PKSigningEthClientLayer {
             &self.eth_sender_config,
             &self.contracts_config,
             self.l1chain_id,
-            private_key,
+            private_key.clone(),
         );
         context.insert_resource(BoundEthInterfaceResource(Arc::new(signing_client)))?;
         Ok(())

--- a/core/tests/loadnext/src/account_pool.rs
+++ b/core/tests/loadnext/src/account_pool.rs
@@ -1,10 +1,11 @@
-use std::{collections::VecDeque, convert::TryFrom, str::FromStr, sync::Arc, time::Duration};
+use std::{collections::VecDeque, convert::TryFrom, sync::Arc, time::Duration};
 
+use anyhow::Context as _;
 use once_cell::sync::OnceCell;
 use rand::Rng;
 use tokio::time::timeout;
 use zksync_eth_signer::PrivateKeySigner;
-use zksync_types::{tx::primitives::PackedEthSignature, Address, L2ChainId, H256};
+use zksync_types::{Address, K256PrivateKey, L2ChainId, H256};
 
 use crate::{
     config::LoadtestConfig,
@@ -44,15 +45,15 @@ impl AddressPool {
 #[derive(Debug, Clone)]
 pub struct AccountCredentials {
     /// Ethereum private key.
-    pub eth_pk: H256,
+    pub eth_pk: K256PrivateKey,
     /// Ethereum address derived from the private key.
     pub address: Address,
 }
 
 impl Random for AccountCredentials {
     fn random(rng: &mut LoadtestRng) -> Self {
-        let eth_pk = H256::random_using(rng);
-        let address = pk_to_address(&eth_pk);
+        let eth_pk = K256PrivateKey::random_using(rng);
+        let address = eth_pk.address();
 
         Self { eth_pk, address }
     }
@@ -109,12 +110,14 @@ impl AccountPool {
         let test_contract = loadnext_contract(&config.test_contracts_path)?;
 
         let master_wallet = {
-            let eth_pk = H256::from_str(&config.master_wallet_pk)
-                .expect("Can't parse master wallet private key");
-            let eth_signer = PrivateKeySigner::new(eth_pk);
-            let address = pk_to_address(&eth_pk);
+            let eth_private_key: H256 = config
+                .master_wallet_pk
+                .parse()
+                .context("cannot parse master wallet private key")?;
+            let eth_private_key = K256PrivateKey::from_bytes(eth_private_key)?;
+            let address = eth_private_key.address();
+            let eth_signer = PrivateKeySigner::new(eth_private_key);
             let signer = Signer::new(eth_signer, address, l2_chain_id);
-
             Arc::new(Wallet::with_http_client(&config.l2_rpc_address, signer).unwrap())
         };
 
@@ -138,6 +141,7 @@ impl AccountPool {
 
             for _ in i..range_end {
                 let eth_credentials = AccountCredentials::random(&mut rng);
+                let private_key_bytes = eth_credentials.eth_pk.expose_secret().secret_bytes();
                 let eth_signer = PrivateKeySigner::new(eth_credentials.eth_pk);
                 let address = eth_credentials.address;
                 let signer = Signer::new(eth_signer, address, l2_chain_id);
@@ -155,7 +159,7 @@ impl AccountPool {
                     corrupted_wallet: Arc::new(corrupted_wallet),
                     test_contract: test_contract.clone(),
                     deployed_contract_address: deployed_contract_address.clone(),
-                    rng: rng.derive(eth_credentials.eth_pk),
+                    rng: rng.derive(private_key_bytes),
                 };
                 accounts.push_back(account);
             }
@@ -167,9 +171,4 @@ impl AccountPool {
             addresses: AddressPool::new(addresses),
         })
     }
-}
-
-fn pk_to_address(eth_pk: &H256) -> Address {
-    PackedEthSignature::address_from_private_key(eth_pk)
-        .expect("Can't get an address from the private key")
 }

--- a/core/tests/loadnext/src/corrupted_tx.rs
+++ b/core/tests/loadnext/src/corrupted_tx.rs
@@ -89,8 +89,7 @@ impl EthereumSigner for CorruptedSigner {
 mod tests {
     use zksync_eth_signer::PrivateKeySigner;
     use zksync_types::{
-        fee::Fee, tokens::ETHEREUM_ADDRESS, tx::primitives::PackedEthSignature, Address, L2ChainId,
-        Nonce, H256,
+        fee::Fee, tokens::ETHEREUM_ADDRESS, Address, K256PrivateKey, L2ChainId, Nonce,
     };
 
     use super::*;
@@ -100,10 +99,9 @@ mod tests {
     const NONCE: Nonce = Nonce(1);
 
     fn get_signer(chain_id: L2ChainId) -> Signer<PrivateKeySigner> {
-        let eth_pk = H256::random();
+        let eth_pk = K256PrivateKey::random();
+        let address = eth_pk.address();
         let eth_signer = PrivateKeySigner::new(eth_pk);
-        let address = PackedEthSignature::address_from_private_key(&eth_pk)
-            .expect("Can't get an address from the private key");
         Signer::new(eth_signer, address, chain_id)
     }
 

--- a/core/tests/loadnext/src/rng.rs
+++ b/core/tests/loadnext/src/rng.rs
@@ -1,7 +1,6 @@
 use std::convert::TryInto;
 
 use rand::{rngs::SmallRng, seq::SliceRandom, thread_rng, RngCore, SeedableRng};
-use zksync_types::H256;
 
 use crate::{all::AllWeighted, sdk::web3::signing::keccak256};
 
@@ -40,18 +39,13 @@ impl LoadtestRng {
         hex::encode(self.seed)
     }
 
-    pub fn derive(&self, eth_pk: H256) -> Self {
+    pub fn derive(&self, private_key_bytes: [u8; 32]) -> Self {
         // We chain the current seed bytes and the Ethereum private key together,
         // and then calculate the hash of this data.
         // This way we obtain a derived seed, unique for each wallet, which will result in
-        // an unique set of operations for each account.
-        let input_bytes: Vec<u8> = self
-            .seed
-            .iter()
-            .flat_map(|val| val.to_be_bytes().to_vec())
-            .chain(eth_pk.as_bytes().iter().copied())
-            .collect();
-        let data_hash = keccak256(input_bytes.as_ref());
+        // a unique set of operations for each account.
+        let input_bytes: Vec<u8> = self.seed.into_iter().chain(private_key_bytes).collect();
+        let data_hash = keccak256(&input_bytes);
         let new_seed = data_hash[..SEED_SIZE].try_into().unwrap();
 
         let rng = SmallRng::from_seed(new_seed);

--- a/core/tests/test_account/src/lib.rs
+++ b/core/tests/test_account/src/lib.rs
@@ -13,8 +13,8 @@ use zksync_types::{
     l1::{OpProcessingType, PriorityQueueType},
     l2::L2Tx,
     utils::deployed_address_create,
-    Address, Execute, ExecuteTransactionCommon, L1TxCommonData, L2ChainId, Nonce,
-    PackedEthSignature, PriorityOpId, Transaction, H256, U256,
+    Address, Execute, ExecuteTransactionCommon, K256PrivateKey, L1TxCommonData, L2ChainId, Nonce,
+    PriorityOpId, Transaction, H256, U256,
 };
 use zksync_utils::bytecode::hash_bytecode;
 
@@ -36,14 +36,14 @@ pub enum TxType {
 
 #[derive(Debug, Clone)]
 pub struct Account {
-    private_key: H256,
+    private_key: K256PrivateKey,
     pub address: Address,
     pub nonce: Nonce,
 }
 
 impl Account {
-    pub fn new(private_key: H256) -> Self {
-        let address = PackedEthSignature::address_from_private_key(&private_key).unwrap();
+    pub fn new(private_key: K256PrivateKey) -> Self {
+        let address = private_key.address();
         Self {
             private_key,
             address,
@@ -52,8 +52,7 @@ impl Account {
     }
 
     pub fn random() -> Self {
-        let pk = H256::random();
-        Self::new(pk)
+        Self::new(K256PrivateKey::random())
     }
 
     pub fn get_l2_tx_for_execute(&mut self, execute: Execute, fee: Option<Fee>) -> Transaction {
@@ -246,7 +245,7 @@ impl Account {
     }
 
     pub fn get_pk_signer(&self) -> PrivateKeySigner {
-        PrivateKeySigner::new(self.private_key)
+        PrivateKeySigner::new(self.private_key.clone())
     }
 
     pub async fn sign_legacy_tx(&self, tx: TransactionParameters) -> Vec<u8> {

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -7647,6 +7647,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "hex",
+ "rand 0.8.5",
  "secp256k1",
  "serde",
  "serde_json",


### PR DESCRIPTION
## What ❔

Uses a dedicated type (`K256PrivateKey`) for secp256k1 private keys.

## Why ❔

Right now, the codebase uses `H256` for these keys, which is problematic for many reasons; it makes keys `Copy` (= difficult to track) and doesn't zeroize keys on drop.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.