### PR TITLE
feat(node_framework): Enforce ability to request and provide tasks/resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8944,6 +8944,7 @@ dependencies = [
  "zksync_node_api_server",
  "zksync_node_consensus",
  "zksync_node_fee_model",
+ "zksync_node_framework_derive",
  "zksync_node_sync",
  "zksync_object_store",
  "zksync_proof_data_handler",
@@ -8956,6 +8957,15 @@ dependencies = [
  "zksync_types",
  "zksync_utils",
  "zksync_web3_decl",
+]
+
+[[package]]
+name = "zksync_node_framework_derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "core/bin/genesis_generator",
     # Node services
     "core/node/node_framework",
+    "core/node/node_framework_derive",
     "core/node/proof_data_handler",
     "core/node/block_reverter",
     "core/node/commitment_generator",
@@ -241,6 +242,7 @@ zksync_crypto_primitives = { path = "core/lib/crypto_primitives" }
 
 # Framework and components
 zksync_node_framework = { path = "core/node/node_framework" }
+zksync_node_framework_derive = { path = "core/node/node_framework_derive" }
 zksync_eth_watch = { path = "core/node/eth_watch" }
 zksync_shared_metrics = { path = "core/node/shared_metrics" }
 zksync_proof_data_handler = { path = "core/node/proof_data_handler" }

--- a/core/node/node_framework/Cargo.toml
+++ b/core/node/node_framework/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 
 [dependencies]
 prometheus_exporter.workspace = true
+zksync_node_framework_derive.workspace = true
 zksync_types.workspace = true
 zksync_health_check.workspace = true
 zksync_dal.workspace = true

--- a/core/node/node_framework/examples/showcase.rs
+++ b/core/node/node_framework/examples/showcase.rs
@@ -9,7 +9,7 @@ use std::{
 
 use zksync_node_framework::{
     resource::Resource,
-    service::{ServiceContext, StopReceiver, ZkStackServiceBuilder},
+    service::{Provides, ServiceContext, StopReceiver, ZkStackServiceBuilder},
     task::Task,
     wiring_layer::{WiringError, WiringLayer},
 };
@@ -182,6 +182,8 @@ impl WiringLayer for DatabaseLayer {
 }
 
 /// Layer where we add tasks.
+#[derive(Provides)]
+#[provides(PutTask, CheckTask)]
 struct TasksLayer;
 
 #[async_trait::async_trait]
@@ -198,8 +200,8 @@ impl WiringLayer for TasksLayer {
         let put_task = PutTask { db: db.clone() };
         let check_task = CheckTask { db };
         // These tasks will be launched by the service once the wiring process is complete.
-        context.add_task(Box::new(put_task));
-        context.add_task(Box::new(check_task));
+        context.add_task(context.token::<Self>(), Box::new(put_task));
+        context.add_task(context.token::<Self>(), Box::new(check_task));
         Ok(())
     }
 }

--- a/core/node/node_framework/src/implementations/layers/l1_gas.rs
+++ b/core/node/node_framework/src/implementations/layers/l1_gas.rs
@@ -13,12 +13,13 @@ use crate::{
         eth_interface::EthInterfaceResource, fee_input::FeeInputResource,
         l1_tx_params::L1TxParamsResource,
     },
-    service::{ServiceContext, StopReceiver},
+    service::{Provides, ServiceContext, StopReceiver},
     task::Task,
     wiring_layer::{WiringError, WiringLayer},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Provides)]
+#[provides(local = "true", GasAdjusterTask)]
 pub struct SequencerL1GasLayer {
     gas_adjuster_config: GasAdjusterConfig,
     genesis_config: GenesisConfig,
@@ -68,7 +69,10 @@ impl WiringLayer for SequencerL1GasLayer {
 
         context.insert_resource(L1TxParamsResource(gas_adjuster.clone()))?;
 
-        context.add_task(Box::new(GasAdjusterTask { gas_adjuster }));
+        context.add_task(
+            context.token::<Self>(),
+            Box::new(GasAdjusterTask { gas_adjuster }),
+        );
         Ok(())
     }
 }

--- a/core/node/node_framework/src/implementations/layers/tee_verifier_input_producer.rs
+++ b/core/node/node_framework/src/implementations/layers/tee_verifier_input_producer.rs
@@ -7,12 +7,13 @@ use crate::{
         object_store::ObjectStoreResource,
         pools::{MasterPool, PoolResource},
     },
-    service::{ServiceContext, StopReceiver},
+    service::{Provides, ServiceContext, StopReceiver},
     task::Task,
     wiring_layer::{WiringError, WiringLayer},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Provides)]
+#[provides(local = "true", TeeVerifierInputProducerTask)]
 pub struct TeeVerifierInputProducerLayer {
     l2_chain_id: L2ChainId,
 }
@@ -40,7 +41,10 @@ impl WiringLayer for TeeVerifierInputProducerLayer {
         let tee =
             TeeVerifierInputProducer::new(pool_resource, object_store.0, self.l2_chain_id).await?;
 
-        context.add_task(Box::new(TeeVerifierInputProducerTask { tee }));
+        context.add_task(
+            context.token::<Self>(),
+            Box::new(TeeVerifierInputProducerTask { tee }),
+        );
 
         Ok(())
     }

--- a/core/node/node_framework/src/implementations/layers/web3_api/server.rs
+++ b/core/node/node_framework/src/implementations/layers/web3_api/server.rs
@@ -13,7 +13,7 @@ use crate::{
         sync_state::SyncStateResource,
         web3_api::{MempoolCacheResource, TreeApiClientResource, TxSenderResource},
     },
