### PR TITLE
fix(zk_toolbox): install zk_inception in `nightly`

### DIFF
--- a/zk_toolbox/README.md
+++ b/zk_toolbox/README.md
@@ -11,13 +11,15 @@ all necessary arguments via the command line.
 
 Install zk_inception from git:
 
-`cargo +nightly install --git https://github.com/matter-labs/zksync-era/ --locked zk_inception --force`
+```bash
+cargo +nightly install --git https://github.com/matter-labs/zksync-era/ --locked zk_inception --force
+```
 
 Manually building from a local copy of the [ZkSync](https://github.com/matter-labs/zksync-era/) repository:
 
-```
+```bash
 cd zk_toolbox
-cargo install --path ./crates/zk_inception --force --locked
+cargo +nightly install --path ./crates/zk_inception --force --locked
 ```
 
 ### Foundry Integration

--- a/zk_toolbox/README.md
+++ b/zk_toolbox/README.md
@@ -11,7 +11,7 @@ all necessary arguments via the command line.
 
 Install zk_inception from git:
 
-`cargo install --git https://github.com/matter-labs/zksync-era/ --locked zk_inception --force`
+`cargo +nightly install --git https://github.com/matter-labs/zksync-era/ --locked zk_inception --force`
 
 Manually building from a local copy of the [ZkSync](https://github.com/matter-labs/zksync-era/) repository:
 


### PR DESCRIPTION
See error 
```rust
error[E0658]: `async fn` return type cannot contain a projection or `Self` that references lifetimes from a parent scope
   --> /Users/yjhmelody/.cargo/registry/src/index.crates.io-6f17d22bba15001f/sqlx-core-0.7.4/src/raw_sql.rs:260:10
    |
260 |     ) -> crate::Result<<E::Database as Database>::Row>
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #103532 <https://github.com/rust-lang/rust/issues/103532> for more information
    = help: add `#![feature(impl_trait_projections)]` to the crate attributes to enable
```

The stable rust is not used on a precise version, so could meet this error.

Or should use a high version stable rust in rust-toolchain