### PR TITLE
feat(tests): Move all env calls to one place in ts-tests

### DIFF
--- a/core/tests/ts-integration/src/context-owner.ts
+++ b/core/tests/ts-integration/src/context-owner.ts
@@ -166,7 +166,7 @@ export class TestContextOwner {
         this.reporter.startAction(`Cancelling allowances transactions`);
         // Since some tx may be pending on stage, we don't want to get stuck because of it.
         // In order to not get stuck transactions, we manually cancel all the pending txs.
-        const chainId = process.env.CHAIN_ETH_ZKSYNC_NETWORK_ID!;
+        const chainId = this.env.l2ChainId;
 
         const bridgehub = await this.mainSyncWallet.getBridgehubContract();
         const erc20Bridge = await bridgehub.sharedBridge();
@@ -275,7 +275,7 @@ export class TestContextOwner {
     ) {
         this.reporter.startAction(`Distributing base tokens on L1`);
         if (baseTokenAddress != zksync.utils.ETH_ADDRESS_IN_CONTRACTS) {
-            const chainId = process.env.CHAIN_ETH_ZKSYNC_NETWORK_ID!;
+            const chainId = this.env.l2ChainId;
             const l1startNonce = await this.mainEthersWallet.getTransactionCount();
             this.reporter.debug(`Start nonce is ${l1startNonce}`);
             const ethIsBaseToken =
@@ -365,7 +365,7 @@ export class TestContextOwner {
         l2erc20DepositAmount: ethers.BigNumber,
         baseTokenAddress: zksync.types.Address
     ) {
-        const chainId = process.env.CHAIN_ETH_ZKSYNC_NETWORK_ID!;
+        const chainId = this.env.l2ChainId;
         this.reporter.startAction(`Distributing tokens on L1`);
         const l1startNonce = await this.mainEthersWallet.getTransactionCount();
         this.reporter.debug(`Start nonce is ${l1startNonce}`);

--- a/core/tests/ts-integration/src/env.ts
+++ b/core/tests/ts-integration/src/env.ts
@@ -2,10 +2,9 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as ethers from 'ethers';
 import * as zksync from 'zksync-ethers';
-import {DataAvailabityMode, NodeMode, TestEnvironment} from './types';
-import {Reporter} from './reporter';
-import {L2_BASE_TOKEN_ADDRESS} from 'zksync-ethers/build/utils';
-
+import { DataAvailabityMode, NodeMode, TestEnvironment } from './types';
+import { Reporter } from './reporter';
+import { L2_BASE_TOKEN_ADDRESS } from 'zksync-ethers/build/utils';
 
 /**
  * Attempts to connect to server.
@@ -55,7 +54,7 @@ export async function loadTestEnvironment(): Promise<TestEnvironment> {
     let mainWalletPK;
     if (network == 'localhost') {
         const testConfigPath = path.join(process.env.ZKSYNC_HOME!, `etc/test_config/constant`);
-        const ethTestConfig = JSON.parse(fs.readFileSync(`${testConfigPath}/eth.json`, {encoding: 'utf-8'}));
+        const ethTestConfig = JSON.parse(fs.readFileSync(`${testConfigPath}/eth.json`, { encoding: 'utf-8' }));
         mainWalletPK = ethers.Wallet.fromMnemonic(ethTestConfig.test_mnemonic as string, "m/44'/60'/0'/0/0").privateKey;
     } else {
         mainWalletPK = ensureVariable(process.env.MASTER_WALLET_PK, 'Main wallet private key');
@@ -106,7 +105,8 @@ export async function loadTestEnvironment(): Promise<TestEnvironment> {
 
     const baseTokenAddressL2 = L2_BASE_TOKEN_ADDRESS;
     const l2ChainId = parseInt(process.env.CHAIN_ETH_ZKSYNC_NETWORK_ID!);
-    const l1BatchCommitDataGeneratorMode = process.env.CHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE! as DataAvailabityMode;
+    const l1BatchCommitDataGeneratorMode = process.env
+        .CHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE! as DataAvailabityMode;
     const minimalL2GasPrice = ethers.BigNumber.from(process.env.CHAIN_STATE_KEEPER_MINIMAL_L2_GAS_PRICE!);
     let nodeMode;
     if (process.env.EN_MAIN_NODE_URL !== undefined) {

--- a/core/tests/ts-integration/src/env.ts
+++ b/core/tests/ts-integration/src/env.ts
@@ -108,6 +108,7 @@ export async function loadTestEnvironment(): Promise<TestEnvironment> {
     const l1BatchCommitDataGeneratorMode = process.env
         .CHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE! as DataAvailabityMode;
     const minimalL2GasPrice = ethers.BigNumber.from(process.env.CHAIN_STATE_KEEPER_MINIMAL_L2_GAS_PRICE!);
+    minimalL2GasPrice.mul(2);
     let nodeMode;
     if (process.env.EN_MAIN_NODE_URL !== undefined) {
         nodeMode = NodeMode.External;

--- a/core/tests/ts-integration/src/env.ts
+++ b/core/tests/ts-integration/src/env.ts
@@ -107,8 +107,12 @@ export async function loadTestEnvironment(): Promise<TestEnvironment> {
     const l2ChainId = parseInt(process.env.CHAIN_ETH_ZKSYNC_NETWORK_ID!);
     const l1BatchCommitDataGeneratorMode = process.env
         .CHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE! as DataAvailabityMode;
-    const minimalL2GasPrice = ethers.BigNumber.from(process.env.CHAIN_STATE_KEEPER_MINIMAL_L2_GAS_PRICE!);
-    minimalL2GasPrice.mul(2);
+    let minimalL2GasPrice;
+    if (process.env.CHAIN_STATE_KEEPER_MINIMAL_L2_GAS_PRICE !== undefined) {
+        minimalL2GasPrice = ethers.BigNumber.from(process.env.CHAIN_STATE_KEEPER_MINIMAL_L2_GAS_PRICE!);
+    } else {
+        minimalL2GasPrice = ethers.BigNumber.from(0);
+    }
     let nodeMode;
     if (process.env.EN_MAIN_NODE_URL !== undefined) {
         nodeMode = NodeMode.External;

--- a/core/tests/ts-integration/src/env.ts
+++ b/core/tests/ts-integration/src/env.ts
@@ -76,7 +76,8 @@ export async function loadTestEnvironment(): Promise<TestEnvironment> {
         ? process.env.CONTRACT_VERIFIER_URL!
         : ensureVariable(process.env.CONTRACT_VERIFIER_URL, 'Contract verification API');
 
-    const tokens = getTokens(process.env.CHAIN_ETH_NETWORK || 'localhost');
+    const pathToHome = path.join(__dirname, '../../../../');
+    const tokens = getTokens(pathToHome, process.env.CHAIN_ETH_NETWORK || 'localhost');
     // wBTC is chosen because it has decimals different from ETH (8 instead of 18).
     // Using this token will help us to detect decimals-related errors.
     // but if it's not available, we'll use the first token from the list.
@@ -103,8 +104,27 @@ export async function loadTestEnvironment(): Promise<TestEnvironment> {
     ).l2TokenAddress(weth.address);
 
     const baseTokenAddressL2 = L2_BASE_TOKEN_ADDRESS;
+    const l2ChainId = parseInt(process.env.CHAIN_ETH_ZKSYNC_NETWORK_ID!);
+    const l1BatchCommitDataGeneratorMode = process.env.CHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE!;
+    const minimalL2GasPrice = ethers.BigNumber.from(process.env.CHAIN_STATE_KEEPER_MINIMAL_L2_GAS_PRICE!);
+    const externalNode = process.env.EN_MAIN_NODE_URL !== undefined;
+    const validationComputationalGasLimit = parseInt(
+        process.env.CHAIN_STATE_KEEPER_VALIDATION_COMPUTATIONAL_GAS_LIMIT!
+    );
+    const priorityTxMaxGasLimit = parseInt(process.env.CONTRACTS_PRIORITY_TX_MAX_GAS_LIMIT!);
+    const maxLogsLimit = parseInt(
+        process.env.EN_REQ_ENTITIES_LIMIT ?? process.env.API_WEB3_JSON_RPC_REQ_ENTITIES_LIMIT!
+    );
 
     return {
+        maxLogsLimit,
+        pathToHome,
+        priorityTxMaxGasLimit,
+        validationComputationalGasLimit,
+        externalNode,
+        minimalL2GasPrice,
+        l1BatchCommitDataGeneratorMode,
+        l2ChainId,
         network,
         mainWalletPK,
         l2NodeUrl,
@@ -152,8 +172,8 @@ type L1Token = {
     address: string;
 };
 
-function getTokens(network: string): L1Token[] {
-    const configPath = `${process.env.ZKSYNC_HOME}/etc/tokens/${network}.json`;
+function getTokens(pathToHome: string, network: string): L1Token[] {
+    const configPath = `${pathToHome}/etc/tokens/${network}.json`;
     if (!fs.existsSync(configPath)) {
         return [];
     }

--- a/core/tests/ts-integration/src/env.ts
+++ b/core/tests/ts-integration/src/env.ts
@@ -2,9 +2,10 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as ethers from 'ethers';
 import * as zksync from 'zksync-ethers';
-import { TestEnvironment } from './types';
-import { Reporter } from './reporter';
-import { L2_BASE_TOKEN_ADDRESS } from 'zksync-ethers/build/utils';
+import {DataAvailabityMode, NodeMode, TestEnvironment} from './types';
+import {Reporter} from './reporter';
+import {L2_BASE_TOKEN_ADDRESS} from 'zksync-ethers/build/utils';
+
 
 /**
  * Attempts to connect to server.
@@ -54,7 +55,7 @@ export async function loadTestEnvironment(): Promise<TestEnvironment> {
     let mainWalletPK;
     if (network == 'localhost') {
         const testConfigPath = path.join(process.env.ZKSYNC_HOME!, `etc/test_config/constant`);
-        const ethTestConfig = JSON.parse(fs.readFileSync(`${testConfigPath}/eth.json`, { encoding: 'utf-8' }));
+        const ethTestConfig = JSON.parse(fs.readFileSync(`${testConfigPath}/eth.json`, {encoding: 'utf-8'}));
         mainWalletPK = ethers.Wallet.fromMnemonic(ethTestConfig.test_mnemonic as string, "m/44'/60'/0'/0/0").privateKey;
     } else {
         mainWalletPK = ensureVariable(process.env.MASTER_WALLET_PK, 'Main wallet private key');
@@ -105,9 +106,15 @@ export async function loadTestEnvironment(): Promise<TestEnvironment> {
 
     const baseTokenAddressL2 = L2_BASE_TOKEN_ADDRESS;
     const l2ChainId = parseInt(process.env.CHAIN_ETH_ZKSYNC_NETWORK_ID!);
-    const l1BatchCommitDataGeneratorMode = process.env.CHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE!;
+    const l1BatchCommitDataGeneratorMode = process.env.CHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE! as DataAvailabityMode;
     const minimalL2GasPrice = ethers.BigNumber.from(process.env.CHAIN_STATE_KEEPER_MINIMAL_L2_GAS_PRICE!);
-    const externalNode = process.env.EN_MAIN_NODE_URL !== undefined;
+    let nodeMode;
+    if (process.env.EN_MAIN_NODE_URL !== undefined) {
+        nodeMode = NodeMode.External;
+    } else {
+        nodeMode = NodeMode.Main;
+    }
+
     const validationComputationalGasLimit = parseInt(
         process.env.CHAIN_STATE_KEEPER_VALIDATION_COMPUTATIONAL_GAS_LIMIT!
     );
@@ -121,7 +128,7 @@ export async function loadTestEnvironment(): Promise<TestEnvironment> {
         pathToHome,
         priorityTxMaxGasLimit,
         validationComputationalGasLimit,
-        externalNode,
+        nodeMode,
         minimalL2GasPrice,
         l1BatchCommitDataGeneratorMode,
         l2ChainId,

--- a/core/tests/ts-integration/src/helpers.ts
+++ b/core/tests/ts-integration/src/helpers.ts
@@ -22,7 +22,7 @@ export function getTestContract(name: string): ZkSyncArtifact {
  * @returns Conta
  */
 export function getContractSource(relativePath: string): string {
-    const contractPath = `${process.env.ZKSYNC_HOME}/core/tests/ts-integration/contracts/${relativePath}`;
+    const contractPath = `${__dirname}/../contracts/${relativePath}`;
     const source = fs.readFileSync(contractPath, 'utf8');
     return source;
 }
@@ -77,6 +77,7 @@ export async function waitForNewL1Batch(wallet: zksync.Wallet): Promise<zksync.t
     }
     return await wallet.provider.getTransactionReceipt(oldReceipt.transactionHash);
 }
+
 /**
  * Waits until the requested block is finalized.
  *

--- a/core/tests/ts-integration/src/types.ts
+++ b/core/tests/ts-integration/src/types.ts
@@ -1,14 +1,13 @@
-import {ethers} from 'ethers';
+import { ethers } from 'ethers';
 
 export enum NodeMode {
     Main,
     External
 }
 
-
 export enum DataAvailabityMode {
-    Rollup = "Rollup",
-    Validium = "Validium"
+    Rollup = 'Rollup',
+    Validium = 'Validium'
 }
 
 /**

--- a/core/tests/ts-integration/src/types.ts
+++ b/core/tests/ts-integration/src/types.ts
@@ -15,6 +15,18 @@ export interface Token {
  * Description of the environment the integration tests are being run in.
  */
 export interface TestEnvironment {
+    maxLogsLimit: number;
+    pathToHome: string;
+    priorityTxMaxGasLimit: number;
+    validationComputationalGasLimit: number;
+    externalNode: boolean;
+    minimalL2GasPrice: ethers.BigNumber;
+    l1BatchCommitDataGeneratorMode: string;
+    /**
+     * Chain Id of the L2 Network
+     */
+    l2ChainId: number;
+
     /**
      * Plaintext name of the L1 network name (i.e. `localhost` or `goerli`).
      */

--- a/core/tests/ts-integration/src/types.ts
+++ b/core/tests/ts-integration/src/types.ts
@@ -1,4 +1,15 @@
-import { ethers } from 'ethers';
+import {ethers} from 'ethers';
+
+export enum NodeMode {
+    Main,
+    External
+}
+
+
+export enum DataAvailabityMode {
+    Rollup = "Rollup",
+    Validium = "Validium"
+}
 
 /**
  * Description of an ERC20 token.
@@ -15,18 +26,38 @@ export interface Token {
  * Description of the environment the integration tests are being run in.
  */
 export interface TestEnvironment {
+    /*
+     * Max Logs limit
+     */
     maxLogsLimit: number;
-    pathToHome: string;
+    /*
+     * Gas limit for priority txs
+     */
     priorityTxMaxGasLimit: number;
+    /*
+     * Gas limit for computations
+     */
     validationComputationalGasLimit: number;
-    externalNode: boolean;
+    /*
+     * Minimal gas price of l2
+     */
     minimalL2GasPrice: ethers.BigNumber;
-    l1BatchCommitDataGeneratorMode: string;
+    /*
+     * Data availability mode
+     */
+    l1BatchCommitDataGeneratorMode: DataAvailabityMode;
+    /*
+     * Path to code home directory
+     */
+    pathToHome: string;
     /**
      * Chain Id of the L2 Network
      */
     l2ChainId: number;
-
+    /*
+     * Mode of the l2 node
+     */
+    nodeMode: NodeMode;
     /**
      * Plaintext name of the L1 network name (i.e. `localhost` or `goerli`).
      */

--- a/core/tests/ts-integration/tests/api/contract-verification.test.ts
+++ b/core/tests/ts-integration/tests/api/contract-verification.test.ts
@@ -44,7 +44,7 @@ describe('Tests for the contract verification API', () => {
             testMaster = TestMaster.getInstance(__filename);
             alice = testMaster.mainAccount();
 
-            if (process.env.ZKSYNC_ENV!.startsWith('ext-node')) {
+            if (testMaster.environment().externalNode) {
                 console.warn("You are trying to run contract verification tests on external node. It's not supported.");
             }
         });
@@ -72,7 +72,7 @@ describe('Tests for the contract verification API', () => {
             let artifact = contracts.counter;
             // TODO: use plugin compilation when it's ready instead of pre-compiled bytecode.
             artifact.bytecode = fs.readFileSync(
-                `${process.env.ZKSYNC_HOME}/core/tests/ts-integration/contracts/counter/zkVM_bytecode.txt`,
+                `${testMaster.environment().pathToHome}/core/tests/ts-integration/contracts/counter/zkVM_bytecode.txt`,
                 'utf8'
             );
 
@@ -136,10 +136,14 @@ describe('Tests for the contract verification API', () => {
         });
 
         test('should test yul contract verification', async () => {
-            const contractPath = `${process.env.ZKSYNC_HOME}/core/tests/ts-integration/contracts/yul/Empty.yul`;
+            const contractPath = `${
+                testMaster.environment().pathToHome
+            }/core/tests/ts-integration/contracts/yul/Empty.yul`;
             const sourceCode = fs.readFileSync(contractPath, 'utf8');
 
-            const bytecodePath = `${process.env.ZKSYNC_HOME}/core/tests/ts-integration/contracts/yul/artifacts/Empty.yul/Empty.yul.zbin`;
+            const bytecodePath = `${
+                testMaster.environment().pathToHome
+            }/core/tests/ts-integration/contracts/yul/artifacts/Empty.yul/Empty.yul.zbin`;
             const bytecode = fs.readFileSync(bytecodePath);
 
             const contractFactory = new zksync.ContractFactory([], bytecode, alice);

--- a/core/tests/ts-integration/tests/api/contract-verification.test.ts
+++ b/core/tests/ts-integration/tests/api/contract-verification.test.ts
@@ -1,10 +1,11 @@
-import { TestMaster } from '../../src/index';
+import {TestMaster} from '../../src/index';
 import * as zksync from 'zksync-ethers';
 import * as ethers from 'ethers';
 import fetch from 'node-fetch';
 import fs from 'fs';
-import { deployContract, getContractSource, getTestContract } from '../../src/helpers';
-import { sleep } from 'zksync-ethers/build/utils';
+import {deployContract, getContractSource, getTestContract} from '../../src/helpers';
+import {sleep} from 'zksync-ethers/build/utils';
+import {NodeMode} from "../../src/types";
 
 // Regular expression to match ISO dates.
 const DATE_REGEX = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{6})?/;
@@ -44,7 +45,7 @@ describe('Tests for the contract verification API', () => {
             testMaster = TestMaster.getInstance(__filename);
             alice = testMaster.mainAccount();
 
-            if (testMaster.environment().externalNode) {
+            if (testMaster.environment().nodeMode == NodeMode.External) {
                 console.warn("You are trying to run contract verification tests on external node. It's not supported.");
             }
         });
@@ -113,7 +114,7 @@ describe('Tests for the contract verification API', () => {
                     }
                 },
                 settings: {
-                    optimizer: { enabled: true },
+                    optimizer: {enabled: true},
                     isSystem: true
                 }
             };

--- a/core/tests/ts-integration/tests/api/contract-verification.test.ts
+++ b/core/tests/ts-integration/tests/api/contract-verification.test.ts
@@ -1,11 +1,11 @@
-import {TestMaster} from '../../src/index';
+import { TestMaster } from '../../src/index';
 import * as zksync from 'zksync-ethers';
 import * as ethers from 'ethers';
 import fetch from 'node-fetch';
 import fs from 'fs';
-import {deployContract, getContractSource, getTestContract} from '../../src/helpers';
-import {sleep} from 'zksync-ethers/build/utils';
-import {NodeMode} from "../../src/types";
+import { deployContract, getContractSource, getTestContract } from '../../src/helpers';
+import { sleep } from 'zksync-ethers/build/utils';
+import { NodeMode } from '../../src/types';
 
 // Regular expression to match ISO dates.
 const DATE_REGEX = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{6})?/;
@@ -114,7 +114,7 @@ describe('Tests for the contract verification API', () => {
                     }
                 },
                 settings: {
-                    optimizer: {enabled: true},
+                    optimizer: { enabled: true },
                     isSystem: true
                 }
             };

--- a/core/tests/ts-integration/tests/api/debug.test.ts
+++ b/core/tests/ts-integration/tests/api/debug.test.ts
@@ -27,7 +27,9 @@ describe('Debug methods', () => {
     });
 
     test('Should not fail for infinity recursion', async () => {
-        const bytecodePath = `${process.env.ZKSYNC_HOME}/core/tests/ts-integration/contracts/zkasm/artifacts/deep_stak.zkasm/deep_stak.zkasm.zbin`;
+        const bytecodePath = `${
+            testMaster.environment().pathToHome
+        }/core/tests/ts-integration/contracts/zkasm/artifacts/deep_stak.zkasm/deep_stak.zkasm.zbin`;
         const bytecode = fs.readFileSync(bytecodePath);
 
         const contractFactory = new zksync.ContractFactory([], bytecode, testMaster.mainAccount());

--- a/core/tests/ts-integration/tests/api/web3.test.ts
+++ b/core/tests/ts-integration/tests/api/web3.test.ts
@@ -1,16 +1,16 @@
 /**
  * This suite contains tests for the Web3 API compatibility and zkSync-specific extensions.
  */
-import {TestMaster} from '../../src';
+import { TestMaster } from '../../src';
 import * as zksync from 'zksync-ethers';
-import {types} from 'zksync-ethers';
-import {BigNumberish, ethers, Event} from 'ethers';
-import {serialize} from '@ethersproject/transactions';
-import {anyTransaction, deployContract, getTestContract, waitForNewL1Batch} from '../../src/helpers';
-import {shouldOnlyTakeFee} from '../../src/modifiers/balance-checker';
-import fetch, {RequestInit} from 'node-fetch';
-import {EIP712_TX_TYPE, PRIORITY_OPERATION_L2_TX_TYPE} from 'zksync-ethers/build/utils';
-import {NodeMode} from "../../src/types";
+import { types } from 'zksync-ethers';
+import { BigNumberish, ethers, Event } from 'ethers';
+import { serialize } from '@ethersproject/transactions';
+import { anyTransaction, deployContract, getTestContract, waitForNewL1Batch } from '../../src/helpers';
+import { shouldOnlyTakeFee } from '../../src/modifiers/balance-checker';
+import fetch, { RequestInit } from 'node-fetch';
+import { EIP712_TX_TYPE, PRIORITY_OPERATION_L2_TX_TYPE } from 'zksync-ethers/build/utils';
+import { NodeMode } from '../../src/types';
 
 // Regular expression to match variable-length hex number.
 const HEX_VALUE_REGEX = /^0x[\da-fA-F]*$/;
@@ -130,7 +130,7 @@ describe('web3 API compatibility tests', () => {
         expect(batchDetails.number).toEqual(block.l1BatchNumber);
         // zks_estimateFee
         const response = await alice.provider.send('zks_estimateFee', [
-            {from: alice.address, to: alice.address, value: '0x1'}
+            { from: alice.address, to: alice.address, value: '0x1' }
         ]);
         const expectedResponse = {
             gas_limit: expect.stringMatching(HEX_VALUE_REGEX),
@@ -664,19 +664,19 @@ describe('web3 API compatibility tests', () => {
 
         // There are around `0.5 * maxLogsLimit` logs in [tx1Receipt.blockNumber, tx1Receipt.blockNumber] range,
         // so query with such filter should succeed.
-        await expect(alice.provider.getLogs({fromBlock: tx1Receipt.blockNumber, toBlock: tx1Receipt.blockNumber}))
+        await expect(alice.provider.getLogs({ fromBlock: tx1Receipt.blockNumber, toBlock: tx1Receipt.blockNumber }))
             .resolves;
 
         // There are at least `1.5 * maxLogsLimit` logs in [tx1Receipt.blockNumber, tx3Receipt.blockNumber] range,
         // so query with such filter should fail.
         await expect(
-            alice.provider.getLogs({fromBlock: tx1Receipt.blockNumber, toBlock: tx3Receipt.blockNumber})
+            alice.provider.getLogs({ fromBlock: tx1Receipt.blockNumber, toBlock: tx3Receipt.blockNumber })
         ).rejects.toThrow(`Query returned more than ${maxLogsLimit} results.`);
     });
 
     test('Should throw error for estimate gas for account with balance < tx.value', async () => {
         let poorBob = testMaster.newEmptyAccount();
-        expect(poorBob.estimateGas({value: 1, to: alice.address})).toBeRejected('insufficient balance for transfer');
+        expect(poorBob.estimateGas({ value: 1, to: alice.address })).toBeRejected('insufficient balance for transfer');
     });
 
     test('Should check API returns correct block for every tag', async () => {
@@ -958,7 +958,7 @@ export class MockMetamask {
 
     // EIP-1193
     async request(req: { method: string; params?: any[] }) {
-        let {method, params} = req;
+        let { method, params } = req;
         params ??= [];
 
         switch (method) {

--- a/core/tests/ts-integration/tests/api/web3.test.ts
+++ b/core/tests/ts-integration/tests/api/web3.test.ts
@@ -1,15 +1,16 @@
 /**
  * This suite contains tests for the Web3 API compatibility and zkSync-specific extensions.
  */
-import { TestMaster } from '../../src';
+import {TestMaster} from '../../src';
 import * as zksync from 'zksync-ethers';
-import { types } from 'zksync-ethers';
-import { BigNumberish, ethers, Event } from 'ethers';
-import { serialize } from '@ethersproject/transactions';
-import { deployContract, getTestContract, waitForNewL1Batch, anyTransaction } from '../../src/helpers';
-import { shouldOnlyTakeFee } from '../../src/modifiers/balance-checker';
-import fetch, { RequestInit } from 'node-fetch';
-import { EIP712_TX_TYPE, PRIORITY_OPERATION_L2_TX_TYPE } from 'zksync-ethers/build/utils';
+import {types} from 'zksync-ethers';
+import {BigNumberish, ethers, Event} from 'ethers';
+import {serialize} from '@ethersproject/transactions';
+import {anyTransaction, deployContract, getTestContract, waitForNewL1Batch} from '../../src/helpers';
+import {shouldOnlyTakeFee} from '../../src/modifiers/balance-checker';
+import fetch, {RequestInit} from 'node-fetch';
+import {EIP712_TX_TYPE, PRIORITY_OPERATION_L2_TX_TYPE} from 'zksync-ethers/build/utils';
+import {NodeMode} from "../../src/types";
 
 // Regular expression to match variable-length hex number.
 const HEX_VALUE_REGEX = /^0x[\da-fA-F]*$/;
@@ -110,7 +111,7 @@ describe('web3 API compatibility tests', () => {
         // zks_getAllAccountBalances
         // NOTE: `getAllBalances` will not work on external node,
         // since TokenListFetcher is not running
-        if (!testMaster.environment().externalNode) {
+        if (testMaster.environment().nodeMode === NodeMode.Main) {
             const balances = await alice.getAllBalances();
             const tokenBalance = await alice.getBalance(l2Token);
             expect(balances[l2Token.toLowerCase()].eq(tokenBalance));
@@ -129,7 +130,7 @@ describe('web3 API compatibility tests', () => {
         expect(batchDetails.number).toEqual(block.l1BatchNumber);
         // zks_estimateFee
         const response = await alice.provider.send('zks_estimateFee', [
-            { from: alice.address, to: alice.address, value: '0x1' }
+            {from: alice.address, to: alice.address, value: '0x1'}
         ]);
         const expectedResponse = {
             gas_limit: expect.stringMatching(HEX_VALUE_REGEX),
@@ -242,7 +243,7 @@ describe('web3 API compatibility tests', () => {
     });
 
     test('Should test getFilterChanges for pending transactions', async () => {
-        if (testMaster.environment().externalNode) {
+        if (testMaster.environment().nodeMode === NodeMode.External) {
             // Pending transactions logic doesn't work on EN since we don't have a proper mempool -
             // transactions only appear in the DB after they are included in the block.
             return;
@@ -663,19 +664,19 @@ describe('web3 API compatibility tests', () => {
 
         // There are around `0.5 * maxLogsLimit` logs in [tx1Receipt.blockNumber, tx1Receipt.blockNumber] range,
         // so query with such filter should succeed.
-        await expect(alice.provider.getLogs({ fromBlock: tx1Receipt.blockNumber, toBlock: tx1Receipt.blockNumber }))
+        await expect(alice.provider.getLogs({fromBlock: tx1Receipt.blockNumber, toBlock: tx1Receipt.blockNumber}))
             .resolves;
 
         // There are at least `1.5 * maxLogsLimit` logs in [tx1Receipt.blockNumber, tx3Receipt.blockNumber] range,
         // so query with such filter should fail.
         await expect(
-            alice.provider.getLogs({ fromBlock: tx1Receipt.blockNumber, toBlock: tx3Receipt.blockNumber })
+            alice.provider.getLogs({fromBlock: tx1Receipt.blockNumber, toBlock: tx3Receipt.blockNumber})
         ).rejects.toThrow(`Query returned more than ${maxLogsLimit} results.`);
     });
 
     test('Should throw error for estimate gas for account with balance < tx.value', async () => {
         let poorBob = testMaster.newEmptyAccount();
-        expect(poorBob.estimateGas({ value: 1, to: alice.address })).toBeRejected('insufficient balance for transfer');
+        expect(poorBob.estimateGas({value: 1, to: alice.address})).toBeRejected('insufficient balance for transfer');
     });
 
     test('Should check API returns correct block for every tag', async () => {
@@ -957,7 +958,7 @@ export class MockMetamask {
 
     // EIP-1193
     async request(req: { method: string; params?: any[] }) {
-        let { method, params } = req;
+        let {method, params} = req;
         params ??= [];
 
         switch (method) {

--- a/core/tests/ts-integration/tests/api/web3.test.ts
+++ b/core/tests/ts-integration/tests/api/web3.test.ts
@@ -30,7 +30,7 @@ describe('web3 API compatibility tests', () => {
         testMaster = TestMaster.getInstance(__filename);
         alice = testMaster.mainAccount();
         l2Token = testMaster.environment().erc20Token.l2Address;
-        chainId = process.env.CHAIN_ETH_ZKSYNC_NETWORK_ID!;
+        chainId = testMaster.environment().l2ChainId;
     });
 
     test('Should test block/transaction web3 methods', async () => {
@@ -110,7 +110,7 @@ describe('web3 API compatibility tests', () => {
         // zks_getAllAccountBalances
         // NOTE: `getAllBalances` will not work on external node,
         // since TokenListFetcher is not running
-        if (!process.env.EN_MAIN_NODE_URL) {
+        if (!testMaster.environment().externalNode) {
             const balances = await alice.getAllBalances();
             const tokenBalance = await alice.getBalance(l2Token);
             expect(balances[l2Token.toLowerCase()].eq(tokenBalance));
@@ -197,7 +197,7 @@ describe('web3 API compatibility tests', () => {
         const tx1 = await alice.provider.getTransaction(tx.transactionHash);
         expect(tx1.l1BatchNumber).toEqual(expect.anything()); // Can be anything except `null` or `undefined`.
         expect(tx1.l1BatchTxIndex).toEqual(expect.anything()); // Can be anything except `null` or `undefined`.
-        expect(tx1.chainId).toEqual(+process.env.CHAIN_ETH_ZKSYNC_NETWORK_ID!);
+        expect(tx1.chainId).toEqual(testMaster.environment().l2ChainId);
         expect(tx1.type).toEqual(EIP1559_TX_TYPE);
 
         expect(receipt.l1BatchNumber).toEqual(expect.anything()); // Can be anything except `null` or `undefined`.
@@ -211,7 +211,7 @@ describe('web3 API compatibility tests', () => {
         blockWithTransactions.transactions.forEach((txInBlock, _) => {
             expect(txInBlock.l1BatchNumber).toEqual(expect.anything()); // Can be anything except `null` or `undefined`.
             expect(txInBlock.l1BatchTxIndex).toEqual(expect.anything()); // Can be anything except `null` or `undefined`.
-            expect(txInBlock.chainId).toEqual(+process.env.CHAIN_ETH_ZKSYNC_NETWORK_ID!);
+            expect(txInBlock.chainId).toEqual(testMaster.environment().l2ChainId);
             expect([0, EIP712_TX_TYPE, PRIORITY_OPERATION_L2_TX_TYPE, EIP1559_TX_TYPE]).toContain(txInBlock.type);
         });
     });
@@ -242,7 +242,7 @@ describe('web3 API compatibility tests', () => {
     });
 
     test('Should test getFilterChanges for pending transactions', async () => {
-        if (process.env.EN_MAIN_NODE_URL) {
+        if (testMaster.environment().externalNode) {
             // Pending transactions logic doesn't work on EN since we don't have a proper mempool -
             // transactions only appear in the DB after they are included in the block.
             return;
@@ -606,7 +606,7 @@ describe('web3 API compatibility tests', () => {
 
     test('Should check metamask interoperability', async () => {
         // Prepare "metamask" wallet.
-        const from = new MockMetamask(alice);
+        const from = new MockMetamask(alice, testMaster.environment().l2ChainId);
         const to = alice.address;
         const web3Provider = new zksync.Web3Provider(from);
         const signer = zksync.Signer.from(web3Provider.getSigner(), alice.provider);
@@ -649,9 +649,7 @@ describe('web3 API compatibility tests', () => {
 
     test('Should check API returns error when there are too many logs in eth_getLogs', async () => {
         const contract = await deployContract(alice, contracts.events, []);
-        const maxLogsLimit = parseInt(
-            process.env.EN_REQ_ENTITIES_LIMIT ?? process.env.API_WEB3_JSON_RPC_REQ_ENTITIES_LIMIT!
-        );
+        const maxLogsLimit = testMaster.environment().maxLogsLimit;
 
         // Send 3 transactions that emit `maxLogsLimit / 2` events.
         const tx1 = await contract.emitManyEvents(maxLogsLimit / 2);
@@ -854,7 +852,7 @@ describe('web3 API compatibility tests', () => {
     });
 
     test('Should check transaction signature', async () => {
-        const CHAIN_ID = +process.env.CHAIN_ETH_ZKSYNC_NETWORK_ID!;
+        const CHAIN_ID = testMaster.environment().l2ChainId;
         const value = 1;
         const gasLimit = 350000;
         const gasPrice = await alice.provider.getGasPrice();
@@ -951,10 +949,11 @@ describe('web3 API compatibility tests', () => {
 
 export class MockMetamask {
     readonly isMetaMask: boolean = true;
-    readonly networkVersion = parseInt(process.env.CHAIN_ETH_ZKSYNC_NETWORK_ID!, 10);
-    readonly chainId: string = ethers.utils.hexlify(parseInt(process.env.CHAIN_ETH_ZKSYNC_NETWORK_ID!, 10));
+    readonly chainId: string;
 
-    constructor(readonly wallet: zksync.Wallet) {}
+    constructor(readonly wallet: zksync.Wallet, readonly networkVersion: number) {
+        this.chainId = ethers.utils.hexlify(networkVersion);
+    }
 
     // EIP-1193
     async request(req: { method: string; params?: any[] }) {

--- a/core/tests/ts-integration/tests/contracts.test.ts
+++ b/core/tests/ts-integration/tests/contracts.test.ts
@@ -371,7 +371,9 @@ describe('Smart contract behavior checks', () => {
     });
 
     test('Should check transient storage', async () => {
-        const artifact = require(`${process.env.ZKSYNC_HOME}/etc/contracts-test-data/artifacts-zk/contracts/storage/storage.sol/StorageTester.json`);
+        const artifact = require(`${
+            testMaster.environment().pathToHome
+        }/etc/contracts-test-data/artifacts-zk/contracts/storage/storage.sol/StorageTester.json`);
         const contractFactory = new zksync.ContractFactory(artifact.abi, artifact.bytecode, alice);
         const storageContract = await contractFactory.deploy();
         await storageContract.deployed();
@@ -383,7 +385,9 @@ describe('Smart contract behavior checks', () => {
 
     test('Should check code oracle works', async () => {
         // Deploy contract that calls CodeOracle.
-        const artifact = require(`${process.env.ZKSYNC_HOME}/etc/contracts-test-data/artifacts-zk/contracts/precompiles/precompiles.sol/Precompiles.json`);
+        const artifact = require(`${
+            testMaster.environment().pathToHome
+        }/etc/contracts-test-data/artifacts-zk/contracts/precompiles/precompiles.sol/Precompiles.json`);
         const contractFactory = new zksync.ContractFactory(artifact.abi, artifact.bytecode, alice);
         const contract = await contractFactory.deploy();
         await contract.deployed();

--- a/core/tests/ts-integration/tests/fees.test.ts
+++ b/core/tests/ts-integration/tests/fees.test.ts
@@ -11,15 +11,15 @@
  */
 import * as utils from 'zk/build/utils';
 import * as fs from 'fs';
-import { TestMaster } from '../src/index';
+import {TestMaster} from '../src/index';
 
 import * as zksync from 'zksync-ethers';
-import { BigNumber, ethers } from 'ethers';
-import { Token } from '../src/types';
+import {BigNumber, ethers} from 'ethers';
+import {DataAvailabityMode, Token} from '../src/types';
 
 const UINT32_MAX = BigNumber.from(2).pow(32).sub(1);
 
-const logs = fs.createWriteStream('fees.log', { flags: 'a' });
+const logs = fs.createWriteStream('fees.log', {flags: 'a'});
 
 // Unless `RUN_FEE_TEST` is provided, skip the test suit
 const testFees = process.env.RUN_FEE_TEST ? describe : describe.skip;
@@ -28,22 +28,22 @@ const testFees = process.env.RUN_FEE_TEST ? describe : describe.skip;
 // For CI we use only 2 gas prices to not slow it down too much.
 const L1_GAS_PRICES_TO_TEST = process.env.CI
     ? [
-          5_000_000_000, // 5 gwei
-          10_000_000_000 // 10 gwei
-      ]
+        5_000_000_000, // 5 gwei
+        10_000_000_000 // 10 gwei
+    ]
     : [
-          1_000_000_000, // 1 gwei
-          5_000_000_000, // 5 gwei
-          10_000_000_000, // 10 gwei
-          25_000_000_000, // 25 gwei
-          50_000_000_000, // 50 gwei
-          100_000_000_000, // 100 gwei
-          200_000_000_000, // 200 gwei
-          400_000_000_000, // 400 gwei
-          800_000_000_000, // 800 gwei
-          1_000_000_000_000, // 1000 gwei
-          2_000_000_000_000 // 2000 gwei
-      ];
+        1_000_000_000, // 1 gwei
+        5_000_000_000, // 5 gwei
+        10_000_000_000, // 10 gwei
+        25_000_000_000, // 25 gwei
+        50_000_000_000, // 50 gwei
+        100_000_000_000, // 100 gwei
+        200_000_000_000, // 200 gwei
+        400_000_000_000, // 400 gwei
+        800_000_000_000, // 800 gwei
+        1_000_000_000_000, // 1000 gwei
+        2_000_000_000_000 // 2000 gwei
+    ];
 
 testFees('Test fees', () => {
     let testMaster: TestMaster;
@@ -134,7 +134,7 @@ testFees('Test fees', () => {
     });
 
     test('Test gas consumption under large L1 gas price', async () => {
-        if (testMaster.environment().l1BatchCommitDataGeneratorMode === 'Validium') {
+        if (testMaster.environment().l1BatchCommitDataGeneratorMode === DataAvailabityMode.Validium) {
             // We skip this test for Validium mode, since L1 gas price has little impact on the gasLimit in this mode.
             return;
         }
@@ -163,7 +163,7 @@ testFees('Test fees', () => {
 
         // Firstly, let's test a successful transaction.
         const largeData = ethers.utils.randomBytes(90_000);
-        const tx = await l1Messenger.sendToL1(largeData, { type: 0 });
+        const tx = await l1Messenger.sendToL1(largeData, {type: 0});
         expect(tx.gasLimit.gt(UINT32_MAX)).toBeTruthy();
         const receipt = await tx.wait();
         expect(receipt.gasUsed.gt(UINT32_MAX)).toBeTruthy();
@@ -283,7 +283,8 @@ async function setInternalL1GasPrice(
     // Make sure server isn't running.
     try {
         await killServerAndWaitForShutdown(provider);
-    } catch (_) {}
+    } catch (_) {
+    }
 
     // Run server in background.
     let command = 'zk server --components api,tree,eth,state_keeper';

--- a/core/tests/ts-integration/tests/fees.test.ts
+++ b/core/tests/ts-integration/tests/fees.test.ts
@@ -144,7 +144,7 @@ testFees('Test fees', () => {
 
         // In this test we will set gas per pubdata byte to its maximum value, while publishing a large L1->L2 message.
 
-        const minimalL2GasPrice = testMaster.environment().minimalL2GasPrice;
+        const minimalL2GasPrice = BigNumber.from(testMaster.environment().minimalL2GasPrice);
 
         // We want the total gas limit to be over u32::MAX, so we need the gas per pubdata to be 50k.
         //

--- a/core/tests/ts-integration/tests/fees.test.ts
+++ b/core/tests/ts-integration/tests/fees.test.ts
@@ -11,15 +11,15 @@
  */
 import * as utils from 'zk/build/utils';
 import * as fs from 'fs';
-import {TestMaster} from '../src/index';
+import { TestMaster } from '../src/index';
 
 import * as zksync from 'zksync-ethers';
-import {BigNumber, ethers} from 'ethers';
-import {DataAvailabityMode, Token} from '../src/types';
+import { BigNumber, ethers } from 'ethers';
+import { DataAvailabityMode, Token } from '../src/types';
 
 const UINT32_MAX = BigNumber.from(2).pow(32).sub(1);
 
-const logs = fs.createWriteStream('fees.log', {flags: 'a'});
+const logs = fs.createWriteStream('fees.log', { flags: 'a' });
 
 // Unless `RUN_FEE_TEST` is provided, skip the test suit
 const testFees = process.env.RUN_FEE_TEST ? describe : describe.skip;
@@ -28,22 +28,22 @@ const testFees = process.env.RUN_FEE_TEST ? describe : describe.skip;
 // For CI we use only 2 gas prices to not slow it down too much.
 const L1_GAS_PRICES_TO_TEST = process.env.CI
     ? [
-        5_000_000_000, // 5 gwei
-        10_000_000_000 // 10 gwei
-    ]
+          5_000_000_000, // 5 gwei
+          10_000_000_000 // 10 gwei
+      ]
     : [
-        1_000_000_000, // 1 gwei
-        5_000_000_000, // 5 gwei
-        10_000_000_000, // 10 gwei
-        25_000_000_000, // 25 gwei
-        50_000_000_000, // 50 gwei
-        100_000_000_000, // 100 gwei
-        200_000_000_000, // 200 gwei
-        400_000_000_000, // 400 gwei
-        800_000_000_000, // 800 gwei
-        1_000_000_000_000, // 1000 gwei
-        2_000_000_000_000 // 2000 gwei
-    ];
+          1_000_000_000, // 1 gwei
+          5_000_000_000, // 5 gwei
+          10_000_000_000, // 10 gwei
+          25_000_000_000, // 25 gwei
+          50_000_000_000, // 50 gwei
+          100_000_000_000, // 100 gwei
+          200_000_000_000, // 200 gwei
+          400_000_000_000, // 400 gwei
+          800_000_000_000, // 800 gwei
+          1_000_000_000_000, // 1000 gwei
+          2_000_000_000_000 // 2000 gwei
+      ];
 
 testFees('Test fees', () => {
     let testMaster: TestMaster;
@@ -163,7 +163,7 @@ testFees('Test fees', () => {
 
         // Firstly, let's test a successful transaction.
         const largeData = ethers.utils.randomBytes(90_000);
-        const tx = await l1Messenger.sendToL1(largeData, {type: 0});
+        const tx = await l1Messenger.sendToL1(largeData, { type: 0 });
         expect(tx.gasLimit.gt(UINT32_MAX)).toBeTruthy();
         const receipt = await tx.wait();
         expect(receipt.gasUsed.gt(UINT32_MAX)).toBeTruthy();
@@ -283,8 +283,7 @@ async function setInternalL1GasPrice(
     // Make sure server isn't running.
     try {
         await killServerAndWaitForShutdown(provider);
-    } catch (_) {
-    }
+    } catch (_) {}
 
     // Run server in background.
     let command = 'zk server --components api,tree,eth,state_keeper';

--- a/core/tests/ts-integration/tests/fees.test.ts
+++ b/core/tests/ts-integration/tests/fees.test.ts
@@ -134,7 +134,7 @@ testFees('Test fees', () => {
     });
 
     test('Test gas consumption under large L1 gas price', async () => {
-        if (process.env.CHAIN_STATE_KEEPER_L1_BATCH_COMMIT_DATA_GENERATOR_MODE === 'Validium') {
+        if (testMaster.environment().l1BatchCommitDataGeneratorMode === 'Validium') {
             // We skip this test for Validium mode, since L1 gas price has little impact on the gasLimit in this mode.
             return;
         }
@@ -144,7 +144,7 @@ testFees('Test fees', () => {
 
         // In this test we will set gas per pubdata byte to its maximum value, while publishing a large L1->L2 message.
 
-        const minimalL2GasPrice = ethers.BigNumber.from(process.env.CHAIN_STATE_KEEPER_MINIMAL_L2_GAS_PRICE!);
+        const minimalL2GasPrice = testMaster.environment().minimalL2GasPrice;
 
         // We want the total gas limit to be over u32::MAX, so we need the gas per pubdata to be 50k.
         //

--- a/core/tests/ts-integration/tests/l1.test.ts
+++ b/core/tests/ts-integration/tests/l1.test.ts
@@ -396,8 +396,8 @@ function calculateAccumulatedRoot(
 }
 
 function maxL2GasLimitForPriorityTxs(maxGasBodyLimit: number): number {
-    // // Find maximum `gasLimit` that satisfies `txBodyGasLimit <= CONTRACTS_PRIORITY_TX_MAX_GAS_LIMIT`
-    // // using binary search.
+    // Find maximum `gasLimit` that satisfies `txBodyGasLimit <= CONTRACTS_PRIORITY_TX_MAX_GAS_LIMIT`
+    // using binary search.
     const overhead = getOverheadForTransaction(
         // We can just pass 0 as `encodingLength` because the overhead for the transaction's slot
         // will be greater than `overheadForLength` for a typical transacction

--- a/core/tests/ts-integration/tests/l1.test.ts
+++ b/core/tests/ts-integration/tests/l1.test.ts
@@ -16,8 +16,6 @@ import {
     REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT
 } from 'zksync-ethers/build/utils';
 
-const SYSTEM_CONFIG = require(`${process.env.ZKSYNC_HOME}/contracts/SystemConfig.json`);
-
 const contracts = {
     counter: getTestContract('Counter'),
     errors: getTestContract('SimpleRequire'),
@@ -53,7 +51,7 @@ describe('Tests for L1 behavior', () => {
     });
 
     test('Should provide allowance to shared bridge, if base token is not ETH', async () => {
-        const baseTokenAddress = process.env.CONTRACTS_BASE_TOKEN_ADDR!;
+        const baseTokenAddress = testMaster.environment().baseToken.l1Address;
         isETHBasedChain = baseTokenAddress == zksync.utils.ETH_ADDRESS_IN_CONTRACTS;
         if (!isETHBasedChain) {
             const baseTokenDetails = testMaster.environment().baseToken;
@@ -67,7 +65,7 @@ describe('Tests for L1 behavior', () => {
         if (!isETHBasedChain) {
             expectedL2Costs = (
                 await alice.getBaseCost({
-                    gasLimit: maxL2GasLimitForPriorityTxs(),
+                    gasLimit: maxL2GasLimitForPriorityTxs(testMaster.environment().priorityTxMaxGasLimit),
                     gasPerPubdataByte: REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT,
                     gasPrice
                 })
@@ -168,7 +166,7 @@ describe('Tests for L1 behavior', () => {
 
     test('Should check max L2 gas limit for priority txs', async () => {
         const gasPrice = scaledGasPrice(alice);
-        const l2GasLimit = maxL2GasLimitForPriorityTxs();
+        const l2GasLimit = maxL2GasLimitForPriorityTxs(testMaster.environment().priorityTxMaxGasLimit);
 
         // Check that the request with higher `gasLimit` fails.
         let priorityOpHandle = await alice.requestExecute({
@@ -216,7 +214,7 @@ describe('Tests for L1 behavior', () => {
         const calldata = contract.interface.encodeFunctionData('writes', [0, 4500, 1]);
         const gasPrice = scaledGasPrice(alice);
 
-        const l2GasLimit = maxL2GasLimitForPriorityTxs();
+        const l2GasLimit = maxL2GasLimitForPriorityTxs(testMaster.environment().priorityTxMaxGasLimit);
 
         const priorityOpHandle = await alice.requestExecute({
             contractAddress: contract.address,
@@ -271,7 +269,7 @@ describe('Tests for L1 behavior', () => {
 
         const calldata = contract.interface.encodeFunctionData('writes', [0, repeatedWritesInOneTx, 2]);
         const gasPrice = scaledGasPrice(alice);
-        const l2GasLimit = maxL2GasLimitForPriorityTxs();
+        const l2GasLimit = maxL2GasLimitForPriorityTxs(testMaster.environment().priorityTxMaxGasLimit);
 
         const priorityOpHandle = await alice.requestExecute({
             contractAddress: contract.address,
@@ -306,7 +304,7 @@ describe('Tests for L1 behavior', () => {
         const calldata = contract.interface.encodeFunctionData('l2_l1_messages', [1000]);
         const gasPrice = scaledGasPrice(alice);
 
-        const l2GasLimit = maxL2GasLimitForPriorityTxs();
+        const l2GasLimit = maxL2GasLimitForPriorityTxs(testMaster.environment().priorityTxMaxGasLimit);
 
         const priorityOpHandle = await alice.requestExecute({
             contractAddress: contract.address,
@@ -336,6 +334,8 @@ describe('Tests for L1 behavior', () => {
 
         const contract = await deployContract(alice, contracts.writesAndMessages, []);
         testMaster.reporter.debug(`Deployed 'writesAndMessages' contract at ${contract.address}`);
+
+        const SYSTEM_CONFIG = require(`${testMaster.environment().pathToHome}/contracts/SystemConfig.json`);
         const MAX_PUBDATA_PER_BATCH = ethers.BigNumber.from(SYSTEM_CONFIG['PRIORITY_TX_PUBDATA_PER_BATCH']);
         // We check that we will run out of gas if we send a bit
         // smaller than `MAX_PUBDATA_PER_BATCH` amount of pubdata in a single tx.
@@ -344,7 +344,7 @@ describe('Tests for L1 behavior', () => {
         ]);
         const gasPrice = scaledGasPrice(alice);
 
-        const l2GasLimit = maxL2GasLimitForPriorityTxs();
+        const l2GasLimit = maxL2GasLimitForPriorityTxs(testMaster.environment().priorityTxMaxGasLimit);
 
         const priorityOpHandle = await alice.requestExecute({
             contractAddress: contract.address,
@@ -395,11 +395,9 @@ function calculateAccumulatedRoot(
     return accumutatedRoot;
 }
 
-function maxL2GasLimitForPriorityTxs(): number {
-    // Find maximum `gasLimit` that satisfies `txBodyGasLimit <= CONTRACTS_PRIORITY_TX_MAX_GAS_LIMIT`
-    // using binary search.
-    let maxGasBodyLimit = +process.env.CONTRACTS_PRIORITY_TX_MAX_GAS_LIMIT!;
-
+function maxL2GasLimitForPriorityTxs(maxGasBodyLimit: number): number {
+    // // Find maximum `gasLimit` that satisfies `txBodyGasLimit <= CONTRACTS_PRIORITY_TX_MAX_GAS_LIMIT`
+    // // using binary search.
     const overhead = getOverheadForTransaction(
         // We can just pass 0 as `encodingLength` because the overhead for the transaction's slot
         // will be greater than `overheadForLength` for a typical transacction

--- a/core/tests/ts-integration/tests/paymaster.test.ts
+++ b/core/tests/ts-integration/tests/paymaster.test.ts
@@ -87,7 +87,8 @@ describe('Paymaster tests', () => {
             alice,
             paymaster.address,
             erc20Address,
-            correctSignature
+            correctSignature,
+            testMaster.environment().l2ChainId
         );
         await expect(txPromise).toBeAccepted([
             checkReceipt(
@@ -122,13 +123,15 @@ describe('Paymaster tests', () => {
         // should not be required from the users. We still do it here for the purpose of the test.
         tx.gasLimit = tx.gasLimit!.add(300000);
 
+        testMaster.environment().l2ChainId;
         const txPromise = sendTxWithTestPaymasterParams(
             tx,
             alice.provider,
             alice,
             paymaster.address,
             erc20Address,
-            correctSignature
+            correctSignature,
+            testMaster.environment().l2ChainId
         );
         await expect(txPromise).toBeAccepted([
             checkReceipt(
@@ -231,7 +234,8 @@ describe('Paymaster tests', () => {
                 alice,
                 paymaster.address,
                 erc20Address,
-                incorrectSignature
+                incorrectSignature,
+                testMaster.environment().l2ChainId
             )
         ).toBeRejected('Paymaster validation error');
     });
@@ -430,12 +434,13 @@ async function sendTxWithTestPaymasterParams(
     sender: Wallet,
     paymasterAddress: string,
     token: string,
-    paymasterSignature: ethers.BytesLike
+    paymasterSignature: ethers.BytesLike,
+    l2ChainId: number
 ) {
     const gasPrice = await web3Provider.getGasPrice();
 
     tx.gasPrice = gasPrice;
-    tx.chainId = parseInt(process.env.CHAIN_ETH_ZKSYNC_NETWORK_ID!, 10);
+    tx.chainId = l2ChainId;
     tx.value = ethers.BigNumber.from(0);
     tx.nonce = await web3Provider.getTransactionCount(sender.address);
     tx.type = 113;

--- a/core/tests/ts-integration/tests/system.test.ts
+++ b/core/tests/ts-integration/tests/system.test.ts
@@ -345,7 +345,9 @@ describe('System behavior checks', () => {
     function bootloaderUtilsContract() {
         const BOOTLOADER_UTILS_ADDRESS = '0x000000000000000000000000000000000000800c';
         const BOOTLOADER_UTILS = new ethers.utils.Interface(
-            require(`${process.env.ZKSYNC_HOME}/contracts/system-contracts/artifacts-zk/contracts-preprocessed/BootloaderUtilities.sol/BootloaderUtilities.json`).abi
+            require(`${
+                testMaster.environment().pathToHome
+            }/contracts/system-contracts/artifacts-zk/contracts-preprocessed/BootloaderUtilities.sol/BootloaderUtilities.json`).abi
         );
 
         return new ethers.Contract(BOOTLOADER_UTILS_ADDRESS, BOOTLOADER_UTILS, alice);


### PR DESCRIPTION
## What ❔

Remove dependency from dev.env envs from ts-tests

## Why ❔

For migrating it later to file-based config we have to consolidate all env calls into one place

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
