### PR TITLE
chore(docs): Fix healthcheck command in EN docker-compose example

### DIFF
--- a/docs/guides/external-node/docker-compose-examples/mainnet-external-node-docker-compose.yml
+++ b/docs/guides/external-node/docker-compose-examples/mainnet-external-node-docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: "3.2"
 services:
   prometheus:
     image: prom/prometheus:v2.35.0
@@ -21,10 +21,10 @@ services:
   postgres:
     image: "postgres:14"
     command: >
-      postgres 
-      -c max_connections=200 
-      -c log_error_verbosity=terse 
-      -c shared_buffers=2GB 
+      postgres
+      -c max_connections=200
+      -c log_error_verbosity=terse
+      -c shared_buffers=2GB
       -c effective_cache_size=4GB
       -c maintenance_work_mem=1GB
       -c checkpoint_completion_target=0.9
@@ -41,12 +41,16 @@ services:
     healthcheck:
       interval: 1s
       timeout: 3s
-      test: psql -U postgres -c "select exists (select * from pg_stat_activity where datname = '{{ database_name }}' and application_name = 'pg_restore')" | grep -e ".f$"
+      test:
+        [
+          "CMD-SHELL",
+          'psql -U postgres -c "select exists (select * from pg_stat_activity where datname = ''{{ database_name }}'' and application_name = ''pg_restore'')" | grep -e ".f$$"',
+        ]
     environment:
       - POSTGRES_PASSWORD=notsecurepassword
       - PGPORT=5430
   external-node:
-    image: "matterlabs/external-node:2.0-v24.2.0"
+    image: "matterlabs/external-node:2.0-v24.6.0"
     depends_on:
       postgres:
         condition: service_healthy
@@ -81,5 +85,5 @@ services:
 volumes:
   mainnet-postgres: {}
   mainnet-rocksdb: {}
-  mainnet-prometheus-data: { }
-  mainnet-grafana-data: { }
+  mainnet-prometheus-data: {}
+  mainnet-grafana-data: {}

--- a/docs/guides/external-node/docker-compose-examples/testnet-external-node-docker-compose.yml
+++ b/docs/guides/external-node/docker-compose-examples/testnet-external-node-docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: "3.2"
 services:
   prometheus:
     image: prom/prometheus:v2.35.0
@@ -20,11 +20,11 @@ services:
       - "127.0.0.1:3000:3000"
   postgres:
     image: "postgres:14"
-    command: > 
-      postgres 
-      -c max_connections=200 
-      -c log_error_verbosity=terse 
-      -c shared_buffers=2GB 
+    command: >
+      postgres
+      -c max_connections=200
+      -c log_error_verbosity=terse
+      -c shared_buffers=2GB
       -c effective_cache_size=4GB
       -c maintenance_work_mem=1GB
       -c checkpoint_completion_target=0.9
@@ -41,12 +41,16 @@ services:
     healthcheck:
       interval: 1s
       timeout: 3s
-      test: psql -U postgres -c "select exists (select * from pg_stat_activity where datname = '{{ database_name }}' and application_name = 'pg_restore')" | grep -e ".f$"
+      test:
+        [
+          "CMD-SHELL",
+          'psql -U postgres -c "select exists (select * from pg_stat_activity where datname = ''{{ database_name }}'' and application_name = ''pg_restore'')" | grep -e ".f$$"',
+        ]
     environment:
       - POSTGRES_PASSWORD=notsecurepassword
       - PGPORT=5430
   external-node:
-    image: "matterlabs/external-node:2.0-v24.2.0"
+    image: "matterlabs/external-node:2.0-v24.6.0"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## What ❔

- Tweaking postgres `healthcheck` command in EN Docker Compose example to work from shells other than bash
- Minor formatting fixes to the aforementioned Docker Compose example files
- EN bump to the latest stable in the aforementioned Docker Compose example files

## Why ❔

Fixes: **https://github.com/zkSync-Community-Hub/zksync-developers/discussions/526#discussioncomment-9552115**

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
