### PR TITLE
refactor(node_framework): Refactor pools layer

### DIFF
--- a/core/lib/db_connection/src/connection.rs
+++ b/core/lib/db_connection/src/connection.rs
@@ -147,7 +147,7 @@ enum ConnectionInner<'a> {
 }
 
 /// Marker trait for restricting using all possible types as a storage marker.
-pub trait DbMarker {}
+pub trait DbMarker: 'static + Send + Sync + Clone {}
 
 /// Storage processor is the main storage interaction point.
 /// It holds down the connection (either direct or pooled) to the database

--- a/core/lib/db_connection/src/utils.rs
+++ b/core/lib/db_connection/src/utils.rs
@@ -4,7 +4,7 @@ use sqlx::{postgres::types::PgInterval, types::chrono::NaiveTime};
 
 use crate::connection::DbMarker;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct InternalMarker;
 
 impl DbMarker for InternalMarker {}

--- a/core/node/node_framework/src/implementations/layers/commitment_generator.rs
+++ b/core/node/node_framework/src/implementations/layers/commitment_generator.rs
@@ -1,7 +1,10 @@
 use zksync_commitment_generator::CommitmentGenerator;
 
 use crate::{
-    implementations::resources::{healthcheck::AppHealthCheckResource, pools::MasterPoolResource},
+    implementations::resources::{
+        healthcheck::AppHealthCheckResource,
+        pools::{MasterPool, PoolResource},
+    },
     service::{ServiceContext, StopReceiver},
     task::Task,
     wiring_layer::{WiringError, WiringLayer},
@@ -16,7 +19,7 @@ impl WiringLayer for CommitmentGeneratorLayer {
     }
 
     async fn wire(self: Box<Self>, mut context: ServiceContext<'_>) -> Result<(), WiringError> {
-        let pool_resource = context.get_resource::<MasterPoolResource>().await?;
+        let pool_resource = context.get_resource::<PoolResource<MasterPool>>().await?;
         let main_pool = pool_resource.get().await.unwrap();
 
         let commitment_generator = CommitmentGenerator::new(main_pool);

--- a/core/node/node_framework/src/implementations/layers/consensus.rs
+++ b/core/node/node_framework/src/implementations/layers/consensus.rs
@@ -11,8 +11,10 @@ use zksync_web3_decl::client::BoxedL2Client;
 
 use crate::{
     implementations::resources::{
-        action_queue::ActionQueueSenderResource, main_node_client::MainNodeClientResource,
-        pools::MasterPoolResource, sync_state::SyncStateResource,
+        action_queue::ActionQueueSenderResource,
+        main_node_client::MainNodeClientResource,
+        pools::{MasterPool, PoolResource},
+        sync_state::SyncStateResource,
     },
     service::{ServiceContext, StopReceiver},
     task::Task,
@@ -41,7 +43,7 @@ impl WiringLayer for ConsensusLayer {
 
     async fn wire(self: Box<Self>, mut context: ServiceContext<'_>) -> Result<(), WiringError> {
         let pool = context
-            .get_resource::<MasterPoolResource>()
+            .get_resource::<PoolResource<MasterPool>>()
             .await?
             .get()
             .await?;

--- a/core/node/node_framework/src/implementations/layers/consistency_checker.rs
+++ b/core/node/node_framework/src/implementations/layers/consistency_checker.rs
@@ -3,9 +3,10 @@ use zksync_types::Address;
 
 use crate::{
     implementations::resources::{
-        eth_interface::EthInterfaceResource, healthcheck::AppHealthCheckResource,
+        eth_interface::EthInterfaceResource,
+        healthcheck::AppHealthCheckResource,
         l1_batch_commit_data_generator::L1BatchCommitDataGeneratorResource,
-        pools::MasterPoolResource,
+        pools::{MasterPool, PoolResource},
     },
     service::{ServiceContext, StopReceiver},
     task::Task,
@@ -40,7 +41,7 @@ impl WiringLayer for ConsistencyCheckerLayer {
         // Get resources.
         let l1_client = context.get_resource::<EthInterfaceResource>().await?.0;
 
-        let pool_resource = context.get_resource::<MasterPoolResource>().await?;
+        let pool_resource = context.get_resource::<PoolResource<MasterPool>>().await?;
         let singleton_pool = pool_resource.get_singleton().await?;
 
         let l1_batch_commit_data_generator = context

--- a/core/node/node_framework/src/implementations/layers/contract_verification_api.rs
+++ b/core/node/node_framework/src/implementations/layers/contract_verification_api.rs
@@ -2,7 +2,7 @@ use zksync_config::ContractVerifierConfig;
 use zksync_dal::{ConnectionPool, Core};
 
 use crate::{
-    implementations::resources::pools::{MasterPoolResource, ReplicaPoolResource},
+    implementations::resources::pools::{MasterPool, PoolResource, ReplicaPool},
     service::{ServiceContext, StopReceiver},
     task::Task,
     wiring_layer::{WiringError, WiringLayer},
@@ -19,12 +19,12 @@ impl WiringLayer for ContractVerificationApiLayer {
 
     async fn wire(self: Box<Self>, mut context: ServiceContext<'_>) -> Result<(), WiringError> {
         let master_pool = context
-            .get_resource::<MasterPoolResource>()
+            .get_resource::<PoolResource<MasterPool>>()
             .await?
             .get()
             .await?;
         let replica_pool = context
-            .get_resource::<ReplicaPoolResource>()
+            .get_resource::<PoolResource<ReplicaPool>>()
             .await?
             .get()
             .await?;

--- a/core/node/node_framework/src/implementations/layers/eth_sender.rs
+++ b/core/node/node_framework/src/implementations/layers/eth_sender.rs
@@ -23,7 +23,7 @@ use crate::{
         eth_interface::BoundEthInterfaceResource,
         l1_tx_params::L1TxParamsResource,
         object_store::ObjectStoreResource,
-        pools::{MasterPoolResource, ReplicaPoolResource},
+        pools::{MasterPool, PoolResource, ReplicaPool},
     },
     service::{ServiceContext, StopReceiver},
     task::Task,
@@ -68,10 +68,10 @@ impl WiringLayer for EthSenderLayer {
 
     async fn wire(self: Box<Self>, mut context: ServiceContext<'_>) -> Result<(), WiringError> {
         // Get resources.
-        let master_pool_resource = context.get_resource::<MasterPoolResource>().await?;
+        let master_pool_resource = context.get_resource::<PoolResource<MasterPool>>().await?;
         let master_pool = master_pool_resource.get().await.unwrap();
 
-        let replica_pool_resource = context.get_resource::<ReplicaPoolResource>().await?;
+        let replica_pool_resource = context.get_resource::<PoolResource<ReplicaPool>>().await?;
         let replica_pool = replica_pool_resource.get().await.unwrap();
 
         let eth_client = context.get_resource::<BoundEthInterfaceResource>().await?.0;

--- a/core/node/node_framework/src/implementations/layers/eth_watch.rs
+++ b/core/node/node_framework/src/implementations/layers/eth_watch.rs
@@ -7,7 +7,10 @@ use zksync_eth_watch::{EthHttpQueryClient, EthWatch};
 use zksync_types::{ethabi::Contract, Address};
 
 use crate::{
-    implementations::resources::{eth_interface::EthInterfaceResource, pools::MasterPoolResource},
+    implementations::resources::{
+        eth_interface::EthInterfaceResource,
+        pools::{MasterPool, PoolResource},
+    },
     service::{ServiceContext, StopReceiver},
     task::Task,
     wiring_layer::{WiringError, WiringLayer},
@@ -35,7 +38,7 @@ impl WiringLayer for EthWatchLayer {
     }
 
     async fn wire(self: Box<Self>, mut context: ServiceContext<'_>) -> Result<(), WiringError> {
-        let pool_resource = context.get_resource::<MasterPoolResource>().await?;
+        let pool_resource = context.get_resource::<PoolResource<MasterPool>>().await?;
         let main_pool = pool_resource.get().await.unwrap();
 
         let client = context.get_resource::<EthInterfaceResource>().await?.0;

--- a/core/node/node_framework/src/implementations/layers/house_keeper.rs
+++ b/core/node/node_framework/src/implementations/layers/house_keeper.rs
@@ -19,7 +19,7 @@ use zksync_house_keeper::{
 };
 
 use crate::{
-    implementations::resources::pools::{ProverPoolResource, ReplicaPoolResource},
+    implementations::resources::pools::{PoolResource, ProverPool, ReplicaPool},
     service::{ServiceContext, StopReceiver},
     task::Task,
     wiring_layer::{WiringError, WiringLayer},
@@ -62,10 +62,10 @@ impl WiringLayer for HouseKeeperLayer {
 
     async fn wire(self: Box<Self>, mut context: ServiceContext<'_>) -> Result<(), WiringError> {
         // initialize resources
-        let replica_pool_resource = context.get_resource::<ReplicaPoolResource>().await?;
+        let replica_pool_resource = context.get_resource::<PoolResource<ReplicaPool>>().await?;
         let replica_pool = replica_pool_resource.get().await?;
 
-        let prover_pool_resource = context.get_resource::<ProverPoolResource>().await?;
+        let prover_pool_resource = context.get_resource::<PoolResource<ProverPool>>().await?;
         let prover_pool = prover_pool_resource.get().await?;
 
         // initialize and add tasks

--- a/core/node/node_framework/src/implementations/layers/pools_layer.rs
+++ b/core/node/node_framework/src/implementations/layers/pools_layer.rs
@@ -1,11 +1,7 @@
-use prover_dal::Prover;
 use zksync_config::configs::PostgresConfig;
-use zksync_dal::{ConnectionPool, Core};
 
 use crate::{
-    implementations::resources::pools::{
-        MasterPoolResource, ProverPoolResource, ReplicaPoolResource,
-    },
+    implementations::resources::pools::{MasterPool, PoolResource, ProverPool, ReplicaPool},
     service::ServiceContext,
     wiring_layer::{WiringError, WiringLayer},
 };
@@ -75,30 +71,27 @@ impl WiringLayer for PoolsLayer {
         }
 
         if self.with_master {
-            let mut master_pool = ConnectionPool::<Core>::builder(
-                self.config.master_url()?,
+            context.insert_resource(PoolResource::<MasterPool>::new(
+                self.config.master_url()?.into(),
                 self.config.max_connections()?,
-            );
-            master_pool.set_statement_timeout(self.config.statement_timeout());
-            context.insert_resource(MasterPoolResource::new(master_pool))?;
+                self.config.statement_timeout(),
+            ))?;
         }
 
         if self.with_replica {
-            let mut replica_pool = ConnectionPool::<Core>::builder(
-                self.config.replica_url()?,
+            context.insert_resource(PoolResource::<ReplicaPool>::new(
+                self.config.replica_url()?.into(),
                 self.config.max_connections()?,
-            );
-            replica_pool.set_statement_timeout(self.config.statement_timeout());
-            context.insert_resource(ReplicaPoolResource::new(replica_pool))?;
+                self.config.statement_timeout(),
+            ))?;
         }
 
         if self.with_prover {
-            let mut prover_pool = ConnectionPool::<Prover>::builder(
-                self.config.prover_url()?,
+            context.insert_resource(PoolResource::<ProverPool>::new(
+                self.config.prover_url()?.into(),
                 self.config.max_connections()?,
-            );
-            prover_pool.set_statement_timeout(self.config.statement_timeout());
-            context.insert_resource(ProverPoolResource::new(prover_pool))?;
+                self.config.statement_timeout(),
+            ))?;
         }
 
         Ok(())

--- a/core/node/node_framework/src/implementations/layers/proof_data_handler.rs
+++ b/core/node/node_framework/src/implementations/layers/proof_data_handler.rs
@@ -6,7 +6,10 @@ use zksync_dal::{ConnectionPool, Core};
 use zksync_object_store::ObjectStore;
 
 use crate::{
-    implementations::resources::{object_store::ObjectStoreResource, pools::MasterPoolResource},
+    implementations::resources::{
+        object_store::ObjectStoreResource,
+        pools::{MasterPool, PoolResource},
+    },
     service::{ServiceContext, StopReceiver},
     task::Task,
     wiring_layer::{WiringError, WiringLayer},
@@ -16,7 +19,7 @@ use crate::{
 ///
 /// ## Effects
 ///
-/// - Resolves `MasterPoolResource`.
+/// - Resolves `PoolResource<MasterPool>`.
 /// - Resolves `ObjectStoreResource`.
 /// - Adds `proof_data_handler` to the node.
 #[derive(Debug)]
@@ -39,7 +42,7 @@ impl WiringLayer for ProofDataHandlerLayer {
     }
 
     async fn wire(self: Box<Self>, mut context: ServiceContext<'_>) -> Result<(), WiringError> {
-        let pool_resource = context.get_resource::<MasterPoolResource>().await?;
+        let pool_resource = context.get_resource::<PoolResource<MasterPool>>().await?;
         let main_pool = pool_resource.get().await.unwrap();
 
         let object_store = context.get_resource::<ObjectStoreResource>().await?;

--- a/core/node/node_framework/src/implementations/layers/state_keeper/main_batch_executor.rs
+++ b/core/node/node_framework/src/implementations/layers/state_keeper/main_batch_executor.rs
@@ -5,7 +5,10 @@ use zksync_core::state_keeper::{AsyncRocksdbCache, MainBatchExecutor};
 use zksync_state::AsyncCatchupTask;
 
 use crate::{
-    implementations::resources::{pools::MasterPoolResource, state_keeper::BatchExecutorResource},
+    implementations::resources::{
+        pools::{MasterPool, PoolResource},
+        state_keeper::BatchExecutorResource,
+    },
     resource::Unique,
     service::{ServiceContext, StopReceiver},
     task::Task,
@@ -34,7 +37,7 @@ impl WiringLayer for MainBatchExecutorLayer {
     }
 
     async fn wire(self: Box<Self>, mut context: ServiceContext<'_>) -> Result<(), WiringError> {
-        let master_pool = context.get_resource::<MasterPoolResource>().await?;
+        let master_pool = context.get_resource::<PoolResource<MasterPool>>().await?;
 
         let (storage_factory, task) = AsyncRocksdbCache::new(
             master_pool.get_singleton().await?,

--- a/core/node/node_framework/src/implementations/layers/state_keeper/mempool_io.rs
+++ b/core/node/node_framework/src/implementations/layers/state_keeper/mempool_io.rs
@@ -16,7 +16,7 @@ use zksync_core::state_keeper::{
 use crate::{
     implementations::resources::{
         fee_input::FeeInputResource,
-        pools::MasterPoolResource,
+        pools::{MasterPool, PoolResource},
         state_keeper::{ConditionalSealerResource, OutputHandlerResource, StateKeeperIOResource},
     },
     resource::Unique,
@@ -53,7 +53,7 @@ impl MempoolIOLayer {
 
     async fn build_mempool_guard(
         &self,
-        master_pool: &MasterPoolResource,
+        master_pool: &PoolResource<MasterPool>,
     ) -> anyhow::Result<MempoolGuard> {
         let connection_pool = master_pool
             .get_singleton()
@@ -78,7 +78,7 @@ impl WiringLayer for MempoolIOLayer {
     async fn wire(self: Box<Self>, mut context: ServiceContext<'_>) -> Result<(), WiringError> {
         // Fetch required resources.
         let batch_fee_input_provider = context.get_resource::<FeeInputResource>().await?.0;
-        let master_pool = context.get_resource::<MasterPoolResource>().await?;
+        let master_pool = context.get_resource::<PoolResource<MasterPool>>().await?;
 
         // Create miniblock sealer task.
         let (persistence, l2_block_sealer) = StateKeeperPersistence::new(

--- a/core/node/node_framework/src/implementations/layers/web3_api/caches.rs
+++ b/core/node/node_framework/src/implementations/layers/web3_api/caches.rs
@@ -3,7 +3,10 @@ use std::time::Duration;
 use zksync_core::api_server::web3::mempool_cache::{self, MempoolCache};
 
 use crate::{
-    implementations::resources::{pools::ReplicaPoolResource, web3_api::MempoolCacheResource},
+    implementations::resources::{
+        pools::{PoolResource, ReplicaPool},
+        web3_api::MempoolCacheResource,
+    },
     service::{ServiceContext, StopReceiver},
     task::Task,
     wiring_layer::{WiringError, WiringLayer},
@@ -31,7 +34,7 @@ impl WiringLayer for MempoolCacheLayer {
     }
 
     async fn wire(self: Box<Self>, mut context: ServiceContext<'_>) -> Result<(), WiringError> {
-        let pool_resource = context.get_resource::<ReplicaPoolResource>().await?;
+        let pool_resource = context.get_resource::<PoolResource<ReplicaPool>>().await?;
         let replica_pool = pool_resource.get().await?;
         let mempool_cache = MempoolCache::new(self.capacity);
         let update_task = mempool_cache.update_task(replica_pool, self.update_interval);

--- a/core/node/node_framework/src/implementations/layers/web3_api/server.rs
+++ b/core/node/node_framework/src/implementations/layers/web3_api/server.rs
@@ -9,7 +9,7 @@ use crate::{
     implementations::resources::{
         circuit_breakers::CircuitBreakersResource,
         healthcheck::AppHealthCheckResource,
-        pools::ReplicaPoolResource,
+        pools::{PoolResource, ReplicaPool},
         sync_state::SyncStateResource,
         web3_api::{MempoolCacheResource, TreeApiClientResource, TxSenderResource},
     },
@@ -111,7 +111,7 @@ impl WiringLayer for Web3ServerLayer {
 
     async fn wire(self: Box<Self>, mut context: ServiceContext<'_>) -> Result<(), WiringError> {
         // Get required resources.
-        let replica_resource_pool = context.get_resource::<ReplicaPoolResource>().await?;
+        let replica_resource_pool = context.get_resource::<PoolResource<ReplicaPool>>().await?;
         let updaters_pool = replica_resource_pool.get_custom(2).await?;
         let replica_pool = replica_resource_pool.get().await?;
         let tx_sender = context.get_resource::<TxSenderResource>().await?.0;

--- a/core/node/node_framework/src/implementations/layers/web3_api/tx_sender.rs
+++ b/core/node/node_framework/src/implementations/layers/web3_api/tx_sender.rs
@@ -9,7 +9,7 @@ use zksync_state::PostgresStorageCaches;
 use crate::{
     implementations::resources::{
         fee_input::FeeInputResource,
-        pools::ReplicaPoolResource,
+        pools::{PoolResource, ReplicaPool},
         state_keeper::ConditionalSealerResource,
         web3_api::{TxSenderResource, TxSinkResource},
     },
@@ -58,7 +58,7 @@ impl WiringLayer for TxSenderLayer {
     async fn wire(self: Box<Self>, mut context: ServiceContext<'_>) -> Result<(), WiringError> {
         // Get required resources.
         let tx_sink = context.get_resource::<TxSinkResource>().await?.0;
-        let pool_resource = context.get_resource::<ReplicaPoolResource>().await?;
+        let pool_resource = context.get_resource::<PoolResource<ReplicaPool>>().await?;
         let replica_pool = pool_resource.get().await?;
         let sealer = match context.get_resource::<ConditionalSealerResource>().await {
             Ok(sealer) => Some(sealer.0),

--- a/core/node/node_framework/src/implementations/layers/web3_api/tx_sink.rs
+++ b/core/node/node_framework/src/implementations/layers/web3_api/tx_sink.rs
@@ -4,7 +4,8 @@ use zksync_core::api_server::tx_sender::{master_pool_sink::MasterPoolSink, proxy
 
 use crate::{
     implementations::resources::{
-        main_node_client::MainNodeClientResource, pools::MasterPoolResource,
+        main_node_client::MainNodeClientResource,
+        pools::{MasterPool, PoolResource},
         web3_api::TxSinkResource,
     },
     service::ServiceContext,
@@ -28,7 +29,7 @@ impl WiringLayer for TxSinkLayer {
         let tx_sink = match self.as_ref() {
             TxSinkLayer::MasterPoolSink => {
                 let pool = context
-                    .get_resource::<MasterPoolResource>()
+                    .get_resource::<PoolResource<MasterPool>>()
                     .await?
                     .get()
                     .await?;

--- a/core/node/node_framework/src/implementations/resources/pools.rs
+++ b/core/node/node_framework/src/implementations/resources/pools.rs
@@ -1,62 +1,103 @@
-use std::sync::{
-    atomic::{AtomicU32, Ordering},
-    Arc,
+use std::{
+    fmt,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    },
+    time::Duration,
 };
 
 use prover_dal::Prover;
+use tokio::sync::Mutex;
 use zksync_dal::{ConnectionPool, Core};
 use zksync_db_connection::connection_pool::ConnectionPoolBuilder;
 
 use crate::resource::Resource;
 
-/// Represents a connection pool to the master database.
-#[derive(Debug, Clone)]
-pub struct MasterPoolResource {
+/// Represents a connection pool to a certain kind of database.
+#[derive(Clone)]
+pub struct PoolResource<P: PoolKind> {
     connections_count: Arc<AtomicU32>,
-    builder: ConnectionPoolBuilder<Core>,
+    url: String,
+    max_connections: u32,
+    statement_timeout: Option<Duration>,
+    unbound_pool: Arc<Mutex<Option<ConnectionPool<P::DbMarker>>>>,
+    _kind: std::marker::PhantomData<P>,
 }
 
-impl Resource for MasterPoolResource {
-    fn name() -> String {
-        "common/master_pool".into()
+impl<P: PoolKind> fmt::Debug for PoolResource<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PoolResource")
+            .field("connections_count", &self.connections_count)
+            .field("url", &"...")
+            .field("max_connections", &self.max_connections)
+            .field("statement_timeout", &self.statement_timeout)
+            .field("unbound_pool", &self.unbound_pool)
+            .finish_non_exhaustive()
     }
 }
 
-impl MasterPoolResource {
-    pub fn new(builder: ConnectionPoolBuilder<Core>) -> Self {
+impl<P: PoolKind> Resource for PoolResource<P> {
+    fn name() -> String {
+        format!("common/{}_pool", P::kind_str())
+    }
+}
+
+impl<P: PoolKind> PoolResource<P> {
+    pub fn new(url: String, max_connections: u32, statement_timeout: Option<Duration>) -> Self {
         Self {
             connections_count: Arc::new(AtomicU32::new(0)),
-            builder,
+            url,
+            max_connections,
+            statement_timeout,
+            unbound_pool: Arc::new(Mutex::new(None)),
+            _kind: std::marker::PhantomData,
         }
     }
 
-    pub async fn get(&self) -> anyhow::Result<ConnectionPool<Core>> {
-        let result = self.builder.build().await;
+    fn builder(&self) -> ConnectionPoolBuilder<P::DbMarker> {
+        let mut builder = ConnectionPool::builder(&self.url, self.max_connections);
+        builder.set_statement_timeout(self.statement_timeout);
+        builder
+    }
 
-        if result.is_ok() {
-            self.connections_count
-                .fetch_add(self.builder.max_size(), Ordering::Relaxed);
-            let total_connections = self.connections_count.load(Ordering::Relaxed);
+    pub async fn get(&self) -> anyhow::Result<ConnectionPool<P::DbMarker>> {
+        let mut unbound_pool = self.unbound_pool.lock().await;
+        if let Some(pool) = unbound_pool.as_ref() {
             tracing::info!(
-                "Created a new master pool. Master pool total connections count: {total_connections}"
+                "Provided a new copy of an existing {} unbound pool",
+                P::kind_str()
             );
+            return Ok(pool.clone());
         }
+        let pool = self.builder().build().await?;
+        *unbound_pool = Some(pool.clone());
 
-        result
+        let old_count = self
+            .connections_count
+            .fetch_add(self.max_connections, Ordering::Relaxed);
+        let total_connections = old_count + self.max_connections;
+        tracing::info!(
+            "Created a new {} pool. Total connections count: {total_connections}",
+            P::kind_str()
+        );
+
+        Ok(pool)
     }
 
-    pub async fn get_singleton(&self) -> anyhow::Result<ConnectionPool<Core>> {
+    pub async fn get_singleton(&self) -> anyhow::Result<ConnectionPool<P::DbMarker>> {
         self.get_custom(1).await
     }
 
-    pub async fn get_custom(&self, size: u32) -> anyhow::Result<ConnectionPool<Core>> {
-        let result = self.builder.clone().set_max_size(size).build().await;
+    pub async fn get_custom(&self, size: u32) -> anyhow::Result<ConnectionPool<P::DbMarker>> {
+        let result = self.builder().set_max_size(size).build().await;
 
         if result.is_ok() {
             let old_count = self.connections_count.fetch_add(size, Ordering::Relaxed);
             let total_connections = old_count + size;
             tracing::info!(
-                "Created a new master pool. Master pool total connections count: {total_connections}"
+                "Created a new {} pool. Total connections count: {total_connections}",
+                P::kind_str()
             );
         }
 
@@ -64,112 +105,44 @@ impl MasterPoolResource {
     }
 }
 
-/// Represents a connection pool to the replica database.
 #[derive(Debug, Clone)]
-pub struct ReplicaPoolResource {
-    connections_count: Arc<AtomicU32>,
-    builder: ConnectionPoolBuilder<Core>,
-}
+#[non_exhaustive]
+pub struct MasterPool {}
 
-impl Resource for ReplicaPoolResource {
-    fn name() -> String {
-        "common/replica_pool".into()
-    }
-}
-
-impl ReplicaPoolResource {
-    pub fn new(builder: ConnectionPoolBuilder<Core>) -> Self {
-        Self {
-            connections_count: Arc::new(AtomicU32::new(0)),
-            builder,
-        }
-    }
-
-    pub async fn get(&self) -> anyhow::Result<ConnectionPool<Core>> {
-        let result = self.builder.build().await;
-
-        if result.is_ok() {
-            self.connections_count
-                .fetch_add(self.builder.max_size(), Ordering::Relaxed);
-            let total_connections = self.connections_count.load(Ordering::Relaxed);
-            tracing::info!(
-                "Created a new replica pool. Replica pool total connections count: {total_connections}"
-            );
-        }
-
-        result
-    }
-
-    pub async fn get_singleton(&self) -> anyhow::Result<ConnectionPool<Core>> {
-        self.get_custom(1).await
-    }
-
-    pub async fn get_custom(&self, size: u32) -> anyhow::Result<ConnectionPool<Core>> {
-        let result = self.builder.clone().set_max_size(size).build().await;
-
-        if result.is_ok() {
-            let old_count = self.connections_count.fetch_add(size, Ordering::Relaxed);
-            let total_connections = old_count + size;
-            tracing::info!(
-                "Created a new replica pool. Replica pool total connections count: {total_connections}"
-            );
-        }
-
-        result
-    }
-}
-
-/// Represents a connection pool to the prover database.
 #[derive(Debug, Clone)]
-pub struct ProverPoolResource {
-    connections_count: Arc<AtomicU32>,
-    builder: ConnectionPoolBuilder<Prover>,
+#[non_exhaustive]
+pub struct ReplicaPool {}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ProverPool {}
+
+pub trait PoolKind: Clone + Sync + Send + 'static {
+    type DbMarker: zksync_db_connection::connection::DbMarker;
+
+    fn kind_str() -> &'static str;
 }
 
-impl Resource for ProverPoolResource {
-    fn name() -> String {
-        "common/prover_pool".into()
+impl PoolKind for MasterPool {
+    type DbMarker = Core;
+
+    fn kind_str() -> &'static str {
+        "master"
     }
 }
 
-impl ProverPoolResource {
-    pub fn new(builder: ConnectionPoolBuilder<Prover>) -> Self {
-        Self {
-            connections_count: Arc::new(AtomicU32::new(0)),
-            builder,
-        }
+impl PoolKind for ReplicaPool {
+    type DbMarker = Core;
+
+    fn kind_str() -> &'static str {
+        "replica"
     }
+}
 
-    pub async fn get(&self) -> anyhow::Result<ConnectionPool<Prover>> {
-        let result = self.builder.build().await;
+impl PoolKind for ProverPool {
+    type DbMarker = Prover;
 
-        if result.is_ok() {
-            self.connections_count
-                .fetch_add(self.builder.max_size(), Ordering::Relaxed);
-            let total_connections = self.connections_count.load(Ordering::Relaxed);
-            tracing::info!(
-                "Created a new prover pool. Master pool total connections count: {total_connections}"
-            );
-        }
-
-        result
-    }
-
-    pub async fn get_singleton(&self) -> anyhow::Result<ConnectionPool<Prover>> {
-        self.get_custom(1).await
-    }
-
-    pub async fn get_custom(&self, size: u32) -> anyhow::Result<ConnectionPool<Prover>> {
-        let result = self.builder.clone().set_max_size(size).build().await;
-
-        if result.is_ok() {
-            let old_count = self.connections_count.fetch_add(size, Ordering::Relaxed);
-            let total_connections = old_count + size;
-            tracing::info!(
-                "Created a new prover pool. Prover pool total connections count: {total_connections}"
-            );
-        }
-
-        result
+    fn kind_str() -> &'static str {
+        "prover"
     }
 }


### PR DESCRIPTION
## What ❔

Refactors pools layer:

- Introduces a single generic type instead of 3 mostly copy-pasted ones.
- Parameters for builder are now passed to the resource instead of cloning a builder.
- Fixes a problem where an unbound pool is created for each requester (now it's lazily initialized and cloned).

## Why ❔

a) less boilerplate
b) align the implementation to the expected behavior

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
