### PR TITLE
refactor(en): Remove chain IDs and unused field from remote EN config

### DIFF
--- a/core/bin/external_node/src/helpers.rs
+++ b/core/bin/external_node/src/helpers.rs
@@ -1,7 +1,17 @@
 //! Miscellaneous helpers for the EN.
 
+use std::time::Duration;
+
+use futures::FutureExt;
+use tokio::sync::watch;
+use zksync_basic_types::{L1ChainId, L2ChainId};
+use zksync_eth_client::EthInterface;
 use zksync_health_check::{async_trait, CheckHealth, Health, HealthStatus};
-use zksync_web3_decl::{client::BoxedL2Client, namespaces::EthNamespaceClient};
+use zksync_web3_decl::{
+    client::BoxedL2Client,
+    error::ClientRpcContext,
+    namespaces::{EthNamespaceClient, ZksNamespaceClient},
+};
 
 /// Main node health check.
 #[derive(Debug)]
@@ -28,5 +38,180 @@ impl CheckHealth for MainNodeHealthCheck {
             return Health::from(HealthStatus::NotReady).with_details(details);
         }
         HealthStatus::Ready.into()
+    }
+}
+
+/// Ethereum client health check.
+#[derive(Debug)]
+pub(crate) struct EthClientHealthCheck(Box<dyn EthInterface>);
+
+impl From<Box<dyn EthInterface>> for EthClientHealthCheck {
+    fn from(client: Box<dyn EthInterface>) -> Self {
+        Self(client.for_component("ethereum_health_check"))
+    }
+}
+
+#[async_trait]
+impl CheckHealth for EthClientHealthCheck {
+    fn name(&self) -> &'static str {
+        "ethereum_http_rpc"
+    }
+
+    async fn check_health(&self) -> Health {
+        if let Err(err) = self.0.block_number().await {
+            tracing::warn!("Health-check call to Ethereum HTTP RPC failed: {err}");
+            let details = serde_json::json!({
+                "error": err.to_string(),
+            });
+            // Unlike main node client, losing connection to L1 is not fatal for the node
+            return Health::from(HealthStatus::Affected).with_details(details);
+        }
+        HealthStatus::Ready.into()
+    }
+}
+
+/// Task that validates chain IDs using main node and Ethereum clients.
+#[derive(Debug)]
+pub(crate) struct ValidateChainIdsTask {
+    l1_chain_id: L1ChainId,
+    l2_chain_id: L2ChainId,
+    eth_client: Box<dyn EthInterface>,
+    main_node_client: BoxedL2Client,
+}
+
+impl ValidateChainIdsTask {
+    const BACKOFF_INTERVAL: Duration = Duration::from_secs(5);
+
+    pub fn new(
+        l1_chain_id: L1ChainId,
+        l2_chain_id: L2ChainId,
+        eth_client: Box<dyn EthInterface>,
+        main_node_client: BoxedL2Client,
+    ) -> Self {
+        Self {
+            l1_chain_id,
+            l2_chain_id,
+            eth_client: eth_client.for_component("chain_ids_validation"),
+            main_node_client: main_node_client.for_component("chain_ids_validation"),
+        }
+    }
+
+    async fn check_eth_client(
+        eth_client: Box<dyn EthInterface>,
+        expected: L1ChainId,
+    ) -> anyhow::Result<()> {
+        loop {
+            match eth_client.fetch_chain_id().await {
+                Ok(chain_id) => {
+                    anyhow::ensure!(
+                        expected == chain_id,
+                        "Configured L1 chain id doesn't match the one from eth node.
+                        Make sure your configuration is correct and you are corrected to the right eth node.
+                        Eth node chain id: {chain_id}. Local config value: {expected}"
+                    );
+                    tracing::info!(
+                        "Checked that L1 chain ID {chain_id} is returned by Ethereum client"
+                    );
+                    return Ok(());
+                }
+                Err(err) => {
+                    tracing::warn!("Error getting L1 chain ID from Ethereum client: {err}");
+                    tokio::time::sleep(Self::BACKOFF_INTERVAL).await;
+                }
+            }
+        }
+    }
+
+    async fn check_l1_chain_using_main_node(
+        main_node_client: BoxedL2Client,
+        expected: L1ChainId,
+    ) -> anyhow::Result<()> {
+        loop {
+            match main_node_client
+                .l1_chain_id()
+                .rpc_context("l1_chain_id")
+                .await
+            {
+                Ok(chain_id) => {
+                    let chain_id = L1ChainId(chain_id.as_u64());
+                    anyhow::ensure!(
+                        expected == chain_id,
+                        "Configured L1 chain id doesn't match the one from main node.
+                        Make sure your configuration is correct and you are corrected to the right main node.
+                        Main node L1 chain id: {chain_id}. Local config value: {expected}"
+                    );
+                    tracing::info!(
+                        "Checked that L1 chain ID {chain_id} is returned by main node client"
+                    );
+                    return Ok(());
+                }
+                Err(err) if err.is_transient() => {
+                    tracing::warn!(
+                        "Transient error getting L1 chain ID from main node client, will retry in {:?}: {err}",
+                        Self::BACKOFF_INTERVAL
+                    );
+                    tokio::time::sleep(Self::BACKOFF_INTERVAL).await;
+                }
+                Err(err) => {
+                    tracing::error!("Error getting L1 chain ID from main node client: {err}");
+                    return Err(err.into());
+                }
+            }
+        }
+    }
+
+    async fn check_l2_chain_using_main_node(
+        main_node_client: BoxedL2Client,
+        expected: L2ChainId,
+    ) -> anyhow::Result<()> {
+        loop {
+            match main_node_client.chain_id().rpc_context("chain_id").await {
+                Ok(chain_id) => {
+                    let chain_id = L2ChainId::try_from(chain_id.as_u64()).map_err(|err| {
+                        anyhow::anyhow!("invalid chain ID supplied by main node: {err}")
+                    })?;
+                    anyhow::ensure!(
+                        expected == chain_id,
+                        "Configured L1 chain id doesn't match the one from main node.
+                        Make sure your configuration is correct and you are corrected to the right main node.
+                        Main node L1 chain id: {chain_id:?}. Local config value: {expected:?}"
+                    );
+                    tracing::info!(
+                        "Checked that L2 chain ID {chain_id:?} is returned by main node client"
+                    );
+                    return Ok(());
+                }
+                Err(err) if err.is_transient() => {
+                    tracing::warn!(
+                        "Transient error getting L2 chain ID from main node client, will retry in {:?}: {err}",
+                        Self::BACKOFF_INTERVAL
+                    );
+                    tokio::time::sleep(Self::BACKOFF_INTERVAL).await;
+                }
+                Err(err) => {
+                    tracing::error!("Error getting L2 chain ID from main node client: {err}");
+                    return Err(err.into());
+                }
+            }
+        }
+    }
+
+    pub async fn run(self, mut stop_receiver: watch::Receiver<bool>) -> anyhow::Result<()> {
+        // Since check futures are fused, they are safe to poll after getting resolved; they will never resolve again,
+        // so we'll just wait for another check or a stop signal.
+        let eth_client_check = Self::check_eth_client(self.eth_client, self.l1_chain_id).fuse();
+        let main_node_l1_check =
+            Self::check_l1_chain_using_main_node(self.main_node_client.clone(), self.l1_chain_id)
+                .fuse();
+        let main_node_l2_check =
+            Self::check_l2_chain_using_main_node(self.main_node_client, self.l2_chain_id).fuse();
+        loop {
+            tokio::select! {
+                Err(err) = eth_client_check => return Err(err),
+                Err(err) = main_node_l1_check => return Err(err),
+                Err(err) = main_node_l2_check => return Err(err),
+                _ = stop_receiver.changed() => return Ok(()),
+            }
+        }
     }
 }

