### PR TITLE
fix(en): Minor node fixes

### DIFF
--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -1019,9 +1019,12 @@ async fn run_node(
 
     let mut tasks = ManagedTasks::new(task_handles);
     tokio::select! {
-        () = tasks.wait_single() => {},
+        // We don't want to log unnecessary warnings in `tasks.wait_single()` if we have received a stop signal.
+        biased;
+
         _ = stop_receiver.changed() => {},
-    };
+        () = tasks.wait_single() => {},
+    }
 
     // Reaching this point means that either some actor exited unexpectedly or we received a stop signal.
     // Broadcast the stop signal (in case it wasn't broadcast previously) to all actors and exit.

--- a/core/lib/web3_decl/src/client/metrics.rs
+++ b/core/lib/web3_decl/src/client/metrics.rs
@@ -83,7 +83,7 @@ impl L2ClientMetrics {
         };
         let info = &self.info[&network];
         if let Err(err) = info.set(config_labels) {
-            tracing::warn!(
+            tracing::debug!(
                 "Error setting configuration info {:?} for L2 client; already set to {:?}",
                 err.into_inner(),
                 info.get()

--- a/core/lib/web3_decl/src/client/mod.rs
+++ b/core/lib/web3_decl/src/client/mod.rs
@@ -196,7 +196,7 @@ impl<Net: Network, C: ClientBase> Client<Net, C> {
             origin,
             &stats,
         );
-        tracing::warn!(
+        tracing::debug!(
             network = network_label,
             component = self.component_name,
             %origin,

--- a/core/lib/web3_decl/src/error.rs
+++ b/core/lib/web3_decl/src/error.rs
@@ -11,7 +11,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use jsonrpsee::core::ClientError;
+use jsonrpsee::{core::ClientError, types::error::ErrorCode};
 use pin_project_lite::pin_project;
 use thiserror::Error;
 use zksync_types::{api::SerializationTransactionError, L1BatchNumber, L2BlockNumber};
@@ -85,10 +85,15 @@ impl EnrichedClientError {
 
     /// Whether the error should be considered transient.
     pub fn is_transient(&self) -> bool {
-        matches!(
-            self.as_ref(),
-            ClientError::Transport(_) | ClientError::RequestTimeout
-        )
+        match self.as_ref() {
+            ClientError::Transport(_) | ClientError::RequestTimeout => true,
+            ClientError::Call(err) => {
+                // At least some RPC providers use "internal error" in case of the server being overloaded
+                err.code() == ErrorCode::ServerIsBusy.code()
+                    || err.code() == ErrorCode::InternalError.code()
+            }
+            _ => false,
+        }
     }
 }
 

--- a/core/node/consensus/src/era.rs
+++ b/core/node/consensus/src/era.rs
@@ -44,7 +44,7 @@ pub async fn run_en(
     let en = en::EN {
         pool: ConnectionPool(pool),
         sync_state: sync_state.clone(),
-        client: main_node_client,
+        client: main_node_client.for_component("block_fetcher"),
     };
     let res = match cfg {
         Some((cfg, secrets)) => en.run(ctx, actions, cfg, secrets).await,


### PR DESCRIPTION
## What ❔

Fixes minor issues with the EN:

- Transient error detection for RPC clients is suboptimal, leading to what really is a transient error crashing consistency checker.
- Since refactoring signal handling, `ManagedTasks::wait_single()` on EN may inappropriately log task termination errors even after a signal is being received.
- Since recent refactoring (?), block fetcher doesn't tag its L2 client.
- Block fetcher may produce many rate limiting logs, which currently have WARN level.
- Initializing L2 client multiple times (e.g., in a load test) produces many WARN logs.

## Why ❔

Improves EN UX.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.