### PR TITLE
fix(prover): Use all 1.5.0 groups for nodes

### DIFF
--- a/prover/prover_fri_utils/src/lib.rs
+++ b/prover/prover_fri_utils/src/lib.rs
@@ -148,7 +148,7 @@ mod tests {
         let res = get_all_circuit_id_round_tuples_for(ids);
         let expected_circuit_ids: Vec<u8> =
             ((ZkSyncRecursionLayerStorageType::LeafLayerCircuitForMainVM as u8)
-                ..=(ZkSyncRecursionLayerStorageType::LeafLayerCircuitForL1MessagesHasher as u8))
+                ..=(ZkSyncRecursionLayerStorageType::LeafLayerCircuitForEIP4844Repack as u8))
                 .collect();
         let expected = expected_circuit_ids
             .into_iter()


### PR DESCRIPTION
This iterates over the newly added circuits in 1.5.0. It is needed for scheduling in a group specific context. In it's absence, nodes will only prove the old circuits.