### PR TITLE
fix(ci): add retried to yarn install

### DIFF
--- a/bin/run_retried
+++ b/bin/run_retried
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+BACKOFF=1
+MAX_ATTEMPTS=5
+attempt=1
+
+while [ $attempt -le $MAX_ATTEMPTS ]; do
+
+    "$@"
+
+    if [ $? -eq 0 ]; then
+        exit 0
+    else
+        echo "Command \"$*\" failed with code $?. Retrying in $BACKOFF seconds..."
+        sleep $BACKOFF
+        let BACKOFF*=2
+        let attempt++
+    fi
+done
+
+echo "Command failed after $MAX_ATTEMPTS attempts."
+exit 1

--- a/bin/zk
+++ b/bin/zk
@@ -41,7 +41,7 @@ check_subdirectory
 check_yarn_version
 if [ -z "$1" ]; then
     cd $ZKSYNC_HOME
-    yarn install --frozen-lockfile && yarn zk build
+    run_retried yarn install --frozen-lockfile && yarn zk build
 else
     # can't start this with yarn since it has quirks with `--` as an argument
     node -- $ZKSYNC_HOME/infrastructure/zk/build/index.js "$@"

--- a/infrastructure/zk/src/run.ts
+++ b/infrastructure/zk/src/run.ts
@@ -56,7 +56,7 @@ export async function tokenInfo(address: string) {
 
 // installs all dependencies
 export async function yarn() {
-    await utils.spawn('yarn install --frozen-lockfile');
+    await utils.spawn('run_retried yarn install --frozen-lockfile');
 }
 
 export async function revertReason(txHash: string, web3url?: string) {


### PR DESCRIPTION
Yarn 1.* doesn't seem to have any sort of built-in mechanisms for retries, so I've added a generic wrapper that just retries provided command. 