### PR TITLE
perf(state-keeper): Improve `FilterWrittenSlots` l1 batch seal stage

### DIFF
--- a/core/lib/multivm/src/glue/types/vm/vm_block_result.rs
+++ b/core/lib/multivm/src/glue/types/vm/vm_block_result.rs
@@ -71,6 +71,7 @@ impl GlueFrom<crate::vm_m5::vm_instance::VmBlockResult> for crate::interface::Fi
             },
             final_bootloader_memory: None,
             pubdata_input: None,
+            initially_written_slots: None,
         }
     }
 }
@@ -130,6 +131,7 @@ impl GlueFrom<crate::vm_m6::vm_instance::VmBlockResult> for crate::interface::Fi
             },
             final_bootloader_memory: None,
             pubdata_input: None,
+            initially_written_slots: None,
         }
     }
 }
@@ -187,6 +189,7 @@ impl GlueFrom<crate::vm_1_3_2::vm_instance::VmBlockResult> for crate::interface:
             },
             final_bootloader_memory: None,
             pubdata_input: None,
+            initially_written_slots: None,
         }
     }
 }

--- a/core/lib/multivm/src/interface/traits/vm.rs
+++ b/core/lib/multivm/src/interface/traits/vm.rs
@@ -143,6 +143,7 @@ pub trait VmInterface<S, H: HistoryMode> {
             final_execution_state: execution_state,
             final_bootloader_memory: Some(bootloader_memory),
             pubdata_input: None,
+            initially_written_slots: None,
         }
     }
 }

--- a/core/lib/multivm/src/interface/types/outputs/finished_l1batch.rs
+++ b/core/lib/multivm/src/interface/types/outputs/finished_l1batch.rs
@@ -1,3 +1,5 @@
+use zksync_types::H256;
+
 use super::{BootloaderMemory, CurrentExecutionState, VmExecutionResultAndLogs};
 
 /// State of the VM after the batch execution.
@@ -7,7 +9,11 @@ pub struct FinishedL1Batch {
     pub block_tip_execution_result: VmExecutionResultAndLogs,
     /// State of the VM after the execution of the last transaction.
     pub final_execution_state: CurrentExecutionState,
-    /// Memory of the bootloader with all executed transactions. Could be optional for old versions of the VM.
+    /// Memory of the bootloader with all executed transactions. Could be none for old versions of the VM.
     pub final_bootloader_memory: Option<BootloaderMemory>,
+    /// Pubdata to be published on L1. Could be none for old versions of the VM.
     pub pubdata_input: Option<Vec<u8>>,
+    /// List of hashed keys of slots that were initially written in the batch.
+    /// Could be none for old versions of the VM.
+    pub initially_written_slots: Option<Vec<H256>>,
 }

--- a/core/lib/multivm/src/versions/vm_1_4_1/vm.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_1/vm.rs
@@ -179,6 +179,7 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
                     .clone()
                     .build_pubdata(false),
             ),
+            initially_written_slots: None,
         }
     }
 }

--- a/core/lib/multivm/src/versions/vm_1_4_2/vm.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_2/vm.rs
@@ -3,7 +3,7 @@ use zksync_state::{StoragePtr, WriteStorage};
 use zksync_types::{
     event::extract_l2tol1logs_from_l1_messenger,
     l2_to_l1_log::{SystemL2ToL1Log, UserL2ToL1Log},
-    Transaction,
+    Transaction, H256,
 };
 use zksync_utils::bytecode::CompressedBytecodeInfo;
 
@@ -178,6 +178,18 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
                     .get_pubdata_information()
                     .clone()
                     .build_pubdata(false),
+            ),
+            initially_written_slots: Some(
+                self.bootloader_state
+                    .get_pubdata_information()
+                    .state_diffs
+                    .iter()
+                    .filter_map(|record| {
+                        record
+                            .is_write_initial()
+                            .then_some(H256(record.derived_key))
+                    })
+                    .collect(),
             ),
         }
     }

--- a/core/lib/multivm/src/versions/vm_boojum_integration/vm.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/vm.rs
@@ -179,6 +179,7 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
                     .clone()
                     .build_pubdata(false),
             ),
+            initially_written_slots: None,
         }
     }
 }

--- a/core/lib/multivm/src/versions/vm_latest/vm.rs
+++ b/core/lib/multivm/src/versions/vm_latest/vm.rs
@@ -3,7 +3,7 @@ use zksync_state::{StoragePtr, WriteStorage};
 use zksync_types::{
     event::extract_l2tol1logs_from_l1_messenger,
     l2_to_l1_log::{SystemL2ToL1Log, UserL2ToL1Log},
-    Transaction, VmVersion,
+    Transaction, VmVersion, H256,
 };
 use zksync_utils::bytecode::CompressedBytecodeInfo;
 
@@ -208,6 +208,18 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface<S, H> for Vm<S, H> {
                     .get_pubdata_information()
                     .clone()
                     .build_pubdata(false),
+            ),
+            initially_written_slots: Some(
+                self.bootloader_state
+                    .get_pubdata_information()
+                    .state_diffs
+                    .iter()
+                    .filter_map(|record| {
+                        record
+                            .is_write_initial()
+                            .then_some(H256(record.derived_key))
+                    })
+                    .collect(),
             ),
         }
     }

--- a/core/lib/types/src/storage/writes/mod.rs
+++ b/core/lib/types/src/storage/writes/mod.rs
@@ -142,6 +142,10 @@ impl StateDiffRecord {
 
         comp_state_diff
     }
+
+    pub fn is_write_initial(&self) -> bool {
+        self.enumeration_index == 0
+    }
 }
 
 /// Compresses a vector of state diff records according to the following:

--- a/core/lib/zksync_core/src/state_keeper/io/persistence.rs
+++ b/core/lib/zksync_core/src/state_keeper/io/persistence.rs
@@ -352,21 +352,18 @@ mod tests {
         let mut batch_result = default_vm_batch_result();
         batch_result
             .final_execution_state
-            .deduplicated_storage_log_queries = storage_logs
-            .iter()
-            .map(|query| query.log_query.clone())
-            .collect();
+            .deduplicated_storage_log_queries =
+            storage_logs.iter().map(|query| query.log_query).collect();
         batch_result.initially_written_slots = Some(
             storage_logs
                 .into_iter()
-                .filter_map(|log| {
-                    (log.log_type == StorageLogQueryType::InitialWrite).then(|| {
-                        let key = StorageKey::new(
-                            AccountTreeId::new(log.log_query.address),
-                            u256_to_h256(log.log_query.key),
-                        );
-                        key.hashed_key()
-                    })
+                .filter(|&log| log.log_type == StorageLogQueryType::InitialWrite)
+                .map(|log| {
+                    let key = StorageKey::new(
+                        AccountTreeId::new(log.log_query.address),
+                        u256_to_h256(log.log_query.key),
+                    );
+                    key.hashed_key()
                 })
                 .collect(),
         );

--- a/core/lib/zksync_core/src/state_keeper/tests/mod.rs
+++ b/core/lib/zksync_core/src/state_keeper/tests/mod.rs
@@ -113,6 +113,7 @@ pub(super) fn default_vm_batch_result() -> FinishedL1Batch {
         },
         final_bootloader_memory: Some(vec![]),
         pubdata_input: Some(vec![]),
+        initially_written_slots: Some(vec![]),
     }
 }
 


### PR DESCRIPTION
## What ❔

New versions of VM (1.4.2 and 1.5.0) return list of initially written slots. State keeper doesn't need to query DB to filter slots anymore.

## Why ❔

Improve L1 batch seal performance.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
