### PR TITLE
snark proof is already verified inside wrap_proof function

### DIFF
--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -71,7 +71,6 @@ vk_setup_data_generator_server_fri = { path = "vk_setup_data_generator_server_fr
 vlog = { path = "../core/lib/vlog" }
 zk_evm = { git = "https://github.com/matter-labs/era-zk_evm.git", branch = "v1.4.1" }
 zkevm_test_harness = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.5.0" }
-zkevm_test_harness_1_3_3 = { git = "https://github.com/matter-labs/era-zkevm_test_harness.git", branch = "v1.3.3", package = "zkevm_test_harness" }
 zksync_basic_types = { path = "../core/lib/basic_types" }
 zksync_config = { path = "../core/lib/config" }
 zksync_dal = { path = "../core/lib/dal" }

--- a/prover/proof_fri_compressor/Cargo.toml
+++ b/prover/proof_fri_compressor/Cargo.toml
@@ -24,7 +24,6 @@ zksync_queued_job_processor.workspace = true
 vk_setup_data_generator_server_fri.workspace = true
 vlog.workspace = true
 
-zkevm_test_harness_1_3_3.workspace = true
 circuit_sequencer_api.workspace = true
 zkevm_test_harness.workspace = true
 

--- a/prover/proof_fri_compressor/src/main.rs
+++ b/prover/proof_fri_compressor/src/main.rs
@@ -77,7 +77,6 @@ async fn main() -> anyhow::Result<()> {
         blob_store,
         pool,
         config.compression_mode,
-        config.verify_wrapper_proof,
         config.max_attempts,
         protocol_version,
     );


### PR DESCRIPTION
## What ❔

This PR avoids using useless era-zkevm-test-harness branch

## Why ❔

The only reason this dependency was used is verification of the wrapper proof that was already verified inside `wrap_proof` function.
