### PR TITLE
Make protocol upgrade tool support semver

### DIFF
--- a/infrastructure/protocol-upgrade/src/l2upgrade/transactions.ts
+++ b/infrastructure/protocol-upgrade/src/l2upgrade/transactions.ts
@@ -3,7 +3,7 @@ import { ComplexUpgraderFactory, ContractDeployerFactory } from 'system-contract
 import { ForceDeployment, L2CanonicalTransaction } from '../transaction';
 import { ForceDeployUpgraderFactory } from 'l2-contracts/typechain';
 import { Command } from 'commander';
-import { getCommonDataFileName, getL2UpgradeFileName } from '../utils';
+import { getCommonDataFileName, getL2UpgradeFileName, unpackStringSemVer } from '../utils';
 import fs from 'fs';
 import { REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT } from 'zksync-ethers/build/utils';
 
@@ -151,7 +151,9 @@ command
                 l2Upgrade.calldata = prepareCallDataForComplexUpgrader(delegatedCalldata, l2UpgraderAddress);
             }
 
-            l2Upgrade.tx = buildL2CanonicalTransaction(l2Upgrade.calldata, commonData.protocolVersion, toAddress);
+            const protocolVersionSemVer: string = commonData.protocolVersion;
+            const minorVersion = unpackStringSemVer(protocolVersionSemVer)[1];
+            l2Upgrade.tx = buildL2CanonicalTransaction(l2Upgrade.calldata, minorVersion, toAddress);
             fs.writeFileSync(l2upgradeFileName, JSON.stringify(l2Upgrade, null, 2));
         } else {
             throw new Error(`No l2 upgrade file found at ${l2upgradeFileName}`);

--- a/infrastructure/protocol-upgrade/src/protocol-upgrade-manager.ts
+++ b/infrastructure/protocol-upgrade/src/protocol-upgrade-manager.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { Command } from 'commander';
 import { DEFAULT_UPGRADE_PATH, getNameOfTheLastUpgrade, getTimestampInSeconds } from './utils';
 
-function createNewUpgrade(name, protocolVersion: number) {
+function createNewUpgrade(name, protocolVersion: string) {
     const timestamp = getTimestampInSeconds();
     const upgradePath = `${DEFAULT_UPGRADE_PATH}/${timestamp}-${name}`;
     fs.mkdirSync(upgradePath, { recursive: true });

--- a/infrastructure/protocol-upgrade/src/transaction.ts
+++ b/infrastructure/protocol-upgrade/src/transaction.ts
@@ -16,7 +16,9 @@ import {
     getL2TransactionsFileName,
     getPostUpgradeCalldataFileName,
     getL2UpgradeFileName,
-    VerifierParams
+    VerifierParams,
+    unpackStringSemVer,
+    packSemver
 } from './utils';
 import fs from 'fs';
 import { Command } from 'commander';
@@ -254,9 +256,10 @@ export function buildDefaultUpgradeTx(
     postUpgradeCalldataFlag
 ) {
     const commonData = JSON.parse(fs.readFileSync(getCommonDataFileName(), { encoding: 'utf-8' }));
-    const protocolVersion = commonData.protocolVersion;
+    const protocolVersionSemVer: string = commonData.protocolVersion;
+    const packedProtocolVersion = packSemver(...unpackStringSemVer(protocolVersionSemVer));
     console.log(
-        `Building default upgrade tx for ${environment} protocol version ${protocolVersion} upgradeTimestamp ${upgradeTimestamp} `
+        `Building default upgrade tx for ${environment} protocol version ${protocolVersionSemVer} upgradeTimestamp ${upgradeTimestamp} `
     );
     let facetCuts = [];
     let facetCutsFileName = getFacetCutsFileName(environment);
@@ -316,7 +319,7 @@ export function buildDefaultUpgradeTx(
 
     let proposeUpgradeTx = buildProposeUpgrade(
         ethers.BigNumber.from(upgradeTimestamp),
-        protocolVersion,
+        packedProtocolVersion,
         '0x',
         postUpgradeCalldata,
         cryptoVerifierParams,
@@ -349,7 +352,8 @@ export function buildDefaultUpgradeTx(
         proposeUpgradeTx,
         l1upgradeCalldata,
         upgradeAddress,
-        protocolVersion,
+        protocolVersionSemVer,
+        packedProtocolVersion,
         diamondUpgradeProposalId,
         upgradeTimestamp,
         ...upgradeData

--- a/infrastructure/protocol-upgrade/src/utils.ts
+++ b/infrastructure/protocol-upgrade/src/utils.ts
@@ -62,3 +62,20 @@ export interface VerifierParams {
     recursionLeafLevelVkHash: BytesLike;
     recursionCircuitsSetVksHash: BytesLike;
 }
+
+// Bit shift by 32 does not work in JS, so we have to multiply by 2^32
+export const SEMVER_MINOR_VERSION_MULTIPLIER = 4294967296;
+
+// The major version is always 0 for now
+export function packSemver(major: number, minor: number, patch: number) {
+    if (major !== 0) {
+        throw new Error('Major version must be 0');
+    }
+
+    return minor * SEMVER_MINOR_VERSION_MULTIPLIER + patch;
+}
+
+export function unpackStringSemVer(semver: string): [number, number, number] {
+    const [major, minor, patch] = semver.split('.');
+    return [parseInt(major), parseInt(minor), parseInt(patch)];
+}


### PR DESCRIPTION
## What ❔

We'll store the semantic version of the protocol in the `common.json`.
For the upgrade itself we'll have to use packed format, but for the l2 transaction we'll use only the `minor` version (for compatibility with the server). It is expected that the upgrade transaction is only present during at least `minor` upgrades and never present during `patch` ones

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
