### PR TITLE
fix(zk init): --run-observability flag

### DIFF
--- a/infrastructure/zk/src/init.ts
+++ b/infrastructure/zk/src/init.ts
@@ -16,8 +16,12 @@ import * as server from './server';
 import { createVolumes, up } from './up';
 
 // Checks if all required tools are installed with the correct versions
-const checkEnv = async (): Promise<void> => {
+const checkEnv = async (runObservability: boolean): Promise<void> => {
     const tools = ['node', 'yarn', 'docker', 'cargo'];
+    if (runObservability) {
+        tools.push('yq');
+    }
+
     for (const tool of tools) {
         await utils.exec(`which ${tool}`);
     }
@@ -37,6 +41,23 @@ const submoduleUpdate = async (): Promise<void> => {
     await utils.exec('git submodule update');
 };
 
+// clone dockprom and zksync-era dashboards
+const setupObservability = async (): Promise<void> => {
+    // clone dockprom, era-observability repos and export era dashboards to dockprom
+    await utils.spawn(
+        `rm -rf ./target/dockprom && git clone git@github.com:stefanprodan/dockprom.git ./target/dockprom \
+            && rm -rf ./target/era-observability && git clone git@github.com:matter-labs/era-observability.git ./target/era-observability \
+            && cp ./target/era-observability/dashboards/* ./target/dockprom/grafana/provisioning/dashboards
+        `
+    );
+    // add scrape configuration to prometheus
+    await utils.spawn(
+        `yq eval '.scrape_configs += [{"job_name": "zksync", "scrape_interval": "5s", "honor_labels": true, "static_configs": [{"targets": ["host.docker.internal:3312"]}]}]' \
+            -i ./target/dockprom/prometheus/prometheus.yml
+        `
+    );
+};
+
 // Sets up docker environment and compiles contracts
 type InitSetupOptions = {
     skipEnvSetup: boolean;
@@ -50,6 +71,10 @@ const initSetup = async ({
     runObservability,
     deploymentMode
 }: InitSetupOptions): Promise<void> => {
+    if (runObservability) {
+        await announced('Pulling observability repos', setupObservability());
+    }
+
     await announced(
         `Initializing in ${deploymentMode == contract.DeploymentMode.Validium ? 'Validium mode' : 'Roll-up mode'}`
     );
@@ -58,7 +83,7 @@ const initSetup = async ({
     }
     if (!process.env.CI && !skipEnvSetup) {
         await announced('Pulling images', docker.pull());
-        await announced('Checking environment', checkEnv());
+        await announced('Checking environment', checkEnv(runObservability));
         await announced('Checking git hooks', env.gitHooks());
         await announced('Create volumes', createVolumes());
         await announced('Setting up containers', up(runObservability));


### PR DESCRIPTION
## What ❔

Run DockProm (Grafana) whenever zk init --run-observability is executed.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔
This functionality was not working on the main branch. Referencing the commit that implements this feature:
[feat: add run-observability to zk (#1359) · matter-labs/zksync-era@2b520f6](https://github.com/matter-labs/zksync-era/commit/2b520f6e0efc2f996e46d06e66be8eb273138633)

## How to Reproduce:

- New dependency: `yq`

```sh
git clone https://github.com/matter-labs/zksync-era.git
cd zksync-era
export ZKSYNC_HOME=$(pwd)
export PATH=$ZKSYNC_HOME/bin:$PATH
zk && zk clean --all && zk env dev && zk init --run-observability && zk server
```

Several transactions were generated in order to test the Grafana's dashboard:

<img width="1129" alt="Screenshot 2024-05-29 at 3 33 14 PM" src="https://github.com/matter-labs/zksync-era/assets/156438142/edb1be3c-da9e-465c-b110-8a8f0ebb49a9">

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
