### PR TITLE
fix(healthcheck): correct interpolation format for postgres healthcheck

### DIFF
--- a/docs/guides/external-node/docker-compose-examples/mainnet-external-node-docker-compose.yml
+++ b/docs/guides/external-node/docker-compose-examples/mainnet-external-node-docker-compose.yml
@@ -41,7 +41,7 @@ services:
     healthcheck:
       interval: 1s
       timeout: 3s
-      test: psql -U postgres -c "select exists (select * from pg_stat_activity where datname = '{{ database_name }}' and application_name = 'pg_restore')" | grep -e ".f$"
+      test: psql -U postgres -c "select exists (select * from pg_stat_activity where datname = '{{ database_name }}' and application_name = 'pg_restore')" | grep -e ".f$$"
     environment:
       - POSTGRES_PASSWORD=notsecurepassword
       - PGPORT=5430


### PR DESCRIPTION
### Summary
This PR fixes the healthcheck interpolation format for the Postgres service in the mainnet-external-node-docker-compose.yml file. The incorrect use of `{{ database_name }}` has been corrected by adding an extra `$` at the end of the command.

### Details
- Updated healthcheck command to use correct interpolation format.
- Ensured compatibility with Docker Compose environment variable handling.

### Before
```bash
healthcheck:
  interval: 1s
  timeout: 3s
  test: psql -U postgres -c "select exists (select * from pg_stat_activity where datname = '{{ database_name }}' and application_name = 'pg_restore')" | grep -e ".f$"
```

### After
```bash
healthcheck:
  interval: 1s
  timeout: 3s
  test: psql -U postgres -c "select exists (select * from pg_stat_activity where datname = '{{ database_name }}' and application_name = 'pg_restore')" | grep -e ".f$$"
```

### Screenshots
![Screenshot 2024-05-25 at 16 08 18](https://github.com/matter-labs/zksync-era/assets/120671243/89465af4-162d-4e7e-a9f1-28c623e2a47b)


### Testing
- [x] Verified the Docker Compose file starts without errors.
- [x] Ensured the healthcheck passes successfully.

