### PR TITLE
feat: tee_verifier_input_producer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8364,10 +8364,12 @@ dependencies = [
  "zksync_protobuf_build",
  "zksync_protobuf_config",
  "zksync_prover_interface",
+ "zksync_queued_job_processor",
  "zksync_shared_metrics",
  "zksync_state",
  "zksync_storage",
  "zksync_system_constants",
+ "zksync_tee_verifier",
  "zksync_test_account",
  "zksync_types",
  "zksync_utils",
@@ -9023,6 +9025,30 @@ version = "0.1.0"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
+ "zksync_utils",
+]
+
+[[package]]
+name = "zksync_tee_verifier"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "multivm",
+ "serde",
+ "tracing",
+ "vm_utils",
+ "zksync_basic_types",
+ "zksync_config",
+ "zksync_contracts",
+ "zksync_crypto",
+ "zksync_dal",
+ "zksync_db_connection",
+ "zksync_merkle_tree",
+ "zksync_object_store",
+ "zksync_prover_interface",
+ "zksync_queued_job_processor",
+ "zksync_state",
+ "zksync_types",
  "zksync_utils",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3725,6 +3725,7 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "once_cell",
+ "serde",
  "thiserror",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
     "core/lib/queued_job_processor",
     "core/lib/state",
     "core/lib/storage",
+    "core/lib/tee_verifier",
     "core/lib/types",
     "core/lib/protobuf_config",
     "core/lib/utils",
@@ -220,6 +221,7 @@ zksync_snapshots_applier = { path = "core/lib/snapshots_applier" }
 zksync_state = { path = "core/lib/state" }
 zksync_storage = { path = "core/lib/storage" }
 zksync_system_constants = { path = "core/lib/constants" }
+zksync_tee_verifier = { path = "core/lib/tee_verifier" }
 zksync_test_account = { path = "core/tests/test_account" }
 zksync_types = { path = "core/lib/types" }
 zksync_utils = { path = "core/lib/utils" }

--- a/checks-config/era.dic
+++ b/checks-config/era.dic
@@ -957,3 +957,6 @@ RECURSION_TIP_ARITY
 empty_proof
 hyperchain
 storages
+vec
+zksync_merkle_tree
+TreeMetadata

--- a/core/bin/zksync_server/src/main.rs
+++ b/core/bin/zksync_server/src/main.rs
@@ -45,7 +45,7 @@ struct Cli {
     /// Comma-separated list of components to launch.
     #[arg(
         long,
-        default_value = "api,tree,eth,state_keeper,housekeeper,commitment_generator"
+        default_value = "api,tree,eth,state_keeper,housekeeper,tee_verifier_input_producer,commitment_generator"
     )]
     components: ComponentsToRun,
     /// Path to the yaml config. If set, it will be used instead of env vars.

--- a/core/lib/contracts/src/lib.rs
+++ b/core/lib/contracts/src/lib.rs
@@ -250,13 +250,13 @@ fn read_zbin_bytecode_from_path(bytecode_path: PathBuf) -> Vec<u8> {
         .unwrap_or_else(|err| panic!("Can't read .zbin bytecode at {:?}: {}", bytecode_path, err))
 }
 /// Hash of code and code which consists of 32 bytes words
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SystemContractCode {
     pub code: Vec<U256>,
     pub hash: H256,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BaseSystemContracts {
     pub bootloader: SystemContractCode,
     pub default_aa: SystemContractCode,

--- a/core/lib/dal/.sqlx/query-0fbdf8da9a000c433c5475d57f6ad2574cd1310dff1d1bf06825d5634ba25f04.json
+++ b/core/lib/dal/.sqlx/query-0fbdf8da9a000c433c5475d57f6ad2574cd1310dff1d1bf06825d5634ba25f04.json
@@ -1,0 +1,30 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE tee_verifier_input_producer_jobs\n            SET\n                status = $1,\n                updated_at = NOW(),\n                time_taken = $3,\n                input_blob_url = $4\n            WHERE\n                l1_batch_number = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "tee_verifier_input_producer_job_status",
+            "kind": {
+              "Enum": [
+                "Queued",
+                "ManuallySkipped",
+                "InProgress",
+                "Successful",
+                "Failed"
+              ]
+            }
+          }
+        },
+        "Int8",
+        "Time",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "0fbdf8da9a000c433c5475d57f6ad2574cd1310dff1d1bf06825d5634ba25f04"
+}

--- a/core/lib/dal/.sqlx/query-0fef49a649d20c9fd263c1dfa40daa9b94d398c635c37746736e98f1f18fcca7.json
+++ b/core/lib/dal/.sqlx/query-0fef49a649d20c9fd263c1dfa40daa9b94d398c635c37746736e98f1f18fcca7.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE tee_verifier_input_producer_jobs\n            SET\n                status = $1,\n                attempts = attempts + 1,\n                updated_at = NOW(),\n                processing_started_at = NOW()\n            WHERE\n                l1_batch_number = (\n                    SELECT\n                        l1_batch_number\n                    FROM\n                        tee_verifier_input_producer_jobs\n                    WHERE\n                        status = $2\n                        OR (\n                            status = $1\n                            AND processing_started_at < NOW() - $4::INTERVAL\n                        )\n                        OR (\n                            status = $3\n                            AND attempts < $5\n                        )\n                    ORDER BY\n                        l1_batch_number ASC\n                    LIMIT\n                        1\n                    FOR UPDATE\n                        SKIP LOCKED\n                )\n            RETURNING\n                tee_verifier_input_producer_jobs.l1_batch_number\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "l1_batch_number",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "tee_verifier_input_producer_job_status",
+            "kind": {
+              "Enum": [
+                "Queued",
+                "ManuallySkipped",
+                "InProgress",
+                "Successful",
+                "Failed"
+              ]
+            }
+          }
+        },
+        {
+          "Custom": {
+            "name": "tee_verifier_input_producer_job_status",
+            "kind": {
+              "Enum": [
+                "Queued",
+                "ManuallySkipped",
+                "InProgress",
+                "Successful",
+                "Failed"
+              ]
+            }
+          }
+        },
+        {
+          "Custom": {
+            "name": "tee_verifier_input_producer_job_status",
+            "kind": {
+              "Enum": [
+                "Queued",
+                "ManuallySkipped",
+                "InProgress",
+                "Successful",
+                "Failed"
+              ]
+            }
+          }
+        },
+        "Interval",
+        "Int2"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "0fef49a649d20c9fd263c1dfa40daa9b94d398c635c37746736e98f1f18fcca7"
+}

--- a/core/lib/dal/.sqlx/query-2ffa321700ef1f70a1c3f516f3162af196d586cc08ea0f23d2c568527e94b41d.json
+++ b/core/lib/dal/.sqlx/query-2ffa321700ef1f70a1c3f516f3162af196d586cc08ea0f23d2c568527e94b41d.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM tee_verifier_input_producer_jobs\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "2ffa321700ef1f70a1c3f516f3162af196d586cc08ea0f23d2c568527e94b41d"
+}

