### PR TITLE
fix(pruning): Fix DB pruner responsiveness during shutdown

### DIFF
--- a/core/lib/db_connection/src/error.rs
+++ b/core/lib/db_connection/src/error.rs
@@ -100,6 +100,7 @@ enum ConnectionAction {
     AcquireConnection,
     StartTransaction,
     CommitTransaction,
+    RollbackTransaction,
 }
 
 impl ConnectionAction {
@@ -108,6 +109,7 @@ impl ConnectionAction {
             Self::AcquireConnection => "acquiring DB connection",
             Self::StartTransaction => "starting DB transaction",
             Self::CommitTransaction => "committing DB transaction",
+            Self::RollbackTransaction => "rolling back DB transaction",
         }
     }
 }
@@ -162,6 +164,17 @@ impl DalConnectionError {
         Self {
             inner,
             action: ConnectionAction::CommitTransaction,
+            connection_tags,
+        }
+    }
+
+    pub(crate) fn rollback_transaction(
+        inner: sqlx::Error,
+        connection_tags: Option<ConnectionTags>,
+    ) -> Self {
+        Self {
+            inner,
+            action: ConnectionAction::RollbackTransaction,
             connection_tags,
         }
     }

--- a/core/node/db_pruner/src/prune_conditions.rs
+++ b/core/node/db_pruner/src/prune_conditions.rs
@@ -5,7 +5,10 @@ use chrono::Utc;
 use zksync_dal::{ConnectionPool, Core, CoreDal};
 use zksync_types::L1BatchNumber;
 
-use crate::PruneCondition;
+#[async_trait]
+pub(crate) trait PruneCondition: fmt::Debug + fmt::Display + Send + Sync + 'static {
+    async fn is_batch_prunable(&self, l1_batch_number: L1BatchNumber) -> anyhow::Result<bool>;
+}
 
 #[derive(Debug)]
 pub(super) struct L1BatchOlderThanPruneCondition {


### PR DESCRIPTION
## What ❔

Makes DB pruner more responsive during node shutdown.

## Why ❔

Improves UX for node operators.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.