-    service::{ServiceContext, StopReceiver},
+    service::{Provides, ServiceContext, StopReceiver},
     task::Task,
     wiring_layer::{WiringError, WiringLayer},
 };
@@ -64,7 +64,8 @@ enum Transport {
     Ws,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Provides)]
+#[provides(local = "true", Web3ApiTask, ApiTaskGarbageCollector)]
 pub struct Web3ServerLayer {
     transport: Transport,
     port: u16,
@@ -178,8 +179,8 @@ impl WiringLayer for Web3ServerLayer {
             task_sender,
         };
         let garbage_collector_task = ApiTaskGarbageCollector { task_receiver };
-        context.add_task(Box::new(web3_api_task));
-        context.add_task(Box::new(garbage_collector_task));
+        context.add_task(context.token::<Self>(), Box::new(web3_api_task));
+        context.add_task(context.token::<Self>(), Box::new(garbage_collector_task));
 
         Ok(())
     }

--- a/core/node/node_framework/src/service/mod.rs
+++ b/core/node/node_framework/src/service/mod.rs
@@ -3,10 +3,15 @@ use std::{collections::HashMap, time::Duration};
 use anyhow::Context;
 use futures::{future::BoxFuture, FutureExt};
 use tokio::{runtime::Runtime, sync::watch};
+pub use zksync_node_framework_derive::Provides;
 use zksync_utils::panic_extractor::try_extract_panic_message;
 
 use self::runnables::Runnables;
-pub use self::{context::ServiceContext, error::ZkStackServiceError, stop_receiver::StopReceiver};
+pub use self::{
+    context::{Provides, Requests, ServiceContext},
+    error::ZkStackServiceError,
+    stop_receiver::StopReceiver,
+};
 use crate::{
     resource::{ResourceId, StoredResource},
     service::runnables::TaskReprs,

--- a/core/node/node_framework_derive/Cargo.toml
+++ b/core/node/node_framework_derive/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "zksync_node_framework_derive"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+syn = { version = "2.0", features = ["full"] }
+quote = "1.0"
+proc-macro2 = "1.0"
+
+[lib]
+proc-macro = true

--- a/core/node/node_framework_derive/src/lib.rs
+++ b/core/node/node_framework_derive/src/lib.rs
@@ -1,0 +1,91 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput, LitStr};
+
+#[derive(Debug, Clone, Copy)]
+enum Macro {
+    Provides,
+    Requests,
+}
+
+impl Macro {
+    fn doc_string(self) -> &'static str {
+        match self {
+            Macro::Provides => "provides",
+            Macro::Requests => "requests",
+        }
+    }
+
+    fn trait_name(self) -> &'static str {
+        match self {
+            Macro::Provides => "Provides",
+            Macro::Requests => "Requests",
+        }
+    }
+
+    fn attribute_name(self) -> &'static str {
+        match self {
+            Macro::Provides => "provides",
+            Macro::Requests => "requests",
+        }
+    }
+
+    fn render(self, input: DeriveInput) -> proc_macro2::TokenStream {
+        // Get the struct name
+        let name = input.ident.clone();
+
+        // Initialize a vector to hold the types
+        let mut provided_types = Vec::new();
+
+        // Whether this derive is called from within the framework crate.
+        let mut is_internal = false;
+
+        // Iterate over attributes to find #[provides(..)]
+        for attr in &input.attrs {
+            if attr.path().is_ident("provides") {
+                attr.parse_nested_meta(|meta| {
+                    // Special attribute that marks the derive as internal.
+                    // Alters the path to the trait to be implemented.
+                    if meta.path.is_ident("local") {
+                        let value = meta.value().unwrap();
+                        let s: LitStr = value.parse().unwrap();
+                        if s.value() == "true" {
+                            is_internal = true;
+                        }
+                    } else {
+                        provided_types.push(meta.path.clone());
+                    }
+                    Ok(())
+                })
+                .unwrap();
+            }
+        }
+
+        let crate_name = if is_internal {
+            quote! { crate }
+        } else {
+            quote! { zksync_node_framework }
+        };
+
+        // Generate the impl blocks for each provided type
+        let impls = provided_types.iter().map(|ty| {
+            quote! {
+                impl #crate_name::service::Provides<#ty> for #name {}
+            }
+        });
+
+        // Combine everything into the final output
+        quote! {
+            #(#impls)*
+        }
+    }
+}
+
+#[proc_macro_derive(Provides, attributes(provides))]
+pub fn provides_derive(input: TokenStream) -> TokenStream {
+    // Parse the input tokens into a syntax tree
+    let input = parse_macro_input!(input as DeriveInput);
+    Macro::Provides.render(input).into()
+}


### PR DESCRIPTION
## What ❔

⚠️ Experimental and heavily WIP

Introduces two new marker traits for the framework: `Requests<T>` and `Provides<T>`.
These marker traits have to be implemented by the `WiringLayer` types in order to be able to request resources and add resources/tasks.

Additionally, this PR adds a new crate with a proc macro to derive `Requests` and `Provides` traits.
The intention of derive macro is to **automatically generate documentation describing which resources/tasks are requested/added by the wiring layer**.

## Why ❔

The framework is highly dynamic, and we are going to rely on the documentation to provide info on WiringLayer behavior (e.g. inputs/outputs). By making it automatic, we will make it less likely to become wrong/outdated.
And even without documentation, having list of requested/provided resources will probably be helpful for developers.
