### PR TITLE
test(en): Fix snapshot recovery test flakiness

### DIFF
--- a/core/tests/snapshot-recovery-test/tests/snapshot-recovery.test.ts
+++ b/core/tests/snapshot-recovery-test/tests/snapshot-recovery.test.ts
@@ -379,13 +379,13 @@ describe('snapshot recovery', () => {
             if (!isDbPrunerReady) {
                 console.log('DB pruner health', health.components.db_pruner);
                 const status = health.components.db_pruner?.status;
-                expect(status).to.be.oneOf([undefined, 'not_ready', 'ready']);
+                expect(status).to.be.oneOf([undefined, 'not_ready', 'affected', 'ready']);
                 isDbPrunerReady = status === 'ready';
             }
             if (!isTreePrunerReady) {
                 console.log('Tree pruner health', health.components.tree_pruner);
                 const status = health.components.tree_pruner?.status;
-                expect(status).to.be.oneOf([undefined, 'not_ready', 'ready']);
+                expect(status).to.be.oneOf([undefined, 'not_ready', 'affected', 'ready']);
                 isTreePrunerReady = status === 'ready';
             }
         }


### PR DESCRIPTION
## What ❔

Fixes flakiness in the snapshot recovery / pruning test by relaxing some checks.

## Why ❔

Flaky tests bad.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.