### PR TITLE
fix(contract-verifier): YUL system-mode verification

### DIFF
--- a/core/bin/contract-verifier/src/verifier.rs
+++ b/core/bin/contract-verifier/src/verifier.rs
@@ -332,9 +332,10 @@ impl ContractVerifier {
                 compiler_input.settings.output_selection = Some(default_output_selection);
                 Ok(ZkSolcInput::StandardJson(compiler_input))
             }
-            SourceCodeData::YulSingleFile(source_code) => {
-                Ok(ZkSolcInput::YulSingleFile(source_code))
-            }
+            SourceCodeData::YulSingleFile(source_code) => Ok(ZkSolcInput::YulSingleFile {
+                source_code,
+                is_system: request.req.is_system,
+            }),
             _ => panic!("Unexpected SourceCode variant"),
         }
     }


### PR DESCRIPTION
## What ❔

Adds opportunity to verify yul contract source code with system-mode on.

## Why ❔

Some contract are compiled with system mode off, some with mode on, all must be verifiable.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
