### PR TITLE
refactor(eth-client): Refactor L1 client interfaces

### DIFF
--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -841,7 +841,7 @@ impl ExternalNodeConfig {
         // We can query them from main node, but it's better to set them explicitly
         // as well to avoid connecting to wrong environment variables unintentionally.
         let eth_chain_id = eth_client
-            .fetch_chain_id("en")
+            .fetch_chain_id()
             .await
             .context("Unable to check L1 chain ID through the configured L1 client")?;
 

--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -210,7 +210,7 @@ async fn run_core(
     config: &ExternalNodeConfig,
     connection_pool: ConnectionPool<Core>,
     main_node_client: BoxedL2Client,
-    eth_client: Arc<dyn EthInterface>,
+    eth_client: Box<dyn EthInterface>,
     task_handles: &mut Vec<task::JoinHandle<anyhow::Result<()>>>,
     app_health: &AppHealthCheck,
     stop_receiver: watch::Receiver<bool>,
@@ -588,7 +588,7 @@ async fn init_tasks(
     connection_pool: ConnectionPool<Core>,
     singleton_pool_builder: ConnectionPoolBuilder<Core>,
     main_node_client: BoxedL2Client,
-    eth_client: Arc<dyn EthInterface>,
+    eth_client: Box<dyn EthInterface>,
     task_handles: &mut Vec<JoinHandle<anyhow::Result<()>>>,
     app_health: &AppHealthCheck,
     stop_receiver: watch::Receiver<bool>,
@@ -821,7 +821,7 @@ async fn main() -> anyhow::Result<()> {
     let main_node_client = BoxedL2Client::new(main_node_client);
 
     let eth_client_url = &required_config.eth_client_url;
-    let eth_client = Arc::new(QueryClient::new(eth_client_url.clone())?);
+    let eth_client = Box::new(QueryClient::new(eth_client_url.clone())?);
 
     let mut config = ExternalNodeConfig::new(
         required_config,
@@ -891,7 +891,7 @@ async fn run_node(
     connection_pool: ConnectionPool<Core>,
     singleton_pool_builder: ConnectionPoolBuilder<Core>,
     main_node_client: BoxedL2Client,
-    eth_client: Arc<dyn EthInterface>,
+    eth_client: Box<dyn EthInterface>,
 ) -> anyhow::Result<()> {
     tracing::warn!("The external node is in the alpha phase, and should be used with caution.");
     tracing::info!("Started the external node");

--- a/core/bin/external_node/src/tests.rs
+++ b/core/bin/external_node/src/tests.rs
@@ -176,7 +176,7 @@ async fn external_node_basics(components_str: &'static str) {
         }
         panic!("Unexpected L1 call: {call:?}");
     });
-    let eth_client = Arc::new(eth_client);
+    let eth_client = Box::new(eth_client);
 
     let (env, env_handles) = TestEnvironment::new();
     let node_handle = tokio::spawn(async move {

--- a/core/lib/eth_client/src/clients/http/query.rs
+++ b/core/lib/eth_client/src/clients/http/query.rs
@@ -30,6 +30,7 @@ use crate::{
 pub struct QueryClient {
     web3: Web3<Http>,
     url: SensitiveUrl,
+    component: &'static str,
 }
 
 impl fmt::Debug for QueryClient {
@@ -48,14 +49,15 @@ impl QueryClient {
         Ok(Self {
             web3: Web3::new(transport),
             url,
+            component: "",
         })
     }
 }
 
 #[async_trait]
 impl EthInterface for QueryClient {
-    async fn fetch_chain_id(&self, component: &'static str) -> Result<L1ChainId, Error> {
-        COUNTERS.call[&(Method::ChainId, component)].inc();
+    async fn fetch_chain_id(&self) -> Result<L1ChainId, Error> {
+        COUNTERS.call[&(Method::ChainId, self.component)].inc();
         let latency = LATENCIES.direct[&Method::ChainId].start();
         let raw_chain_id = self.web3.eth().chain_id().await?;
         latency.observe();
@@ -68,9 +70,8 @@ impl EthInterface for QueryClient {
         &self,
         account: Address,
         block: BlockNumber,
-        component: &'static str,
     ) -> Result<U256, Error> {
-        COUNTERS.call[&(Method::NonceAtForAccount, component)].inc();
+        COUNTERS.call[&(Method::NonceAtForAccount, self.component)].inc();
         let latency = LATENCIES.direct[&Method::NonceAtForAccount].start();
         let nonce = self
             .web3
@@ -81,16 +82,16 @@ impl EthInterface for QueryClient {
         Ok(nonce)
     }
 
-    async fn block_number(&self, component: &'static str) -> Result<U64, Error> {
-        COUNTERS.call[&(Method::BlockNumber, component)].inc();
+    async fn block_number(&self) -> Result<U64, Error> {
+        COUNTERS.call[&(Method::BlockNumber, self.component)].inc();
         let latency = LATENCIES.direct[&Method::BlockNumber].start();
         let block_number = self.web3.eth().block_number().await?;
         latency.observe();
         Ok(block_number)
     }
 
-    async fn get_gas_price(&self, component: &'static str) -> Result<U256, Error> {
-        COUNTERS.call[&(Method::GetGasPrice, component)].inc();
+    async fn get_gas_price(&self) -> Result<U256, Error> {
+        COUNTERS.call[&(Method::GetGasPrice, self.component)].inc();
         let latency = LATENCIES.direct[&Method::GetGasPrice].start();
         let network_gas_price = self.web3.eth().gas_price().await?;
         latency.observe();
@@ -108,11 +109,10 @@ impl EthInterface for QueryClient {
         &self,
         upto_block: usize,
         block_count: usize,
-        component: &'static str,
     ) -> Result<Vec<u64>, Error> {
         const MAX_REQUEST_CHUNK: usize = 1024;
 
-        COUNTERS.call[&(Method::BaseFeeHistory, component)].inc();
+        COUNTERS.call[&(Method::BaseFeeHistory, self.component)].inc();
         let latency = LATENCIES.direct[&Method::BaseFeeHistory].start();
         let mut history = Vec::with_capacity(block_count);
         let from_block = upto_block.saturating_sub(block_count);
@@ -142,11 +142,8 @@ impl EthInterface for QueryClient {
         Ok(history.into_iter().map(|fee| fee.as_u64()).collect())
     }
 
-    async fn get_pending_block_base_fee_per_gas(
-        &self,
-        component: &'static str,
-    ) -> Result<U256, Error> {
-        COUNTERS.call[&(Method::PendingBlockBaseFee, component)].inc();
+    async fn get_pending_block_base_fee_per_gas(&self) -> Result<U256, Error> {
+        COUNTERS.call[&(Method::PendingBlockBaseFee, self.component)].inc();
         let latency = LATENCIES.direct[&Method::PendingBlockBaseFee].start();
 
         let block = self
@@ -171,15 +168,11 @@ impl EthInterface for QueryClient {
         Ok(block.base_fee_per_gas.unwrap())
     }
 
-    async fn get_tx_status(
-        &self,
-        hash: H256,
-        component: &'static str,
-    ) -> Result<Option<ExecutedTxStatus>, Error> {
-        COUNTERS.call[&(Method::GetTxStatus, component)].inc();
+    async fn get_tx_status(&self, hash: H256) -> Result<Option<ExecutedTxStatus>, Error> {
+        COUNTERS.call[&(Method::GetTxStatus, self.component)].inc();
         let latency = LATENCIES.direct[&Method::GetTxStatus].start();
 
-        let receipt = self.tx_receipt(hash, component).await?;
+        let receipt = self.tx_receipt(hash).await?;
         let res = receipt.and_then(|receipt| match receipt.status {
             Some(status) if receipt.block_number.is_some() => {
                 let success = status.as_u64() == 1;
@@ -251,12 +244,8 @@ impl EthInterface for QueryClient {
         }
     }
 
-    async fn get_tx(
-        &self,
-        hash: H256,
-        component: &'static str,
-    ) -> Result<Option<Transaction>, Error> {
-        COUNTERS.call[&(Method::GetTx, component)].inc();
+    async fn get_tx(&self, hash: H256) -> Result<Option<Transaction>, Error> {
+        COUNTERS.call[&(Method::GetTx, self.component)].inc();
         let tx = self
             .web3
             .eth()
@@ -284,40 +273,32 @@ impl EthInterface for QueryClient {
         Ok(res)
     }
 
-    async fn tx_receipt(
-        &self,
-        tx_hash: H256,
-        component: &'static str,
-    ) -> Result<Option<TransactionReceipt>, Error> {
-        COUNTERS.call[&(Method::TxReceipt, component)].inc();
+    async fn tx_receipt(&self, tx_hash: H256) -> Result<Option<TransactionReceipt>, Error> {
+        COUNTERS.call[&(Method::TxReceipt, self.component)].inc();
         let latency = LATENCIES.direct[&Method::TxReceipt].start();
         let receipt = self.web3.eth().transaction_receipt(tx_hash).await?;
         latency.observe();
         Ok(receipt)
     }
 
-    async fn eth_balance(&self, address: Address, component: &'static str) -> Result<U256, Error> {
-        COUNTERS.call[&(Method::EthBalance, component)].inc();
+    async fn eth_balance(&self, address: Address) -> Result<U256, Error> {
+        COUNTERS.call[&(Method::EthBalance, self.component)].inc();
         let latency = LATENCIES.direct[&Method::EthBalance].start();
         let balance = self.web3.eth().balance(address, None).await?;
         latency.observe();
         Ok(balance)
     }
 
-    async fn logs(&self, filter: Filter, component: &'static str) -> Result<Vec<Log>, Error> {
-        COUNTERS.call[&(Method::Logs, component)].inc();
+    async fn logs(&self, filter: Filter) -> Result<Vec<Log>, Error> {
+        COUNTERS.call[&(Method::Logs, self.component)].inc();
         let latency = LATENCIES.direct[&Method::Logs].start();
         let logs = self.web3.eth().logs(filter).await?;
         latency.observe();
         Ok(logs)
     }
 
-    async fn block(
-        &self,
-        block_id: BlockId,
-        component: &'static str,
-    ) -> Result<Option<Block<H256>>, Error> {
-        COUNTERS.call[&(Method::Block, component)].inc();
+    async fn block(&self, block_id: BlockId) -> Result<Option<Block<H256>>, Error> {
+        COUNTERS.call[&(Method::Block, self.component)].inc();
         let latency = LATENCIES.direct[&Method::Block].start();
         // Copy of `web3::block` implementation. It's required to deserialize response as `crate::types::Block`
         // that has EIP-4844 fields.

--- a/core/lib/eth_client/src/clients/http/query.rs
+++ b/core/lib/eth_client/src/clients/http/query.rs
@@ -38,6 +38,7 @@ impl fmt::Debug for QueryClient {
         formatter
             .debug_struct("QueryClient")
             .field("url", &self.url)
+            .field("component", &self.component)
             .finish()
     }
 }

--- a/core/lib/eth_client/src/clients/http/query.rs
+++ b/core/lib/eth_client/src/clients/http/query.rs
@@ -56,6 +56,15 @@ impl QueryClient {
 
 #[async_trait]
 impl EthInterface for QueryClient {
+    fn clone_boxed(&self) -> Box<dyn EthInterface> {
+        Box::new(self.clone())
+    }
+
+    fn for_component(mut self: Box<Self>, component_name: &'static str) -> Box<dyn EthInterface> {
+        self.component = component_name;
+        self
+    }
+
     async fn fetch_chain_id(&self) -> Result<L1ChainId, Error> {
         COUNTERS.call[&(Method::ChainId, self.component)].inc();
         let latency = LATENCIES.direct[&Method::ChainId].start();

--- a/core/lib/eth_client/src/clients/http/signing.rs
+++ b/core/lib/eth_client/src/clients/http/signing.rs
@@ -108,7 +108,6 @@ impl<S: EthereumSigner> BoundEthInterface for SigningClient<S> {
         data: Vec<u8>,
         contract_addr: H160,
         options: Options,
-        component: &'static str,
     ) -> Result<SignedCallResult, Error> {
         let latency = LATENCIES.direct[&Method::SignPreparedTx].start();
         // Fetch current max priority fee per gas
@@ -130,10 +129,7 @@ impl<S: EthereumSigner> BoundEthInterface for SigningClient<S> {
         let max_fee_per_gas = match options.max_fee_per_gas {
             Some(max_fee_per_gas) => max_fee_per_gas,
             None => {
-                self.as_ref()
-                    .get_pending_block_base_fee_per_gas(component)
-                    .await?
-                    + max_priority_fee_per_gas
+                self.as_ref().get_pending_block_base_fee_per_gas().await? + max_priority_fee_per_gas
             }
         };
 
@@ -146,7 +142,7 @@ impl<S: EthereumSigner> BoundEthInterface for SigningClient<S> {
 
         let nonce = match options.nonce {
             Some(nonce) => nonce,
-            None => self.pending_nonce(component).await?,
+            None => self.pending_nonce().await?,
         };
 
         let gas = options.gas.unwrap_or_else(|| {

--- a/core/lib/eth_client/src/clients/http/signing.rs
+++ b/core/lib/eth_client/src/clients/http/signing.rs
@@ -153,18 +153,14 @@ impl<S: EthereumSigner> BoundEthInterface for SigningClient<S> {
 
         let nonce = match options.nonce {
             Some(nonce) => nonce,
-            None => self.pending_nonce().await?,
+            None => <dyn BoundEthInterface>::pending_nonce(self).await?,
         };
 
         let gas = options.gas.unwrap_or_else(|| {
             // Verbosity level is set to `error`, since we expect all the transactions to have
             // a set limit, but don't want to crаsh the application if for some reason in some
             // place limit was not set.
-            tracing::error!(
-                "No gas limit was set for transaction, using the default limit: {}",
-                FALLBACK_GAS_LIMIT
-            );
-
+            tracing::error!("No gas limit was set for transaction, using the default limit: {FALLBACK_GAS_LIMIT}");
             U256::from(FALLBACK_GAS_LIMIT)
         });
 

--- a/core/lib/eth_client/src/lib.rs
+++ b/core/lib/eth_client/src/lib.rs
@@ -73,8 +73,12 @@ impl Options {
 /// contract or account address. For that, you can use the `BoundEthInterface` trait.
 #[async_trait]
 pub trait EthInterface: 'static + Sync + Send + fmt::Debug {
+    /// Clones this client.
     fn clone_boxed(&self) -> Box<dyn EthInterface>;
 
+    /// Tags this client as working for a specific component. The component name can be used in logging,
+    /// metrics etc. The component name should be the clones of this client, but should not be passed
+    /// to clients this one was cloned from.
     fn for_component(self: Box<Self>, component_name: &'static str) -> Box<dyn EthInterface>;
 
     /// Fetches the L1 chain ID (in contrast to [`BoundEthInterface::chain_id()`] which returns
@@ -169,6 +173,9 @@ pub trait BoundEthInterface: AsRef<dyn EthInterface> + 'static + Sync + Send + f
     /// Clones this client.
     fn clone_boxed(&self) -> Box<dyn BoundEthInterface>;
 
+    /// Tags this client as working for a specific component. The component name can be used in logging,
+    /// metrics etc. The component name should be the clones of this client, but should not be passed
+    /// to clients this one was cloned from.
     fn for_component(self: Box<Self>, component_name: &'static str) -> Box<dyn BoundEthInterface>;
 
     /// ABI of the contract that is used by the implementer.

--- a/core/lib/eth_client/src/lib.rs
+++ b/core/lib/eth_client/src/lib.rs
@@ -71,25 +71,17 @@ impl Options {
 /// there are no assumptions about the contract or account that is used to perform the queries.
 /// If you want to add a method to this trait, make sure that it doesn't depend on any particular
 /// contract or account address. For that, you can use the `BoundEthInterface` trait.
-///
-/// ## `component` method
-///
-/// Most of the trait methods support the `component` parameter. This parameter is used to
-/// describe the caller of the method. It may be useful to find the component that makes an
-/// unnecessary high amount of Web3 calls. Implementations are advice to count invocations
-/// per component and expose them to Prometheus.
 #[async_trait]
 pub trait EthInterface: 'static + Sync + Send + fmt::Debug {
     /// Fetches the L1 chain ID (in contrast to [`BoundEthInterface::chain_id()`] which returns
     /// the *expected* L1 chain ID).
-    async fn fetch_chain_id(&self, component: &'static str) -> Result<L1ChainId, Error>;
+    async fn fetch_chain_id(&self) -> Result<L1ChainId, Error>;
 
     /// Returns the nonce of the provided account at the specified block.
     async fn nonce_at_for_account(
         &self,
         account: Address,
         block: BlockNumber,
-        component: &'static str,
     ) -> Result<U256, Error>;
 
     /// Collects the base fee history for the specified block range.
@@ -100,20 +92,16 @@ pub trait EthInterface: 'static + Sync + Send + fmt::Debug {
         &self,
         from_block: usize,
         block_count: usize,
-        component: &'static str,
     ) -> Result<Vec<u64>, Error>;
 
     /// Returns the `base_fee_per_gas` value for the currently pending L1 block.
-    async fn get_pending_block_base_fee_per_gas(
-        &self,
-        component: &'static str,
-    ) -> Result<U256, Error>;
+    async fn get_pending_block_base_fee_per_gas(&self) -> Result<U256, Error>;
 
     /// Returns the current gas price.
-    async fn get_gas_price(&self, component: &'static str) -> Result<U256, Error>;
+    async fn get_gas_price(&self) -> Result<U256, Error>;
 
     /// Returns the current block number.
-    async fn block_number(&self, component: &'static str) -> Result<U64, Error>;
+    async fn block_number(&self) -> Result<U64, Error>;
 
     /// Sends a transaction to the Ethereum network.
     async fn send_raw_tx(&self, tx: RawTransactionBytes) -> Result<H256, Error>;
@@ -122,11 +110,7 @@ pub trait EthInterface: 'static + Sync + Send + fmt::Debug {
     ///
     /// Returns `Ok(None)` if the transaction is either not found or not executed yet.
     /// Returns `Err` only if the request fails (e.g. due to network issues).
-    async fn get_tx_status(
-        &self,
-        hash: H256,
-        component: &'static str,
-    ) -> Result<Option<ExecutedTxStatus>, Error>;
+    async fn get_tx_status(&self, hash: H256) -> Result<Option<ExecutedTxStatus>, Error>;
 
     /// For a reverted transaction, attempts to recover information on the revert reason.
     ///
@@ -137,35 +121,23 @@ pub trait EthInterface: 'static + Sync + Send + fmt::Debug {
     async fn failure_reason(&self, tx_hash: H256) -> Result<Option<FailureInfo>, Error>;
 
     /// Returns the transaction for the specified hash.
-    async fn get_tx(
-        &self,
-        hash: H256,
-        component: &'static str,
-    ) -> Result<Option<Transaction>, Error>;
+    async fn get_tx(&self, hash: H256) -> Result<Option<Transaction>, Error>;
 
     /// Returns the receipt for the specified transaction hash.
-    async fn tx_receipt(
-        &self,
-        tx_hash: H256,
-        component: &'static str,
-    ) -> Result<Option<TransactionReceipt>, Error>;
+    async fn tx_receipt(&self, tx_hash: H256) -> Result<Option<TransactionReceipt>, Error>;
 
     /// Returns the ETH balance of the specified token for the specified address.
-    async fn eth_balance(&self, address: Address, component: &'static str) -> Result<U256, Error>;
+    async fn eth_balance(&self, address: Address) -> Result<U256, Error>;
 
     /// Invokes a function on a contract specified by `contract_address` / `contract_abi` using `eth_call`.
     async fn call_contract_function(&self, call: ContractCall)
         -> Result<Vec<ethabi::Token>, Error>;
 
     /// Returns the logs for the specified filter.
-    async fn logs(&self, filter: Filter, component: &'static str) -> Result<Vec<Log>, Error>;
+    async fn logs(&self, filter: Filter) -> Result<Vec<Log>, Error>;
 
     /// Returns the block header for the specified block number or hash.
-    async fn block(
-        &self,
-        block_id: BlockId,
-        component: &'static str,
-    ) -> Result<Option<Block<H256>>, Error>;
+    async fn block(&self, block_id: BlockId) -> Result<Option<Block<H256>>, Error>;
 }
 
 #[cfg(test)]
@@ -214,24 +186,23 @@ pub trait BoundEthInterface: AsRef<dyn EthInterface> + 'static + Sync + Send + f
         data: Vec<u8>,
         contract_addr: H160,
         options: Options,
-        component: &'static str,
     ) -> Result<SignedCallResult, Error>;
 
     /// Returns the nonce of the `Self::sender_account()` at the specified block.
-    async fn nonce_at(&self, block: BlockNumber, component: &'static str) -> Result<U256, Error> {
+    async fn nonce_at(&self, block: BlockNumber) -> Result<U256, Error> {
         self.as_ref()
-            .nonce_at_for_account(self.sender_account(), block, component)
+            .nonce_at_for_account(self.sender_account(), block)
             .await
     }
 
     /// Returns the current nonce of the `Self::sender_account()`.
-    async fn current_nonce(&self, component: &'static str) -> Result<U256, Error> {
-        self.nonce_at(BlockNumber::Latest, component).await
+    async fn current_nonce(&self) -> Result<U256, Error> {
+        self.nonce_at(BlockNumber::Latest).await
     }
 
     /// Returns the pending nonce of the `Self::sender_account()`.
-    async fn pending_nonce(&self, component: &'static str) -> Result<U256, Error> {
-        self.nonce_at(BlockNumber::Pending, component).await
+    async fn pending_nonce(&self) -> Result<U256, Error> {
+        self.nonce_at(BlockNumber::Pending).await
     }
 
     /// Similar to [`EthInterface::sign_prepared_tx_for_addr`], but is fixed over `Self::contract_addr()`.
@@ -239,17 +210,14 @@ pub trait BoundEthInterface: AsRef<dyn EthInterface> + 'static + Sync + Send + f
         &self,
         data: Vec<u8>,
         options: Options,
-        component: &'static str,
     ) -> Result<SignedCallResult, Error> {
-        self.sign_prepared_tx_for_addr(data, self.contract_addr(), options, component)
+        self.sign_prepared_tx_for_addr(data, self.contract_addr(), options)
             .await
     }
 
     /// Returns the ETH balance of `Self::sender_account()`.
-    async fn sender_eth_balance(&self, component: &'static str) -> Result<U256, Error> {
-        self.as_ref()
-            .eth_balance(self.sender_account(), component)
-            .await
+    async fn sender_eth_balance(&self) -> Result<U256, Error> {
+        self.as_ref().eth_balance(self.sender_account()).await
     }
 
     /// Returns the certain ERC20 token allowance for the `Self::sender_account()`.

--- a/core/lib/zksync_core/src/consistency_checker/mod.rs
+++ b/core/lib/zksync_core/src/consistency_checker/mod.rs
@@ -362,7 +362,7 @@ impl ConsistencyChecker {
 
         let commit_tx_status = self
             .l1_client
-            .get_tx_status(commit_tx_hash, "consistency_checker")
+            .get_tx_status(commit_tx_hash)
             .await?
             .with_context(|| format!("receipt for tx {commit_tx_hash:?} not found on L1"))
             .map_err(CheckError::Validation)?;
@@ -374,7 +374,7 @@ impl ConsistencyChecker {
         // We can't get tx calldata from the DB because it can be fake.
         let commit_tx = self
             .l1_client
-            .get_tx(commit_tx_hash, "consistency_checker")
+            .get_tx(commit_tx_hash)
             .await?
             .with_context(|| format!("commit transaction {commit_tx_hash:?} not found on L1"))
             .map_err(CheckError::Internal)?; // we've got a transaction receipt previously, thus an internal error

--- a/core/lib/zksync_core/src/consistency_checker/mod.rs
+++ b/core/lib/zksync_core/src/consistency_checker/mod.rs
@@ -310,7 +310,7 @@ pub struct ConsistencyChecker {
     /// How many past batches to check when starting
     max_batches_to_recheck: u32,
     sleep_interval: Duration,
-    l1_client: Arc<dyn EthInterface>,
+    l1_client: Box<dyn EthInterface>,
     event_handler: Box<dyn HandleConsistencyCheckerEvent>,
     l1_data_mismatch_behavior: L1DataMismatchBehavior,
     pool: ConnectionPool<Core>,
@@ -322,7 +322,7 @@ impl ConsistencyChecker {
     const DEFAULT_SLEEP_INTERVAL: Duration = Duration::from_secs(5);
 
     pub fn new(
-        l1_client: Arc<dyn EthInterface>,
+        l1_client: Box<dyn EthInterface>,
         max_batches_to_recheck: u32,
         pool: ConnectionPool<Core>,
         l1_batch_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
@@ -333,7 +333,7 @@ impl ConsistencyChecker {
             diamond_proxy_addr: None,
             max_batches_to_recheck,
             sleep_interval: Self::DEFAULT_SLEEP_INTERVAL,
-            l1_client,
+            l1_client: l1_client.for_component("consistency_checker"),
             event_handler: Box::new(health_updater),
             l1_data_mismatch_behavior: L1DataMismatchBehavior::Log,
             pool,

--- a/core/lib/zksync_core/src/consistency_checker/tests/mod.rs
+++ b/core/lib/zksync_core/src/consistency_checker/tests/mod.rs
@@ -99,7 +99,7 @@ pub(crate) fn create_mock_checker(
         diamond_proxy_addr: Some(DIAMOND_PROXY_ADDR),
         max_batches_to_recheck: 100,
         sleep_interval: Duration::from_millis(10),
-        l1_client: Arc::new(client),
+        l1_client: Box::new(client),
         event_handler: Box::new(health_updater),
         l1_data_mismatch_behavior: L1DataMismatchBehavior::Bail,
         pool,

--- a/core/lib/zksync_core/src/eth_sender/eth_tx_aggregator.rs
+++ b/core/lib/zksync_core/src/eth_sender/eth_tx_aggregator.rs
@@ -47,7 +47,7 @@ pub struct MulticallData {
 #[derive(Debug)]
 pub struct EthTxAggregator {
     aggregator: Aggregator,
-    eth_client: Arc<dyn BoundEthInterface>,
+    eth_client: Box<dyn BoundEthInterface>,
     config: SenderConfig,
     timelock_contract_address: Address,
     l1_multicall3_address: Address,
@@ -76,7 +76,7 @@ impl EthTxAggregator {
         pool: ConnectionPool<Core>,
         config: SenderConfig,
         aggregator: Aggregator,
-        eth_client: Arc<dyn BoundEthInterface>,
+        eth_client: Box<dyn BoundEthInterface>,
         timelock_contract_address: Address,
         l1_multicall3_address: Address,
         state_transition_chain_contract: Address,
@@ -84,6 +84,7 @@ impl EthTxAggregator {
         custom_commit_sender_addr: Option<Address>,
         l1_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
     ) -> Self {
+        let eth_client = eth_client.for_component("eth_tx_aggregator");
         let functions = ZkSyncFunctions::default();
         let base_nonce = eth_client.pending_nonce().await.unwrap().as_u64();
 

--- a/core/lib/zksync_core/src/eth_sender/eth_tx_aggregator.rs
+++ b/core/lib/zksync_core/src/eth_sender/eth_tx_aggregator.rs
@@ -85,17 +85,13 @@ impl EthTxAggregator {
         l1_commit_data_generator: Arc<dyn L1BatchCommitDataGenerator>,
     ) -> Self {
         let functions = ZkSyncFunctions::default();
-        let base_nonce = eth_client
-            .pending_nonce("eth_sender")
-            .await
-            .unwrap()
-            .as_u64();
+        let base_nonce = eth_client.pending_nonce().await.unwrap().as_u64();
 
         let base_nonce_custom_commit_sender = match custom_commit_sender_addr {
             Some(addr) => Some(
                 (*eth_client)
                     .as_ref()
-                    .nonce_at_for_account(addr, BlockNumber::Pending, "eth_sender")
+                    .nonce_at_for_account(addr, BlockNumber::Pending)
                     .await
                     .unwrap()
                     .as_u64(),

--- a/core/lib/zksync_core/src/eth_sender/eth_tx_manager.rs
+++ b/core/lib/zksync_core/src/eth_sender/eth_tx_manager.rs
@@ -88,7 +88,7 @@ impl EthTxManager {
         tx_hash: H256,
     ) -> Result<Option<ExecutedTxStatus>, ETHSenderError> {
         self.query_client()
-            .get_tx_status(tx_hash, "eth_tx_manager")
+            .get_tx_status(tx_hash)
             .await
             .map_err(Into::into)
     }
@@ -333,14 +333,14 @@ impl EthTxManager {
     ) -> Result<OperatorNonce, ETHSenderError> {
         let finalized = self
             .ethereum_gateway
-            .nonce_at(block_numbers.finalized.0.into(), "eth_tx_manager")
+            .nonce_at(block_numbers.finalized.0.into())
             .await?
             .as_u32()
             .into();
 
         let latest = self
             .ethereum_gateway
-            .nonce_at(block_numbers.latest.0.into(), "eth_tx_manager")
+            .nonce_at(block_numbers.latest.0.into())
             .await?
             .as_u32()
             .into();
@@ -355,13 +355,13 @@ impl EthTxManager {
             None => Ok(None),
             Some(gateway) => {
                 let finalized = gateway
-                    .nonce_at(block_numbers.finalized.0.into(), "eth_tx_manager")
+                    .nonce_at(block_numbers.finalized.0.into())
                     .await?
                     .as_u32()
                     .into();
 
                 let latest = gateway
-                    .nonce_at(block_numbers.latest.0.into(), "eth_tx_manager")
+                    .nonce_at(block_numbers.latest.0.into())
                     .await?
                     .as_u32()
                     .into();
@@ -372,18 +372,14 @@ impl EthTxManager {
 
     async fn get_l1_block_numbers(&self) -> Result<L1BlockNumbers, ETHSenderError> {
         let (finalized, safe) = if let Some(confirmations) = self.config.wait_confirmations {
-            let latest_block_number = self
-                .query_client()
-                .block_number("eth_tx_manager")
-                .await?
-                .as_u64();
+            let latest_block_number = self.query_client().block_number().await?.as_u64();
 
             let finalized = (latest_block_number.saturating_sub(confirmations) as u32).into();
             (finalized, finalized)
         } else {
             let finalized = self
                 .query_client()
-                .block(BlockId::Number(BlockNumber::Finalized), "eth_tx_manager")
+                .block(BlockId::Number(BlockNumber::Finalized))
                 .await?
                 .expect("Finalized block must be present on L1")
                 .number
@@ -393,7 +389,7 @@ impl EthTxManager {
 
             let safe = self
                 .query_client()
-                .block(BlockId::Number(BlockNumber::Safe), "eth_tx_manager")
+                .block(BlockId::Number(BlockNumber::Safe))
                 .await?
                 .expect("Safe block must be present on L1")
                 .number
@@ -403,12 +399,7 @@ impl EthTxManager {
             (finalized, safe)
         };
 
-        let latest = self
-            .query_client()
-            .block_number("eth_tx_manager")
-            .await?
-            .as_u32()
-            .into();
+        let latest = self.query_client().block_number().await?.as_u32().into();
 
         Ok(L1BlockNumbers {
             finalized,
@@ -578,7 +569,6 @@ impl EthTxManager {
                             .collect(),
                     });
                 }),
-                "eth_tx_manager",
             )
             .await
             .expect("Failed to sign transaction")

--- a/core/lib/zksync_core/src/eth_sender/eth_tx_manager.rs
+++ b/core/lib/zksync_core/src/eth_sender/eth_tx_manager.rs
@@ -53,10 +53,10 @@ pub(super) struct L1BlockNumbers {
 #[derive(Debug)]
 pub struct EthTxManager {
     /// A gateway through which the operator normally sends all its transactions.
-    ethereum_gateway: Arc<dyn BoundEthInterface>,
+    ethereum_gateway: Box<dyn BoundEthInterface>,
     /// If the operator is in 4844 mode this is sent to `Some` and used to send
     /// commit transactions.
-    ethereum_gateway_blobs: Option<Arc<dyn BoundEthInterface>>,
+    ethereum_gateway_blobs: Option<Box<dyn BoundEthInterface>>,
     config: SenderConfig,
     gas_adjuster: Arc<dyn L1TxParamsProvider>,
     pool: ConnectionPool<Core>,
@@ -67,12 +67,13 @@ impl EthTxManager {
         pool: ConnectionPool<Core>,
         config: SenderConfig,
         gas_adjuster: Arc<dyn L1TxParamsProvider>,
-        ethereum_gateway: Arc<dyn BoundEthInterface>,
-        ethereum_gateway_blobs: Option<Arc<dyn BoundEthInterface>>,
+        ethereum_gateway: Box<dyn BoundEthInterface>,
+        ethereum_gateway_blobs: Option<Box<dyn BoundEthInterface>>,
     ) -> Self {
         Self {
-            ethereum_gateway,
-            ethereum_gateway_blobs,
+            ethereum_gateway: ethereum_gateway.for_component("eth_tx_manager"),
+            ethereum_gateway_blobs: ethereum_gateway_blobs
+                .map(|eth| eth.for_component("eth_tx_manager")),
             config,
             gas_adjuster,
             pool,

--- a/core/lib/zksync_core/src/eth_sender/tests.rs
+++ b/core/lib/zksync_core/src/eth_sender/tests.rs
@@ -67,7 +67,7 @@ fn mock_multicall_response() -> Token {
 #[derive(Debug)]
 struct EthSenderTester {
     conn: ConnectionPool<Core>,
-    gateway: Arc<MockEthereum>,
+    gateway: Box<MockEthereum>,
     manager: MockEthTxManager,
     aggregator: EthTxAggregator,
     gas_adjuster: Arc<GasAdjuster>,
@@ -104,7 +104,7 @@ impl EthSenderTester {
                 mock_multicall_response()
             });
         gateway.advance_block_number(Self::WAIT_CONFIRMATIONS);
-        let gateway = Arc::new(gateway);
+        let gateway = Box::new(gateway);
 
         let pubdata_pricing: Arc<dyn PubdataPricing> = match deployment_mode {
             DeploymentMode::Validium => Arc::new(ValidiumPubdataPricing {}),

--- a/core/lib/zksync_core/src/eth_sender/tests.rs
+++ b/core/lib/zksync_core/src/eth_sender/tests.rs
@@ -181,7 +181,7 @@ impl EthSenderTester {
     }
 
     async fn get_block_numbers(&self) -> L1BlockNumbers {
-        let latest = self.gateway.block_number("").await.unwrap().as_u32().into();
+        let latest = self.gateway.block_number().await.unwrap().as_u32().into();
         let finalized = latest - Self::WAIT_CONFIRMATIONS as u32;
         L1BlockNumbers {
             finalized,
@@ -256,7 +256,7 @@ async fn confirm_many(
                 &mut tester.conn.connection().await.unwrap(),
                 &tx,
                 0,
-                L1BlockNumber(tester.gateway.block_number("").await?.as_u32()),
+                L1BlockNumber(tester.gateway.block_number().await?.as_u32()),
             )
             .await?;
         hashes.push(hash);
@@ -326,7 +326,7 @@ async fn resend_each_block(deployment_mode: DeploymentMode) -> anyhow::Result<()
     tester.gateway.advance_block_number(3);
     tester.gas_adjuster.keep_updated().await?;
 
-    let block = L1BlockNumber(tester.gateway.block_number("").await?.as_u32());
+    let block = L1BlockNumber(tester.gateway.block_number().await?.as_u32());
     let tx = tester
         .aggregator
         .save_eth_tx(
@@ -357,7 +357,7 @@ async fn resend_each_block(deployment_mode: DeploymentMode) -> anyhow::Result<()
 
     let sent_tx = tester
         .gateway
-        .get_tx(hash, "")
+        .get_tx(hash)
         .await
         .unwrap()
         .expect("no transaction");
@@ -405,7 +405,7 @@ async fn resend_each_block(deployment_mode: DeploymentMode) -> anyhow::Result<()
 
     let resent_tx = tester
         .gateway
-        .get_tx(resent_hash, "")
+        .get_tx(resent_hash)
         .await
         .unwrap()
         .expect("no transaction");
@@ -448,7 +448,7 @@ async fn dont_resend_already_mined(deployment_mode: DeploymentMode) -> anyhow::R
             &mut tester.conn.connection().await.unwrap(),
             &tx,
             0,
-            L1BlockNumber(tester.gateway.block_number("").await.unwrap().as_u32()),
+            L1BlockNumber(tester.gateway.block_number().await.unwrap().as_u32()),
         )
         .await
         .unwrap();
@@ -530,7 +530,7 @@ async fn three_scenarios(deployment_mode: DeploymentMode) -> anyhow::Result<()> 
                 &mut tester.conn.connection().await.unwrap(),
                 &tx,
                 0,
-                L1BlockNumber(tester.gateway.block_number("").await.unwrap().as_u32()),
+                L1BlockNumber(tester.gateway.block_number().await.unwrap().as_u32()),
             )
             .await
             .unwrap();
@@ -607,7 +607,7 @@ async fn failed_eth_tx(deployment_mode: DeploymentMode) {
             &mut tester.conn.connection().await.unwrap(),
             &tx,
             0,
-            L1BlockNumber(tester.gateway.block_number("").await.unwrap().as_u32()),
+            L1BlockNumber(tester.gateway.block_number().await.unwrap().as_u32()),
         )
         .await
         .unwrap();
@@ -1081,7 +1081,7 @@ async fn send_operation(
             &mut tester.conn.connection().await.unwrap(),
             &tx,
             0,
-            L1BlockNumber(tester.gateway.block_number("").await.unwrap().as_u32()),
+            L1BlockNumber(tester.gateway.block_number().await.unwrap().as_u32()),
         )
         .await
         .unwrap();

--- a/core/lib/zksync_core/src/genesis.rs
+++ b/core/lib/zksync_core/src/genesis.rs
@@ -596,10 +596,7 @@ pub async fn save_set_chain_id_tx(
     let pool = ConnectionPool::<Core>::singleton(db_url).build().await?;
     let mut storage = pool.connection().await?;
 
-    let to = query_client
-        .block_number("fetch_chain_id_tx")
-        .await?
-        .as_u64();
+    let to = query_client.block_number().await?.as_u64();
     let from = to.saturating_sub(PRIORITY_EXPIRATION);
     let filter = FilterBuilder::default()
         .address(vec![state_transition_manager_address])
@@ -612,7 +609,7 @@ pub async fn save_set_chain_id_tx(
         .from_block(from.into())
         .to_block(BlockNumber::Latest)
         .build();
-    let mut logs = query_client.logs(filter, "fetch_chain_id_tx").await?;
+    let mut logs = query_client.logs(filter).await?;
     anyhow::ensure!(
         logs.len() == 1,
         "Expected a single set_chain_id event, got these {}: {:?}",

--- a/core/lib/zksync_core/src/l1_gas_price/gas_adjuster/mod.rs
+++ b/core/lib/zksync_core/src/l1_gas_price/gas_adjuster/mod.rs
@@ -46,12 +46,12 @@ impl GasAdjuster {
         // the info about the latest block is not yet present on the node.
         // This sometimes happens on Infura.
         let current_block = eth_client
-            .block_number("gas_adjuster")
+            .block_number()
             .await?
             .as_usize()
             .saturating_sub(1);
         let base_fee_history = eth_client
-            .base_fee_history(current_block, config.max_base_fee_samples, "gas_adjuster")
+            .base_fee_history(current_block, config.max_base_fee_samples)
             .await?;
 
         // Web3 API doesn't provide a method to fetch blob fees for multiple blocks using single request,
@@ -85,7 +85,7 @@ impl GasAdjuster {
         // This sometimes happens on Infura.
         let current_block = self
             .eth_client
-            .block_number("gas_adjuster")
+            .block_number()
             .await?
             .as_usize()
             .saturating_sub(1);
@@ -212,9 +212,7 @@ impl GasAdjuster {
         let mut base_fee_history = Vec::new();
         let mut blob_base_fee_history = Vec::new();
         for block_number in block_range {
-            let header = eth_client
-                .block(U64::from(block_number).into(), "gas_adjuster")
-                .await?;
+            let header = eth_client.block(U64::from(block_number).into()).await?;
             if let Some(base_fee_per_gas) =
                 header.as_ref().and_then(|header| header.base_fee_per_gas)
             {

--- a/core/lib/zksync_core/src/l1_gas_price/gas_adjuster/tests.rs
+++ b/core/lib/zksync_core/src/l1_gas_price/gas_adjuster/tests.rs
@@ -35,7 +35,7 @@ fn samples_queue() {
 #[test_casing(2, [DeploymentMode::Rollup, DeploymentMode::Validium])]
 #[tokio::test]
 async fn kept_updated(deployment_mode: DeploymentMode) {
-    let eth_client = Arc::new(
+    let eth_client = Box::new(
         MockEthereum::default()
             .with_fee_history(vec![0, 4, 6, 8, 7, 5, 5, 8, 10, 9])
             .with_excess_blob_gas_history(vec![

--- a/core/lib/zksync_core/src/l1_gas_price/singleton.rs
+++ b/core/lib/zksync_core/src/l1_gas_price/singleton.rs
@@ -43,7 +43,7 @@ impl GasAdjusterSingleton {
             let query_client =
                 QueryClient::new(self.web3_url.clone()).context("QueryClient::new()")?;
             let adjuster = GasAdjuster::new(
-                Arc::new(query_client),
+                Box::new(query_client),
                 self.gas_adjuster_config,
                 self.pubdata_sending_mode,
                 self.pubdata_pricing.clone(),

--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -304,7 +304,7 @@ pub async fn initialize_components(
     });
 
     let query_client = QueryClient::new(eth.web3_url.clone()).context("Ethereum client")?;
-    let query_client = Arc::new(query_client);
+    let query_client = Box::new(query_client);
     let gas_adjuster_config = eth.gas_adjuster.context("gas_adjuster")?;
     let sender = eth.sender.as_ref().context("sender")?;
     let pubdata_pricing: Arc<dyn PubdataPricing> =
@@ -672,7 +672,7 @@ pub async fn initialize_components(
                 operator_blobs_address.is_some(),
                 l1_batch_commit_data_generator.clone(),
             ),
-            Arc::new(eth_client),
+            Box::new(eth_client),
             contracts_config.validator_timelock_addr,
             contracts_config.l1_multicall3_addr,
             diamond_proxy_addr,
@@ -717,13 +717,14 @@ pub async fn initialize_components(
 
         let eth_client_blobs = if let Some(blob_operator) = eth_sender_wallets.blob_operator {
             let operator_blob_private_key = blob_operator.private_key().clone();
-            Some(PKSigningClient::new_raw(
+            let client = Box::new(PKSigningClient::new_raw(
                 operator_blob_private_key,
                 diamond_proxy_addr,
                 default_priority_fee_per_gas,
                 l1_chain_id,
                 query_client,
-            ))
+            ));
+            Some(client as Box<dyn BoundEthInterface>)
         } else {
             None
         };
@@ -735,8 +736,8 @@ pub async fn initialize_components(
                 .get_or_init()
                 .await
                 .context("gas_adjuster.get_or_init()")?,
-            Arc::new(eth_client),
-            eth_client_blobs.map(|c| Arc::new(c) as Arc<dyn BoundEthInterface>),
+            Box::new(eth_client),
+            eth_client_blobs,
         );
         task_futures.extend([tokio::spawn(
             eth_tx_manager_actor.run(stop_receiver.clone()),
@@ -915,7 +916,7 @@ async fn add_state_keeper_to_task_futures(
 pub async fn start_eth_watch(
     config: EthWatchConfig,
     pool: ConnectionPool<Core>,
-    eth_gateway: Arc<dyn EthInterface>,
+    eth_gateway: Box<dyn EthInterface>,
     diamond_proxy_addr: Address,
     state_transition_manager_addr: Option<Address>,
     governance: (Contract, Address),

--- a/core/lib/zksync_core/src/state_keeper/io/tests/tester.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/tests/tester.rs
@@ -75,7 +75,7 @@ impl Tester {
         };
 
         GasAdjuster::new(
-            Arc::new(eth_client),
+            Box::new(eth_client),
             gas_adjuster_config,
             PubdataSendingMode::Calldata,
             self.pubdata_pricing.clone(),

--- a/core/node/eth_watch/src/client.rs
+++ b/core/node/eth_watch/src/client.rs
@@ -93,7 +93,7 @@ impl EthHttpQueryClient {
             .to_block(to)
             .topics(Some(topics), None, None, None)
             .build();
-        self.client.logs(filter, "watch").await
+        self.client.logs(filter).await
     }
 }
 
@@ -147,7 +147,7 @@ impl EthClient for EthHttpQueryClient {
                 };
                 let to_number = match to {
                     BlockNumber::Number(num) => num,
-                    BlockNumber::Latest => self.client.block_number("watch").await?,
+                    BlockNumber::Latest => self.client.block_number().await?,
                     _ => {
                         // invalid variant
                         return result;
@@ -184,12 +184,12 @@ impl EthClient for EthHttpQueryClient {
 
     async fn finalized_block_number(&self) -> Result<u64, EthClientError> {
         if let Some(confirmations) = self.confirmations_for_eth_event {
-            let latest_block_number = self.client.block_number("watch").await?.as_u64();
+            let latest_block_number = self.client.block_number().await?.as_u64();
             Ok(latest_block_number.saturating_sub(confirmations))
         } else {
             let block = self
                 .client
-                .block(BlockId::Number(BlockNumber::Finalized), "watch")
+                .block(BlockId::Number(BlockNumber::Finalized))
                 .await?
                 .ok_or_else(|| {
                     web3::Error::InvalidResponse("Finalized block must be present on L1".into())

--- a/core/node/eth_watch/src/client.rs
+++ b/core/node/eth_watch/src/client.rs
@@ -1,4 +1,4 @@
-use std::{fmt, sync::Arc};
+use std::fmt;
 
 use zksync_contracts::verifier_contract;
 pub(super) use zksync_eth_client::Error as EthClientError;
@@ -38,7 +38,7 @@ const TOO_MANY_RESULTS_ALCHEMY: &str = "response size exceeded";
 /// Implementation of [`EthClient`] based on HTTP JSON-RPC (encapsulated via [`EthInterface`]).
 #[derive(Debug)]
 pub struct EthHttpQueryClient {
-    client: Arc<dyn EthInterface>,
+    client: Box<dyn EthInterface>,
     topics: Vec<H256>,
     diamond_proxy_addr: Address,
     governance_address: Address,
@@ -50,7 +50,7 @@ pub struct EthHttpQueryClient {
 
 impl EthHttpQueryClient {
     pub fn new(
-        client: Arc<dyn EthInterface>,
+        client: Box<dyn EthInterface>,
         diamond_proxy_addr: Address,
         state_transition_manager_address: Option<Address>,
         governance_address: Address,
@@ -62,7 +62,7 @@ impl EthHttpQueryClient {
             governance_address
         );
         Self {
-            client,
+            client: client.for_component("watch"),
             topics: Vec::new(),
             diamond_proxy_addr,
             state_transition_manager_address,

--- a/core/node/node_framework/src/implementations/layers/pk_signing_eth_client.rs
+++ b/core/node/node_framework/src/implementations/layers/pk_signing_eth_client.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use anyhow::Context as _;
 use zksync_config::{
     configs::{wallets, ContractsConfig},
@@ -62,7 +60,7 @@ impl WiringLayer for PKSigningEthClientLayer {
             self.l1_chain_id,
             query_client.clone(),
         );
-        context.insert_resource(BoundEthInterfaceResource(Arc::new(signing_client)))?;
+        context.insert_resource(BoundEthInterfaceResource(Box::new(signing_client)))?;
 
         if let Some(blob_operator) = &self.wallets.blob_operator {
             let private_key = blob_operator.private_key();
@@ -73,7 +71,7 @@ impl WiringLayer for PKSigningEthClientLayer {
                 self.l1_chain_id,
                 query_client,
             );
-            context.insert_resource(BoundEthInterfaceForBlobsResource(Arc::new(
+            context.insert_resource(BoundEthInterfaceForBlobsResource(Box::new(
                 signing_client_for_blobs,
             )))?;
         }

--- a/core/node/node_framework/src/implementations/layers/query_eth_client.rs
+++ b/core/node/node_framework/src/implementations/layers/query_eth_client.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use anyhow::Context;
 use zksync_eth_client::clients::QueryClient;
 use zksync_types::url::SensitiveUrl;
@@ -29,7 +27,7 @@ impl WiringLayer for QueryEthClientLayer {
 
     async fn wire(self: Box<Self>, mut context: ServiceContext<'_>) -> Result<(), WiringError> {
         let query_client = QueryClient::new(self.web3_url.clone()).context("QueryClient::new()")?;
-        context.insert_resource(EthInterfaceResource(Arc::new(query_client)))?;
+        context.insert_resource(EthInterfaceResource(Box::new(query_client)))?;
         Ok(())
     }
 }

--- a/core/node/node_framework/src/implementations/resources/eth_interface.rs
+++ b/core/node/node_framework/src/implementations/resources/eth_interface.rs
@@ -1,11 +1,9 @@
-use std::sync::Arc;
-
 use zksync_eth_client::{BoundEthInterface, EthInterface};
 
 use crate::resource::Resource;
 
 #[derive(Debug, Clone)]
-pub struct EthInterfaceResource(pub Arc<dyn EthInterface>);
+pub struct EthInterfaceResource(pub Box<dyn EthInterface>);
 
 impl Resource for EthInterfaceResource {
     fn name() -> String {
@@ -14,7 +12,7 @@ impl Resource for EthInterfaceResource {
 }
 
 #[derive(Debug, Clone)]
-pub struct BoundEthInterfaceResource(pub Arc<dyn BoundEthInterface>);
+pub struct BoundEthInterfaceResource(pub Box<dyn BoundEthInterface>);
 
 impl Resource for BoundEthInterfaceResource {
     fn name() -> String {
@@ -23,7 +21,7 @@ impl Resource for BoundEthInterfaceResource {
 }
 
 #[derive(Debug, Clone)]
-pub struct BoundEthInterfaceForBlobsResource(pub Arc<dyn BoundEthInterface>);
+pub struct BoundEthInterfaceForBlobsResource(pub Box<dyn BoundEthInterface>);
 
 impl Resource for BoundEthInterfaceForBlobsResource {
     fn name() -> String {

--- a/core/tests/loadnext/src/account/tx_command_executor.rs
+++ b/core/tests/loadnext/src/account/tx_command_executor.rs
@@ -103,7 +103,7 @@ impl AccountLifespan {
         let gas_price = ethereum
             .client()
             .as_ref()
-            .get_gas_price("executor")
+            .get_gas_price()
             .await
             .map_err(|_| ClientError::Other)?;
 

--- a/core/tests/loadnext/src/executor.rs
+++ b/core/tests/loadnext/src/executor.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use futures::{channel::mpsc, future, SinkExt};
-use zksync_eth_client::{BoundEthInterface, Options};
+use zksync_eth_client::Options;
 use zksync_eth_signer::PrivateKeySigner;
 use zksync_system_constants::MAX_L1_TRANSACTION_GAS_LIMIT;
 use zksync_types::{

--- a/core/tests/loadnext/src/executor.rs
+++ b/core/tests/loadnext/src/executor.rs
@@ -151,7 +151,7 @@ impl Executor {
         let mint_tx_hash = match mint_tx_hash {
             Err(error) => {
                 let balance = ethereum.balance().await;
-                let gas_price = ethereum.query_client().get_gas_price("executor").await;
+                let gas_price = ethereum.query_client().get_gas_price().await;
 
                 anyhow::bail!(
                     "{:?}, Balance: {:?}, Gas Price: {:?}",
@@ -369,7 +369,7 @@ impl Executor {
 
         // 2 txs per account (1 ERC-20 & 1 ETH transfer).
         let mut eth_txs = Vec::with_capacity(txs_amount * 2);
-        let mut eth_nonce = ethereum.client().pending_nonce("loadnext").await?;
+        let mut eth_nonce = ethereum.client().pending_nonce().await?;
 
         for account in self.pool.accounts.iter().take(accounts_to_process) {
             let target_address = account.wallet.address();
@@ -381,11 +381,8 @@ impl Executor {
 
             // If we don't need to send l1 txs we don't need to distribute the funds
             if weight_of_l1_txs != 0.0 {
-                let balance = ethereum
-                    .query_client()
-                    .eth_balance(target_address, "loadnext")
-                    .await?;
-                let gas_price = ethereum.query_client().get_gas_price("loadnext").await?;
+                let balance = ethereum.query_client().eth_balance(target_address).await?;
+                let gas_price = ethereum.query_client().get_gas_price().await?;
 
                 if balance < eth_to_distribute {
                     let options = Options {
@@ -614,7 +611,7 @@ impl Executor {
             .expect("Can't get Ethereum client");
 
         // Assuming that gas prices on testnets are somewhat stable, we will consider it a constant.
-        let average_gas_price = ethereum.query_client().get_gas_price("executor").await?;
+        let average_gas_price = ethereum.query_client().get_gas_price().await?;
 
         let gas_price_with_priority = average_gas_price + U256::from(DEFAULT_PRIORITY_FEE);
 
@@ -674,11 +671,11 @@ async fn deposit_with_attempts(
     deposit_amount: U256,
     max_attempts: usize,
 ) -> anyhow::Result<TransactionReceipt> {
-    let nonce = ethereum.client().current_nonce("loadtest").await.unwrap();
+    let nonce = ethereum.client().current_nonce().await.unwrap();
     for attempt in 1..=max_attempts {
         let pending_block_base_fee_per_gas = ethereum
             .query_client()
-            .get_pending_block_base_fee_per_gas("loadtest")
+            .get_pending_block_base_fee_per_gas()
             .await
             .unwrap();
 

--- a/core/tests/loadnext/src/sdk/ethereum/mod.rs
+++ b/core/tests/loadnext/src/sdk/ethereum/mod.rs
@@ -1,10 +1,6 @@
 //! Utilities for the on-chain operations, such as `Deposit` and `FullExit`.
 
-use std::{
-    convert::TryFrom,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 use serde_json::{Map, Value};
 use zksync_eth_client::{
@@ -105,7 +101,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
         let query_client = QueryClient::new(eth_web3_url)
             .map_err(|err| ClientError::NetworkError(err.to_string()))?;
         let eth_client = SigningClient::new(
-            Arc::new(query_client),
+            Box::new(query_client).for_component("provider"),
             hyperchain_contract(),
             eth_addr,
             eth_signer,

--- a/core/tests/loadnext/src/sdk/ethereum/mod.rs
+++ b/core/tests/loadnext/src/sdk/ethereum/mod.rs
@@ -123,7 +123,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
     }
 
     /// Exposes Ethereum node `web3` API.
-    pub fn client(&self) -> &SigningClient<S> {
+    pub fn client(&self) -> &dyn BoundEthInterface {
         &self.eth_client
     }
 
@@ -367,7 +367,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
             "l2TransactionBaseCost",
             (gas_price, gas_limit, gas_per_pubdata_byte),
         );
-        let res = self.eth_client.call_main_contract_function(args).await?;
+        let res = self.client().call_main_contract_function(args).await?;
         Ok(U256::from_tokens(res)?)
     }
 
@@ -398,7 +398,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
             .await
             .map_err(|e| ClientError::NetworkError(e.to_string()))?;
         let value = base_cost + operator_tip + l2_value;
-        let tx_data = self.eth_client.encode_tx_data(
+        let tx_data = self.client().encode_tx_data(
             "requestL2Transaction",
             (
                 contract_address,
@@ -413,7 +413,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
         );
 
         let tx = self
-            .eth_client
+            .client()
             .sign_prepared_tx(
                 tx_data,
                 Options::with(|f| {

--- a/core/tests/loadnext/src/sdk/ethereum/mod.rs
+++ b/core/tests/loadnext/src/sdk/ethereum/mod.rs
@@ -143,7 +143,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
     /// Returns the Ethereum account balance.
     pub async fn balance(&self) -> Result<U256, ClientError> {
         self.client()
-            .sender_eth_balance("provider")
+            .sender_eth_balance()
             .await
             .map_err(|err| ClientError::NetworkError(err.to_string()))
     }
@@ -167,7 +167,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
     /// Returns the pending nonce for the Ethereum account.
     pub async fn nonce(&self) -> Result<U256, ClientError> {
         self.client()
-            .pending_nonce("provider")
+            .pending_nonce()
             .await
             .map_err(|err| ClientError::NetworkError(err.to_string()))
     }
@@ -254,7 +254,6 @@ impl<S: EthereumSigner> EthereumProvider<S> {
                     gas: Some(300_000.into()),
                     ..Default::default()
                 },
-                "provider",
             )
             .await
             .map_err(|_| ClientError::IncorrectCredentials)?;
@@ -284,7 +283,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
                 ..options.unwrap_or_default()
             };
             self.client()
-                .sign_prepared_tx_for_addr(Vec::new(), to, options, "provider")
+                .sign_prepared_tx_for_addr(Vec::new(), to, options)
                 .await
                 .map_err(|_| ClientError::IncorrectCredentials)?
         } else {
@@ -305,7 +304,6 @@ impl<S: EthereumSigner> EthereumProvider<S> {
                         gas: Some(300_000.into()),
                         ..options.unwrap_or_default()
                     },
-                    "provider",
                 )
                 .await
                 .map_err(|_| ClientError::IncorrectCredentials)?
@@ -344,7 +342,6 @@ impl<S: EthereumSigner> EthereumProvider<S> {
                         gas: Some(100_000.into()),
                         ..Default::default()
                     },
-                    "provider",
                 )
                 .await
                 .map_err(|_| ClientError::IncorrectCredentials)?
@@ -368,7 +365,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
         let gas_price = if let Some(gas_price) = gas_price {
             gas_price
         } else {
-            self.query_client().get_gas_price("zksync-rs").await?
+            self.query_client().get_gas_price().await?
         };
         let args = CallFunctionArgs::new(
             "l2TransactionBaseCost",
@@ -396,7 +393,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
             gas_price
         } else {
             self.query_client()
-                .get_gas_price("zksync-rs")
+                .get_gas_price()
                 .await
                 .map_err(|e| ClientError::NetworkError(e.to_string()))?
         };
@@ -428,7 +425,6 @@ impl<S: EthereumSigner> EthereumProvider<S> {
                     f.value = Some(value);
                     f.gas_price = Some(gas_price)
                 }),
-                "zksync-rs",
             )
             .await
             .map_err(|e| ClientError::NetworkError(e.to_string()))?;
@@ -488,7 +484,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
         } else {
             let gas_price = self
                 .query_client()
-                .get_gas_price("zksync-rs")
+                .get_gas_price()
                 .await
                 .map_err(|e| ClientError::NetworkError(e.to_string()))?;
 
@@ -554,7 +550,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
 
             let signed_tx = self
                 .eth_client
-                .sign_prepared_tx_for_addr(data, bridge_address, options, "provider")
+                .sign_prepared_tx_for_addr(data, bridge_address, options)
                 .await
                 .map_err(|_| ClientError::IncorrectCredentials)?;
             self.query_client()
@@ -584,7 +580,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
         loop {
             if let Some(receipt) = self
                 .query_client()
-                .tx_receipt(tx_hash, "provider")
+                .tx_receipt(tx_hash)
                 .await
                 .map_err(|err| ClientError::NetworkError(err.to_string()))?
             {


### PR DESCRIPTION
## What ❔

Refactors L1 client interfaces so that they work similarly to L2 client ones.

## Why ❔

DevEx and maintainability.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [x] Linkcheck has been run via `zk linkcheck`.