### PR TITLE
refactor(state-keeper): Propagate errors in batch executor

### DIFF
--- a/core/node/state_keeper/src/batch_executor/mod.rs
+++ b/core/node/state_keeper/src/batch_executor/mod.rs
@@ -1,5 +1,6 @@
-use std::{fmt, sync::Arc};
+use std::{error::Error as StdError, fmt, sync::Arc};
 
+use anyhow::Context as _;
 use async_trait::async_trait;
 use multivm::interface::{
     FinishedL1Batch, Halt, L1BatchEnv, L2BlockEnv, SystemEnv, VmExecutionResultAndLogs,
@@ -66,12 +67,45 @@ pub trait BatchExecutor: 'static + Send + Sync + fmt::Debug {
     ) -> Option<BatchExecutorHandle>;
 }
 
+#[derive(Debug)]
+enum HandleOrError {
+    Handle(JoinHandle<anyhow::Result<()>>),
+    Err(Arc<dyn StdError + Send + Sync>),
+}
+
+impl HandleOrError {
+    async fn wait_for_error(&mut self) -> anyhow::Error {
+        let err_arc = match self {
+            Self::Handle(handle) => {
+                let err = match handle.await {
+                    Ok(Ok(())) => anyhow::anyhow!("batch executor unexpectedly stopped"),
+                    Ok(Err(err)) => err,
+                    Err(err) => anyhow::Error::new(err).context("batch executor panicked"),
+                };
+                let err: Box<dyn StdError + Send + Sync> = err.into();
+                let err: Arc<dyn StdError + Send + Sync> = err.into();
+                *self = Self::Err(err.clone());
+                err
+            }
+            Self::Err(err) => err.clone(),
+        };
+        anyhow::Error::new(err_arc)
+    }
+
+    async fn wait(self) -> anyhow::Result<()> {
+        match self {
+            Self::Handle(handle) => handle.await.context("batch executor panicked")?,
+            Self::Err(err_arc) => Err(anyhow::Error::new(err_arc)),
+        }
+    }
+}
+
 /// A public interface for interaction with the `BatchExecutor`.
 /// `BatchExecutorHandle` is stored in the state keeper and is used to invoke or rollback transactions, and also seal
 /// the batches.
 #[derive(Debug)]
 pub struct BatchExecutorHandle {
-    handle: JoinHandle<()>,
+    handle: HandleOrError,
     commands: mpsc::Sender<Command>,
 }
 
