### PR TITLE
fix(en): Fix transient error detection in consistency checker

### DIFF
--- a/core/node/consistency_checker/src/lib.rs
+++ b/core/node/consistency_checker/src/lib.rs
@@ -42,10 +42,12 @@ enum CheckError {
 
 impl CheckError {
     fn is_transient(&self) -> bool {
-        matches!(
-            self,
-            Self::Web3(err) if err.is_transient()
-        )
+        match self {
+            Self::Web3(err) | Self::ContractCall(ContractCallError::EthereumGateway(err)) => {
+                err.is_transient()
+            }
+            _ => false,
+        }
     }
 }
 
@@ -532,7 +534,10 @@ impl ConsistencyChecker {
 
         while let Err(err) = self.sanity_check_diamond_proxy_addr().await {
             if err.is_transient() {
-                tracing::warn!("Transient error checking diamond proxy contract; will retry after a delay: {err}");
+                tracing::warn!(
+                    "Transient error checking diamond proxy contract; will retry after a delay: {:#}",
+                    anyhow::Error::from(err)
+                );
                 if tokio::time::timeout(self.sleep_interval, stop_receiver.changed())
                     .await
                     .is_ok()
@@ -629,7 +634,10 @@ impl ConsistencyChecker {
                     }
                 }
                 Err(err) if err.is_transient() => {
-                    tracing::warn!("Transient error while verifying L1 batch #{batch_number}; will retry after a delay: {err}");
+                    tracing::warn!(
+                        "Transient error while verifying L1 batch #{batch_number}; will retry after a delay: {:#}",
+                        anyhow::Error::from(err)
+                    );
                     if tokio::time::timeout(self.sleep_interval, stop_receiver.changed())
                         .await
                         .is_ok()


### PR DESCRIPTION
## What ❔

Considers a subset of contract call errors as transient.

## Why ❔

Currently, consistency checker considers all contract call errors fatal, which leads to EN terminating when it shouldn't.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.