### PR TITLE
fix(block-reverter): Fix reverting snapshot files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9037,6 +9037,7 @@ dependencies = [
  "google-cloud-storage",
  "http",
  "prost 0.12.1",
+ "rand 0.8.5",
  "serde_json",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9027,6 +9027,7 @@ name = "zksync_object_store"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-trait",
  "bincode",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8023,6 +8023,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "async-trait",
+ "futures 0.3.28",
  "serde",
  "tempfile",
  "test-casing",

--- a/core/lib/object_store/Cargo.toml
+++ b/core/lib/object_store/Cargo.toml
@@ -22,6 +22,7 @@ google-cloud-auth.workspace = true
 http.workspace = true
 serde_json.workspace = true
 flate2.workspace = true
+rand.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 prost.workspace = true

--- a/core/lib/object_store/Cargo.toml
+++ b/core/lib/object_store/Cargo.toml
@@ -27,4 +27,5 @@ tracing.workspace = true
 prost.workspace = true
 
 [dev-dependencies]
+assert_matches.workspace = true
 tempfile.workspace = true

--- a/core/lib/object_store/src/file.rs
+++ b/core/lib/object_store/src/file.rs
@@ -9,7 +9,10 @@ impl From<io::Error> for ObjectStoreError {
     fn from(err: io::Error) -> Self {
         match err.kind() {
             io::ErrorKind::NotFound => ObjectStoreError::KeyNotFound(err.into()),
-            _ => ObjectStoreError::Other(err.into()),
+            kind => ObjectStoreError::Other {
+                is_transient: matches!(kind, io::ErrorKind::Interrupted | io::ErrorKind::TimedOut),
+                source: err.into(),
+            },
         }
     }
 }

--- a/core/lib/object_store/src/file.rs
+++ b/core/lib/object_store/src/file.rs
@@ -23,7 +23,7 @@ pub(crate) struct FileBackedObjectStore {
 }
 
 impl FileBackedObjectStore {
-    pub async fn new(base_dir: String) -> Self {
+    pub async fn new(base_dir: String) -> Result<Self, ObjectStoreError> {
         for bucket in &[
             Bucket::ProverJobs,
             Bucket::WitnessInput,
@@ -39,13 +39,9 @@ impl FileBackedObjectStore {
             Bucket::TeeVerifierInput,
         ] {
             let bucket_path = format!("{base_dir}/{bucket}");
-            fs::create_dir_all(&bucket_path)
-                .await
-                .unwrap_or_else(|err| {
-                    panic!("failed creating bucket `{bucket_path}`: {err}");
-                });
+            fs::create_dir_all(&bucket_path).await?;
         }
-        FileBackedObjectStore { base_dir }
+        Ok(FileBackedObjectStore { base_dir })
     }
 
     fn filename(&self, bucket: Bucket, key: &str) -> String {
@@ -90,12 +86,12 @@ mod test {
     async fn test_get() {
         let dir = TempDir::new().unwrap();
         let path = dir.into_path().into_os_string().into_string().unwrap();
-        let object_store = FileBackedObjectStore::new(path).await;
+        let object_store = FileBackedObjectStore::new(path).await.unwrap();
         let expected = vec![9, 0, 8, 9, 0, 7];
-        let result = object_store
+        object_store
             .put_raw(Bucket::ProverJobs, "test-key.bin", expected.clone())
-            .await;
-        assert!(result.is_ok(), "result must be OK");
+            .await
+            .unwrap();
         let bytes = object_store
             .get_raw(Bucket::ProverJobs, "test-key.bin")
             .await
@@ -107,26 +103,26 @@ mod test {
     async fn test_put() {
         let dir = TempDir::new().unwrap();
         let path = dir.into_path().into_os_string().into_string().unwrap();
-        let object_store = FileBackedObjectStore::new(path).await;
+        let object_store = FileBackedObjectStore::new(path).await.unwrap();
         let bytes = vec![9, 0, 8, 9, 0, 7];
-        let result = object_store
+        object_store
             .put_raw(Bucket::ProverJobs, "test-key.bin", bytes)
-            .await;
-        assert!(result.is_ok(), "result must be OK");
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
     async fn test_remove() {
         let dir = TempDir::new().unwrap();
         let path = dir.into_path().into_os_string().into_string().unwrap();
-        let object_store = FileBackedObjectStore::new(path).await;
-        let result = object_store
+        let object_store = FileBackedObjectStore::new(path).await.unwrap();
+        object_store
             .put_raw(Bucket::ProverJobs, "test-key.bin", vec![0, 1])
-            .await;
-        assert!(result.is_ok(), "result must be OK");
-        let result = object_store
+            .await
+            .unwrap();
+        object_store
             .remove_raw(Bucket::ProverJobs, "test-key.bin")
-            .await;
-        assert!(result.is_ok(), "result must be OK");
+            .await
+            .unwrap();
     }
 }

--- a/core/lib/object_store/src/gcs.rs
+++ b/core/lib/object_store/src/gcs.rs
@@ -3,7 +3,7 @@
 use std::{fmt, future::Future, time::Duration};
 
 use async_trait::async_trait;
-use google_cloud_auth::{credentials::CredentialsFile, error::Error};
+use google_cloud_auth::{credentials::CredentialsFile, error::Error as AuthError};
 use google_cloud_storage::{
     client::{Client, ClientConfig},
     http::{
@@ -23,10 +23,9 @@ use crate::{
     raw::{Bucket, ObjectStore, ObjectStoreError},
 };
 
-async fn retry<T, E, Fut, F>(max_retries: u16, mut f: F) -> Result<T, E>
+async fn retry<T, Fut, F>(max_retries: u16, mut f: F) -> Result<T, ObjectStoreError>
 where
-    E: fmt::Display,
-    Fut: Future<Output = Result<T, E>>,
+    Fut: Future<Output = Result<T, ObjectStoreError>>,
     F: FnMut() -> Fut,
 {
     let mut retries = 1;
@@ -34,14 +33,19 @@ where
     loop {
         match f().await {
             Ok(result) => return Ok(result),
-            Err(err) => {
-                tracing::warn!(%err, "Failed GCS request {retries}/{max_retries}, retrying.");
+            Err(err) if err.is_transient() => {
                 if retries > max_retries {
+                    tracing::warn!(%err, "Exhausted {max_retries} retries performing GCS request; returning last error");
                     return Err(err);
                 }
+                tracing::info!(%err, "Failed GCS request {retries}/{max_retries}, retrying.");
                 retries += 1;
                 tokio::time::sleep(Duration::from_secs(backoff)).await;
                 backoff *= 2;
+            }
+            Err(err) => {
+                tracing::warn!(%err, "Failed GCS request with a fatal error");
+                return Err(err);
             }
         }
     }
@@ -71,14 +75,19 @@ pub enum GoogleCloudStorageAuthMode {
 }
 
 impl GoogleCloudStorage {
+    // FIXME: propagate errors?
     pub async fn new(
         auth_mode: GoogleCloudStorageAuthMode,
         bucket_prefix: String,
         max_retries: u16,
     ) -> Self {
-        let client_config = retry(max_retries, || Self::get_client_config(auth_mode.clone()))
-            .await
-            .expect("failed fetching GCS client config after retries");
+        let client_config = retry(max_retries, || async {
+            Self::get_client_config(auth_mode.clone())
+                .await
+                .map_err(Into::into)
+        })
+        .await
+        .expect("failed fetching GCS client config after retries");
 
         Self {
             client: Client::new(client_config),
@@ -89,12 +98,10 @@ impl GoogleCloudStorage {
 
     async fn get_client_config(
         auth_mode: GoogleCloudStorageAuthMode,
-    ) -> Result<ClientConfig, Error> {
+    ) -> Result<ClientConfig, AuthError> {
         match auth_mode {
             GoogleCloudStorageAuthMode::AuthenticatedWithCredentialFile(path) => {
-                let cred_file = CredentialsFile::new_from_file(path)
-                    .await
-                    .expect("failed loading GCS credential file");
+                let cred_file = CredentialsFile::new_from_file(path).await?;
                 ClientConfig::default().with_credentials(cred_file).await
             }
             GoogleCloudStorageAuthMode::Authenticated => ClientConfig::default().with_auth().await,
@@ -127,9 +134,24 @@ impl GoogleCloudStorage {
             ..DeleteObjectRequest::default()
         };
         async move {
-            retry(self.max_retries, || self.client.delete_object(&request))
-                .await
-                .map_err(ObjectStoreError::from)
+            retry(self.max_retries, || async {
+                self.client
+                    .delete_object(&request)
+                    .await
+                    .map_err(ObjectStoreError::from)
+            })
+            .await
+        }
+    }
+}
+
+impl From<AuthError> for ObjectStoreError {
+    fn from(err: AuthError) -> Self {
+        let is_transient =
+            matches!(&err, AuthError::HttpError(err) if err.is_timeout() || err.is_connect());
+        Self::Initialization {
+            source: err.into(),
+            is_transient,
         }
     }
 }
@@ -147,7 +169,12 @@ impl From<HttpError> for ObjectStoreError {
         if is_not_found {
             ObjectStoreError::KeyNotFound(err.into())
         } else {
-            ObjectStoreError::Other(err.into())
+            let is_transient =
+                matches!(&err, HttpError::HttpClient(err) if err.is_timeout() || err.is_connect());
+            ObjectStoreError::Other {
+                is_transient,
+                source: err.into(),
+            }
         }
     }
 }
@@ -168,8 +195,11 @@ impl ObjectStore for GoogleCloudStorage {
             ..GetObjectRequest::default()
         };
         let range = Range::default();
-        let blob = retry(self.max_retries, || {
-            self.client.download_object(&request, &range)
+        let blob = retry(self.max_retries, || async {
+            self.client
+                .download_object(&request, &range)
+                .await
+                .map_err(Into::into)
         })
         .await;
 
@@ -177,7 +207,7 @@ impl ObjectStore for GoogleCloudStorage {
         tracing::trace!(
             "Fetched data from GCS for key {key} from bucket {bucket} and it took: {elapsed:?}"
         );
-        blob.map_err(ObjectStoreError::from)
+        blob
     }
 
     async fn put_raw(
@@ -198,9 +228,11 @@ impl ObjectStore for GoogleCloudStorage {
             bucket: self.bucket_prefix.clone(),
             ..Default::default()
         };
-        let object = retry(self.max_retries, || {
+        let object = retry(self.max_retries, || async {
             self.client
                 .upload_object(&request, value.clone(), &upload_type)
+                .await
+                .map_err(Into::into)
         })
         .await;
 
@@ -208,7 +240,7 @@ impl ObjectStore for GoogleCloudStorage {
         tracing::trace!(
             "Stored data to GCS for key {key} from bucket {bucket} and it took: {elapsed:?}"
         );
-        object.map(drop).map_err(ObjectStoreError::from)
+        object.map(drop)
     }
 
     async fn remove_raw(&self, bucket: Bucket, key: &str) -> Result<(), ObjectStoreError> {
@@ -228,38 +260,47 @@ impl ObjectStore for GoogleCloudStorage {
 mod test {
     use std::sync::atomic::{AtomicU16, Ordering};
 
+    use assert_matches::assert_matches;
+
     use super::*;
+
+    fn transient_error() -> ObjectStoreError {
+        ObjectStoreError::Other {
+            is_transient: true,
+            source: "oops".into(),
+        }
+    }
 
     #[tokio::test]
     async fn test_retry_success_immediate() {
-        let result = retry(2, || async { Ok::<_, &'static str>(42) }).await;
-        assert_eq!(result, Ok(42));
+        let result = retry(2, || async { Ok(42) }).await.unwrap();
+        assert_eq!(result, 42);
     }
 
     #[tokio::test]
     async fn test_retry_failure_exhausted() {
-        let result = retry(2, || async { Err::<i32, _>("oops") }).await;
-        assert_eq!(result, Err("oops"));
+        let err = retry(2, || async { Err::<i32, _>(transient_error()) })
+            .await
+            .unwrap_err();
+        assert_matches!(err, ObjectStoreError::Other { .. });
     }
 
-    async fn retry_success_after_n_retries(n: u16) -> Result<u32, String> {
+    async fn retry_success_after_n_retries(n: u16) -> Result<u32, ObjectStoreError> {
         let retries = AtomicU16::new(0);
-        let result = retry(n, || async {
+        retry(n, || async {
             let retries = retries.fetch_add(1, Ordering::Relaxed);
             if retries + 1 == n {
                 Ok(42)
             } else {
-                Err("oops")
+                Err(transient_error())
             }
         })
-        .await;
-
-        result.map_err(|_| "Retry failed".to_string())
+        .await
     }
 
     #[tokio::test]
     async fn test_retry_success_after_retry() {
-        let result = retry(2, || retry_success_after_n_retries(2)).await;
-        assert_eq!(result, Ok(42));
+        let result = retry(2, || retry_success_after_n_retries(2)).await.unwrap();
+        assert_eq!(result, 42);
     }
 }

--- a/core/lib/snapshots_applier/src/lib.rs
+++ b/core/lib/snapshots_applier/src/lib.rs
@@ -78,13 +78,10 @@ enum SnapshotsApplierError {
 
 impl SnapshotsApplierError {
     fn object_store(err: ObjectStoreError, context: String) -> Self {
-        match err {
-            ObjectStoreError::KeyNotFound(_) | ObjectStoreError::Serialization(_) => {
-                Self::Fatal(anyhow::Error::from(err).context(context))
-            }
-            ObjectStoreError::Other(_) => {
-                Self::Retryable(anyhow::Error::from(err).context(context))
-            }
+        if err.is_transient() {
+            Self::Retryable(anyhow::Error::from(err).context(context))
+        } else {
+            Self::Fatal(anyhow::Error::from(err).context(context))
         }
     }
 }

--- a/core/node/block_reverter/Cargo.toml
+++ b/core/node/block_reverter/Cargo.toml
@@ -21,11 +21,13 @@ zksync_state.workspace = true
 zksync_merkle_tree.workspace = true
 
 anyhow.workspace = true
+futures.workspace = true
 tokio = { workspace = true, features = ["time", "fs"] }
 serde.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
+async-trait.workspace = true
 tempfile.workspace = true
 test-casing.workspace = true

--- a/core/node/block_reverter/src/lib.rs
+++ b/core/node/block_reverter/src/lib.rs
@@ -2,7 +2,7 @@ use std::{path::Path, sync::Arc, time::Duration};
 
 use anyhow::Context as _;
 use serde::Serialize;
-use tokio::fs;
+use tokio::{fs, sync::Semaphore};
 use zksync_config::{configs::chain::NetworkConfig, ContractsConfig, EthConfig};
 use zksync_contracts::hyperchain_contract;
 use zksync_dal::{ConnectionPool, Core, CoreDal};
@@ -380,6 +380,8 @@ impl BlockReverter {
         object_store: &dyn ObjectStore,
         deleted_snapshots: &[SnapshotMetadata],
     ) -> anyhow::Result<()> {
+        const CONCURRENT_REMOVE_REQUESTS: usize = 20;
+
         fn ignore_not_found_errors(err: ObjectStoreError) -> Result<(), ObjectStoreError> {
             match err {
                 ObjectStoreError::KeyNotFound(err) => {
@@ -419,18 +421,28 @@ impl BlockReverter {
                 });
             combine_results(&mut overall_result, result);
 
-            for chunk_id in 0..snapshot.storage_logs_filepaths.len() as u64 {
+            let remove_semaphore = &Semaphore::new(CONCURRENT_REMOVE_REQUESTS);
+            let chunks_len = snapshot.storage_logs_filepaths.len();
+            let remove_futures = (0..chunks_len as u64).map(|chunk_id| async move {
+                let _permit = remove_semaphore
+                    .acquire()
+                    .await
+                    .context("semaphore is never closed")?;
+
                 let key = SnapshotStorageLogsStorageKey {
                     l1_batch_number: snapshot.l1_batch_number,
                     chunk_id,
                 };
                 tracing::info!("Removing storage logs chunk {key:?}");
-
-                let result = object_store
+                object_store
                     .remove::<SnapshotStorageLogsChunk>(key)
                     .await
                     .or_else(ignore_not_found_errors)
-                    .with_context(|| format!("failed removing storage logs chunk {key:?}"));
+                    .with_context(|| format!("failed removing storage logs chunk {key:?}"))
+            });
+            let remove_results = futures::future::join_all(remove_futures).await;
+
+            for result in remove_results {
                 combine_results(&mut overall_result, result);
             }
         }

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -8171,6 +8171,7 @@ dependencies = [
  "google-cloud-storage",
  "http",
  "prost 0.12.3",
+ "rand 0.8.5",
  "serde_json",
  "tokio",
  "tracing",


### PR DESCRIPTION
## What ❔

- Does not retry "not found" errors when removing objects.
- Makes rolling back snapshot files optional.

## Why ❔

The current implementation leads to very slow reverts because of retries.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.