### PR TITLE
fix(zk_toolbox): Some args not work and always use prompt values

### DIFF
--- a/zk_toolbox/crates/zk_inception/src/commands/ecosystem/args/create.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/ecosystem/args/create.rs
@@ -50,7 +50,9 @@ impl EcosystemCreateArgs {
             }
         });
 
-        let l1_network = PromptSelect::new("Select the L1 network", L1Network::iter()).ask();
+        let l1_network = self
+            .l1_network
+            .unwrap_or_else(|| PromptSelect::new("Select the L1 network", L1Network::iter()).ask());
 
         let l1_rpc_url = self.l1_rpc_url.unwrap_or_else(|| {
             let mut prompt = Prompt::new("What is the RPC URL of the L1 network?");


### PR DESCRIPTION
## What ❔

Some args not work and always use prompt values.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
