### PR TITLE
fix(en): Delete old txs by (init_addr, nonce)

### DIFF
--- a/core/lib/dal/.sqlx/query-8cc3cf441b12a8b6a2f25f4fe5581e33845ec68e386ef032715ad1222e2fdc8b.json
+++ b/core/lib/dal/.sqlx/query-8cc3cf441b12a8b6a2f25f4fe5581e33845ec68e386ef032715ad1222e2fdc8b.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    DELETE FROM transactions\n                    WHERE\n                        initiator_address = $1\n                        AND nonce = $2\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8cc3cf441b12a8b6a2f25f4fe5581e33845ec68e386ef032715ad1222e2fdc8b"
+}


### PR DESCRIPTION
## What ❔

Delete txs not only by hash but also by (init_addr, nonce) before inserting them

## Why ❔

Fix bug

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
