### PR TITLE
feat(node_framework): Synchronize pools layer with logic in initialize_components

### DIFF
--- a/core/node/node_framework/src/implementations/resources/pools.rs
+++ b/core/node/node_framework/src/implementations/resources/pools.rs
@@ -1,5 +1,4 @@
 use std::{
-    fmt,
     sync::{
         atomic::{AtomicU32, Ordering},
         Arc,
@@ -16,26 +15,15 @@ use zksync_types::url::SensitiveUrl;
 use crate::resource::Resource;
 
 /// Represents a connection pool to a certain kind of database.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct PoolResource<P: PoolKind> {
     connections_count: Arc<AtomicU32>,
     url: SensitiveUrl,
     max_connections: u32,
     statement_timeout: Option<Duration>,
+    acquire_timeout: Option<Duration>,
     unbound_pool: Arc<Mutex<Option<ConnectionPool<P::DbMarker>>>>,
     _kind: std::marker::PhantomData<P>,
-}
-
-impl<P: PoolKind> fmt::Debug for PoolResource<P> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PoolResource")
-            .field("connections_count", &self.connections_count)
-            .field("url", &self.url)
-            .field("max_connections", &self.max_connections)
-            .field("statement_timeout", &self.statement_timeout)
-            .field("unbound_pool", &self.unbound_pool)
-            .finish_non_exhaustive()
-    }
 }
 
 impl<P: PoolKind> Resource for PoolResource<P> {
@@ -49,12 +37,14 @@ impl<P: PoolKind> PoolResource<P> {
         url: SensitiveUrl,
         max_connections: u32,
         statement_timeout: Option<Duration>,
+        acquire_timeout: Option<Duration>,
     ) -> Self {
         Self {
             connections_count: Arc::new(AtomicU32::new(0)),
             url,
             max_connections,
             statement_timeout,
+            acquire_timeout,
             unbound_pool: Arc::new(Mutex::new(None)),
             _kind: std::marker::PhantomData,
         }
@@ -63,6 +53,7 @@ impl<P: PoolKind> PoolResource<P> {
     fn builder(&self) -> ConnectionPoolBuilder<P::DbMarker> {
         let mut builder = ConnectionPool::builder(self.url.clone(), self.max_connections);
         builder.set_statement_timeout(self.statement_timeout);
+        builder.set_statement_timeout(self.acquire_timeout);
         builder
     }
 


### PR DESCRIPTION
## What ❔

There was some new logic related to the configuration of DAL/pools in `initialize_components` that wasn't mirrored in the pools layer.
This PR changes the pools layer to match logic in `initialize_components`.

## Why ❔

We do not intend the framework to change the way the server works.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
