### PR TITLE
chore(docs): fix typos

### DIFF
--- a/docs/guides/external-node/00_quick_start.md
+++ b/docs/guides/external-node/00_quick_start.md
@@ -43,7 +43,7 @@ The HTTP JSON-RPC API can be accessed on port `3060` and WebSocket API can be ac
 
 > [!NOTE]
 >
-> The node will recover from a snapshot on it's first run, this may take up to 10h. Before the recovery is finished, the
+> The node will recover from a snapshot on its first run, this may take up to 10h. Before the recovery is finished, the
 > API server won't serve any requests.
 
 > [!NOTE]

--- a/docs/guides/external-node/03_running.md
+++ b/docs/guides/external-node/03_running.md
@@ -21,7 +21,7 @@ namespace. If you want to clear some space and aren't using the `debug` namespac
 ## Infrastructure
 
 You need to set up a PostgreSQL server, however it is out of the scope of these docs, but the popular choice is to run
-it in Docker. There are many of guides on that,
+it in Docker. There are many guides on that,
 [here's one example](https://www.docker.com/blog/how-to-use-the-postgres-docker-official-image/).
 
 Note however that if you run PostgresSQL as a stand-alone Docker image (e.g. not in Docker-compose with a network shared

--- a/docs/specs/blocks_batches.md
+++ b/docs/specs/blocks_batches.md
@@ -137,7 +137,7 @@ will return values for L2 blocks.
 
 At the time of this writing, the migration has been complete on testnet, i.e. there we already have only the L2 block
 information returned. However, the [migration](https://github.com/zkSync-Community-Hub/zksync-developers/discussions/87)
-on mainnet is still ongoing and most likely will end on late October / early November.
+on mainnet is still ongoing and most likely will end in late October / early November.
 
 ## Blocks’ processing and consistency checks
 

--- a/docs/specs/data_availability/compression.md
+++ b/docs/specs/data_availability/compression.md
@@ -15,7 +15,7 @@ the efficient compression of keys and values separately.
 Keys will be packed in the same way as they were before. The only change is that we’ll avoid using the 8-byte
 enumeration index and will pack it to the minimal necessary number of bytes. This number will be part of the pubdata.
 Once a key has been used, it can already use the 4 or 5 byte enumeration index and it is very hard to have something
-cheaper for keys that has been used already. The opportunity comes when remembering the ids for accounts to spare some
+cheaper for keys that have been used already. The opportunity comes when remembering the ids for accounts to spare some
 bytes on nonce/balance key, but ultimately the complexity may not be worth it.
 
 There is some room for optimization of the keys that are being written for the first time, however, optimizing those is

--- a/docs/specs/data_availability/overview.md
+++ b/docs/specs/data_availability/overview.md
@@ -13,7 +13,7 @@ We also [compress](./compression.md) all the data that we send to L1, to reduce 
 By posting all the data to L1, we can [reconstruct](./reconstruction.md) the state of the chain from the data on L1.
 This is a key security property of the rollup.
 
-The the chain chooses not to post this data, they become a validium. This makes transactions there much cheaper, but
+The chain chooses not to post this data, they become a validium. This makes transactions there much cheaper, but
 less secure. Because we use state diffs to post data, we can combine the rollup and validium features, by separating
 storage slots that need to post data from the ones that don't. This construction combines the benefits of rollups and
 validiums, and it is called a [zkPorter](./validium_zk_porter.md).

--- a/docs/specs/data_availability/pubdata.md
+++ b/docs/specs/data_availability/pubdata.md
@@ -47,7 +47,7 @@ failed deposits for bridges.
   possible (in practice, a maximum of 2048 would likely be enough for the foreseeable future).
 - Extending the tree in the circuits will be hard to do and hard to maintain.
 - The hash of the contents of the L2→L1 messages needs to be rehashed to support the danksharding blobs, so we want to
-  keep only the essential logs as parts of calldata and the rest should be separated so that they could be moved the
+  keep only the essential logs as parts of calldata and the rest should be separated so that they could be moved to the
   EIP4844 blob in the future.
 
 #### Solution
@@ -63,7 +63,7 @@ natively by VM _system_ logs. Here is a short comparison table for better unders
 | System logs                                                                                                     | User logs                                                                                                                                                                                                                           |
 | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Emitted by VM via an opcode.                                                                                    | VM knows nothing about them.                                                                                                                                                                                                        |
-| Consistency and correctness is enforced by the verifier on L1 (i.e. their hash is part of the block commitment. | Consistency and correctness is enforced by the L1Messenger system contract. The correctness of the behavior of the L1Messenger is enforced implicitly by prover in a sense that it proves the correctness of the execution overall. |
+| Consistency and correctness are enforced by the verifier on L1 (i.e. their hash is part of the block commitment. | Consistency and correctness are enforced by the L1Messenger system contract. The correctness of the behavior of the L1Messenger is enforced implicitly by prover in a sense that it proves the correctness of the execution overall. |
 | We don’t calculate their Merkle root.                                                                           | We calculate their Merkle root on the L1Messenger system contract.                                                                                                                                                                  |
 | We have constant small number of those.                                                                         | We can have as much as possible as long as the commitBatches function on L1 remains executable (it is the job of the operator to ensure that only such transactions are selected)                                                   |
 | In EIP4844 they will remain part of the calldata.                                                               | In EIP4844 they will become part of the blobs.                                                                                                                                                                                      |
@@ -133,7 +133,7 @@ to the message’s rolling hash too `chainedMessagesHash = keccak256(chainedMess
 A very similar approach for bytecodes is used, where their rolling hash is calculated and then the preimages are
 provided at the end of the batch to form the full pubdata for the batch.
 
-Note, that in for backward compatibility, just like before any long message or bytecode is accompanied by the
+Note, that for backward compatibility, just like before any long message or bytecode is accompanied by the
 corresponding user L2→L1 log.
 
 #### Using system L2→L1 logs vs the user logs
@@ -298,7 +298,7 @@ for potential shards in the future, we currently have only one shard and it is i
 We call this `H(S,A)` _derived key_, because it is derived from the address and the actual key in the storage of the
 account. Since our tree is flat, whenever a change happens, we can publish a pair `DK, V`, where `DK=H(S,A)`.
 
-However, these is an optimization that could be done:
+However, this is an optimization that could be done:
 
 - Whenever a change to a key is used for the first time, we publish a pair of `DK,V` and we assign some sequential id to
   this derived key. This is called an _initial write_. It happens for the first time and that’s why we must publish the
@@ -402,7 +402,7 @@ following three values via system logs:
 
 - The root of the L2→L1 log Merkle tree. It will be stored and used for proving withdrawals.
 - The hash of the `totalPubdata` (i.e. the pubdata that contains the preimages above as well as packed state diffs).
-- The hash of the state diffs provided by the operator (it later on be included in the block commitment and its will be
+- The hash of the state diffs provided by the operator (it later on be included in the block commitment and it will be
   enforced by the circuits).
 
 The `totalPubdata` has the following structure:

--- a/docs/specs/l1_l2_communication/l1_to_l2.md
+++ b/docs/specs/l1_l2_communication/l1_to_l2.md
@@ -39,7 +39,7 @@ two variables:
 
 Whenever a priority transaction is processed, the `numberOfPriorityTransactions` gets incremented by 1, while
 `priorityOperationsRollingHash` is assigned to `keccak256(priorityOperationsRollingHash, processedPriorityOpHash)`,
-where `processedPriorityOpHash` is the hash of the priority operations that has been just processed.
+where `processedPriorityOpHash` is the hash of the priority operations that have been just processed.
 
 Also, for each priority transaction, we
 [emit](https://github.com/code-423n4/2023-10-zksync/blob/ef99273a8fdb19f5912ca38ba46d6bd02071363d/code/system-contracts/bootloader/bootloader.yul#L966)
@@ -84,7 +84,7 @@ been complete.
 
 ### Bootloader
 
-The upgrade transactions are processed just like with priority transactions, with only the following differences:
+The upgrade transactions are processed just like priority transactions, with only the following differences:
 
 - We can have only one upgrade transaction per batch & this transaction must be the first transaction in the batch.
 - The system contracts upgrade transaction is not appended to `priorityOperationsRollingHash` and doesn't increment

--- a/docs/specs/l1_l2_communication/l2_to_l1.md
+++ b/docs/specs/l1_l2_communication/l2_to_l1.md
@@ -63,10 +63,10 @@ log and prove its presence.
 
 ## Priority operations
 
-Also, for each priority operation, we would send its hash and it status via an L2→L1 log. On L1 we would then
+Also, for each priority operation, we would send its hash and it's status via an L2→L1 log. On L1 we would then
 reconstruct the rolling hash of the processed priority transactions, allowing to correctly verify during the
 `executeBatches` method that indeed the batch contained the correct priority operations.
 
-Importantly, the fact that both hash and status were sent, it made it possible to
+Importantly, the fact that both hash and status were sent, made it possible to
 [prove](https://github.com/code-423n4/2023-10-zksync/blob/ef99273a8fdb19f5912ca38ba46d6bd02071363d/code/contracts/ethereum/contracts/bridge/L1ERC20Bridge.sol#L255)
 that the L2 part of a deposit has failed and ask the bridge to release funds.

--- a/docs/specs/prover/boojum_function_check_if_satisfied.md
+++ b/docs/specs/prover/boojum_function_check_if_satisfied.md
@@ -48,7 +48,7 @@ For each row and gate, we need several things.
 Placement is either UniqueOnRow or MultipleOnRow. UniqueOnRow means there is only one gate on the row (typically because
 the gate is larger / more complicated). MultipleOnRow means there are multiple gates within the same row (typically
 because the gate is smaller). For example, if a gate only needs 30 columns, but we have 150 columns, we could include
-five copies fo that gate in the same row.
+five copies of that gate in the same row.
 
 Next, if the placement is UniqueOnRow, we call evaluate_over_general_purpose_columns. All of the evaluations should be
 equal to zero, or we panic.

--- a/docs/specs/prover/boojum_gadgets.md
+++ b/docs/specs/prover/boojum_gadgets.md
@@ -127,7 +127,7 @@ In gadgets we have a lot of hash implementation:
 - poseidon/poseidon2
 - sha256
 
-Each of them perform different functions in our proof system.
+Each of them performs different functions in our proof system.
 
 ## Queues
 
@@ -147,7 +147,7 @@ The structure consists of `head` and `tail` commitments that basically are rolli
 the queue. These three fields are allocated inside the constraint system. Also, there is a `witness`, that keeps actual
 values that are now stored in the queue.
 
-And here is the main functions:
+And here are the main functions:
 
 ```rust
 fn push(&mut self, value: Element) {

--- a/docs/specs/prover/circuit_testing.md
+++ b/docs/specs/prover/circuit_testing.md
@@ -38,7 +38,7 @@ Now the constraint system is ready! We can start the main part of the test!
 ![Contest(8).png](<./img/circuit_testing/Contest(8).png>)
 
 Here we have hard coded a secret key with its associated public key, and generate a signature. We will test our circuit
-on these inputs! Next we “allocate” these inputs as witnessess:
+on these inputs! Next we “allocate” these inputs as witnesses:
 
 ![Contest(9).png](<./img/circuit_testing/Contest(9).png>)
 

--- a/docs/specs/prover/getting_started.md
+++ b/docs/specs/prover/getting_started.md
@@ -18,4 +18,4 @@ cargo test basic_test  --release -- --nocapture
 
 ```
 
-This test may take several minutes to run, but you will see lot’s of information along the way!
+This test may take several minutes to run, but you will see lots of information along the way!

--- a/docs/specs/the_hyperchain/shared_bridge.md
+++ b/docs/specs/the_hyperchain/shared_bridge.md
@@ -124,7 +124,7 @@ be able to leverage them when available).
   bridges are the `WETH` and `ERC20` bridges.
 
   - The pair on L2 is deployed from L1. The hash of the factory dependencies is stored on L1, and when a hyperchain
-    wants to register, it can passes it in for deployment, it is verified, and the contract is deployed on L2. The
+    wants to register, it can pass it in for deployment, it is verified, and the contract is deployed on L2. The
     actual token contracts on L2 are deployed by the L2 bridge.
 
   ```
@@ -159,7 +159,7 @@ This topic is now covered more thoroughly by the Custom native token discussion.
     for all chains. Registration is not permissionless but happens based on the registrations in the bridgehub’s
     `Registry`. At registration a `DiamondProxy` is deployed and initialized with the appropriate `Facets` for each
     Hyperchain.
-  - `Facets` and `Verifier` are shared across chains that relies on the same ST: `Base`, `Executor` , `Getters`, `Admin`
+  - `Facets` and `Verifier` are shared across chains that rely on the same ST: `Base`, `Executor` , `Getters`, `Admin`
     , `Mailbox.`The `Verifier` is the contract that actually verifies the proof, and is called by the `Executor`.
   - Upgrade Mechanism The system requires all chains to be up-to-date with the latest implementation, so whenever an
     update is needed, we have to “force” each chain to update, but due to decentralization, we have to give each chain a
@@ -210,7 +210,7 @@ corresponding bridge and ERC20 contract. This is deployed from L1, but the L2 ad
 #### Deposit WETH
 
 The user can deposit WETH into the ecosystem using the WETH bridge on L1. The destination chain ID has to be specified.
-The Bridgehub unwraps the WETH, and keeps the ETH, and send a message to the destination L2 to mint WETH to the
+The Bridgehub unwraps the WETH, and keeps the ETH, and sends a message to the destination L2 to mint WETH to the
 specified address.
 
 ![depositWeth.png](./img/depositWeth.png)

--- a/docs/specs/zk_evm/account_abstraction.md
+++ b/docs/specs/zk_evm/account_abstraction.md
@@ -6,7 +6,7 @@ the documentation on our AA protocol here:
 
 ### Account versioning
 
-Each account can also specify which version of the account abstraction protocol do they support. This is needed to allow
+Each account can also specify which version of the account abstraction protocol it supports. This is needed to allow
 breaking changes of the protocol in the future.
 
 Currently, two versions are supported: `None` (i.e. it is a simple contract and it should never be used as `from` field
@@ -36,5 +36,5 @@ are paid as part of the execution and so they need to be estimated as part of th
 costs.
 
 Generally, the accounts are recommended to perform as many operations as during normal validation, but only return the
-invalid magic in the end of the validation. This will allow to correctly (or at least as correctly as possible) estimate
+invalid magic at the end of the validation. This will allow to correctly (or at least as correctly as possible) estimate
 the price for the validation of the account.


### PR DESCRIPTION
chore(docs): fix typos

I understand you're working on enhancing the spellcheck first, but most of those grammar typos may slip through undetected.