### PR TITLE
refactor: Add tree writes persistence

### DIFF
--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -41,7 +41,7 @@ use zksync_reorg_detector::ReorgDetector;
 use zksync_state::{PostgresStorageCaches, RocksdbStorageOptions};
 use zksync_state_keeper::{
     seal_criteria::NoopSealer, AsyncRocksdbCache, BatchExecutor, MainBatchExecutor, OutputHandler,
-    StateKeeperPersistence, ZkSyncStateKeeper,
+    StateKeeperPersistence, TreeWritesPersistence, ZkSyncStateKeeper,
 };
 use zksync_storage::RocksDB;
 use zksync_types::L2ChainId;
@@ -234,9 +234,11 @@ async fn run_core(
         tracing::warn!("Disabling persisting protective reads; this should be safe, but is considered an experimental option at the moment");
         persistence = persistence.without_protective_reads();
     }
+    let tree_writes_persistence = TreeWritesPersistence::new(connection_pool.clone());
 
-    let output_handler =
-        OutputHandler::new(Box::new(persistence)).with_handler(Box::new(sync_state.clone()));
+    let output_handler = OutputHandler::new(Box::new(persistence))
+        .with_handler(Box::new(tree_writes_persistence))
+        .with_handler(Box::new(sync_state.clone()));
     let state_keeper = build_state_keeper(
         action_queue,
         config.required.state_cache_path.clone(),

--- a/core/lib/zksync_core_leftovers/src/lib.rs
+++ b/core/lib/zksync_core_leftovers/src/lib.rs
@@ -73,6 +73,7 @@ use zksync_state::{PostgresStorageCaches, RocksdbStorageOptions};
 use zksync_state_keeper::{
     create_state_keeper, io::seal_logic::l2_block_seal_subtasks::L2BlockSealProcess,
     AsyncRocksdbCache, MempoolFetcher, MempoolGuard, OutputHandler, StateKeeperPersistence,
+    TreeWritesPersistence,
 };
 use zksync_tee_verifier_input_producer::TeeVerifierInputProducer;
 use zksync_types::{ethabi::Contract, fee_model::FeeModelConfig, Address, L2ChainId};
@@ -815,7 +816,7 @@ async fn add_state_keeper_to_task_futures(
     };
 
     // L2 Block sealing process is parallelized, so we have to provide enough pooled connections.
-    let l2_block_sealer_pool = ConnectionPool::<Core>::builder(
+    let persistence_pool = ConnectionPool::<Core>::builder(
         postgres_config.master_url()?,
         L2BlockSealProcess::subtasks_len(),
     )
@@ -823,7 +824,7 @@ async fn add_state_keeper_to_task_futures(
     .await
     .context("failed to build l2_block_sealer_pool")?;
     let (persistence, l2_block_sealer) = StateKeeperPersistence::new(
-        l2_block_sealer_pool,
+        persistence_pool.clone(),
         contracts_config
             .l2_shared_bridge_addr
             .context("`l2_shared_bridge_addr` config is missing")?,
@@ -848,6 +849,10 @@ async fn add_state_keeper_to_task_futures(
         db_config.state_keeper_db_path.clone(),
         cache_options,
     );
+
+    let tree_writes_persistence = TreeWritesPersistence::new(persistence_pool);
+    let output_handler =
+        OutputHandler::new(Box::new(persistence)).with_handler(Box::new(tree_writes_persistence));
     let state_keeper = create_state_keeper(
         state_keeper_config,
         state_keeper_wallets,
@@ -857,7 +862,7 @@ async fn add_state_keeper_to_task_futures(
         state_keeper_pool,
         mempool.clone(),
         batch_fee_input_provider.clone(),
-        OutputHandler::new(Box::new(persistence)),
+        output_handler,
         stop_receiver.clone(),
     )
     .await;

--- a/core/node/metadata_calculator/src/tests.rs
+++ b/core/node/metadata_calculator/src/tests.rs
@@ -111,10 +111,14 @@ async fn expected_tree_hash(pool: &ConnectionPool<Core>) -> H256 {
         .expect("No L1 batches in Postgres");
     let mut all_logs = vec![];
     for i in 0..=sealed_l1_batch_number.0 {
-        let logs =
-            L1BatchWithLogs::new(&mut storage, L1BatchNumber(i), MerkleTreeMode::Lightweight)
-                .await
-                .unwrap();
+        let logs = L1BatchWithLogs::new(
+            &mut storage,
+            L1BatchNumber(i),
+            MerkleTreeMode::Lightweight,
+            false,
+        )
+        .await
+        .unwrap();
         let logs = logs.expect("no L1 batch").storage_logs;
 
         all_logs.extend(logs);

--- a/core/node/metadata_calculator/src/updater.rs
+++ b/core/node/metadata_calculator/src/updater.rs
@@ -86,17 +86,23 @@ impl TreeUpdater {
         &mut self,
         storage: &mut Connection<'_, Core>,
         l1_batch_numbers: ops::RangeInclusive<u32>,
+        last_sealed_l1_batch: L1BatchNumber,
     ) -> anyhow::Result<L1BatchNumber> {
         let tree_mode = self.tree.mode();
         let start = Instant::now();
         tracing::info!("Processing L1 batches #{l1_batch_numbers:?} in {tree_mode:?} mode");
         let first_l1_batch_number = L1BatchNumber(*l1_batch_numbers.start());
         let last_l1_batch_number = L1BatchNumber(*l1_batch_numbers.end());
-        let mut l1_batch_data = L1BatchWithLogs::new(storage, first_l1_batch_number, tree_mode)
-            .await
-            .with_context(|| {
-                format!("failed fetching tree input for L1 batch #{first_l1_batch_number}")
-            })?;
+        let mut l1_batch_data = L1BatchWithLogs::new(
+            storage,
+            first_l1_batch_number,
+            tree_mode,
+            first_l1_batch_number == last_sealed_l1_batch,
+        )
+        .await
+        .with_context(|| {
+            format!("failed fetching tree input for L1 batch #{first_l1_batch_number}")
+        })?;
 
         let mut total_logs = 0;
         let mut updated_headers = vec![];
@@ -111,13 +117,16 @@ impl TreeUpdater {
             let load_next_l1_batch_task = async {
                 if l1_batch_number < last_l1_batch_number {
                     let next_l1_batch_number = l1_batch_number + 1;
-                    L1BatchWithLogs::new(storage, next_l1_batch_number, tree_mode)
-                        .await
-                        .with_context(|| {
-                            format!(
-                                "failed fetching tree input for L1 batch #{next_l1_batch_number}"
-                            )
-                        })
+                    L1BatchWithLogs::new(
+                        storage,
+                        next_l1_batch_number,
+                        tree_mode,
+                        next_l1_batch_number == last_sealed_l1_batch,
+                    )
+                    .await
+                    .with_context(|| {
+                        format!("failed fetching tree input for L1 batch #{next_l1_batch_number}")
+                    })
                 } else {
                     Ok(None) // Don't need to load the next L1 batch after the last one we're processing.
                 }
@@ -192,7 +201,7 @@ impl TreeUpdater {
         } else {
             tracing::info!("Updating Merkle tree with L1 batches #{l1_batch_numbers:?}");
             *next_l1_batch_to_seal = self
-                .process_multiple_batches(&mut storage, l1_batch_numbers)
+                .process_multiple_batches(&mut storage, l1_batch_numbers, last_sealed_l1_batch)
                 .await?;
         }
         Ok(())
@@ -219,7 +228,7 @@ impl TreeUpdater {
                 earliest_l1_batch == L1BatchNumber(0),
                 "Non-zero earliest L1 batch #{earliest_l1_batch} is not supported without previous tree recovery"
             );
-            let batch = L1BatchWithLogs::new(&mut storage, earliest_l1_batch, tree.mode())
+            let batch = L1BatchWithLogs::new(&mut storage, earliest_l1_batch, tree.mode(), false)
                 .await
                 .with_context(|| {
                     format!("failed fetching tree input for L1 batch #{earliest_l1_batch}")

--- a/core/node/node_framework/src/implementations/layers/state_keeper/mempool_io.rs
+++ b/core/node/node_framework/src/implementations/layers/state_keeper/mempool_io.rs
@@ -9,7 +9,8 @@ use zksync_config::{
     ContractsConfig,
 };
 use zksync_state_keeper::{
-    MempoolFetcher, MempoolGuard, MempoolIO, OutputHandler, SequencerSealer, StateKeeperPersistence,
+    io::seal_logic::l2_block_seal_subtasks::L2BlockSealProcess, MempoolFetcher, MempoolGuard,
+    MempoolIO, OutputHandler, SequencerSealer, StateKeeperPersistence, TreeWritesPersistence,
 };
 
 use crate::{
@@ -79,16 +80,20 @@ impl WiringLayer for MempoolIOLayer {
         let batch_fee_input_provider = context.get_resource::<FeeInputResource>().await?.0;
         let master_pool = context.get_resource::<PoolResource<MasterPool>>().await?;
 
-        // Create miniblock sealer task.
+        // Create L2 block sealer task and output handler.
+        // L2 Block sealing process is parallelized, so we have to provide enough pooled connections.
+        let persistence_pool = master_pool
+            .get_custom(L2BlockSealProcess::subtasks_len())
+            .await
+            .context("Get master pool")?;
         let (persistence, l2_block_sealer) = StateKeeperPersistence::new(
-            master_pool
-                .get_singleton()
-                .await
-                .context("Get master pool")?,
+            persistence_pool.clone(),
             self.contracts_config.l2_shared_bridge_addr.unwrap(),
             self.state_keeper_config.l2_block_seal_queue_capacity,
         );
-        let output_handler = OutputHandler::new(Box::new(persistence));
+        let tree_writes_persistence = TreeWritesPersistence::new(persistence_pool);
+        let output_handler = OutputHandler::new(Box::new(persistence))
+            .with_handler(Box::new(tree_writes_persistence));
         context.insert_resource(OutputHandlerResource(Unique::new(output_handler)))?;
         context.add_task(Box::new(L2BlockSealerTask(l2_block_sealer)));
 

--- a/core/node/node_sync/src/tests.rs
+++ b/core/node/node_sync/src/tests.rs
@@ -14,7 +14,7 @@ use zksync_state_keeper::{
     io::{L1BatchParams, L2BlockParams},
     seal_criteria::NoopSealer,
     testonly::test_batch_executor::TestBatchExecutorBuilder,
-    OutputHandler, StateKeeperPersistence, ZkSyncStateKeeper,
+    OutputHandler, StateKeeperPersistence, TreeWritesPersistence, ZkSyncStateKeeper,
 };
 use zksync_types::{
     api,
@@ -105,7 +105,9 @@ impl StateKeeperHandles {
         let sync_state = SyncState::default();
         let (persistence, l2_block_sealer) =
             StateKeeperPersistence::new(pool.clone(), Address::repeat_byte(1), 5);
+        let tree_writes_persistence = TreeWritesPersistence::new(pool.clone());
         let output_handler = OutputHandler::new(Box::new(persistence.with_tx_insertion()))
+            .with_handler(Box::new(tree_writes_persistence))
             .with_handler(Box::new(sync_state.clone()));
 
         tokio::spawn(l2_block_sealer.run());

--- a/core/node/state_keeper/src/io/mod.rs
+++ b/core/node/state_keeper/src/io/mod.rs
@@ -13,7 +13,7 @@ use zksync_types::{
 pub use self::{
     common::IoCursor,
     output_handler::{OutputHandler, StateKeeperOutputHandler},
-    persistence::{L2BlockSealerTask, StateKeeperPersistence},
+    persistence::{L2BlockSealerTask, StateKeeperPersistence, TreeWritesPersistence},
 };
 use super::seal_criteria::IoSealCriteria;
 

--- a/core/node/state_keeper/src/lib.rs
+++ b/core/node/state_keeper/src/lib.rs
@@ -13,7 +13,7 @@ pub use self::{
     batch_executor::{main_executor::MainBatchExecutor, BatchExecutor},
     io::{
         mempool::MempoolIO, L2BlockSealerTask, OutputHandler, StateKeeperIO,
-        StateKeeperOutputHandler, StateKeeperPersistence,
+        StateKeeperOutputHandler, StateKeeperPersistence, TreeWritesPersistence,
     },
     keeper::ZkSyncStateKeeper,
     mempool_actor::MempoolFetcher,


### PR DESCRIPTION
## What ❔

Refactors state keeper, so tree writes are saved in a separate output handler.

## Why ❔

Code quality: split `seal_l1_batch` method which is already huge.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
