### PR TITLE
fix(utils): bincode ser-/deserialization for `BytesToHexSerde`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9115,6 +9115,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bigdecimal",
+ "bincode",
  "futures 0.3.28",
  "hex",
  "itertools 0.10.5",

--- a/core/lib/utils/Cargo.toml
+++ b/core/lib/utils/Cargo.toml
@@ -30,3 +30,4 @@ itertools.workspace = true
 serde_json.workspace = true
 rand.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
+bincode.workspace = true


### PR DESCRIPTION
## What ❔

Only do a hex string conversion if serializer/deserializer `.is_human_readable()`.

## Why ❔

bincode does not need a hex string presentation.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