--- a/core/lib/dal/.sqlx/query-30e5c8710b1611872da06b72ac681aff512b3a9b2587b8e59848345c07dd8f3b.json
+++ b/core/lib/dal/.sqlx/query-30e5c8710b1611872da06b72ac681aff512b3a9b2587b8e59848345c07dd8f3b.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE tee_verifier_input_producer_jobs\n            SET\n                status = $1,\n                updated_at = NOW(),\n                time_taken = $3,\n                error = $4\n            WHERE\n                l1_batch_number = $2\n                AND status != $5\n            RETURNING\n                tee_verifier_input_producer_jobs.attempts\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "attempts",
+        "type_info": "Int2"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "tee_verifier_input_producer_job_status",
+            "kind": {
+              "Enum": [
+                "Queued",
+                "ManuallySkipped",
+                "InProgress",
+                "Successful",
+                "Failed"
+              ]
+            }
+          }
+        },
+        "Int8",
+        "Time",
+        "Text",
+        {
+          "Custom": {
+            "name": "tee_verifier_input_producer_job_status",
+            "kind": {
+              "Enum": [
+                "Queued",
+                "ManuallySkipped",
+                "InProgress",
+                "Successful",
+                "Failed"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "30e5c8710b1611872da06b72ac681aff512b3a9b2587b8e59848345c07dd8f3b"
+}

--- a/core/lib/dal/.sqlx/query-5c7409ff9e413e7684cea5df6046f1a607a0bcc6864490c5961dd4e2ee12ed78.json
+++ b/core/lib/dal/.sqlx/query-5c7409ff9e413e7684cea5df6046f1a607a0bcc6864490c5961dd4e2ee12ed78.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                attempts\n            FROM\n                tee_verifier_input_producer_jobs\n            WHERE\n                l1_batch_number = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "attempts",
+        "type_info": "Int2"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "5c7409ff9e413e7684cea5df6046f1a607a0bcc6864490c5961dd4e2ee12ed78"
+}

--- a/core/lib/dal/.sqlx/query-718d29517c100ad9d258a7ee90c48449c1c4bed4d0236fcedc177c9478e72262.json
+++ b/core/lib/dal/.sqlx/query-718d29517c100ad9d258a7ee90c48449c1c4bed4d0236fcedc177c9478e72262.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO\n                tee_verifier_input_producer_jobs (l1_batch_number, status, created_at, updated_at)\n            VALUES\n                ($1, $2, NOW(), NOW())\n            ON CONFLICT (l1_batch_number) DO NOTHING\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        {
+          "Custom": {
+            "name": "tee_verifier_input_producer_job_status",
+            "kind": {
+              "Enum": [
+                "Queued",
+                "ManuallySkipped",
+                "InProgress",
+                "Successful",
+                "Failed"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "718d29517c100ad9d258a7ee90c48449c1c4bed4d0236fcedc177c9478e72262"
+}

--- a/core/lib/dal/migrations/20240325133100_add_tee_verifier_input_producer_jobs_table.down.sql
+++ b/core/lib/dal/migrations/20240325133100_add_tee_verifier_input_producer_jobs_table.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_tee_verifier_input_producer_jobs_status_processing_attempts;
+
+DROP TABLE IF EXISTS tee_verifier_input_producer_jobs;
+
+DROP TYPE IF EXISTS tee_verifier_input_producer_job_status;

--- a/core/lib/dal/migrations/20240325143100_add_tee_verifier_input_producer_jobs_table.up.sql
+++ b/core/lib/dal/migrations/20240325143100_add_tee_verifier_input_producer_jobs_table.up.sql
@@ -1,0 +1,18 @@
+CREATE TYPE tee_verifier_input_producer_job_status AS ENUM ('Queued', 'ManuallySkipped', 'InProgress', 'Successful', 'Failed');
+
+CREATE TABLE IF NOT EXISTS tee_verifier_input_producer_jobs
+(
+    l1_batch_number       BIGINT    NOT NULL PRIMARY KEY,
+    attempts              SMALLINT  NOT NULL DEFAULT 0,
+    status                tee_verifier_input_producer_job_status,
+    picked_by             TEXT,
+    input_blob_url        TEXT,
+    error                 TEXT,
+    created_at            TIMESTAMP NOT NULL,
+    updated_at            TIMESTAMP NOT NULL,
+    processing_started_at TIMESTAMP,
+    time_taken            TIME
+);
+
+CREATE INDEX IF NOT EXISTS idx_tee_verifier_input_producer_jobs_status_processing_attempts
+    ON tee_verifier_input_producer_jobs (status, processing_started_at, attempts);

--- a/core/lib/dal/src/lib.rs
+++ b/core/lib/dal/src/lib.rs
@@ -20,7 +20,8 @@ use crate::{
     snapshot_recovery_dal::SnapshotRecoveryDal, snapshots_creator_dal::SnapshotsCreatorDal,
     snapshots_dal::SnapshotsDal, storage_logs_dal::StorageLogsDal,
     storage_logs_dedup_dal::StorageLogsDedupDal, storage_web3_dal::StorageWeb3Dal,
-    sync_dal::SyncDal, system_dal::SystemDal, tokens_dal::TokensDal,
+    sync_dal::SyncDal, system_dal::SystemDal,
+    tee_verifier_input_producer_dal::TeeVerifierInputProducerDal, tokens_dal::TokensDal,
     tokens_web3_dal::TokensWeb3Dal, transactions_dal::TransactionsDal,
     transactions_web3_dal::TransactionsWeb3Dal,
 };
@@ -48,6 +49,7 @@ pub mod storage_logs_dedup_dal;
 pub mod storage_web3_dal;
 pub mod sync_dal;
 pub mod system_dal;
+pub mod tee_verifier_input_producer_dal;
 pub mod tokens_dal;
 pub mod tokens_web3_dal;
 pub mod transactions_dal;
@@ -70,6 +72,8 @@ where
     fn transactions_dal(&mut self) -> TransactionsDal<'_, 'a>;
 
     fn transactions_web3_dal(&mut self) -> TransactionsWeb3Dal<'_, 'a>;
+
+    fn tee_verifier_input_producer_dal(&mut self) -> TeeVerifierInputProducerDal<'_, 'a>;
 
     fn blocks_dal(&mut self) -> BlocksDal<'_, 'a>;
 
@@ -131,6 +135,10 @@ impl<'a> CoreDal<'a> for Connection<'a, Core> {
 
     fn transactions_web3_dal(&mut self) -> TransactionsWeb3Dal<'_, 'a> {
         TransactionsWeb3Dal { storage: self }
+    }
+
+    fn tee_verifier_input_producer_dal(&mut self) -> TeeVerifierInputProducerDal<'_, 'a> {
+        TeeVerifierInputProducerDal { storage: self }
     }
 
     fn blocks_dal(&mut self) -> BlocksDal<'_, 'a> {

--- a/core/lib/dal/src/tee_verifier_input_producer_dal.rs
+++ b/core/lib/dal/src/tee_verifier_input_producer_dal.rs
@@ -1,0 +1,232 @@
+use std::time::{Duration, Instant};
+
+use sqlx::postgres::types::PgInterval;
+use zksync_db_connection::{
+    connection::Connection,
+    error::DalResult,
+    instrument::InstrumentExt,
+    utils::{duration_to_naive_time, pg_interval_from_duration},
+};
+use zksync_types::L1BatchNumber;
+
+use crate::Core;
+
+#[derive(Debug)]
+pub struct TeeVerifierInputProducerDal<'a, 'c> {
+    pub(crate) storage: &'a mut Connection<'c, Core>,
+}
+
+/// The amount of attempts to process a job before giving up.
+pub const JOB_MAX_ATTEMPT: i16 = 2;
+
+/// Time to wait for job to be processed
+const JOB_PROCESSING_TIMEOUT: PgInterval = pg_interval_from_duration(Duration::from_secs(10 * 60));
+
+/// Status of a job that the producer will work on.
+
+#[derive(Debug, sqlx::Type)]
+#[sqlx(type_name = "tee_verifier_input_producer_job_status")]
+pub enum TeeVerifierInputProducerJobStatus {
+    /// When the job is queued. Metadata calculator creates the job and marks it as queued.
+    Queued,
+    /// The job is not going to be processed. This state is designed for manual operations on DB.
+    /// It is expected to be used if some jobs should be skipped like:
+    /// - testing purposes (want to check a specific L1 Batch, I can mark everything before it skipped)
+    /// - trim down costs on some environments (if I've done breaking changes,
+    /// makes no sense to wait for everything to be processed, I can just skip them and save resources)
+    ManuallySkipped,
+    /// Currently being processed by one of the jobs. Transitory state, will transition to either
+    /// [`TeeVerifierInputProducerStatus::Successful`] or [`TeeVerifierInputProducerStatus::Failed`].
+    InProgress,
+    /// The final (happy case) state we expect all jobs to end up. After the run is complete,
+    /// the job uploaded it's inputs, it lands in successful.
+    Successful,
+    /// The job failed for reasons. It will be marked as such and the error persisted in DB.
+    /// If it failed less than MAX_ATTEMPTs, the job will be retried,
+    /// otherwise it will stay in this state as final state.
+    Failed,
+}
+
+impl TeeVerifierInputProducerDal<'_, '_> {
+    pub async fn create_tee_verifier_input_producer_job(
+        &mut self,
+        l1_batch_number: L1BatchNumber,
+    ) -> DalResult<()> {
+        sqlx::query!(
+            r#"
+            INSERT INTO
+                tee_verifier_input_producer_jobs (l1_batch_number, status, created_at, updated_at)
+            VALUES
+                ($1, $2, NOW(), NOW())
+            ON CONFLICT (l1_batch_number) DO NOTHING
+            "#,
+            i64::from(l1_batch_number.0),
+            TeeVerifierInputProducerJobStatus::Queued as TeeVerifierInputProducerJobStatus,
+        )
+        .instrument("create_tee_verifier_input_producer_job")
+        .with_arg("l1_batch_number", &l1_batch_number)
+        .report_latency()
+        .execute(self.storage)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn get_next_tee_verifier_input_producer_job(
+        &mut self,
+    ) -> DalResult<Option<L1BatchNumber>> {
+        let l1_batch_number = sqlx::query!(
+            r#"
+            UPDATE tee_verifier_input_producer_jobs
+            SET
+                status = $1,
+                attempts = attempts + 1,
+                updated_at = NOW(),
+                processing_started_at = NOW()
+            WHERE
+                l1_batch_number = (
+                    SELECT
+                        l1_batch_number
+                    FROM
+                        tee_verifier_input_producer_jobs
+                    WHERE
+                        status = $2
+                        OR (
+                            status = $1
+                            AND processing_started_at < NOW() - $4::INTERVAL
+                        )
+                        OR (
+                            status = $3
+                            AND attempts < $5
+                        )
+                    ORDER BY
+                        l1_batch_number ASC
+                    LIMIT
+                        1
+                    FOR UPDATE
+                        SKIP LOCKED
+                )
+            RETURNING
+                tee_verifier_input_producer_jobs.l1_batch_number
+            "#,
+            TeeVerifierInputProducerJobStatus::InProgress as TeeVerifierInputProducerJobStatus,
+            TeeVerifierInputProducerJobStatus::Queued as TeeVerifierInputProducerJobStatus,
+            TeeVerifierInputProducerJobStatus::Failed as TeeVerifierInputProducerJobStatus,
+            &JOB_PROCESSING_TIMEOUT,
+            JOB_MAX_ATTEMPT,
+        )
+        .instrument("get_next_tee_verifier_input_producer_job")
+        .report_latency()
+        .fetch_optional(self.storage)
+        .await?
+        .map(|job| L1BatchNumber(job.l1_batch_number as u32));
+
+        Ok(l1_batch_number)
+    }
+
+    pub async fn get_tee_verifier_input_producer_job_attempts(
+        &mut self,
+        l1_batch_number: L1BatchNumber,
+    ) -> DalResult<Option<u32>> {
+        let attempts = sqlx::query!(
+            r#"
+            SELECT
+                attempts
+            FROM
+                tee_verifier_input_producer_jobs
+            WHERE
+                l1_batch_number = $1
+            "#,
+            i64::from(l1_batch_number.0),
+        )
+        .instrument("get_tee_verifier_input_producer_job_attempts")
+        .with_arg("l1_batch_number", &l1_batch_number)
+        .fetch_optional(self.storage)
+        .await?
+        .map(|job| job.attempts as u32);
+
+        Ok(attempts)
+    }
+
+    pub async fn mark_job_as_successful(
+        &mut self,
+        l1_batch_number: L1BatchNumber,
+        started_at: Instant,
+        object_path: &str,
+    ) -> DalResult<()> {
+        sqlx::query!(
+            r#"
+            UPDATE tee_verifier_input_producer_jobs
+            SET
+                status = $1,
+                updated_at = NOW(),
+                time_taken = $3,
+                input_blob_url = $4
+            WHERE
+                l1_batch_number = $2
+            "#,
+            TeeVerifierInputProducerJobStatus::Successful as TeeVerifierInputProducerJobStatus,
+            i64::from(l1_batch_number.0),
+            duration_to_naive_time(started_at.elapsed()),
+            object_path,
+        )
+        .instrument("mark_job_as_successful")
+        .with_arg("l1_batch_number", &l1_batch_number)
+        .report_latency()
+        .execute(self.storage)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn mark_job_as_failed(
+        &mut self,
+        l1_batch_number: L1BatchNumber,
+        started_at: Instant,
+        error: String,
+    ) -> DalResult<Option<u32>> {
+        let attempts = sqlx::query!(
+            r#"
+            UPDATE tee_verifier_input_producer_jobs
+            SET
+                status = $1,
+                updated_at = NOW(),
+                time_taken = $3,
+                error = $4
+            WHERE
+                l1_batch_number = $2
+                AND status != $5
+            RETURNING
+                tee_verifier_input_producer_jobs.attempts
+            "#,
+            TeeVerifierInputProducerJobStatus::Failed as TeeVerifierInputProducerJobStatus,
+            i64::from(l1_batch_number.0),
+            duration_to_naive_time(started_at.elapsed()),
+            error,
+            TeeVerifierInputProducerJobStatus::Successful as TeeVerifierInputProducerJobStatus,
+        )
+        .instrument("mark_job_as_failed")
+        .with_arg("l1_batch_number", &l1_batch_number)
+        .report_latency()
+        .fetch_optional(self.storage)
+        .await?
+        .map(|job| job.attempts as u32);
+
+        Ok(attempts)
+    }
+}
+
+/// These functions should only be used for tests.
+impl TeeVerifierInputProducerDal<'_, '_> {
+    pub async fn delete_all_jobs(&mut self) -> DalResult<()> {
+        sqlx::query!(
+            r#"
+            DELETE FROM tee_verifier_input_producer_jobs
+            "#
+        )
+        .instrument("delete_all_tee_verifier_jobs")
+        .execute(self.storage)
+        .await?;
+        Ok(())
+    }
+}

--- a/core/lib/multivm/Cargo.toml
+++ b/core/lib/multivm/Cargo.toml
@@ -33,6 +33,7 @@ anyhow.workspace = true
 hex.workspace = true
 itertools.workspace = true
 once_cell.workspace = true
+serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 vise.workspace = true

--- a/core/lib/multivm/src/interface/types/inputs/l1_batch_env.rs
+++ b/core/lib/multivm/src/interface/types/inputs/l1_batch_env.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use zksync_types::{fee_model::BatchFeeInput, Address, L1BatchNumber, H256};
 
 use super::L2BlockEnv;
@@ -7,7 +8,7 @@ use super::L2BlockEnv;
 /// Eventually, most of these parameters (`l1_gas_price`, `fair_l2_gas_price`, `fee_account`,
 /// `enforced_base_fee`) will be moved to [`L2BlockEnv`]. For now, the VM doesn't support changing
 /// them in the middle of execution; that's why these params are specified here.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct L1BatchEnv {
     // If previous batch hash is None, then this is the first batch
     pub previous_batch_hash: Option<H256>,

--- a/core/lib/multivm/src/interface/types/inputs/l2_block.rs
+++ b/core/lib/multivm/src/interface/types/inputs/l2_block.rs
@@ -1,6 +1,7 @@
+use serde::{Deserialize, Serialize};
 use zksync_types::{block::L2BlockExecutionData, H256};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct L2BlockEnv {
     pub number: u32,
     pub timestamp: u64,

--- a/core/lib/multivm/src/interface/types/inputs/system_env.rs
+++ b/core/lib/multivm/src/interface/types/inputs/system_env.rs
@@ -1,10 +1,11 @@
 use std::fmt::Debug;
 
+use serde::{Deserialize, Serialize};
 use zksync_contracts::BaseSystemContracts;
 use zksync_types::{L2ChainId, ProtocolVersionId};
 
 /// Params related to the execution process, not batch it self
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct SystemEnv {
     // Always false for VM
     pub zk_porter_available: bool,
@@ -44,7 +45,7 @@ impl Debug for SystemEnv {
 /// With `VerifyExecute` mode, transaction will be executed normally.
 /// With `EstimateFee`, the bootloader will be used that has the same behavior
 /// as the full `VerifyExecute` block, but errors in the account validation will be ignored.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TxExecutionMode {
     VerifyExecute,
     EstimateFee,

--- a/core/lib/object_store/src/file.rs
+++ b/core/lib/object_store/src/file.rs
@@ -33,6 +33,7 @@ impl FileBackedObjectStore {
             Bucket::SchedulerWitnessJobsFri,
             Bucket::ProofsFri,
             Bucket::StorageSnapshot,
+            Bucket::TeeVerifierInput,
         ] {
             let bucket_path = format!("{base_dir}/{bucket}");
             fs::create_dir_all(&bucket_path)

--- a/core/lib/object_store/src/raw.rs
+++ b/core/lib/object_store/src/raw.rs
@@ -24,6 +24,7 @@ pub enum Bucket {
     SchedulerWitnessJobsFri,
     ProofsFri,
     StorageSnapshot,
+    TeeVerifierInput,
 }
 
 impl Bucket {
@@ -40,6 +41,7 @@ impl Bucket {
             Self::SchedulerWitnessJobsFri => "scheduler_witness_jobs_fri",
             Self::ProofsFri => "proofs_fri",
             Self::StorageSnapshot => "storage_logs_snapshots",
+            Self::TeeVerifierInput => "tee_verifier_inputs",
         }
     }
 }

--- a/core/lib/prover_interface/src/inputs.rs
+++ b/core/lib/prover_interface/src/inputs.rs
@@ -58,7 +58,7 @@ impl StorageLogMetadata {
 /// 256 items with the current Merkle tree). The following items may have less hashes in their
 /// Merkle paths; if this is the case, the starting hashes are skipped and are the same
 /// as in the first path.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PrepareBasicCircuitsJob {
     // Merkle paths and some auxiliary information for each read / write operation in a block.
     merkle_paths: Vec<StorageLogMetadata>,

--- a/core/lib/state/src/in_memory.rs
+++ b/core/lib/state/src/in_memory.rs
@@ -85,6 +85,18 @@ impl InMemoryStorage {
     }
 
     /// Sets the storage `value` at the specified `key`.
+    pub fn set_value_hashed_enum(&mut self, key: H256, enum_index_set: u64, value: StorageValue) {
+        match self.state.entry(key) {
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().0 = value;
+            }
+            Entry::Vacant(entry) => {
+                entry.insert((value, enum_index_set));
+            }
+        }
+    }
+
+    /// Sets the storage `value` at the specified `key`.
     pub fn set_value(&mut self, key: StorageKey, value: StorageValue) {
         match self.state.entry(key.hashed_key()) {
             Entry::Occupied(mut entry) => {

--- a/core/lib/tee_verifier/Cargo.toml
+++ b/core/lib/tee_verifier/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "zksync_tee_verifier"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow.workspace = true
+multivm.workspace = true
+serde.workspace = true
+tracing.workspace = true
+vm_utils.workspace = true
+zksync_basic_types.workspace = true
+zksync_config.workspace = true
+zksync_crypto.workspace = true
+zksync_dal.workspace = true
+zksync_db_connection.workspace = true
+zksync_merkle_tree.workspace = true
+zksync_object_store.workspace = true
+zksync_prover_interface.workspace = true
+zksync_queued_job_processor.workspace = true
+zksync_state.workspace = true
+zksync_types.workspace = true
+zksync_utils.workspace = true
+zksync_contracts.workspace = true

--- a/core/lib/tee_verifier/Cargo.toml
+++ b/core/lib/tee_verifier/Cargo.toml
@@ -17,7 +17,6 @@ multivm.workspace = true
 serde.workspace = true
 tracing.workspace = true
 vm_utils.workspace = true
-zksync_basic_types.workspace = true
 zksync_config.workspace = true
 zksync_crypto.workspace = true
 zksync_dal.workspace = true
@@ -29,4 +28,7 @@ zksync_queued_job_processor.workspace = true
 zksync_state.workspace = true
 zksync_types.workspace = true
 zksync_utils.workspace = true
+
+[dev-dependencies]
 zksync_contracts.workspace = true
+zksync_basic_types.workspace = true

--- a/core/lib/tee_verifier/src/lib.rs
+++ b/core/lib/tee_verifier/src/lib.rs
@@ -1,0 +1,712 @@
+//! Tee verifier
+//!
+//! Verifies that a L1Batch has the expected root hash after
+//! executing the VM and verifying all the accessed memory slots by their
+//! merkle path.
+//!
+//! The crate/library shadows some structures to avoid polluting the global code
+//! base with a stable (De-)Serialize ABI.
+//! If additional components need to (De-)Serialize these structures, we can revisit this decision.
+
+use std::{cell::RefCell, rc::Rc};
+
+use anyhow::Context;
+use multivm::{
+    interface::{FinishedL1Batch, L1BatchEnv, L2BlockEnv, SystemEnv, TxExecutionMode, VmInterface},
+    vm_latest::HistoryEnabled,
+    zk_evm_latest::ethereum_types::U256,
+    VmInstance,
+};
+use serde::{Deserialize, Serialize};
+use vm_utils::execute_tx;
+use zksync_basic_types::{protocol_version::ProtocolVersionId, Address, L2BlockNumber, L2ChainId};
+use zksync_contracts::{BaseSystemContracts, SystemContractCode};
+use zksync_crypto::hasher::blake2::Blake2Hasher;
+use zksync_merkle_tree::{
+    BlockOutputWithProofs, TreeInstruction, TreeLogEntry, TreeLogEntryWithProof,
+};
+use zksync_object_store::{serialize_using_bincode, Bucket, StoredObject};
+use zksync_prover_interface::inputs::{PrepareBasicCircuitsJob, StorageLogMetadata};
+use zksync_state::{InMemoryStorage, StorageView, WriteStorage};
+use zksync_types::{
+    block::L2BlockExecutionData,
+    ethabi::ethereum_types::BigEndianHash,
+    fee_model::{BatchFeeInput, L1PeggedBatchFeeModelInput, PubdataIndependentBatchFeeModelInput},
+    zk_evm_types::LogQuery,
+    AccountTreeId, L1BatchNumber, StorageKey, Transaction, H256,
+};
+use zksync_utils::{bytecode::hash_bytecode, u256_to_h256};
+
+/// Shadowed struct of [`L2BlockExecutionData`]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct V1L2BlockExecutionData {
+    number: L2BlockNumber,
+    timestamp: u64,
+    prev_block_hash: H256,
+    virtual_blocks: u32,
+    txs: Vec<Transaction>,
+}
+
+impl From<V1L2BlockExecutionData> for L2BlockExecutionData {
+    fn from(value: V1L2BlockExecutionData) -> Self {
+        L2BlockExecutionData {
+            number: value.number,
+            timestamp: value.timestamp,
+            prev_block_hash: value.prev_block_hash,
+            virtual_blocks: value.virtual_blocks,
+            txs: value.txs,
+        }
+    }
+}
+
+impl From<L2BlockExecutionData> for V1L2BlockExecutionData {
+    fn from(value: L2BlockExecutionData) -> Self {
+        V1L2BlockExecutionData {
+            number: value.number,
+            timestamp: value.timestamp,
+            prev_block_hash: value.prev_block_hash,
+            virtual_blocks: value.virtual_blocks,
+            txs: value.txs,
+        }
+    }
+}
+
+/// Shadowed struct of [`L1PeggedBatchFeeModelInput`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+struct V1L1PeggedBatchFeeModelInput {
+    /// Fair L2 gas price to provide
+    fair_l2_gas_price: u64,
+    /// The L1 gas price to provide to the VM.
+    l1_gas_price: u64,
+}
+impl From<V1L1PeggedBatchFeeModelInput> for L1PeggedBatchFeeModelInput {
+    fn from(value: V1L1PeggedBatchFeeModelInput) -> Self {
+        L1PeggedBatchFeeModelInput {
+            fair_l2_gas_price: value.fair_l2_gas_price,
+            l1_gas_price: value.l1_gas_price,
+        }
+    }
+}
+
+impl From<L1PeggedBatchFeeModelInput> for V1L1PeggedBatchFeeModelInput {
+    fn from(value: L1PeggedBatchFeeModelInput) -> Self {
+        V1L1PeggedBatchFeeModelInput {
+            fair_l2_gas_price: value.fair_l2_gas_price,
+            l1_gas_price: value.l1_gas_price,
+        }
+    }
+}
+/// Shadowed struct of [`PubdataIndependentBatchFeeModelInput`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+struct V1PubdataIndependentBatchFeeModelInput {
+    fair_l2_gas_price: u64,
+    fair_pubdata_price: u64,
+    l1_gas_price: u64,
+}
+
+impl From<V1PubdataIndependentBatchFeeModelInput> for PubdataIndependentBatchFeeModelInput {
+    fn from(value: V1PubdataIndependentBatchFeeModelInput) -> Self {
+        PubdataIndependentBatchFeeModelInput {
+            fair_l2_gas_price: value.fair_l2_gas_price,
+            fair_pubdata_price: value.fair_pubdata_price,
+            l1_gas_price: value.l1_gas_price,
+        }
+    }
+}
+
+impl From<PubdataIndependentBatchFeeModelInput> for V1PubdataIndependentBatchFeeModelInput {
+    fn from(value: PubdataIndependentBatchFeeModelInput) -> Self {
+        V1PubdataIndependentBatchFeeModelInput {
+            fair_l2_gas_price: value.fair_l2_gas_price,
+            fair_pubdata_price: value.fair_pubdata_price,
+            l1_gas_price: value.l1_gas_price,
+        }
+    }
+}
+
+/// Shadowed struct of [`BatchFeeInput`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+enum V1BatchFeeInput {
+    L1Pegged(V1L1PeggedBatchFeeModelInput),
+    PubdataIndependent(V1PubdataIndependentBatchFeeModelInput),
+}
+
+impl From<V1BatchFeeInput> for BatchFeeInput {
+    fn from(value: V1BatchFeeInput) -> Self {
+        match value {
+            V1BatchFeeInput::L1Pegged(input) => BatchFeeInput::L1Pegged(input.into()),
+            V1BatchFeeInput::PubdataIndependent(input) => {
+                BatchFeeInput::PubdataIndependent(input.into())
+            }
+        }
+    }
+}
+
+impl From<BatchFeeInput> for V1BatchFeeInput {
+    fn from(value: BatchFeeInput) -> Self {
+        match value {
+            BatchFeeInput::L1Pegged(input) => V1BatchFeeInput::L1Pegged(input.into()),
+            BatchFeeInput::PubdataIndependent(input) => {
+                V1BatchFeeInput::PubdataIndependent(input.into())
+            }
+        }
+    }
+}
+
+/// Shadowed struct of [`L2BlockEnv`]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+struct V1L2BlockEnv {
+    number: u32,
+    timestamp: u64,
+    prev_block_hash: H256,
+    max_virtual_blocks_to_create: u32,
+}
+
+impl From<V1L2BlockEnv> for L2BlockEnv {
+    fn from(value: V1L2BlockEnv) -> Self {
+        L2BlockEnv {
+            number: value.number,
+            timestamp: value.timestamp,
+            prev_block_hash: value.prev_block_hash,
+            max_virtual_blocks_to_create: value.max_virtual_blocks_to_create,
+        }
+    }
+}
+
+impl From<L2BlockEnv> for V1L2BlockEnv {
+    fn from(value: L2BlockEnv) -> Self {
+        V1L2BlockEnv {
+            number: value.number,
+            timestamp: value.timestamp,
+            prev_block_hash: value.prev_block_hash,
+            max_virtual_blocks_to_create: value.max_virtual_blocks_to_create,
+        }
+    }
+}
+
+/// Shadowed struct of [`L1BatchEnv`]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct V1L1BatchEnv {
+    previous_batch_hash: Option<H256>,
+    number: L1BatchNumber,
+    timestamp: u64,
+    fee_input: V1BatchFeeInput,
+    fee_account: Address,
+    enforced_base_fee: Option<u64>,
+    first_l2_block: V1L2BlockEnv,
+}
+
+impl From<V1L1BatchEnv> for L1BatchEnv {
+    fn from(value: V1L1BatchEnv) -> Self {
+        let V1L1BatchEnv {
+            previous_batch_hash,
+            number,
+            timestamp,
+            fee_input,
+            fee_account,
+            enforced_base_fee,
+            first_l2_block,
+        } = value;
+
+        L1BatchEnv {
+            previous_batch_hash,
+            number,
+            timestamp,
+            fee_input: fee_input.into(),
+            fee_account,
+            enforced_base_fee,
+            first_l2_block: first_l2_block.into(),
+        }
+    }
+}
+
+impl From<L1BatchEnv> for V1L1BatchEnv {
+    fn from(value: L1BatchEnv) -> Self {
+        let L1BatchEnv {
+            previous_batch_hash,
+            number,
+            timestamp,
+            fee_input,
+            fee_account,
+            enforced_base_fee,
+            first_l2_block,
+        } = value;
+
+        V1L1BatchEnv {
+            previous_batch_hash,
+            number,
+            timestamp,
+            fee_input: fee_input.into(),
+            fee_account,
+            enforced_base_fee,
+            first_l2_block: first_l2_block.into(),
+        }
+    }
+}
+
+/// Shadowed struct of [`SystemContractCode`]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct V1SystemContractCode {
+    code: Vec<U256>,
+    hash: H256,
+}
+
+impl From<V1SystemContractCode> for SystemContractCode {
+    fn from(value: V1SystemContractCode) -> Self {
+        let V1SystemContractCode { code, hash } = value;
+        SystemContractCode { code, hash }
+    }
+}
+
+impl From<SystemContractCode> for V1SystemContractCode {
+    fn from(value: SystemContractCode) -> Self {
+        let SystemContractCode { code, hash } = value;
+        V1SystemContractCode { code, hash }
+    }
+}
+
+/// Shadowed struct of [`BaseSystemContracts`]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct V1BaseSystemContracts {
+    bootloader: V1SystemContractCode,
+    default_aa: V1SystemContractCode,
+}
+
+impl From<V1BaseSystemContracts> for BaseSystemContracts {
+    fn from(value: V1BaseSystemContracts) -> Self {
+        let V1BaseSystemContracts {
+            bootloader,
+            default_aa,
+        } = value;
+
+        BaseSystemContracts {
+            bootloader: bootloader.into(),
+            default_aa: default_aa.into(),
+        }
+    }
+}
+
+impl From<BaseSystemContracts> for V1BaseSystemContracts {
+    fn from(value: BaseSystemContracts) -> Self {
+        let BaseSystemContracts {
+            bootloader,
+            default_aa,
+        } = value;
+
+        V1BaseSystemContracts {
+            bootloader: bootloader.into(),
+            default_aa: default_aa.into(),
+        }
+    }
+}
+
+/// Shadowed struct of [`SystemEnv`]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct V1SystemEnv {
+    // Always false for VM
+    zk_porter_available: bool,
+    version: ProtocolVersionId,
+    base_system_smart_contracts: V1BaseSystemContracts,
+    bootloader_gas_limit: u32,
+    execution_mode: V1TxExecutionMode,
+    default_validation_computational_gas_limit: u32,
+    chain_id: L2ChainId,
+}
+
+impl From<V1SystemEnv> for SystemEnv {
+    fn from(value: V1SystemEnv) -> Self {
+        let V1SystemEnv {
+            zk_porter_available,
+            version,
+            base_system_smart_contracts,
+            bootloader_gas_limit,
+            execution_mode,
+            default_validation_computational_gas_limit,
+            chain_id,
+        } = value;
+
+        SystemEnv {
+            default_validation_computational_gas_limit,
+            chain_id,
+            zk_porter_available,
+            version,
+            execution_mode: execution_mode.into(),
+            base_system_smart_contracts: base_system_smart_contracts.into(),
+            bootloader_gas_limit,
+        }
+    }
+}
+
+impl From<SystemEnv> for V1SystemEnv {
+    fn from(value: SystemEnv) -> Self {
+        let SystemEnv {
+            zk_porter_available,
+            version,
+            base_system_smart_contracts,
+            bootloader_gas_limit,
+            execution_mode,
+            default_validation_computational_gas_limit,
+            chain_id,
+        } = value;
+
+        V1SystemEnv {
+            default_validation_computational_gas_limit,
+            chain_id,
+            zk_porter_available,
+            version,
+            execution_mode: execution_mode.into(),
+            base_system_smart_contracts: base_system_smart_contracts.into(),
+            bootloader_gas_limit,
+        }
+    }
+}
+
+/// Shadowed struct of [`TxExecutionMode`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+enum V1TxExecutionMode {
+    VerifyExecute,
+    EstimateFee,
+    EthCall,
+}
+
+impl From<V1TxExecutionMode> for TxExecutionMode {
+    fn from(value: V1TxExecutionMode) -> Self {
+        match value {
+            V1TxExecutionMode::VerifyExecute => TxExecutionMode::VerifyExecute,
+            V1TxExecutionMode::EstimateFee => TxExecutionMode::EstimateFee,
+            V1TxExecutionMode::EthCall => TxExecutionMode::EthCall,
+        }
+    }
+}
+
+impl From<TxExecutionMode> for V1TxExecutionMode {
+    fn from(value: TxExecutionMode) -> Self {
+        match value {
+            TxExecutionMode::VerifyExecute => V1TxExecutionMode::VerifyExecute,
+            TxExecutionMode::EstimateFee => V1TxExecutionMode::EstimateFee,
+            TxExecutionMode::EthCall => V1TxExecutionMode::EthCall,
+        }
+    }
+}
+
+/// Version 1 of the data used as input for the TEE verifier.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct V1TeeVerifierInput {
+    prepare_basic_circuits_job: PrepareBasicCircuitsJob,
+    l2_blocks_execution_data: Vec<V1L2BlockExecutionData>,
+    l1_batch_env: V1L1BatchEnv,
+    system_env: V1SystemEnv,
+    used_contracts: Vec<(H256, Vec<u8>)>,
+}
+
+/// Data used as input for the TEE verifier.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[non_exhaustive]
+#[allow(clippy::large_enum_variant)]
+pub enum TeeVerifierInput {
+    /// `V0` suppresses warning about irrefutable `let...else` pattern
+    V0,
+    V1(V1TeeVerifierInput),
+}
+
+impl TeeVerifierInput {
+    pub fn new(
+        prepare_basic_circuits_job: PrepareBasicCircuitsJob,
+        l2_blocks_execution_data: Vec<L2BlockExecutionData>,
+        l1_batch_env: L1BatchEnv,
+        system_env: SystemEnv,
+        used_contracts: Vec<(H256, Vec<u8>)>,
+    ) -> Self {
+        TeeVerifierInput::V1(V1TeeVerifierInput {
+            prepare_basic_circuits_job,
+            l2_blocks_execution_data: l2_blocks_execution_data
+                .into_iter()
+                .map(|v| v.into())
+                .collect(),
+            l1_batch_env: l1_batch_env.into(),
+            system_env: system_env.into(),
+            used_contracts,
+        })
+    }
+
+    /// Verify that the L1Batch produces the expected root hash
+    /// by executing the VM and verifying the merkle paths of all
+    /// touch storage slots.
+    ///
+    /// # Errors
+    ///
+    /// Returns a verbose error of the failure, because any error is
+    /// not actionable.
+    pub fn verify(self) -> anyhow::Result<()> {
+        let TeeVerifierInput::V1(V1TeeVerifierInput {
+            prepare_basic_circuits_job,
+            l2_blocks_execution_data,
+            l1_batch_env,
+            system_env,
+            used_contracts,
+        }) = self
+        else {
+            tracing::error!("TeeVerifierInput variant not supported");
+            anyhow::bail!("TeeVerifierInput variant not supported");
+        };
+
+        let old_root_hash = l1_batch_env.previous_batch_hash.unwrap();
+        let l2_chain_id = system_env.chain_id;
+        let enumeration_index = prepare_basic_circuits_job.next_enumeration_index();
+
+        let mut raw_storage = InMemoryStorage::with_custom_system_contracts_and_chain_id(
+            l2_chain_id,
+            hash_bytecode,
+            Vec::with_capacity(0),
+        );
+
+        for (hash, bytes) in used_contracts.into_iter() {
+            tracing::trace!("raw_storage.store_factory_dep({hash}, bytes)");
+            raw_storage.store_factory_dep(hash, bytes)
+        }
+
+        let block_output_with_proofs =
+            Self::get_bowp_and_set_initial_values(prepare_basic_circuits_job, &mut raw_storage);
+
+        let storage_view = Rc::new(RefCell::new(StorageView::new(&raw_storage)));
+
+        let vm = VmInstance::new(l1_batch_env.into(), system_env.into(), storage_view);
+
+        let l2_blocks_execution_data = l2_blocks_execution_data
+            .into_iter()
+            .map(|v| v.into())
+            .collect();
+
+        let vm_out = Self::execute_vm(l2_blocks_execution_data, vm)?;
+
+        let instructions: Vec<TreeInstruction> =
+            Self::generate_tree_instructions(enumeration_index, &block_output_with_proofs, vm_out)?;
+
+        block_output_with_proofs
+            .verify_proofs(&Blake2Hasher, old_root_hash, &instructions)
+            .context("Failed to verify_proofs {l1_batch_number} correctly!")?;
+
+        Ok(())
+    }
+
+    /// Sets the initial storage values and returns `BlockOutputWithProofs`
+    fn get_bowp_and_set_initial_values(
+        prepare_basic_circuits_job: PrepareBasicCircuitsJob,
+        raw_storage: &mut InMemoryStorage,
+    ) -> BlockOutputWithProofs {
+        let logs = prepare_basic_circuits_job
+            .into_merkle_paths()
+            .map(
+                |StorageLogMetadata {
+                     root_hash,
+                     merkle_paths,
+                     is_write,
+                     first_write,
+                     leaf_enumeration_index,
+                     value_read,
+                     leaf_hashed_key: leaf_storage_key,
+                     ..
+                 }| {
+                    let root_hash = root_hash.into();
+                    let merkle_path = merkle_paths.into_iter().map(|x| x.into()).collect();
+                    let base: TreeLogEntry = match (is_write, first_write, leaf_enumeration_index) {
+                        (false, _, 0) => TreeLogEntry::ReadMissingKey,
+                        (false, _, _) => {
+                            // This is a special U256 here, which needs `to_little_endian`
+                            let mut hashed_key = [0_u8; 32];
+                            leaf_storage_key.to_little_endian(&mut hashed_key);
+                            raw_storage.set_value_hashed_enum(
+                                hashed_key.into(),
+                                leaf_enumeration_index,
+                                value_read.into(),
+                            );
+                            TreeLogEntry::Read {
+                                leaf_index: leaf_enumeration_index,
+                                value: value_read.into(),
+                            }
+                        }
+                        (true, true, _) => TreeLogEntry::Inserted,
+                        (true, false, _) => {
+                            // This is a special U256 here, which needs `to_little_endian`
+                            let mut hashed_key = [0_u8; 32];
+                            leaf_storage_key.to_little_endian(&mut hashed_key);
+                            raw_storage.set_value_hashed_enum(
+                                hashed_key.into(),
+                                leaf_enumeration_index,
+                                value_read.into(),
+                            );
+                            TreeLogEntry::Updated {
+                                leaf_index: leaf_enumeration_index,
+                                previous_value: value_read.into(),
+                            }
+                        }
+                    };
+                    TreeLogEntryWithProof {
+                        base,
+                        merkle_path,
+                        root_hash,
+                    }
+                },
+            )
+            .collect();
+
+        BlockOutputWithProofs {
+            logs,
+            leaf_count: 0,
+        }
+    }
+
+    /// Executes the VM and returns `FinishedL1Batch` on success.
+    fn execute_vm<S: WriteStorage>(
+        l2_blocks_execution_data: Vec<L2BlockExecutionData>,
+        mut vm: VmInstance<S, HistoryEnabled>,
+    ) -> anyhow::Result<FinishedL1Batch> {
+        let next_l2_blocks_data = l2_blocks_execution_data.iter().skip(1);
+
+        let l2_blocks_data = l2_blocks_execution_data.iter().zip(next_l2_blocks_data);
+
+        for (l2_block_data, next_l2_block_data) in l2_blocks_data {
+            tracing::trace!(
+                "Started execution of l2_block: {:?}, executing {:?} transactions",
+                l2_block_data.number,
+                l2_block_data.txs.len(),
+            );
+            for tx in &l2_block_data.txs {
+                tracing::trace!("Started execution of tx: {tx:?}");
+                execute_tx(tx, &mut vm)
+                    .context("failed to execute transaction in TeeVerifierInputProducer")?;
+                tracing::trace!("Finished execution of tx: {tx:?}");
+            }
+            vm.start_new_l2_block(L2BlockEnv::from_l2_block_data(next_l2_block_data));
+
+            tracing::trace!("Finished execution of l2_block: {:?}", l2_block_data.number);
+        }
+
+        Ok(vm.finish_batch())
+    }
+
+    /// Map `LogQuery` and `TreeLogEntry` to a `TreeInstruction`
+    fn map_log_tree(
+        log_query: &LogQuery,
+        tree_log_entry: &TreeLogEntry,
+        idx: &mut u64,
+    ) -> anyhow::Result<TreeInstruction> {
+        let key = StorageKey::new(
+            AccountTreeId::new(log_query.address),
+            u256_to_h256(log_query.key),
+        )
+        .hashed_key_u256();
+        Ok(match (log_query.rw_flag, *tree_log_entry) {
+            (true, TreeLogEntry::Updated { leaf_index, .. }) => {
+                TreeInstruction::write(key, leaf_index, H256(log_query.written_value.into()))
+            }
+            (true, TreeLogEntry::Inserted) => {
+                let leaf_index = *idx;
+                *idx += 1;
+                TreeInstruction::write(key, leaf_index, H256(log_query.written_value.into()))
+            }
+            (false, TreeLogEntry::Read { value, .. }) => {
+                if log_query.read_value != value.into_uint() {
+                    tracing::error!(
+                        "Failed to map LogQuery to TreeInstruction: {:#?} != {:#?}",
+                        log_query.read_value,
+                        value
+                    );
+                    anyhow::bail!(
+                        "Failed to map LogQuery to TreeInstruction: {:#?} != {:#?}",
+                        log_query.read_value,
+                        value
+                    );
+                }
+                TreeInstruction::Read(key)
+            }
+            (false, TreeLogEntry::ReadMissingKey { .. }) => TreeInstruction::Read(key),
+            _ => {
+                tracing::error!("Failed to map LogQuery to TreeInstruction");
+                anyhow::bail!("Failed to map LogQuery to TreeInstruction");
+            }
+        })
+    }
+
+    /// Generates the `TreeInstruction`s from the VM executions.
+    fn generate_tree_instructions(
+        mut idx: u64,
+        bowp: &BlockOutputWithProofs,
+        vm_out: FinishedL1Batch,
+    ) -> anyhow::Result<Vec<TreeInstruction>> {
+        vm_out
+            .final_execution_state
+            .deduplicated_storage_log_queries
+            .into_iter()
+            .zip(bowp.logs.iter())
+            .map(|(log_query, tree_log_entry)| {
+                Self::map_log_tree(&log_query, &tree_log_entry.base, &mut idx)
+            })
+            .collect::<Result<Vec<_>, _>>()
+    }
+}
+
+impl StoredObject for TeeVerifierInput {
+    const BUCKET: Bucket = Bucket::TeeVerifierInput;
+    type Key<'a> = L1BatchNumber;
+
+    fn encode_key(key: Self::Key<'_>) -> String {
+        format!("tee_verifier_input_for_l1_batch_{key}.bin")
+    }
+
+    serialize_using_bincode!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_v1_serialization() {
+        let tvi = TeeVerifierInput::new(
+            PrepareBasicCircuitsJob::new(0),
+            vec![],
+            L1BatchEnv {
+                previous_batch_hash: Some(H256([1; 32])),
+                number: Default::default(),
+                timestamp: 0,
+                fee_input: Default::default(),
+                fee_account: Default::default(),
+                enforced_base_fee: None,
+                first_l2_block: L2BlockEnv {
+                    number: 0,
+                    timestamp: 0,
+                    prev_block_hash: H256([1; 32]),
+                    max_virtual_blocks_to_create: 0,
+                },
+            },
+            SystemEnv {
+                zk_porter_available: false,
+                version: Default::default(),
+                base_system_smart_contracts: BaseSystemContracts {
+                    bootloader: SystemContractCode {
+                        code: vec![U256([1; 4])],
+                        hash: H256([1; 32]),
+                    },
+                    default_aa: SystemContractCode {
+                        code: vec![U256([1; 4])],
+                        hash: H256([1; 32]),
+                    },
+                },
+                bootloader_gas_limit: 0,
+                execution_mode: TxExecutionMode::VerifyExecute,
+                default_validation_computational_gas_limit: 0,
+                chain_id: Default::default(),
+            },
+            vec![(H256([1; 32]), vec![0, 1, 2, 3, 4])],
+        );
+
+        let serialized = <TeeVerifierInput as StoredObject>::serialize(&tvi)
+            .expect("Failed to serialize TeeVerifierInput.");
+        let deserialized: TeeVerifierInput =
+            <TeeVerifierInput as StoredObject>::deserialize(serialized)
+                .expect("Failed to deserialize TeeVerifierInput.");
+
+        assert_eq!(tvi, deserialized);
+    }
+}

--- a/core/lib/tee_verifier/src/lib.rs
+++ b/core/lib/tee_verifier/src/lib.rs
@@ -3,24 +3,17 @@
 //! Verifies that a L1Batch has the expected root hash after
 //! executing the VM and verifying all the accessed memory slots by their
 //! merkle path.
-//!
-//! The crate/library shadows some structures to avoid polluting the global code
-//! base with a stable (De-)Serialize ABI.
-//! If additional components need to (De-)Serialize these structures, we can revisit this decision.
 
 use std::{cell::RefCell, rc::Rc};
 
 use anyhow::Context;
 use multivm::{
-    interface::{FinishedL1Batch, L1BatchEnv, L2BlockEnv, SystemEnv, TxExecutionMode, VmInterface},
+    interface::{FinishedL1Batch, L1BatchEnv, L2BlockEnv, SystemEnv, VmInterface},
     vm_latest::HistoryEnabled,
-    zk_evm_latest::ethereum_types::U256,
     VmInstance,
 };
 use serde::{Deserialize, Serialize};
 use vm_utils::execute_tx;
-use zksync_basic_types::{protocol_version::ProtocolVersionId, Address, L2BlockNumber, L2ChainId};
-use zksync_contracts::{BaseSystemContracts, SystemContractCode};
 use zksync_crypto::hasher::blake2::Blake2Hasher;
 use zksync_merkle_tree::{
     BlockOutputWithProofs, TreeInstruction, TreeLogEntry, TreeLogEntryWithProof,
@@ -29,373 +22,18 @@ use zksync_object_store::{serialize_using_bincode, Bucket, StoredObject};
 use zksync_prover_interface::inputs::{PrepareBasicCircuitsJob, StorageLogMetadata};
 use zksync_state::{InMemoryStorage, StorageView, WriteStorage};
 use zksync_types::{
-    block::L2BlockExecutionData,
-    ethabi::ethereum_types::BigEndianHash,
-    fee_model::{BatchFeeInput, L1PeggedBatchFeeModelInput, PubdataIndependentBatchFeeModelInput},
-    zk_evm_types::LogQuery,
-    AccountTreeId, L1BatchNumber, StorageKey, Transaction, H256,
+    block::L2BlockExecutionData, ethabi::ethereum_types::BigEndianHash, zk_evm_types::LogQuery,
+    AccountTreeId, L1BatchNumber, StorageKey, H256,
 };
 use zksync_utils::{bytecode::hash_bytecode, u256_to_h256};
-
-/// Shadowed struct of [`L2BlockExecutionData`]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-struct V1L2BlockExecutionData {
-    number: L2BlockNumber,
-    timestamp: u64,
-    prev_block_hash: H256,
-    virtual_blocks: u32,
-    txs: Vec<Transaction>,
-}
-
-impl From<V1L2BlockExecutionData> for L2BlockExecutionData {
-    fn from(value: V1L2BlockExecutionData) -> Self {
-        L2BlockExecutionData {
-            number: value.number,
-            timestamp: value.timestamp,
-            prev_block_hash: value.prev_block_hash,
-            virtual_blocks: value.virtual_blocks,
-            txs: value.txs,
-        }
-    }
-}
-
-impl From<L2BlockExecutionData> for V1L2BlockExecutionData {
-    fn from(value: L2BlockExecutionData) -> Self {
-        V1L2BlockExecutionData {
-            number: value.number,
-            timestamp: value.timestamp,
-            prev_block_hash: value.prev_block_hash,
-            virtual_blocks: value.virtual_blocks,
-            txs: value.txs,
-        }
-    }
-}
-
-/// Shadowed struct of [`L1PeggedBatchFeeModelInput`]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-struct V1L1PeggedBatchFeeModelInput {
-    /// Fair L2 gas price to provide
-    fair_l2_gas_price: u64,
-    /// The L1 gas price to provide to the VM.
-    l1_gas_price: u64,
-}
-impl From<V1L1PeggedBatchFeeModelInput> for L1PeggedBatchFeeModelInput {
-    fn from(value: V1L1PeggedBatchFeeModelInput) -> Self {
-        L1PeggedBatchFeeModelInput {
-            fair_l2_gas_price: value.fair_l2_gas_price,
-            l1_gas_price: value.l1_gas_price,
-        }
-    }
-}
-
-impl From<L1PeggedBatchFeeModelInput> for V1L1PeggedBatchFeeModelInput {
-    fn from(value: L1PeggedBatchFeeModelInput) -> Self {
-        V1L1PeggedBatchFeeModelInput {
-            fair_l2_gas_price: value.fair_l2_gas_price,
-            l1_gas_price: value.l1_gas_price,
-        }
-    }
-}
-/// Shadowed struct of [`PubdataIndependentBatchFeeModelInput`]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-struct V1PubdataIndependentBatchFeeModelInput {
-    fair_l2_gas_price: u64,
-    fair_pubdata_price: u64,
-    l1_gas_price: u64,
-}
-
-impl From<V1PubdataIndependentBatchFeeModelInput> for PubdataIndependentBatchFeeModelInput {
-    fn from(value: V1PubdataIndependentBatchFeeModelInput) -> Self {
-        PubdataIndependentBatchFeeModelInput {
-            fair_l2_gas_price: value.fair_l2_gas_price,
-            fair_pubdata_price: value.fair_pubdata_price,
-            l1_gas_price: value.l1_gas_price,
-        }
-    }
-}
-
-impl From<PubdataIndependentBatchFeeModelInput> for V1PubdataIndependentBatchFeeModelInput {
-    fn from(value: PubdataIndependentBatchFeeModelInput) -> Self {
-        V1PubdataIndependentBatchFeeModelInput {
-            fair_l2_gas_price: value.fair_l2_gas_price,
-            fair_pubdata_price: value.fair_pubdata_price,
-            l1_gas_price: value.l1_gas_price,
-        }
-    }
-}
-
-/// Shadowed struct of [`BatchFeeInput`]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-enum V1BatchFeeInput {
-    L1Pegged(V1L1PeggedBatchFeeModelInput),
-    PubdataIndependent(V1PubdataIndependentBatchFeeModelInput),
-}
-
-impl From<V1BatchFeeInput> for BatchFeeInput {
-    fn from(value: V1BatchFeeInput) -> Self {
-        match value {
-            V1BatchFeeInput::L1Pegged(input) => BatchFeeInput::L1Pegged(input.into()),
-            V1BatchFeeInput::PubdataIndependent(input) => {
-                BatchFeeInput::PubdataIndependent(input.into())
-            }
-        }
-    }
-}
-
-impl From<BatchFeeInput> for V1BatchFeeInput {
-    fn from(value: BatchFeeInput) -> Self {
-        match value {
-            BatchFeeInput::L1Pegged(input) => V1BatchFeeInput::L1Pegged(input.into()),
-            BatchFeeInput::PubdataIndependent(input) => {
-                V1BatchFeeInput::PubdataIndependent(input.into())
-            }
-        }
-    }
-}
-
-/// Shadowed struct of [`L2BlockEnv`]
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
-struct V1L2BlockEnv {
-    number: u32,
-    timestamp: u64,
-    prev_block_hash: H256,
-    max_virtual_blocks_to_create: u32,
-}
-
-impl From<V1L2BlockEnv> for L2BlockEnv {
-    fn from(value: V1L2BlockEnv) -> Self {
-        L2BlockEnv {
-            number: value.number,
-            timestamp: value.timestamp,
-            prev_block_hash: value.prev_block_hash,
-            max_virtual_blocks_to_create: value.max_virtual_blocks_to_create,
-        }
-    }
-}
-
-impl From<L2BlockEnv> for V1L2BlockEnv {
-    fn from(value: L2BlockEnv) -> Self {
-        V1L2BlockEnv {
-            number: value.number,
-            timestamp: value.timestamp,
-            prev_block_hash: value.prev_block_hash,
-            max_virtual_blocks_to_create: value.max_virtual_blocks_to_create,
-        }
-    }
-}
-
-/// Shadowed struct of [`L1BatchEnv`]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-struct V1L1BatchEnv {
-    previous_batch_hash: Option<H256>,
-    number: L1BatchNumber,
-    timestamp: u64,
-    fee_input: V1BatchFeeInput,
-    fee_account: Address,
-    enforced_base_fee: Option<u64>,
-    first_l2_block: V1L2BlockEnv,
-}
-
-impl From<V1L1BatchEnv> for L1BatchEnv {
-    fn from(value: V1L1BatchEnv) -> Self {
-        let V1L1BatchEnv {
-            previous_batch_hash,
-            number,
-            timestamp,
-            fee_input,
-            fee_account,
-            enforced_base_fee,
-            first_l2_block,
-        } = value;
-
-        L1BatchEnv {
-            previous_batch_hash,
-            number,
-            timestamp,
-            fee_input: fee_input.into(),
-            fee_account,
-            enforced_base_fee,
-            first_l2_block: first_l2_block.into(),
-        }
-    }
-}
-
-impl From<L1BatchEnv> for V1L1BatchEnv {
-    fn from(value: L1BatchEnv) -> Self {
-        let L1BatchEnv {
-            previous_batch_hash,
-            number,
-            timestamp,
-            fee_input,
-            fee_account,
-            enforced_base_fee,
-            first_l2_block,
-        } = value;
-
-        V1L1BatchEnv {
-            previous_batch_hash,
-            number,
-            timestamp,
-            fee_input: fee_input.into(),
-            fee_account,
-            enforced_base_fee,
-            first_l2_block: first_l2_block.into(),
-        }
-    }
-}
-
-/// Shadowed struct of [`SystemContractCode`]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-struct V1SystemContractCode {
-    code: Vec<U256>,
-    hash: H256,
-}
-
-impl From<V1SystemContractCode> for SystemContractCode {
-    fn from(value: V1SystemContractCode) -> Self {
-        let V1SystemContractCode { code, hash } = value;
-        SystemContractCode { code, hash }
-    }
-}
-
-impl From<SystemContractCode> for V1SystemContractCode {
-    fn from(value: SystemContractCode) -> Self {
-        let SystemContractCode { code, hash } = value;
-        V1SystemContractCode { code, hash }
-    }
-}
-
-/// Shadowed struct of [`BaseSystemContracts`]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-struct V1BaseSystemContracts {
-    bootloader: V1SystemContractCode,
-    default_aa: V1SystemContractCode,
-}
-
-impl From<V1BaseSystemContracts> for BaseSystemContracts {
-    fn from(value: V1BaseSystemContracts) -> Self {
-        let V1BaseSystemContracts {
-            bootloader,
-            default_aa,
-        } = value;
-
-        BaseSystemContracts {
-            bootloader: bootloader.into(),
-            default_aa: default_aa.into(),
-        }
-    }
-}
-
-impl From<BaseSystemContracts> for V1BaseSystemContracts {
-    fn from(value: BaseSystemContracts) -> Self {
-        let BaseSystemContracts {
-            bootloader,
-            default_aa,
-        } = value;
-
-        V1BaseSystemContracts {
-            bootloader: bootloader.into(),
-            default_aa: default_aa.into(),
-        }
-    }
-}
-
-/// Shadowed struct of [`SystemEnv`]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-struct V1SystemEnv {
-    // Always false for VM
-    zk_porter_available: bool,
-    version: ProtocolVersionId,
-    base_system_smart_contracts: V1BaseSystemContracts,
-    bootloader_gas_limit: u32,
-    execution_mode: V1TxExecutionMode,
-    default_validation_computational_gas_limit: u32,
-    chain_id: L2ChainId,
-}
-
-impl From<V1SystemEnv> for SystemEnv {
-    fn from(value: V1SystemEnv) -> Self {
-        let V1SystemEnv {
-            zk_porter_available,
-            version,
-            base_system_smart_contracts,
-            bootloader_gas_limit,
-            execution_mode,
-            default_validation_computational_gas_limit,
-            chain_id,
-        } = value;
-
-        SystemEnv {
-            default_validation_computational_gas_limit,
-            chain_id,
-            zk_porter_available,
-            version,
-            execution_mode: execution_mode.into(),
-            base_system_smart_contracts: base_system_smart_contracts.into(),
-            bootloader_gas_limit,
-        }
-    }
-}
-
-impl From<SystemEnv> for V1SystemEnv {
-    fn from(value: SystemEnv) -> Self {
-        let SystemEnv {
-            zk_porter_available,
-            version,
-            base_system_smart_contracts,
-            bootloader_gas_limit,
-            execution_mode,
-            default_validation_computational_gas_limit,
-            chain_id,
-        } = value;
-
-        V1SystemEnv {
-            default_validation_computational_gas_limit,
-            chain_id,
-            zk_porter_available,
-            version,
-            execution_mode: execution_mode.into(),
-            base_system_smart_contracts: base_system_smart_contracts.into(),
-            bootloader_gas_limit,
-        }
-    }
-}
-
-/// Shadowed struct of [`TxExecutionMode`]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-enum V1TxExecutionMode {
-    VerifyExecute,
-    EstimateFee,
-    EthCall,
-}
-
-impl From<V1TxExecutionMode> for TxExecutionMode {
-    fn from(value: V1TxExecutionMode) -> Self {
-        match value {
-            V1TxExecutionMode::VerifyExecute => TxExecutionMode::VerifyExecute,
-            V1TxExecutionMode::EstimateFee => TxExecutionMode::EstimateFee,
-            V1TxExecutionMode::EthCall => TxExecutionMode::EthCall,
-        }
-    }
-}
-
-impl From<TxExecutionMode> for V1TxExecutionMode {
-    fn from(value: TxExecutionMode) -> Self {
-        match value {
-            TxExecutionMode::VerifyExecute => V1TxExecutionMode::VerifyExecute,
-            TxExecutionMode::EstimateFee => V1TxExecutionMode::EstimateFee,
-            TxExecutionMode::EthCall => V1TxExecutionMode::EthCall,
-        }
-    }
-}
 
 /// Version 1 of the data used as input for the TEE verifier.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct V1TeeVerifierInput {
     prepare_basic_circuits_job: PrepareBasicCircuitsJob,
