### PR TITLE
fix(merkle-tree): Fix tree API health check status

### DIFF
--- a/core/lib/web3_decl/src/error.rs
+++ b/core/lib/web3_decl/src/error.rs
@@ -39,11 +39,12 @@ pub enum Web3Error {
     LogsLimitExceeded(usize, u32, u32),
     #[error("invalid filter: if blockHash is supplied fromBlock and toBlock must not be")]
     InvalidFilterBlockHash,
-    #[error("Not implemented")]
-    NotImplemented,
-    /// This covers both transient unavailability (e.g., due to connection issues) and unavailability
-    /// caused by node configuration.
-    #[error("Tree API is not available")]
+    /// Weaker form of a "method not found" error; the method implementation is technically present,
+    /// but the node configuration prevents the method from functioning.
+    #[error("Method not implemented")]
+    MethodNotImplemented,
+    /// Unavailability caused by node configuration is returned as [`Self::MethodNotImplemented`].
+    #[error("Tree API is temporarily unavailable")]
     TreeApiUnavailable,
     #[error("Internal error")]
     InternalError(#[from] anyhow::Error),

--- a/core/lib/web3_decl/src/error.rs
+++ b/core/lib/web3_decl/src/error.rs
@@ -41,7 +41,8 @@ pub enum Web3Error {
     InvalidFilterBlockHash,
     #[error("Not implemented")]
     NotImplemented,
-
+    /// This covers both transient unavailability (e.g., due to connection issues) and unavailability
+    /// caused by node configuration.
     #[error("Tree API is not available")]
     TreeApiUnavailable,
     #[error("Internal error")]

--- a/core/node/api_server/src/web3/backend_jsonrpsee/mod.rs
+++ b/core/node/api_server/src/web3/backend_jsonrpsee/mod.rs
@@ -31,7 +31,7 @@ impl MethodTracer {
             _ => None,
         };
         let code = match err {
-            Web3Error::NotImplemented => ErrorCode::MethodNotFound.code(),
+            Web3Error::MethodNotImplemented => ErrorCode::MethodNotFound.code(),
             Web3Error::InternalError(_) => ErrorCode::InternalError.code(),
             Web3Error::NoBlock
             | Web3Error::PrunedBlock(_)

--- a/core/node/api_server/src/web3/metrics.rs
+++ b/core/node/api_server/src/web3/metrics.rs
@@ -185,7 +185,7 @@ impl Web3ErrorKind {
             Web3Error::LogsLimitExceeded(..) => Self::LogsLimitExceeded,
             Web3Error::InvalidFilterBlockHash => Self::InvalidFilterBlockHash,
             Web3Error::TreeApiUnavailable => Self::TreeApiUnavailable,
-            Web3Error::InternalError(_) | Web3Error::NotImplemented => Self::Internal,
+            Web3Error::InternalError(_) | Web3Error::MethodNotImplemented => Self::Internal,
         }
     }
 }

--- a/core/node/api_server/src/web3/namespaces/eth.rs
+++ b/core/node/api_server/src/web3/namespaces/eth.rs
@@ -179,7 +179,7 @@ impl EthNamespace {
             .state
             .installed_filters
             .as_ref()
-            .ok_or(Web3Error::NotImplemented)?;
+            .ok_or(Web3Error::MethodNotImplemented)?;
         // We clone the filter to not hold the filter lock for an extended period of time.
         let maybe_filter = installed_filters.lock().await.get_and_update_stats(idx);
 
@@ -483,7 +483,7 @@ impl EthNamespace {
             .state
             .installed_filters
             .as_ref()
-            .ok_or(Web3Error::NotImplemented)?;
+            .ok_or(Web3Error::MethodNotImplemented)?;
         let mut storage = self.state.acquire_connection().await?;
         let last_block_number = storage
             .blocks_dal()
@@ -505,7 +505,7 @@ impl EthNamespace {
             .state
             .installed_filters
             .as_ref()
-            .ok_or(Web3Error::NotImplemented)?;
+            .ok_or(Web3Error::MethodNotImplemented)?;
         if let Some(topics) = filter.topics.as_ref() {
             if topics.len() > EVENT_TOPIC_NUMBER_LIMIT {
                 return Err(Web3Error::TooManyTopics);
@@ -525,7 +525,7 @@ impl EthNamespace {
             .state
             .installed_filters
             .as_ref()
-            .ok_or(Web3Error::NotImplemented)?;
+            .ok_or(Web3Error::MethodNotImplemented)?;
         Ok(installed_filters
             .lock()
             .await
@@ -539,7 +539,7 @@ impl EthNamespace {
             .state
             .installed_filters
             .as_ref()
-            .ok_or(Web3Error::NotImplemented)?;
+            .ok_or(Web3Error::MethodNotImplemented)?;
         let mut filter = installed_filters
             .lock()
             .await
@@ -565,7 +565,7 @@ impl EthNamespace {
             .state
             .installed_filters
             .as_ref()
-            .ok_or(Web3Error::NotImplemented)?;
+            .ok_or(Web3Error::MethodNotImplemented)?;
         Ok(installed_filters.lock().await.remove(idx))
     }
 

--- a/core/node/api_server/src/web3/namespaces/zks.rs
+++ b/core/node/api_server/src/web3/namespaces/zks.rs
@@ -496,7 +496,7 @@ impl ZksNamespace {
         let proofs_result = tree_api.get_proofs(l1_batch_number, hashed_keys).await;
         let proofs = match proofs_result {
             Ok(proofs) => proofs,
-            Err(TreeApiError::NotReady) => return Err(Web3Error::TreeApiUnavailable),
+            Err(TreeApiError::NotReady(_)) => return Err(Web3Error::TreeApiUnavailable),
             Err(TreeApiError::NoVersion(err)) => {
                 return if err.missing_version > err.version_count {
                     Ok(None)

--- a/core/node/api_server/src/web3/namespaces/zks.rs
+++ b/core/node/api_server/src/web3/namespaces/zks.rs
@@ -492,7 +492,7 @@ impl ZksNamespace {
             .state
             .tree_api
             .as_deref()
-            .ok_or(Web3Error::TreeApiUnavailable)?;
+            .ok_or(Web3Error::MethodNotImplemented)?;
         let proofs_result = tree_api.get_proofs(l1_batch_number, hashed_keys).await;
         let proofs = match proofs_result {
             Ok(proofs) => proofs,
@@ -536,7 +536,7 @@ impl ZksNamespace {
         self.state
             .api_config
             .base_token_address
-            .ok_or(Web3Error::NotImplemented)
+            .ok_or(Web3Error::MethodNotImplemented)
     }
 
     #[tracing::instrument(skip(self))]


### PR DESCRIPTION
## What ❔

- Makes health status "affected" if the tree API is not available.
- Distinguishes between "tree API not enabled on the node" and "tree API temporarily unavailable" errors.

## Why ❔

Right now, the status is "not ready", meaning that the entire app health status is "not ready" as well. This makes API servers excluded from serving traffic, which is not desirable (they can still serve all of requests other than `zks_getProof`).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.