### PR TITLE
feat(sync-layer): adapt `MiniMerkleTree` to manage priority queue

### DIFF
--- a/core/lib/mini_merkle_tree/benches/tree.rs
+++ b/core/lib/mini_merkle_tree/benches/tree.rs
@@ -10,11 +10,7 @@ const TREE_SIZES: &[usize] = &[32, 64, 128, 256, 512, 1_024];
 fn compute_merkle_root(bencher: &mut Bencher<'_>, tree_size: usize) {
     let leaves = (0..tree_size).map(|i| [i as u8; 88]);
     let tree = MiniMerkleTree::new(leaves, None);
-    bencher.iter_batched(
-        || tree.clone(),
-        MiniMerkleTree::merkle_root,
-        BatchSize::SmallInput,
-    );
+    bencher.iter_batched(|| &tree, MiniMerkleTree::merkle_root, BatchSize::SmallInput);
 }
 
 fn compute_merkle_path(bencher: &mut Bencher<'_>, tree_size: usize) {

--- a/core/lib/mini_merkle_tree/src/lib.rs
+++ b/core/lib/mini_merkle_tree/src/lib.rs
@@ -115,6 +115,21 @@ where
         (root_hash, right_path)
     }
 
+    /// Returns the root hash and the Merkle proof for an interval of leafs.
+    /// The interval is [0, `length`), where `0` is the leftmost uncached leaf.
+    pub fn merkle_root_and_paths_for_interval(
+        &self,
+        length: usize,
+    ) -> (H256, Vec<H256>, Vec<H256>) {
+        let (mut left_path, mut right_path) = (vec![], vec![]);
+        let root_hash = self.compute_merkle_root_and_path(
+            length - 1,
+            Some((&mut left_path, &mut right_path)),
+            None,
+        );
+        (root_hash, left_path, right_path)
+    }
+
     /// Adds a new leaf to the tree (replaces leftmost empty leaf).
     /// If the tree is full, its size is doubled.
     /// Note: empty leaves != zero leaves.
@@ -209,7 +224,7 @@ where
             }
 
             right_index = (right_index + parity) / 2;
-            level_len = level_len / 2 + ((head_index % 2) | (level_len % 2));
+            level_len = level_len / 2 + (parity | (level_len % 2));
             head_index /= 2;
         }
         hashes[0]

--- a/core/lib/mini_merkle_tree/src/lib.rs
+++ b/core/lib/mini_merkle_tree/src/lib.rs
@@ -99,7 +99,7 @@ where
             hashes,
             binary_tree_size,
             head_index: 0,
-            left_cache: vec![H256::default(); depth + 1],
+            left_cache: vec![],
         }
     }
 
@@ -154,7 +154,6 @@ where
         self.hashes.push_back(leaf_hash);
         if self.head_index + self.hashes.len() > self.binary_tree_size {
             self.binary_tree_size *= 2;
-            self.left_cache.push(H256::default());
         }
     }
 
@@ -168,7 +167,6 @@ where
         self.compute_merkle_root_and_path(count - 1, None, Some(&mut new_cache));
         self.hashes.drain(0..count);
         self.head_index += count;
-        debug_assert!(self.left_cache.len() == new_cache.len());
         self.left_cache = new_cache;
     }
 

--- a/core/lib/mini_merkle_tree/src/tests.rs
+++ b/core/lib/mini_merkle_tree/src/tests.rs
@@ -367,3 +367,16 @@ fn cache_all_and_grow() {
         .unwrap();
     assert_eq!(tree.merkle_root(), expected_root);
 }
+
+#[test]
+fn cache_all_and_check_root() {
+    let mut tree = MiniMerkleTree::new(iter::repeat([1; 88]).take(4), None);
+    let root = tree.merkle_root();
+    tree.cache(4);
+    assert_eq!(tree.merkle_root(), root);
+
+    let mut tree = MiniMerkleTree::new(iter::repeat([1; 88]).take(4), Some(8));
+    let root = tree.merkle_root();
+    tree.cache(4);
+    assert_eq!(tree.merkle_root(), root);
+}

--- a/core/lib/mini_merkle_tree/src/tests.rs
+++ b/core/lib/mini_merkle_tree/src/tests.rs
@@ -158,7 +158,7 @@ fn verify_merkle_proof(
 
 fn verify_interval_merkle_proof(
     items: &[[u8; 88]],
-    mut index: usize,
+    mut head_index: usize,
     left_path: &[H256],
     right_path: &[H256],
     merkle_root: H256,
@@ -170,7 +170,7 @@ fn verify_interval_merkle_proof(
     let mut level_len = hashes.len();
 
     for (left_item, right_item) in left_path.iter().zip(right_path.iter()) {
-        let parity = index % 2;
+        let parity = head_index % 2;
         let next_level_len = level_len / 2 + (parity | (level_len % 2));
 
         for i in 0..next_level_len {
@@ -188,7 +188,7 @@ fn verify_interval_merkle_proof(
         }
 
         level_len = next_level_len;
-        index /= 2;
+        head_index /= 2;
     }
 
     assert_eq!(hashes[0], merkle_root);
@@ -357,5 +357,13 @@ fn pushing_new_leaves() {
     }
 }
 
-// TODO:
-// - test for getting & proving intervals
+#[test]
+fn cache_all_and_grow() {
+    let mut tree = MiniMerkleTree::new(iter::repeat([1; 88]).take(4), None);
+    tree.cache(4);
+    tree.push([1; 88]);
+    let expected_root = "0xfa4c924185122254742622b10b68df8de89d33f685ee579f37a50c552b0d245d"
+        .parse()
+        .unwrap();
+    assert_eq!(tree.merkle_root(), expected_root);
+}


### PR DESCRIPTION
## What ❔

Enables the `MiniMerkleTree` to be used for priority queue to efficiently calculate merkle proofs for priority transactions.

## Why ❔

As part of preparation for the priority queue migration to sync layer.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