-    l2_blocks_execution_data: Vec<V1L2BlockExecutionData>,
-    l1_batch_env: V1L1BatchEnv,
-    system_env: V1SystemEnv,
+    l2_blocks_execution_data: Vec<L2BlockExecutionData>,
+    l1_batch_env: L1BatchEnv,
+    system_env: SystemEnv,
     used_contracts: Vec<(H256, Vec<u8>)>,
 }
 
@@ -419,12 +57,9 @@ impl TeeVerifierInput {
     ) -> Self {
         TeeVerifierInput::V1(V1TeeVerifierInput {
             prepare_basic_circuits_job,
-            l2_blocks_execution_data: l2_blocks_execution_data
-                .into_iter()
-                .map(|v| v.into())
-                .collect(),
-            l1_batch_env: l1_batch_env.into(),
-            system_env: system_env.into(),
+            l2_blocks_execution_data,
+            l1_batch_env,
+            system_env,
             used_contracts,
         })
     }
@@ -470,12 +105,7 @@ impl TeeVerifierInput {
 
         let storage_view = Rc::new(RefCell::new(StorageView::new(&raw_storage)));
 
-        let vm = VmInstance::new(l1_batch_env.into(), system_env.into(), storage_view);
-
-        let l2_blocks_execution_data = l2_blocks_execution_data
-            .into_iter()
-            .map(|v| v.into())
-            .collect();
+        let vm = VmInstance::new(l1_batch_env, system_env, storage_view);
 
         let vm_out = Self::execute_vm(l2_blocks_execution_data, vm)?;
 
@@ -659,6 +289,10 @@ impl StoredObject for TeeVerifierInput {
 
 #[cfg(test)]
 mod tests {
+    use multivm::interface::TxExecutionMode;
+    use zksync_basic_types::U256;
+    use zksync_contracts::{BaseSystemContracts, SystemContractCode};
+
     use super::*;
 
     #[test]

--- a/core/lib/types/src/block.rs
+++ b/core/lib/types/src/block.rs
@@ -93,7 +93,7 @@ pub struct StorageOracleInfo {
 }
 
 /// Data needed to execute an L2 block in the VM.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct L2BlockExecutionData {
     pub number: L2BlockNumber,
     pub timestamp: u64,

--- a/core/lib/types/src/fee_model.rs
+++ b/core/lib/types/src/fee_model.rs
@@ -9,7 +9,7 @@ use crate::ProtocolVersionId;
 /// versions of Era prior to 1.4.1 integration.
 /// - `PubdataIndependent`: L1 gas price and pubdata price are not necessarily dependent on one another. This options is more suitable for the
 /// versions of Era after the 1.4.1 integration. It is expected that if a VM supports `PubdataIndependent` version, then it should also support `L1Pegged` version, but converting it into `PubdataIndependentBatchFeeModelInput` in-place.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BatchFeeInput {
     L1Pegged(L1PeggedBatchFeeModelInput),
     PubdataIndependent(PubdataIndependentBatchFeeModelInput),
@@ -137,7 +137,7 @@ impl BatchFeeInput {
 }
 
 /// Pubdata is only published via calldata and so its price is pegged to the L1 gas price.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct L1PeggedBatchFeeModelInput {
     /// Fair L2 gas price to provide
     pub fair_l2_gas_price: u64,

--- a/core/lib/zksync_core/Cargo.toml
+++ b/core/lib/zksync_core/Cargo.toml
@@ -30,10 +30,12 @@ zksync_l1_contract_interface.workspace = true
 zksync_mempool.workspace = true
 zksync_circuit_breaker.workspace = true
 zksync_storage.workspace = true
+zksync_tee_verifier.workspace = true
 zksync_merkle_tree.workspace = true
 zksync_mini_merkle_tree.workspace = true
 prometheus_exporter.workspace = true
 zksync_prover_interface.workspace = true
+zksync_queued_job_processor.workspace = true
 zksync_web3_decl = { workspace = true, features = [
     "server",
     "client",

--- a/core/lib/zksync_core/src/lib.rs
+++ b/core/lib/zksync_core/src/lib.rs
@@ -82,6 +82,7 @@ use zksync_object_store::{ObjectStore, ObjectStoreFactory};
 use zksync_proof_data_handler::blob_processor::{
     BlobProcessor, RollupBlobProcessor, ValidiumBlobProcessor,
 };
+use zksync_queued_job_processor::JobProcessor;
 use zksync_shared_metrics::{InitStage, APP_METRICS};
 use zksync_state::{PostgresStorageCaches, RocksdbStorageOptions};
 use zksync_types::{ethabi::Contract, fee_model::FeeModelConfig, Address, L2ChainId};
@@ -100,6 +101,7 @@ use crate::{
         create_state_keeper, AsyncRocksdbCache, MempoolFetcher, MempoolGuard, OutputHandler,
         SequencerSealer, StateKeeperPersistence,
     },
+    tee_verifier_input_producer::TeeVerifierInputProducer,
     utils::ensure_l1_batch_commit_data_generation_mode,
 };
 
@@ -111,6 +113,7 @@ pub mod proto;
 pub mod reorg_detector;
 pub mod state_keeper;
 pub mod sync_layer;
+pub mod tee_verifier_input_producer;
 pub mod temp_config_store;
 pub mod utils;
 
@@ -179,6 +182,9 @@ pub enum Component {
     EthTxManager,
     /// State keeper.
     StateKeeper,
+    /// Produces input for the TEE verifier.
+    /// The blob is later used as input for TEE verifier.
+    TeeVerifierInputProducer,
     /// Component for housekeeping task such as cleaning blobs from GCS, reporting metrics etc.
     Housekeeper,
     /// Component for exposing APIs to prover for providing proof generation data and accepting proofs.
@@ -209,6 +215,9 @@ impl FromStr for Components {
             "tree_api" => Ok(Components(vec![Component::TreeApi])),
             "state_keeper" => Ok(Components(vec![Component::StateKeeper])),
             "housekeeper" => Ok(Components(vec![Component::Housekeeper])),
+            "tee_verifier_input_producer" => {
+                Ok(Components(vec![Component::TeeVerifierInputProducer]))
+            }
             "eth" => Ok(Components(vec![
                 Component::EthWatcher,
                 Component::EthTxAggregator,
@@ -774,6 +783,23 @@ pub async fn initialize_components(
     .await
     .context("add_trees_to_task_futures()")?;
 
+    if components.contains(&Component::TeeVerifierInputProducer) {
+        let singleton_connection_pool =
+            ConnectionPool::<Core>::singleton(postgres_config.master_url()?)
+                .build()
+                .await
+                .context("failed to build singleton connection_pool")?;
+        add_tee_verifier_input_producer_to_task_futures(
+            &mut task_futures,
+            &singleton_connection_pool,
+            &store_factory,
+            l2_chain_id,
+            stop_receiver.clone(),
+        )
+        .await
+        .context("add_tee_verifier_input_producer_to_task_futures()")?;
+    }
+
     if components.contains(&Component::Housekeeper) {
         add_house_keeper_to_task_futures(configs, &mut task_futures, stop_receiver.clone())
             .await
@@ -1054,6 +1080,27 @@ async fn run_tree(
     let elapsed = started_at.elapsed();
     APP_METRICS.init_latency[&InitStage::Tree].set(elapsed);
     tracing::info!("Initialized {mode_str} tree in {elapsed:?}");
+    Ok(())
+}
+
+async fn add_tee_verifier_input_producer_to_task_futures(
+    task_futures: &mut Vec<JoinHandle<anyhow::Result<()>>>,
+    connection_pool: &ConnectionPool<Core>,
+    store_factory: &ObjectStoreFactory,
+    l2_chain_id: L2ChainId,
+    stop_receiver: watch::Receiver<bool>,
+) -> anyhow::Result<()> {
+    let started_at = Instant::now();
+    tracing::info!("initializing TeeVerifierInputProducer");
+    let producer =
+        TeeVerifierInputProducer::new(connection_pool.clone(), store_factory, l2_chain_id).await?;
+    task_futures.push(tokio::spawn(producer.run(stop_receiver, None)));
+    tracing::info!(
+        "Initialized TeeVerifierInputProducer in {:?}",
+        started_at.elapsed()
+    );
+    let elapsed = started_at.elapsed();
+    APP_METRICS.init_latency[&InitStage::TeeVerifierInputProducer].set(elapsed);
     Ok(())
 }
 

--- a/core/lib/zksync_core/src/metadata_calculator/updater.rs
+++ b/core/lib/zksync_core/src/metadata_calculator/updater.rs
@@ -143,6 +143,12 @@ impl TreeUpdater {
 
             if let Some(object_key) = &object_key {
                 storage
+                    .tee_verifier_input_producer_dal()
+                    .create_tee_verifier_input_producer_job(l1_batch_number)
+                    .await
+                    .expect("failed to create tee_verifier_input_producer job");
+                // Save the proof generation details to Postgres
+                storage
                     .proof_generation_dal()
                     .insert_proof_generation_details(l1_batch_number, object_key)
                     .await;

--- a/core/lib/zksync_core/src/tee_verifier_input_producer/metrics.rs
+++ b/core/lib/zksync_core/src/tee_verifier_input_producer/metrics.rs
@@ -1,0 +1,18 @@
+//! Metrics
+
+use std::time::Duration;
+
+use vise::{Buckets, Gauge, Histogram, Metrics, Unit};
+
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "tee_verifier_input_producer")]
+pub(crate) struct TeeVerifierInputProducerMetrics {
+    #[metrics(buckets = Buckets::LATENCIES, unit = Unit::Seconds)]
+    pub process_batch_time: Histogram<Duration>,
+    #[metrics(buckets = Buckets::LATENCIES, unit = Unit::Seconds)]
+    pub upload_input_time: Histogram<Duration>,
+    pub block_number_processed: Gauge,
+}
+
+#[vise::register]
+pub(super) static METRICS: vise::Global<TeeVerifierInputProducerMetrics> = vise::Global::new();

--- a/core/lib/zksync_core/src/tee_verifier_input_producer/mod.rs
+++ b/core/lib/zksync_core/src/tee_verifier_input_producer/mod.rs
@@ -1,0 +1,287 @@
+//! Produces input for a TEE Verifier
+//!
+//! Extract all data needed to re-execute and verify an L1Batch without accessing
+//! the DB and/or the object store.
+//!
+//! For testing purposes, the L1 batch is re-executed immediately for now.
+//! Eventually, this component will only extract the inputs and send them to another
+//! machine over a "to be defined" channel, e.g., save them to an object store.
+
+use std::{sync::Arc, time::Instant};
+
+use anyhow::Context;
+use async_trait::async_trait;
+use multivm::zk_evm_latest::ethereum_types::H256;
+use tokio::{runtime::Handle, task::JoinHandle};
+use vm_utils::storage::L1BatchParamsProvider;
+use zksync_dal::{tee_verifier_input_producer_dal::JOB_MAX_ATTEMPT, ConnectionPool, Core, CoreDal};
+use zksync_object_store::{ObjectStore, ObjectStoreFactory};
+use zksync_prover_interface::inputs::PrepareBasicCircuitsJob;
+use zksync_queued_job_processor::JobProcessor;
+use zksync_state::{PostgresStorage, ReadStorage};
+use zksync_tee_verifier::TeeVerifierInput;
+use zksync_types::{block::L1BatchHeader, L1BatchNumber, L2BlockNumber, L2ChainId};
+use zksync_utils::u256_to_h256;
+
+use self::metrics::METRICS;
+
+mod metrics;
+
+/// Component that extracts all data (from DB) necessary to run a TEE Verifier.
+#[derive(Debug)]
+pub struct TeeVerifierInputProducer {
+    connection_pool: ConnectionPool<Core>,
+    l2_chain_id: L2ChainId,
+    object_store: Arc<dyn ObjectStore>,
+}
+
+impl TeeVerifierInputProducer {
+    pub async fn new(
+        connection_pool: ConnectionPool<Core>,
+        store_factory: &ObjectStoreFactory,
+        l2_chain_id: L2ChainId,
+    ) -> anyhow::Result<Self> {
+        Ok(TeeVerifierInputProducer {
+            connection_pool,
+            object_store: store_factory.create_store().await,
+            l2_chain_id,
+        })
+    }
+
+    async fn process_job_impl(
+        rt_handle: Handle,
+        l1_batch_number: L1BatchNumber,
+        started_at: Instant,
+        connection_pool: ConnectionPool<Core>,
+        object_store: Arc<dyn ObjectStore>,
+        l2_chain_id: L2ChainId,
+    ) -> anyhow::Result<TeeVerifierInput> {
+        let prepare_basic_circuits_job: PrepareBasicCircuitsJob = object_store
+            .get(l1_batch_number)
+            .await
+            .context("failed to get PrepareBasicCircuitsJob from object store")?;
+
+        let mut connection = connection_pool
+            .connection()
+            .await
+            .context("failed to get connection for TeeVerifierInputProducer")?;
+
+        let l2_blocks_execution_data = connection
+            .transactions_dal()
+            .get_l2_blocks_to_execute_for_l1_batch(l1_batch_number)
+            .await?;
+
+        let last_batch_miniblock_number = l2_blocks_execution_data.first().unwrap().number - 1;
+
+        let l1_batch_header = connection
+            .blocks_dal()
+            .get_l1_batch_header(l1_batch_number)
+            .await
+            .with_context(|| format!("header is missing for L1 batch #{l1_batch_number}"))?
+            .unwrap();
+
+        let l1_batch_params_provider = L1BatchParamsProvider::new(&mut connection)
+            .await
+            .context("failed initializing L1 batch params provider")?;
+
+        let first_miniblock_in_batch = l1_batch_params_provider
+            .load_first_l2_block_in_batch(&mut connection, l1_batch_number)
+            .await
+            .with_context(|| {
+                format!("failed loading first miniblock in L1 batch #{l1_batch_number}")
+            })?
+            .with_context(|| format!("no miniblocks persisted for L1 batch #{l1_batch_number}"))?;
+
+        // In the state keeper, this value is used to reject execution.
+        // All batches have already been executed by State Keeper.
+        // This means we don't want to reject any execution, therefore we're using MAX as an allow all.
+        let validation_computational_gas_limit = u32::MAX;
+
+        let (system_env, l1_batch_env) = l1_batch_params_provider
+            .load_l1_batch_params(
+                &mut connection,
+                &first_miniblock_in_batch,
+                validation_computational_gas_limit,
+                l2_chain_id,
+            )
+            .await
+            .context("expected miniblock to be executed and sealed")?;
+
+        // need a new connection in the next block
+        drop(connection);
+
+        // `PostgresStorage` needs a blocking context
+        let used_contracts = rt_handle
+            .spawn_blocking(move || {
+                Self::get_used_contracts(
+                    last_batch_miniblock_number,
+                    l1_batch_header,
+                    connection_pool,
+                )
+            })
+            .await??;
+
+        tracing::info!("Started execution of l1_batch: {l1_batch_number:?}");
+
+        let tee_verifier_input = TeeVerifierInput::new(
+            prepare_basic_circuits_job,
+            l2_blocks_execution_data,
+            l1_batch_env,
+            system_env,
+            used_contracts,
+        );
+
+        // TODO (SEC-263): remove these 2 lines after successful testnet runs
+        tee_verifier_input.clone().verify()?;
+        tracing::info!("Looks like we verified {l1_batch_number} correctly");
+
+        tracing::info!("Finished execution of l1_batch: {l1_batch_number:?}");
+
+        METRICS.process_batch_time.observe(started_at.elapsed());
+        tracing::debug!(
+            "TeeVerifierInputProducer took {:?} for L1BatchNumber {}",
+            started_at.elapsed(),
+            l1_batch_number.0
+        );
+
+        Ok(tee_verifier_input)
+    }
+
+    fn get_used_contracts(
+        last_batch_miniblock_number: L2BlockNumber,
+        l1_batch_header: L1BatchHeader,
+        connection_pool: ConnectionPool<Core>,
+    ) -> anyhow::Result<Vec<(H256, Vec<u8>)>> {
+        let rt_handle = Handle::current();
+
+        let connection = rt_handle
+            .block_on(connection_pool.connection())
+            .context("failed to get connection for TeeVerifierInputProducer")?;
+
+        let mut pg_storage =
+            PostgresStorage::new(rt_handle, connection, last_batch_miniblock_number, true);
+
+        Ok(l1_batch_header
+            .used_contract_hashes
+            .into_iter()
+            .filter_map(|hash| {
+                pg_storage
+                    .load_factory_dep(u256_to_h256(hash))
+                    .map(|bytes| (u256_to_h256(hash), bytes))
+            })
+            .collect())
+    }
+}
+
+#[async_trait]
+impl JobProcessor for TeeVerifierInputProducer {
+    type Job = L1BatchNumber;
+    type JobId = L1BatchNumber;
+    type JobArtifacts = TeeVerifierInput;
+    const SERVICE_NAME: &'static str = "tee_verifier_input_producer";
+
+    async fn get_next_job(&self) -> anyhow::Result<Option<(Self::JobId, Self::Job)>> {
+        let mut connection = self.connection_pool.connection().await?;
+        let l1_batch_to_process = connection
+            .tee_verifier_input_producer_dal()
+            .get_next_tee_verifier_input_producer_job()
+            .await
+            .context("failed to get next basic witness input producer job")?;
+        Ok(l1_batch_to_process.map(|number| (number, number)))
+    }
+
+    async fn save_failure(&self, job_id: Self::JobId, started_at: Instant, error: String) {
+        let attempts = self
+            .connection_pool
+            .connection()
+            .await
+            .unwrap()
+            .tee_verifier_input_producer_dal()
+            .mark_job_as_failed(job_id, started_at, error)
+            .await
+            .expect("errored whilst marking job as failed");
+        if let Some(tries) = attempts {
+            tracing::warn!("Failed to process job: {job_id:?}, after {tries} tries.");
+        } else {
+            tracing::warn!("L1 Batch {job_id:?} was processed successfully by another worker.");
+        }
+    }
+
+    async fn process_job(
+        &self,
+        _job_id: &Self::JobId,
+        job: Self::Job,
+        started_at: Instant,
+    ) -> JoinHandle<anyhow::Result<Self::JobArtifacts>> {
+        let l2_chain_id = self.l2_chain_id;
+        let connection_pool = self.connection_pool.clone();
+        let object_store = self.object_store.clone();
+        tokio::task::spawn(async move {
+            let rt_handle = Handle::current();
+            Self::process_job_impl(
+                rt_handle,
+                job,
+                started_at,
+                connection_pool.clone(),
+                object_store,
+                l2_chain_id,
+            )
+            .await
+        })
+    }
+
+    async fn save_result(
+        &self,
+        job_id: Self::JobId,
+        started_at: Instant,
+        artifacts: Self::JobArtifacts,
+    ) -> anyhow::Result<()> {
+        let upload_started_at = Instant::now();
+        let object_path = self
+            .object_store
+            .put(job_id, &artifacts)
+            .await
+            .context("failed to upload artifacts for TeeVerifierInputProducer")?;
+        METRICS
+            .upload_input_time
+            .observe(upload_started_at.elapsed());
+        let mut connection = self
+            .connection_pool
+            .connection()
+            .await
+            .context("failed to acquire DB connection for TeeVerifierInputProducer")?;
+        let mut transaction = connection
+            .start_transaction()
+            .await
+            .context("failed to acquire DB transaction for TeeVerifierInputProducer")?;
+        transaction
+            .tee_verifier_input_producer_dal()
+            .mark_job_as_successful(job_id, started_at, &object_path)
+            .await
+            .context("failed to mark job as successful for TeeVerifierInputProducer")?;
+        transaction
+            .commit()
+            .await
+            .context("failed to commit DB transaction for TeeVerifierInputProducer")?;
+        METRICS.block_number_processed.set(job_id.0 as i64);
+        Ok(())
+    }
+
+    fn max_attempts(&self) -> u32 {
+        JOB_MAX_ATTEMPT as u32
+    }
+
+    async fn get_job_attempts(&self, job_id: &L1BatchNumber) -> anyhow::Result<u32> {
+        let mut connection = self
+            .connection_pool
+            .connection()
+            .await
+            .context("failed to acquire DB connection for TeeVerifierInputProducer")?;
+        connection
+            .tee_verifier_input_producer_dal()
+            .get_tee_verifier_input_producer_job_attempts(*job_id)
+            .await
+            .map(|attempts| attempts.unwrap_or(0))
+            .context("failed to get job attempts for TeeVerifierInputProducer")
+    }
+}

--- a/core/node/shared_metrics/src/lib.rs
+++ b/core/node/shared_metrics/src/lib.rs
@@ -27,6 +27,7 @@ pub enum InitStage {
     EthTxAggregator,
     EthTxManager,
     Tree,
+    TeeVerifierInputProducer,
     Consensus,
 }
 
@@ -41,6 +42,7 @@ impl fmt::Display for InitStage {
             Self::EthTxAggregator => formatter.write_str("eth_tx_aggregator"),
             Self::EthTxManager => formatter.write_str("eth_tx_manager"),
             Self::Tree => formatter.write_str("tree"),
+            Self::TeeVerifierInputProducer => formatter.write_str("tee_verifier_input_producer"),
             Self::Consensus => formatter.write_str("consensus"),
         }
     }

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -3485,6 +3485,7 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "once_cell",
+ "serde",
  "thiserror",
  "tracing",
  "vise",


### PR DESCRIPTION
## What ❔

Extract all data needed to re-execute and verify an L1Batch without accessing the DB and/or the object store.

For testing purposes, the L1 batch is re-executed immediately for now. Eventually, this component will only extract the inputs and send them to another machine over a "to be defined" channel, e.g., save them to an object store.

## Why ❔

Have an additional proof 2F verification running inside a TEE

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