--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -66,7 +66,7 @@ use crate::{
         observability::observability_config_from_env, ExternalNodeConfig, OptionalENConfig,
         RequiredENConfig,
     },
-    helpers::MainNodeHealthCheck,
+    helpers::{EthClientHealthCheck, MainNodeHealthCheck, ValidateChainIdsTask},
     init::ensure_storage_initialized,
     metrics::RUST_METRICS,
 };
@@ -830,14 +830,9 @@ async fn main() -> anyhow::Result<()> {
     let eth_client_url = &required_config.eth_client_url;
     let eth_client = Box::new(QueryClient::new(eth_client_url.clone())?);
 
-    let mut config = ExternalNodeConfig::new(
-        required_config,
-        optional_config,
-        &main_node_client,
-        eth_client.as_ref(),
-    )
-    .await
-    .context("Failed to load external node config")?;
+    let mut config = ExternalNodeConfig::new(required_config, optional_config, &main_node_client)
+        .await
+        .context("Failed to load external node config")?;
     if !opt.enable_consensus {
         config.consensus = None;
     }
@@ -911,6 +906,7 @@ async fn run_node(
     app_health.insert_custom_component(Arc::new(MainNodeHealthCheck::from(
         main_node_client.clone(),
     )))?;
+    app_health.insert_custom_component(Arc::new(EthClientHealthCheck::from(eth_client.clone())))?;
     app_health.insert_custom_component(Arc::new(ConnectionPoolHealthCheck::new(
         connection_pool.clone(),
     )))?;
@@ -935,6 +931,14 @@ async fn run_node(
         Ok(())
     });
 
+    let validate_chain_ids_task = ValidateChainIdsTask::new(
+        config.required.l1_chain_id,
+        config.required.l2_chain_id,
+        eth_client.clone(),
+        main_node_client.clone(),
+    );
+    let validate_chain_ids_task = tokio::spawn(validate_chain_ids_task.run(stop_receiver.clone()));
+
     let version_sync_task_pool = connection_pool.clone();
     let version_sync_task_main_node_client = main_node_client.clone();
     let mut stop_receiver_for_version_sync = stop_receiver.clone();
@@ -948,7 +952,7 @@ async fn run_node(
         stop_receiver_for_version_sync.changed().await.ok();
         Ok(())
     });
