### PR TITLE
fix(en): Remove L1 client health check

### DIFF
--- a/core/bin/external_node/src/helpers.rs
+++ b/core/bin/external_node/src/helpers.rs
@@ -41,35 +41,6 @@ impl CheckHealth for MainNodeHealthCheck {
     }
 }
 
-/// Ethereum client health check.
-#[derive(Debug)]
-pub(crate) struct EthClientHealthCheck(Box<DynClient<L1>>);
-
-impl From<Box<DynClient<L1>>> for EthClientHealthCheck {
-    fn from(client: Box<DynClient<L1>>) -> Self {
-        Self(client.for_component("ethereum_health_check"))
-    }
-}
-
-#[async_trait]
-impl CheckHealth for EthClientHealthCheck {
-    fn name(&self) -> &'static str {
-        "ethereum_http_rpc"
-    }
-
-    async fn check_health(&self) -> Health {
-        if let Err(err) = self.0.block_number().await {
-            tracing::warn!("Health-check call to Ethereum HTTP RPC failed: {err}");
-            let details = serde_json::json!({
-                "error": err.to_string(),
-            });
-            // Unlike main node client, losing connection to L1 is not fatal for the node
-            return Health::from(HealthStatus::Affected).with_details(details);
-        }
-        HealthStatus::Ready.into()
-    }
-}
-
 /// Task that validates chain IDs using main node and Ethereum clients.
 #[derive(Debug)]
 pub(crate) struct ValidateChainIdsTask {

--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -54,7 +54,7 @@ use zksync_web3_decl::{
 
 use crate::{
     config::ExternalNodeConfig,
-    helpers::{EthClientHealthCheck, MainNodeHealthCheck, ValidateChainIdsTask},
+    helpers::{MainNodeHealthCheck, ValidateChainIdsTask},
     init::ensure_storage_initialized,
     metrics::RUST_METRICS,
 };
@@ -854,7 +854,6 @@ async fn run_node(
     app_health.insert_custom_component(Arc::new(MainNodeHealthCheck::from(
         main_node_client.clone(),
     )))?;
-    app_health.insert_custom_component(Arc::new(EthClientHealthCheck::from(eth_client.clone())))?;
     app_health.insert_custom_component(Arc::new(ConnectionPoolHealthCheck::new(
         connection_pool.clone(),
     )))?;


### PR DESCRIPTION
## What ❔

Removes L1 client health check from EN.

## Why ❔

Doesn't bring that much value and leads to L1 client getting rate-limited for our GCS ENs.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.