### PR TITLE
fix(node_framework): Use custom pool for commitiment generator

### DIFF
--- a/core/node/node_framework/src/implementations/layers/commitment_generator.rs
+++ b/core/node/node_framework/src/implementations/layers/commitment_generator.rs
@@ -30,7 +30,8 @@ impl WiringLayer for CommitmentGeneratorLayer {
 
     async fn wire(self: Box<Self>, mut context: ServiceContext<'_>) -> Result<(), WiringError> {
         let pool_resource = context.get_resource::<PoolResource<MasterPool>>().await?;
-        let main_pool = pool_resource.get().await?;
+        let pool_size = CommitmentGenerator::default_parallelism().get();
+        let main_pool = pool_resource.get_custom(pool_size).await?;
 
         let commitment_generator = CommitmentGenerator::new(main_pool, self.mode);
 


### PR DESCRIPTION
## What ❔

We create a custom pool for commitment generator in `initialize_components`, but use "global" pool in the framework.

## Why ❔

Align implementations.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
