### PR TITLE
refactor(config): Remove `proof_loading_mode`  variable

### DIFF
--- a/core/lib/config/src/configs/eth_sender.rs
+++ b/core/lib/config/src/configs/eth_sender.rs
@@ -39,7 +39,6 @@ impl EthConfig {
                 timestamp_criteria_max_allowed_lag: 30,
                 l1_batch_min_age_before_execute_seconds: None,
                 max_acceptable_priority_fee_in_gwei: 100000000000,
-                proof_loading_mode: ProofLoadingMode::OldProofFromDb,
                 pubdata_sending_mode: PubdataSendingMode::Calldata,
             }),
             gas_adjuster: Some(GasAdjusterConfig {
@@ -114,9 +113,6 @@ pub struct SenderConfig {
     pub l1_batch_min_age_before_execute_seconds: Option<u64>,
     // Max acceptable fee for sending tx it acts as a safeguard to prevent sending tx with very high fees.
     pub max_acceptable_priority_fee_in_gwei: u64,
-
-    /// The mode in which proofs are loaded, either from DB/GCS for FRI/Old proof.
-    pub proof_loading_mode: ProofLoadingMode,
 
     /// The mode in which we send pubdata, either Calldata or Blobs
     pub pubdata_sending_mode: PubdataSendingMode,

--- a/core/lib/config/src/testonly.rs
+++ b/core/lib/config/src/testonly.rs
@@ -366,7 +366,6 @@ impl Distribution<configs::eth_sender::SenderConfig> for EncodeDist {
             timestamp_criteria_max_allowed_lag: self.sample(rng),
             l1_batch_min_age_before_execute_seconds: self.sample(rng),
             max_acceptable_priority_fee_in_gwei: self.sample(rng),
-            proof_loading_mode: self.sample(rng),
             pubdata_sending_mode: PubdataSendingMode::Calldata,
         }
     }

--- a/core/lib/env_config/src/eth_sender.rs
+++ b/core/lib/env_config/src/eth_sender.rs
@@ -41,9 +41,7 @@ impl FromEnv for GasAdjusterConfig {
 
 #[cfg(test)]
 mod tests {
-    use zksync_config::configs::eth_sender::{
-        ProofLoadingMode, ProofSendingMode, PubdataSendingMode,
-    };
+    use zksync_config::configs::eth_sender::{ProofSendingMode, PubdataSendingMode};
 
     use super::*;
     use crate::test_utils::{hash, EnvMutex};
@@ -71,7 +69,6 @@ mod tests {
                     proof_sending_mode: ProofSendingMode::SkipEveryProof,
                     l1_batch_min_age_before_execute_seconds: Some(1000),
                     max_acceptable_priority_fee_in_gwei: 100_000_000_000,
-                    proof_loading_mode: ProofLoadingMode::OldProofFromDb,
                     pubdata_sending_mode: PubdataSendingMode::Calldata,
                 }),
                 gas_adjuster: Some(GasAdjusterConfig {
@@ -133,7 +130,6 @@ mod tests {
             ETH_SENDER_SENDER_MAX_ETH_TX_DATA_SIZE="120000"
             ETH_SENDER_SENDER_L1_BATCH_MIN_AGE_BEFORE_EXECUTE_SECONDS="1000"
             ETH_SENDER_SENDER_MAX_ACCEPTABLE_PRIORITY_FEE_IN_GWEI="100000000000"
-            ETH_SENDER_SENDER_PROOF_LOADING_MODE="OldProofFromDb"
             ETH_SENDER_SENDER_PUBDATA_SENDING_MODE="Calldata"
             ETH_CLIENT_WEB3_URL="http://127.0.0.1:8545"
 

--- a/core/lib/protobuf_config/src/eth.rs
+++ b/core/lib/protobuf_config/src/eth.rs
@@ -24,24 +24,6 @@ impl proto::ProofSendingMode {
     }
 }
 
-impl proto::ProofLoadingMode {
-    fn new(x: &configs::eth_sender::ProofLoadingMode) -> Self {
-        use configs::eth_sender::ProofLoadingMode as From;
-        match x {
-            From::OldProofFromDb => Self::OldProofFromDb,
-            From::FriProofFromGcs => Self::FriProofFromGcs,
-        }
-    }
-
-    fn parse(&self) -> configs::eth_sender::ProofLoadingMode {
-        use configs::eth_sender::ProofLoadingMode as To;
-        match self {
-            Self::OldProofFromDb => To::OldProofFromDb,
-            Self::FriProofFromGcs => To::FriProofFromGcs,
-        }
-    }
-}
-
 impl proto::PubdataSendingMode {
     fn new(x: &configs::eth_sender::PubdataSendingMode) -> Self {
         use configs::eth_sender::PubdataSendingMode as From;
@@ -127,10 +109,6 @@ impl ProtoRepr for proto::Sender {
                 .and_then(|x| Ok(proto::PubdataSendingMode::try_from(*x)?))
                 .context("pubdata_sending_mode")?
                 .parse(),
-            proof_loading_mode: required(&self.proof_loading_mode)
-                .and_then(|x| Ok(proto::ProofLoadingMode::try_from(*x)?))
-                .context("proof_loading_mode")?
-                .parse(),
         })
     }
 
@@ -161,7 +139,6 @@ impl ProtoRepr for proto::Sender {
             pubdata_sending_mode: Some(
                 proto::PubdataSendingMode::new(&this.pubdata_sending_mode).into(),
             ),
-            proof_loading_mode: Some(proto::ProofLoadingMode::new(&this.proof_loading_mode).into()),
         }
     }
 }

--- a/core/lib/protobuf_config/src/proto/config/eth_sender.proto
+++ b/core/lib/protobuf_config/src/proto/config/eth_sender.proto
@@ -43,7 +43,6 @@ message Sender {
   optional uint64 l1_batch_min_age_before_execute_seconds = 15; // optional; s
   optional uint64 max_acceptable_priority_fee_in_gwei = 16; // required; gwei
   optional PubdataSendingMode pubdata_sending_mode = 18; // required
-  optional ProofLoadingMode proof_loading_mode = 19;
 }
 
 message GasAdjuster {

--- a/etc/env/base/eth_sender.toml
+++ b/etc/env/base/eth_sender.toml
@@ -46,8 +46,6 @@ max_single_tx_gas = 6000000
 # Max acceptable fee for sending tx to L1
 max_acceptable_priority_fee_in_gwei = 100000000000
 
-proof_loading_mode="FriProofFromGcs"
-
 pubdata_sending_mode = "Blobs"
 
 [eth_sender.gas_adjuster]

--- a/etc/env/file_based/general.yaml
+++ b/etc/env/file_based/general.yaml
@@ -131,7 +131,6 @@ eth:
     aggregated_proof_sizes: [ 1,4 ]
     max_aggregated_tx_gas: 4000000
     max_acceptable_priority_fee_in_gwei: 100000000000
-    proof_loading_mode: OLD_PROOF_FROM_DB
     pubdata_sending_mode: BLOBS
   gas_adjuster:
     default_priority_fee_per_gas: 1000000000

--- a/infrastructure/zk/src/prover_setup.ts
+++ b/infrastructure/zk/src/prover_setup.ts
@@ -23,7 +23,6 @@ export async function setupProver(proverType: ProverType) {
     if (proverType == ProverType.GPU || proverType == ProverType.CPU) {
         env.modify('PROVER_TYPE', proverType, process.env.ENV_FILE!);
         env.modify('ETH_SENDER_SENDER_PROOF_SENDING_MODE', 'OnlyRealProofs', process.env.ENV_FILE!);
-        env.modify('ETH_SENDER_SENDER_PROOF_LOADING_MODE', 'FriProofFromGcs', process.env.ENV_FILE!);
         env.modify('FRI_PROVER_GATEWAY_API_POLL_DURATION_SECS', '120', process.env.ENV_FILE!);
         await setupArtifactsMode();
         if (!process.env.CI) {

--- a/infrastructure/zk/src/status.ts
+++ b/infrastructure/zk/src/status.ts
@@ -190,11 +190,6 @@ export async function statusProver() {
     main_pool = new Pool({ connectionString: process.env.DATABASE_URL });
     prover_pool = new Pool({ connectionString: process.env.DATABASE_PROVER_URL });
 
-    if (process.env.ETH_SENDER_SENDER_PROOF_LOADING_MODE != 'FriProofFromGcs') {
-        console.log(`${redStart}Can only show status for FRI provers.${resetColor}`);
-        return;
-    }
-
     // Fetch the first and most recent sealed batch numbers
     const stateKeeperStatus = (
         await queryAndReturnRows(main_pool, 'select min(number), max(number) from l1_batches')

--- a/prover/setup.sh
+++ b/prover/setup.sh
@@ -14,7 +14,6 @@ if [[ -z "${ZKSYNC_HOME}" ]]; then
 fi
 
 sed -i.backup 's/^proof_sending_mode=.*$/proof_sending_mode="OnlyRealProofs"/' ../etc/env/base/eth_sender.toml
-sed -i.backup 's/^proof_loading_mode=.*$/proof_loading_mode="FriProofFromGcs"/' ../etc/env/base/eth_sender.toml
 rm ../etc/env/base/eth_sender.toml.backup
 sed -i.backup 's/^setup_data_path=.*$/setup_data_path="vk_setup_data_generator_server_fri\/data\/"/' ../etc/env/base/fri_prover.toml
 rm ../etc/env/base/fri_prover.toml.backup


### PR DESCRIPTION
## What ❔
Clear code base from `proof_loading_mode` variable

## Why ❔

We do not use `OldProofFromDb ` option anymore. It is expected to always be `FriProofFromGcs `

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
