### PR TITLE
fix(node_framework): Fix the connection pool size for the catchup task

### DIFF
--- a/core/node/node_framework/src/implementations/layers/state_keeper/mod.rs
+++ b/core/node/node_framework/src/implementations/layers/state_keeper/mod.rs
@@ -77,7 +77,7 @@ impl WiringLayer for StateKeeperLayer {
             max_open_files: self.db_config.experimental.state_keeper_db_max_open_files,
         };
         let (storage_factory, task) = AsyncRocksdbCache::new(
-            master_pool.get_singleton().await?,
+            master_pool.get_custom(2).await?,
             self.db_config.state_keeper_db_path,
             cache_options,
         );


### PR DESCRIPTION
## What ❔

`AsyncRocksdbCache` requires at least 2 connections, but in the glue it was provided with only 1.

## Why ❔

Bug

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
