### PR TITLE
fix(Prover CLI): Handle `in_gpu_proof` status

### DIFF
--- a/core/lib/basic_types/src/prover_dal.rs
+++ b/core/lib/basic_types/src/prover_dal.rs
@@ -159,6 +159,8 @@ pub enum ProverJobStatus {
     Skipped,
     #[strum(serialize = "ignored")]
     Ignored,
+    #[strum(serialize = "in_gpu_proof")]
+    InGPUProof,
 }
 
 #[derive(Debug, Clone, strum::Display, strum::EnumString, strum::AsRefStr)]


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Fixes the case where the prover job is in `in_gpu_proof` status.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

It panics when you run the `status batch` command in a GPU prover:

```
in_gpu_proof
thread 'main' panicked at /home/admin/zksync-era-2/prover/prover_dal/src/fri_prover_dal.rs:679:64:
called `Result::unwrap()` on an `Err` value: VariantNotFound
```

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.
