### PR TITLE
fix(loadtest): Do not initiate transactions with 0 amount

### DIFF
--- a/core/tests/loadnext/src/command/tx_command.rs
+++ b/core/tests/loadnext/src/command/tx_command.rs
@@ -189,6 +189,6 @@ impl TxCommand {
     }
 
     fn random_amount(rng: &mut LoadtestRng) -> U256 {
-        rng.gen_range(0u64..2u64.pow(18)).into()
+        rng.gen_range(1u64..2u64.pow(18)).into()
     }
 }


### PR DESCRIPTION
## What ❔

Makes sure that any transaction has amount of 1 wei at least.

## Why ❔

- It is no longer possible to withdraw 0 wei, so the test became flaky.
- Testing edge cases is not a point for loadtest, we have integration tests for that.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
