### PR TITLE
fix(basic_types): bincode deserialization for `web3::Bytes`

### DIFF
--- a/core/lib/basic_types/src/web3/mod.rs
+++ b/core/lib/basic_types/src/web3/mod.rs
@@ -119,6 +119,20 @@ impl<'a> Visitor<'a> for BytesVisitor {
     {
         self.visit_str(value.as_ref())
     }
+
+    fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(Bytes(value.to_vec()))
+    }
+
+    fn visit_byte_buf<E>(self, value: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(Bytes(value))
+    }
 }
 
 // `Log`: from `web3::types::log`

--- a/core/lib/basic_types/src/web3/mod.rs
+++ b/core/lib/basic_types/src/web3/mod.rs
@@ -66,7 +66,7 @@ impl Serialize for Bytes {
             serialized.push_str(&hex::encode(&self.0));
             serializer.serialize_str(serialized.as_ref())
         } else {
-            serializer.serialize_bytes(&self.0)
+            self.0.serialize(serializer)
         }
     }
 }

--- a/core/lib/basic_types/src/web3/mod.rs
+++ b/core/lib/basic_types/src/web3/mod.rs
@@ -61,9 +61,13 @@ impl Serialize for Bytes {
     where
         S: Serializer,
     {
-        let mut serialized = "0x".to_owned();
-        serialized.push_str(&hex::encode(&self.0));
-        serializer.serialize_str(serialized.as_ref())
+        if serializer.is_human_readable() {
+            let mut serialized = "0x".to_owned();
+            serialized.push_str(&hex::encode(&self.0));
+            serializer.serialize_str(serialized.as_ref())
+        } else {
+            serializer.serialize_bytes(&self.0)
+        }
     }
 }
 
@@ -72,7 +76,11 @@ impl<'a> Deserialize<'a> for Bytes {
     where
         D: Deserializer<'a>,
     {
-        deserializer.deserialize_identifier(BytesVisitor)
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_identifier(BytesVisitor)
+        } else {
+            Vec::<u8>::deserialize(deserializer).map(Bytes)
+        }
     }
 }
 

--- a/core/lib/basic_types/src/web3/tests.rs
+++ b/core/lib/basic_types/src/web3/tests.rs
@@ -83,3 +83,27 @@ fn block_can_be_deserialized() {
     let block: Block<H256> = serde_json::from_str(pre_dencun).unwrap();
     assert!(block.excess_blob_gas.is_none());
 }
+
+#[test]
+fn test_bytes_serde_bincode() {
+    let original = Bytes(vec![0, 1, 2, 3, 4]);
+    let encoded: Vec<u8> = bincode::serialize(&original).unwrap();
+    let decoded: Bytes = bincode::deserialize(&encoded).unwrap();
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn test_bytes_serde_bincode_snapshot() {
+    let original = Bytes(vec![0, 1, 2, 3, 4]);
+    let encoded: Vec<u8> = vec![5, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4];
+    let decoded: Bytes = bincode::deserialize(&encoded).unwrap();
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn test_bytes_serde_json() {
+    let original = Bytes(vec![0, 1, 2, 3, 4]);
+    let encoded = serde_json::to_string(&original).unwrap();
+    let decoded: Bytes = serde_json::from_str(&encoded).unwrap();
+    assert_eq!(original, decoded);
+}


### PR DESCRIPTION
## What ❔

Only use custom format, if human readable serializer is used.

## Why ❔

Don't assume we only use serde_json... Make bincode ser/deser work

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
