### PR TITLE
fix(basic_types): bincode deserialization for `L2ChainId`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8115,6 +8115,7 @@ name = "zksync_basic_types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode",
  "chrono",
  "num_enum 0.7.2",
  "serde",

--- a/core/lib/basic_types/Cargo.toml
+++ b/core/lib/basic_types/Cargo.toml
@@ -17,3 +17,6 @@ chrono.workspace = true
 strum = { workspace = true, features = ["derive"] }
 num_enum.workspace = true
 anyhow.workspace = true
+
+[dev-dependencies]
+bincode.workspace = true

--- a/core/lib/basic_types/src/lib.rs
+++ b/core/lib/basic_types/src/lib.rs
@@ -92,17 +92,21 @@ impl<'de> Deserialize<'de> for L2ChainId {
     where
         D: Deserializer<'de>,
     {
-        let value: serde_json::Value = Deserialize::deserialize(deserializer)?;
-        match &value {
-            serde_json::Value::Number(number) => Self::new(number.as_u64().ok_or(
-                de::Error::custom(format!("Failed to parse: {}, Expected u64", number)),
-            )?)
-            .map_err(de::Error::custom),
-            serde_json::Value::String(string) => string.parse().map_err(de::Error::custom),
-            _ => Err(de::Error::custom(format!(
-                "Failed to parse: {}, Expected number or string",
-                value
-            ))),
+        if deserializer.is_human_readable() {
+            let value: serde_json::Value = Deserialize::deserialize(deserializer)?;
+            match &value {
+                serde_json::Value::Number(number) => Self::new(number.as_u64().ok_or(
+                    de::Error::custom(format!("Failed to parse: {}, Expected u64", number)),
+                )?)
+                .map_err(de::Error::custom),
+                serde_json::Value::String(string) => string.parse().map_err(de::Error::custom),
+                _ => Err(de::Error::custom(format!(
+                    "Failed to parse: {}, Expected number or string",
+                    value
+                ))),
+            }
+        } else {
+            u64::deserialize(deserializer).map(L2ChainId)
         }
     }
 }
@@ -263,9 +267,23 @@ mod tests {
         };
         let result_ser = serde_json::to_string(&test).unwrap();
         let result_deser: Test = serde_json::from_str(&result_ser).unwrap();
-        assert_eq!(test.chain_id, result_deser.chain_id)
+        assert_eq!(test.chain_id, result_deser.chain_id);
+        assert_eq!(result_ser, "{\"chain_id\":200}")
     }
 
+    #[test]
+    fn test_serialize_deserialize_bincode() {
+        #[derive(Serialize, Deserialize)]
+        struct Test {
+            chain_id: L2ChainId,
+        }
+        let test = Test {
+            chain_id: L2ChainId(200),
+        };
+        let result_ser = bincode::serialize(&test).unwrap();
+        let result_deser: Test = bincode::deserialize(&result_ser).unwrap();
+        assert_eq!(test.chain_id, result_deser.chain_id);
+    }
     #[test]
     fn test_from_str_valid_hexadecimal() {
         let input = "0x2A";


### PR DESCRIPTION
## What ❔

Skip the `serde_json` workarounds, if the serializer is not human readable.

## Why ❔

Deserialization with the `bincode` serializer is broken, because it is assumed to be json.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.
