### PR TITLE
feat: Add protocol_version label to WG jobs metric

### DIFF
--- a/core/node/house_keeper/src/prover/metrics.rs
+++ b/core/node/house_keeper/src/prover/metrics.rs
@@ -109,8 +109,9 @@ impl From<&str> for WitnessType {
 pub(crate) struct ServerMetrics {
     pub prover_fri_requeued_jobs: Counter<u64>,
     pub requeued_jobs: Family<WitnessType, Counter<u64>>,
-    #[metrics(labels = ["type", "round"])]
-    pub witness_generator_jobs_by_round: LabeledFamily<(&'static str, String), Gauge<u64>, 2>,
+    #[metrics(labels = ["type", "round", "protocol_version"])]
+    pub witness_generator_jobs_by_round:
+        LabeledFamily<(&'static str, String, String), Gauge<u64>, 3>,
     #[metrics(labels = ["type", "protocol_version"])]
     pub witness_generator_jobs: LabeledFamily<(&'static str, String), Gauge<u64>, 2>,
     pub leaf_fri_witness_generator_waiting_to_queued_jobs_transitions: Counter<u64>,

--- a/core/node/house_keeper/src/prover/queue_reporter/fri_witness_generator_queue_reporter.rs
+++ b/core/node/house_keeper/src/prover/queue_reporter/fri_witness_generator_queue_reporter.rs
@@ -72,9 +72,17 @@ fn emit_metrics_for_round(round: AggregationRound, stats: JobCountStatistics) {
         );
     }
 
-    SERVER_METRICS.witness_generator_jobs_by_round[&("queued", format!("{:?}", round))]
+    SERVER_METRICS.witness_generator_jobs_by_round[&(
+        "queued",
+        format!("{:?}", round),
+        ProtocolVersionId::current_prover_version().to_string(),
+    )]
         .set(stats.queued as u64);
-    SERVER_METRICS.witness_generator_jobs_by_round[&("in_progress", format!("{:?}", round))]
+    SERVER_METRICS.witness_generator_jobs_by_round[&(
+        "in_progress",
+        format!("{:?}", round),
+        ProtocolVersionId::current_prover_version().to_string(),
+    )]
         .set(stats.queued as u64);
 }
 


### PR DESCRIPTION
## What ❔

Add protocol_version label to WG jobs metric

## Why ❔

To be able to use autoscaler for protocol versions

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