@@ -79,23 +113,36 @@ impl BatchExecutorHandle {
     /// Creates a batch executor handle from the provided sender and thread join handle.
     /// Can be used to inject an alternative batch executor implementation.
     #[doc(hidden)]
-    pub(super) fn from_raw(handle: JoinHandle<()>, commands: mpsc::Sender<Command>) -> Self {
-        Self { handle, commands }
+    pub(super) fn from_raw(
+        handle: JoinHandle<anyhow::Result<()>>,
+        commands: mpsc::Sender<Command>,
+    ) -> Self {
+        Self {
+            handle: HandleOrError::Handle(handle),
+            commands,
+        }
     }
 
-    pub async fn execute_tx(&self, tx: Transaction) -> TxExecutionResult {
+    pub async fn execute_tx(&mut self, tx: Transaction) -> anyhow::Result<TxExecutionResult> {
         let tx_gas_limit = tx.gas_limit().as_u64();
 
         let (response_sender, response_receiver) = oneshot::channel();
-        self.commands
+        let send_failed = self
+            .commands
             .send(Command::ExecuteTx(Box::new(tx), response_sender))
             .await
-            .unwrap();
+            .is_err();
+        if send_failed {
+            return Err(self.handle.wait_for_error().await);
+        }
 
         let latency = EXECUTOR_METRICS.batch_executor_command_response_time
             [&ExecutorCommand::ExecuteTx]
             .start();
-        let res = response_receiver.await.unwrap();
+        let res = match response_receiver.await {
+            Ok(res) => res,
+            Err(_) => return Err(self.handle.wait_for_error().await),
+        };
         let elapsed = latency.observe();
 
         if let TxExecutionResult::Success { tx_metrics, .. } = &res {
@@ -112,52 +159,76 @@ impl BatchExecutorHandle {
                 .failed_tx_gas_limit_per_nanosecond
                 .observe(tx_gas_limit as f64 / elapsed.as_nanos() as f64);
         }
-        res
+        Ok(res)
     }
 
-    pub async fn start_next_l2_block(&self, env: L2BlockEnv) {
+    pub async fn start_next_l2_block(&mut self, env: L2BlockEnv) -> anyhow::Result<()> {
         // While we don't get anything from the channel, it's useful to have it as a confirmation that the operation
         // indeed has been processed.
         let (response_sender, response_receiver) = oneshot::channel();
-        self.commands
+        let send_failed = self
+            .commands
             .send(Command::StartNextL2Block(env, response_sender))
             .await
-            .unwrap();
+            .is_err();
+        if send_failed {
+            return Err(self.handle.wait_for_error().await);
+        }
+
         let latency = EXECUTOR_METRICS.batch_executor_command_response_time
             [&ExecutorCommand::StartNextL2Block]
             .start();
-        response_receiver.await.unwrap();
+        if response_receiver.await.is_err() {
+            return Err(self.handle.wait_for_error().await);
+        }
         latency.observe();
+        Ok(())
     }
 
-    pub async fn rollback_last_tx(&self) {
+    pub async fn rollback_last_tx(&mut self) -> anyhow::Result<()> {
         // While we don't get anything from the channel, it's useful to have it as a confirmation that the operation
         // indeed has been processed.
         let (response_sender, response_receiver) = oneshot::channel();
-        self.commands
+        let send_failed = self
+            .commands
             .send(Command::RollbackLastTx(response_sender))
             .await
-            .unwrap();
+            .is_err();
+        if send_failed {
+            return Err(self.handle.wait_for_error().await);
+        }
+
         let latency = EXECUTOR_METRICS.batch_executor_command_response_time
             [&ExecutorCommand::RollbackLastTx]
             .start();
-        response_receiver.await.unwrap();
+        if response_receiver.await.is_err() {
+            return Err(self.handle.wait_for_error().await);
+        }
         latency.observe();
+        Ok(())
     }
 
-    pub async fn finish_batch(self) -> FinishedL1Batch {
+    pub async fn finish_batch(mut self) -> anyhow::Result<FinishedL1Batch> {
         let (response_sender, response_receiver) = oneshot::channel();
-        self.commands
+        let send_failed = self
+            .commands
             .send(Command::FinishBatch(response_sender))
             .await
-            .unwrap();
+            .is_err();
+        if send_failed {
+            return Err(self.handle.wait_for_error().await);
+        }
+
         let latency = EXECUTOR_METRICS.batch_executor_command_response_time
             [&ExecutorCommand::FinishBatch]
             .start();
-        let finished_batch = response_receiver.await.unwrap();
-        self.handle.await.unwrap();
+        let finished_batch = match response_receiver.await {
+            Ok(batch) => batch,
+            Err(_) => return Err(self.handle.wait_for_error().await),
+        };
+        self.handle.wait().await?;
         latency.observe();
-        finished_batch
+        Ok(finished_batch)
     }
 }
 

--- a/core/node/state_keeper/src/batch_executor/tests/mod.rs
+++ b/core/node/state_keeper/src/batch_executor/tests/mod.rs
@@ -50,11 +50,11 @@ async fn execute_l2_tx(storage_type: StorageType) {
     let mut tester = Tester::new(connection_pool);
     tester.genesis().await;
     tester.fund(&[alice.address()]).await;
-    let executor = tester.create_batch_executor(storage_type).await;
+    let mut executor = tester.create_batch_executor(storage_type).await;
 
-    let res = executor.execute_tx(alice.execute()).await;
+    let res = executor.execute_tx(alice.execute()).await.unwrap();
     assert_executed(&res);
-    executor.finish_batch().await;
+    executor.finish_batch().await.unwrap();
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -107,13 +107,13 @@ async fn execute_l2_tx_after_snapshot_recovery(
     let snapshot = storage_snapshot.recover(&connection_pool).await;
 
     let mut tester = Tester::new(connection_pool);
-    let executor = tester
+    let mut executor = tester
         .recover_batch_executor_custom(&storage_type, &snapshot)
         .await;
-    let res = executor.execute_tx(alice.execute()).await;
+    let res = executor.execute_tx(alice.execute()).await.unwrap();
     if mutation.is_none() {
         assert_executed(&res);
-        executor.finish_batch().await;
+        executor.finish_batch().await.unwrap();
     } else {
         assert_rejected(&res);
     }
@@ -129,13 +129,16 @@ async fn execute_l1_tx() {
 
     tester.genesis().await;
     tester.fund(&[alice.address()]).await;
-    let executor = tester
+    let mut executor = tester
         .create_batch_executor(StorageType::AsyncRocksdbCache)
         .await;
 
-    let res = executor.execute_tx(alice.l1_execute(PriorityOpId(1))).await;
+    let res = executor
+        .execute_tx(alice.l1_execute(PriorityOpId(1)))
+        .await
+        .unwrap();
     assert_executed(&res);
-    executor.finish_batch().await;
+    executor.finish_batch().await.unwrap();
 }
 
 /// Checks that we can successfully execute a single L2 tx and a single L1 tx in batch executor.
@@ -147,17 +150,20 @@ async fn execute_l2_and_l1_txs() {
     let mut tester = Tester::new(connection_pool);
     tester.genesis().await;
     tester.fund(&[alice.address()]).await;
-    let executor = tester
+    let mut executor = tester
         .create_batch_executor(StorageType::AsyncRocksdbCache)
         .await;
 
-    let res = executor.execute_tx(alice.execute()).await;
+    let res = executor.execute_tx(alice.execute()).await.unwrap();
     assert_executed(&res);
 
-    let res = executor.execute_tx(alice.l1_execute(PriorityOpId(1))).await;
+    let res = executor
+        .execute_tx(alice.l1_execute(PriorityOpId(1)))
+        .await
+        .unwrap();
     assert_executed(&res);
 
-    executor.finish_batch().await;
+    executor.finish_batch().await.unwrap();
 }
 
 /// Checks that we can successfully rollback the transaction and execute it once again.
@@ -170,18 +176,18 @@ async fn rollback() {
 
     tester.genesis().await;
     tester.fund(&[alice.address()]).await;
-    let executor = tester
+    let mut executor = tester
         .create_batch_executor(StorageType::AsyncRocksdbCache)
         .await;
 
     let tx = alice.execute();
-    let res_old = executor.execute_tx(tx.clone()).await;
+    let res_old = executor.execute_tx(tx.clone()).await.unwrap();
     assert_executed(&res_old);
 
-    executor.rollback_last_tx().await;
+    executor.rollback_last_tx().await.unwrap();
 
     // Execute the same transaction, it must succeed.
-    let res_new = executor.execute_tx(tx).await;
+    let res_new = executor.execute_tx(tx).await.unwrap();
     assert_executed(&res_new);
 
     let (
@@ -203,7 +209,7 @@ async fn rollback() {
         "Execution results must be the same"
     );
 
-    executor.finish_batch().await;
+    executor.finish_batch().await.unwrap();
 }
 
 /// Checks that incorrect transactions are marked as rejected.
@@ -215,12 +221,12 @@ async fn reject_tx() {
     let mut tester = Tester::new(connection_pool);
 
     tester.genesis().await;
-    let executor = tester
+    let mut executor = tester
         .create_batch_executor(StorageType::AsyncRocksdbCache)
         .await;
 
     // Wallet is not funded, it can't pay for fees.
-    let res = executor.execute_tx(alice.execute()).await;
+    let res = executor.execute_tx(alice.execute()).await.unwrap();
     assert_rejected(&res);
 }
 
@@ -234,15 +240,15 @@ async fn too_big_gas_limit() {
     let mut tester = Tester::new(connection_pool);
     tester.genesis().await;
     tester.fund(&[alice.address()]).await;
-    let executor = tester
+    let mut executor = tester
         .create_batch_executor(StorageType::AsyncRocksdbCache)
         .await;
 
     let big_gas_limit_tx = alice.execute_with_gas_limit(u32::MAX);
 
-    let res = executor.execute_tx(big_gas_limit_tx).await;
+    let res = executor.execute_tx(big_gas_limit_tx).await.unwrap();
     assert_executed(&res);
-    executor.finish_batch().await;
+    executor.finish_batch().await.unwrap();
 }
 
 /// Checks that we can't execute the same transaction twice.
@@ -254,16 +260,16 @@ async fn tx_cant_be_reexecuted() {
     let mut tester = Tester::new(connection_pool);
     tester.genesis().await;
     tester.fund(&[alice.address()]).await;
-    let executor = tester
+    let mut executor = tester
         .create_batch_executor(StorageType::AsyncRocksdbCache)
         .await;
 
     let tx = alice.execute();
-    let res1 = executor.execute_tx(tx.clone()).await;
+    let res1 = executor.execute_tx(tx.clone()).await.unwrap();
     assert_executed(&res1);
 
     // Nonce is used for the second tx.
-    let res2 = executor.execute_tx(tx).await;
+    let res2 = executor.execute_tx(tx).await.unwrap();
     assert_rejected(&res2);
 }
 
@@ -276,23 +282,25 @@ async fn deploy_and_call_loadtest() {
     let mut tester = Tester::new(connection_pool);
     tester.genesis().await;
     tester.fund(&[alice.address()]).await;
-    let executor = tester
+    let mut executor = tester
         .create_batch_executor(StorageType::AsyncRocksdbCache)
         .await;
 
     let tx = alice.deploy_loadnext_tx();
-    assert_executed(&executor.execute_tx(tx.tx).await);
+    assert_executed(&executor.execute_tx(tx.tx).await.unwrap());
     assert_executed(
         &executor
             .execute_tx(alice.loadnext_custom_gas_call(tx.address, 10, 10_000_000))
-            .await,
+            .await
+            .unwrap(),
     );
     assert_executed(
         &executor
             .execute_tx(alice.loadnext_custom_writes_call(tx.address, 1, 500_000_000))
-            .await,
+            .await
+            .unwrap(),
     );
-    executor.finish_batch().await;
+    executor.finish_batch().await.unwrap();
 }
 
 /// Checks that a tx that is reverted by the VM still can be included into a batch.
@@ -305,12 +313,12 @@ async fn execute_reverted_tx() {
 
     tester.genesis().await;
     tester.fund(&[alice.address()]).await;
-    let executor = tester
+    let mut executor = tester
         .create_batch_executor(StorageType::AsyncRocksdbCache)
         .await;
 
     let tx = alice.deploy_loadnext_tx();
-    assert_executed(&executor.execute_tx(tx.tx).await);
+    assert_executed(&executor.execute_tx(tx.tx).await.unwrap());
 
     assert_reverted(
         &executor
@@ -318,9 +326,10 @@ async fn execute_reverted_tx() {
                 tx.address, 1,
                 1_000_000, // We provide enough gas for tx to be executed, but not enough for the call to be successful.
             ))
-            .await,
+            .await
+            .unwrap(),
     );
-    executor.finish_batch().await;
+    executor.finish_batch().await.unwrap();
 }
 
 /// Runs the batch executor through a semi-realistic basic scenario:
@@ -336,44 +345,53 @@ async fn execute_realistic_scenario() {
     tester.genesis().await;
     tester.fund(&[alice.address()]).await;
     tester.fund(&[bob.address()]).await;
-    let executor = tester
+    let mut executor = tester
         .create_batch_executor(StorageType::AsyncRocksdbCache)
         .await;
 
     // A good tx should be executed successfully.
-    let res = executor.execute_tx(alice.execute()).await;
+    let res = executor.execute_tx(alice.execute()).await.unwrap();
     assert_executed(&res);
 
     // Execute a good tx successfully, roll if back, and execute it again.
     let tx_to_be_rolled_back = alice.execute();
-    let res = executor.execute_tx(tx_to_be_rolled_back.clone()).await;
+    let res = executor
+        .execute_tx(tx_to_be_rolled_back.clone())
+        .await
+        .unwrap();
     assert_executed(&res);
 
-    executor.rollback_last_tx().await;
+    executor.rollback_last_tx().await.unwrap();
 
-    let res = executor.execute_tx(tx_to_be_rolled_back.clone()).await;
+    let res = executor
+        .execute_tx(tx_to_be_rolled_back.clone())
+        .await
+        .unwrap();
     assert_executed(&res);
 
     // A good tx from a different account should be executed successfully.
-    let res = executor.execute_tx(bob.execute()).await;
+    let res = executor.execute_tx(bob.execute()).await.unwrap();
     assert_executed(&res);
 
     // If we try to execute an already executed again it should be rejected.
-    let res = executor.execute_tx(tx_to_be_rolled_back).await;
+    let res = executor.execute_tx(tx_to_be_rolled_back).await.unwrap();
     assert_rejected(&res);
 
     // An unrelated good tx should be executed successfully.
-    executor.rollback_last_tx().await; // Roll back the vm to the pre-rejected-tx state.
+    executor.rollback_last_tx().await.unwrap(); // Roll back the vm to the pre-rejected-tx state.
 
     // No need to reset the nonce because a tx with the current nonce was indeed executed.
-    let res = executor.execute_tx(alice.execute()).await;
+    let res = executor.execute_tx(alice.execute()).await.unwrap();
     assert_executed(&res);
 
     // A good L1 tx should also be executed successfully.
-    let res = executor.execute_tx(alice.l1_execute(PriorityOpId(1))).await;
+    let res = executor
+        .execute_tx(alice.l1_execute(PriorityOpId(1)))
+        .await
+        .unwrap();
     assert_executed(&res);
 
-    executor.finish_batch().await;
+    executor.finish_batch().await.unwrap();
 }
 
 /// Checks that we handle the bootloader out of gas error on execution phase.
@@ -393,11 +411,11 @@ async fn bootloader_out_of_gas_for_any_tx() {
 
     tester.genesis().await;
     tester.fund(&[alice.address()]).await;
-    let executor = tester
+    let mut executor = tester
         .create_batch_executor(StorageType::AsyncRocksdbCache)
         .await;
 
-    let res = executor.execute_tx(alice.execute()).await;
+    let res = executor.execute_tx(alice.execute()).await.unwrap();
     assert_matches!(res, TxExecutionResult::BootloaderOutOfGasForTx);
 }
 
@@ -412,14 +430,14 @@ async fn bootloader_tip_out_of_gas() {
 
     tester.genesis().await;
     tester.fund(&[alice.address()]).await;
-    let executor = tester
+    let mut executor = tester
         .create_batch_executor(StorageType::AsyncRocksdbCache)
         .await;
 
-    let res = executor.execute_tx(alice.execute()).await;
+    let res = executor.execute_tx(alice.execute()).await.unwrap();
     assert_executed(&res);
 
-    let finished_batch = executor.finish_batch().await;
+    let finished_batch = executor.finish_batch().await.unwrap();
 
     // Just a bit below the gas used for the previous batch execution should be fine to execute the tx
     // but not enough to execute the block tip.
@@ -435,11 +453,11 @@ async fn bootloader_tip_out_of_gas() {
         validation_computational_gas_limit: u32::MAX,
     });
 
-    let second_executor = tester
+    let mut second_executor = tester
         .create_batch_executor(StorageType::AsyncRocksdbCache)
         .await;
 
-    let res = second_executor.execute_tx(alice.execute()).await;
+    let res = second_executor.execute_tx(alice.execute()).await.unwrap();
     assert_matches!(res, TxExecutionResult::BootloaderOutOfGasForTx);
 }
 
@@ -455,34 +473,34 @@ async fn catchup_rocksdb_cache() {
     tester.fund(&[alice.address(), bob.address()]).await;
 
     // Execute a bunch of transactions to populate Postgres-based storage (note that RocksDB stays empty)
-    let executor = tester.create_batch_executor(StorageType::Postgres).await;
+    let mut executor = tester.create_batch_executor(StorageType::Postgres).await;
     for _ in 0..10 {
-        let res = executor.execute_tx(alice.execute()).await;
+        let res = executor.execute_tx(alice.execute()).await.unwrap();
         assert_executed(&res);
     }
 
     // Execute one more tx on PG
     let tx = alice.execute();
-    let res = executor.execute_tx(tx.clone()).await;
+    let res = executor.execute_tx(tx.clone()).await.unwrap();
     assert_executed(&res);
-    executor.finish_batch().await;
+    executor.finish_batch().await.unwrap();
 
     // Async RocksDB cache should be aware of the tx and should reject it
-    let executor = tester
+    let mut executor = tester
         .create_batch_executor(StorageType::AsyncRocksdbCache)
         .await;
-    let res = executor.execute_tx(tx.clone()).await;
+    let res = executor.execute_tx(tx.clone()).await.unwrap();
     assert_rejected(&res);
     // Execute one tx just so we can finish the batch
-    executor.rollback_last_tx().await; // Roll back the vm to the pre-rejected-tx state.
-    let res = executor.execute_tx(bob.execute()).await;
+    executor.rollback_last_tx().await.unwrap(); // Roll back the vm to the pre-rejected-tx state.
+    let res = executor.execute_tx(bob.execute()).await.unwrap();
     assert_executed(&res);
-    executor.finish_batch().await;
+    executor.finish_batch().await.unwrap();
     // Wait for all background tasks to exit, otherwise we might still be holding a RocksDB lock
     tester.wait_for_tasks().await;
 
     // Sync RocksDB storage should be aware of the tx and should reject it
-    let executor = tester.create_batch_executor(StorageType::Rocksdb).await;
-    let res = executor.execute_tx(tx).await;
+    let mut executor = tester.create_batch_executor(StorageType::Rocksdb).await;
+    let res = executor.execute_tx(tx).await.unwrap();
     assert_rejected(&res);
 }

--- a/core/node/state_keeper/src/batch_executor/tests/tester.rs
+++ b/core/node/state_keeper/src/batch_executor/tests/tester.rs
@@ -492,7 +492,7 @@ impl StorageSnapshot {
             .collect();
         drop(storage);
 
-        let executor = tester
+        let mut executor = tester
             .create_batch_executor(StorageType::AsyncRocksdbCache)
             .await;
         let mut l2_block_env = L2BlockEnv {
@@ -506,7 +506,7 @@ impl StorageSnapshot {
         for _ in 0..transaction_count {
             let tx = alice.execute();
             let tx_hash = tx.hash(); // probably incorrect
-            let res = executor.execute_tx(tx).await;
+            let res = executor.execute_tx(tx).await.unwrap();
             if let TxExecutionResult::Success { tx_result, .. } = res {
                 let storage_logs = &tx_result.logs.storage_logs;
                 storage_writes_deduplicator
@@ -525,10 +525,10 @@ impl StorageSnapshot {
             l2_block_env.number += 1;
             l2_block_env.timestamp += 1;
             l2_block_env.prev_block_hash = hasher.finalize(ProtocolVersionId::latest());
-            executor.start_next_l2_block(l2_block_env).await;
+            executor.start_next_l2_block(l2_block_env).await.unwrap();
         }
 
-        let finished_batch = executor.finish_batch().await;
+        let finished_batch = executor.finish_batch().await.unwrap();
         let storage_logs = &finished_batch.block_tip_execution_result.logs.storage_logs;
         storage_writes_deduplicator.apply(storage_logs.iter().filter(|log| log.log_query.rw_flag));
         let modified_entries = storage_writes_deduplicator.into_modified_key_values();

--- a/core/node/state_keeper/src/testonly/mod.rs
+++ b/core/node/state_keeper/src/testonly/mod.rs
@@ -95,10 +95,11 @@ impl BatchExecutor for MockBatchExecutor {
                     Command::FinishBatch(resp) => {
                         // Blanket result, it doesn't really matter.
                         resp.send(default_vm_batch_result()).unwrap();
-                        return;
+                        break;
                     }
                 }
             }
+            anyhow::Ok(())
         });
         Some(BatchExecutorHandle::from_raw(handle, send))
     }


### PR DESCRIPTION
## What ❔

Propagates errors in the batch executor instead of panicking.

## Why ❔

Batch executor somewhat frequently panics on node shutdown. This is suboptimal UX, can lead to false positive bug reports etc.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.