### PR TITLE
feat(eth_sender): add max basefee and max blob fee config 

### DIFF
--- a/core/lib/config/src/configs/eth_sender.rs
+++ b/core/lib/config/src/configs/eth_sender.rs
@@ -39,6 +39,8 @@ impl EthConfig {
                 timestamp_criteria_max_allowed_lag: 30,
                 l1_batch_min_age_before_execute_seconds: None,
                 max_acceptable_priority_fee_in_gwei: 100000000000,
+                max_acceptable_base_fee_in_gwei: 1000000000000,
+                max_acceptable_blob_fee_in_gwei: 1000000000000,
                 pubdata_sending_mode: PubdataSendingMode::Calldata,
             }),
             gas_adjuster: Some(GasAdjusterConfig {
@@ -111,11 +113,16 @@ pub struct SenderConfig {
     /// Note that this number must be slightly higher than the one set on the contract,
     /// because the contract uses block.timestamp which lags behind the clock time.
     pub l1_batch_min_age_before_execute_seconds: Option<u64>,
-    // Max acceptable fee for sending tx it acts as a safeguard to prevent sending tx with very high fees.
+    // Max acceptable priority fee for sending tx it acts as a safeguard to prevent sending tx with very high fees.
     pub max_acceptable_priority_fee_in_gwei: u64,
 
     /// The mode in which we send pubdata, either Calldata or Blobs
     pub pubdata_sending_mode: PubdataSendingMode,
+
+    // Max acceptable base fee for sending tx it acts as a safeguard to prevent sending tx with very high fees.
+    pub max_acceptable_base_fee_in_gwei: u64,
+    // Max acceptable blob fee for sending tx it acts as a safeguard to prevent sending tx with very high fees.
+    pub max_acceptable_blob_fee_in_gwei: u64,
 }
 
 impl SenderConfig {

--- a/core/lib/config/src/testonly.rs
+++ b/core/lib/config/src/testonly.rs
@@ -369,6 +369,8 @@ impl Distribution<configs::eth_sender::SenderConfig> for EncodeDist {
             timestamp_criteria_max_allowed_lag: self.sample(rng),
             l1_batch_min_age_before_execute_seconds: self.sample(rng),
             max_acceptable_priority_fee_in_gwei: self.sample(rng),
+            max_acceptable_base_fee_in_gwei: self.sample(rng),
+            max_acceptable_blob_fee_in_gwei: self.sample(rng),
             pubdata_sending_mode: PubdataSendingMode::Calldata,
         }
     }

--- a/core/lib/env_config/src/eth_sender.rs
+++ b/core/lib/env_config/src/eth_sender.rs
@@ -69,6 +69,8 @@ mod tests {
                     proof_sending_mode: ProofSendingMode::SkipEveryProof,
                     l1_batch_min_age_before_execute_seconds: Some(1000),
                     max_acceptable_priority_fee_in_gwei: 100_000_000_000,
+                    max_acceptable_base_fee_in_gwei: 1_000_000_000_000,
+                    max_acceptable_blob_fee_in_gwei: 1_000_000_000_000,
                     pubdata_sending_mode: PubdataSendingMode::Calldata,
                 }),
                 gas_adjuster: Some(GasAdjusterConfig {
@@ -130,6 +132,8 @@ mod tests {
             ETH_SENDER_SENDER_MAX_ETH_TX_DATA_SIZE="120000"
             ETH_SENDER_SENDER_L1_BATCH_MIN_AGE_BEFORE_EXECUTE_SECONDS="1000"
             ETH_SENDER_SENDER_MAX_ACCEPTABLE_PRIORITY_FEE_IN_GWEI="100000000000"
+            ETH_SENDER_SENDER_MAX_ACCEPTABLE_BASE_FEE_IN_GWEI="1000000000000"
+            ETH_SENDER_SENDER_MAX_ACCEPTABLE_BLOB_FEE_IN_GWEI="1000000000000"
             ETH_SENDER_SENDER_PUBDATA_SENDING_MODE="Calldata"
             ETH_CLIENT_WEB3_URL="http://127.0.0.1:8545"
 

--- a/core/lib/protobuf_config/src/eth.rs
+++ b/core/lib/protobuf_config/src/eth.rs
@@ -109,6 +109,14 @@ impl ProtoRepr for proto::Sender {
                 .and_then(|x| Ok(proto::PubdataSendingMode::try_from(*x)?))
                 .context("pubdata_sending_mode")?
                 .parse(),
+            max_acceptable_base_fee_in_gwei: *required(
+                &self.max_acceptable_base_fee_in_gwei,
+            )
+                .context("max_acceptable_base_fee_in_gwei")?,
+            max_acceptable_blob_fee_in_gwei: *required(
+                &self.max_acceptable_blob_fee_in_gwei,
+            )
+                .context("max_acceptable_blob_fee_in_gwei")?,
         })
     }
 
@@ -139,6 +147,8 @@ impl ProtoRepr for proto::Sender {
             pubdata_sending_mode: Some(
                 proto::PubdataSendingMode::new(&this.pubdata_sending_mode).into(),
             ),
+            max_acceptable_base_fee_in_gwei: Some(this.max_acceptable_base_fee_in_gwei),
+            max_acceptable_blob_fee_in_gwei: Some(this.max_acceptable_blob_fee_in_gwei),
         }
     }
 }

--- a/core/lib/protobuf_config/src/proto/config/eth_sender.proto
+++ b/core/lib/protobuf_config/src/proto/config/eth_sender.proto
@@ -44,6 +44,8 @@ message Sender {
   optional uint64 max_acceptable_priority_fee_in_gwei = 16; // required; gwei
   optional PubdataSendingMode pubdata_sending_mode = 18; // required
   reserved 19; reserved "proof_loading_mode";
+  optional uint64 max_acceptable_base_fee_in_gwei = 20; // required; gwei
+  optional uint64 max_acceptable_blob_fee_in_gwei = 21; // required; gwei
 }
 
 message GasAdjuster {

--- a/etc/env/base/eth_sender.toml
+++ b/etc/env/base/eth_sender.toml
@@ -45,6 +45,8 @@ max_single_tx_gas = 6000000
 
 # Max acceptable fee for sending tx to L1
 max_acceptable_priority_fee_in_gwei = 100000000000
+max_acceptable_base_fee_in_gwei = 1000000000000
+max_acceptable_blob_fee_in_gwei = 1000000000000
 
 pubdata_sending_mode = "Blobs"
 

--- a/etc/env/file_based/general.yaml
+++ b/etc/env/file_based/general.yaml
@@ -131,6 +131,8 @@ eth:
     aggregated_proof_sizes: [ 1,4 ]
     max_aggregated_tx_gas: 4000000
     max_acceptable_priority_fee_in_gwei: 100000000000
+    max_acceptable_priority_base_in_gwei: 1000000000000
+    max_acceptable_priority_blob_in_gwei: 1000000000000
     pubdata_sending_mode: BLOBS
   gas_adjuster:
     default_priority_fee_per_gas: 1000000000


### PR DESCRIPTION
## What ❔

Add two extra configs `max_acceptable_base_fee_in_gwei` and `max_acceptable_blob_fee_in_gwei` to avoid sending transactions to L1 when fee become unreasonable. 

## Why ❔

In case the network fee become too crazy, we want to prevent eth_sender to send transactions to L1 because it could lead to lost for the operators when the fee collected on L2 cannot recoup the price


## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
