### PR TITLE
fix(prover): Setup script

### DIFF
--- a/prover/setup.sh
+++ b/prover/setup.sh
@@ -13,12 +13,9 @@ if [[ -z "${ZKSYNC_HOME}" ]]; then
   exit 1
 fi
 
-sed -i.backup 's/^proof_sending_mode=.*$/proof_sending_mode="OnlyRealProofs"/' ../etc/env/base/eth_sender.toml
-rm ../etc/env/base/eth_sender.toml.backup
-sed -i.backup 's/^setup_data_path=.*$/setup_data_path="vk_setup_data_generator_server_fri\/data\/"/' ../etc/env/base/fri_prover.toml
-rm ../etc/env/base/fri_prover.toml.backup
-sed -i.backup 's/^universal_setup_path=.*$/universal_setup_path="..\/keys\/setup\/setup_2^26.key"/' ../etc/env/base/fri_proof_compressor.toml
-rm ../etc/env/base/fri_proof_compressor.toml.backup
+sed -i '' -e 's/^proof_sending_mode =.*$/proof_sending_mode = "OnlyRealProofs"/' ../etc/env/base/eth_sender.toml
+sed -i '' -e 's;^setup_data_path =.*$;setup_data_path = "vk_setup_data_generator_server_fri/data/";' ../etc/env/base/fri_prover.toml
+sed -i '' -e 's;^universal_setup_path =.*$;universal_setup_path = "../keys/setup/setup_2^26.key";' ../etc/env/base/fri_proof_compressor.toml
 
 zk config compile dev
 


### PR DESCRIPTION
## What ❔

Fix `sed` replacements in prover setup scripts
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

The replacements were broken because of the lack of spaces between `=`
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