-    let mut task_handles = vec![metrics_task, version_sync_task];
+    let mut task_handles = vec![metrics_task, validate_chain_ids_task, version_sync_task];
 
     // Make sure that the node storage is initialized either via genesis or snapshot recovery.
     ensure_storage_initialized(

--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -253,7 +253,7 @@ async fn run_core(
         main_node_client.clone(),
         output_handler,
         stop_receiver.clone(),
-        config.remote.l2_chain_id,
+        config.required.l2_chain_id,
         task_handles,
     )
     .await?;
@@ -959,7 +959,7 @@ async fn run_node(
         connection_pool.clone(),
         main_node_client.clone(),
         &app_health,
-        config.remote.l2_chain_id,
+        config.required.l2_chain_id,
         config.optional.snapshots_recovery_enabled,
     )
     .await?;

--- a/core/bin/external_node/src/metrics.rs
+++ b/core/bin/external_node/src/metrics.rs
@@ -32,8 +32,8 @@ impl ExternalNodeMetrics {
     pub(crate) fn observe_config(&self, config: &ExternalNodeConfig) {
         let info = ExternalNodeInfo {
             server_version: SERVER_VERSION,
-            l1_chain_id: config.remote.l1_chain_id.0,
-            l2_chain_id: config.remote.l2_chain_id.as_u64(),
+            l1_chain_id: config.required.l1_chain_id.0,
+            l2_chain_id: config.required.l2_chain_id.as_u64(),
             postgres_pool_size: config.postgres.max_connections,
         };
         tracing::info!("Setting general node information: {info:?}");

--- a/core/bin/external_node/src/tests.rs
+++ b/core/bin/external_node/src/tests.rs
@@ -5,7 +5,7 @@ use test_casing::test_casing;
 use zksync_basic_types::protocol_version::ProtocolVersionId;
 use zksync_eth_client::clients::MockEthereum;
 use zksync_node_genesis::{insert_genesis_batch, GenesisParams};
-use zksync_types::{api, ethabi, fee_model::FeeParams, L1BatchNumber, L2BlockNumber, H256};
+use zksync_types::{api, ethabi, fee_model::FeeParams, L1BatchNumber, L2BlockNumber, H256, U64};
 use zksync_web3_decl::client::{BoxedL2Client, MockL2Client};
 
 use super::*;
@@ -134,6 +134,9 @@ async fn external_node_basics(components_str: &'static str) {
     let l2_client = MockL2Client::new(move |method, params| {
         tracing::info!("Called L2 client: {method}({params:?})");
         match method {
+            "eth_chainId" => Ok(serde_json::json!(U64::from(270))),
+            "zks_L1ChainId" => Ok(serde_json::json!(U64::from(9))),
+
             "zks_L1BatchNumber" => Ok(serde_json::json!("0x0")),
             "zks_getL1BatchDetails" => {
                 let (number,): (L1BatchNumber,) = serde_json::from_value(params)?;

--- a/core/lib/zksync_core/src/api_server/tx_sender/mod.rs
+++ b/core/lib/zksync_core/src/api_server/tx_sender/mod.rs
@@ -239,7 +239,6 @@ pub struct TxSenderConfig {
     pub vm_execution_cache_misses_limit: Option<usize>,
     pub validation_computational_gas_limit: u32,
     pub chain_id: L2ChainId,
-    pub max_pubdata_per_batch: u64,
     pub whitelisted_tokens_for_aa: Vec<Address>,
 }
 
@@ -259,7 +258,6 @@ impl TxSenderConfig {
             validation_computational_gas_limit: state_keeper_config
                 .validation_computational_gas_limit,
             chain_id,
-            max_pubdata_per_batch: state_keeper_config.max_pubdata_per_batch,
             whitelisted_tokens_for_aa: web3_json_config.whitelisted_tokens_for_aa.clone(),
         }
     }


### PR DESCRIPTION
## What ❔

- Removes `max_pubdata_per_batch` from the remote EN config.
- Moves L1 and L2 chain IDs from the remote config to the required one. Adds a managed task asynchronously validating these IDs.

## Why ❔

- `max_pubdata_per_batch` is unused.
- L1 and L2 chain IDs are required to start a node anyway. Async validation means that the EN can now start w/o connecting to L1 / L2 nodes (well, other than to fetch contract addresses etc., but those will be dealt with separately).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
- [ ] Linkcheck has been run via `zk linkcheck`.