### PR TITLE
fix(Validium): `getPubdataPricingMode` contract call

### DIFF
--- a/core/lib/zksync_core/src/utils/mod.rs
+++ b/core/lib/zksync_core/src/utils/mod.rs
@@ -172,7 +172,7 @@ async fn get_pubdata_pricing_mode(
 ) -> Result<Vec<ethabi::Token>, EthClientError> {
     let args = CallFunctionArgs::new("getPubdataPricingMode", ()).for_contract(
         diamond_proxy_address,
-        zksync_contracts::state_transition_manager_contract(),
+        zksync_contracts::hyperchain_contract(),
     );
     eth_client.call_contract_function(args).await
 }


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Change to which contract we call when calling the method `getPubdataPricingMode`.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

Now `getPubdataPricingMode` method is in the `IZkSyncHyperchain` [interface](https://github.com/matter-labs/zksync-era/blob/main/core/tests/loadnext/src/sdk/abi/IZkSyncHyperchain.json#L1438). 

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
