### PR TITLE
fix(api): Fix getting pending block

### DIFF
--- a/core/node/api_server/src/web3/namespaces/debug.rs
+++ b/core/node/api_server/src/web3/namespaces/debug.rs
@@ -63,6 +63,10 @@ impl DebugNamespace {
         options: Option<TracerConfig>,
     ) -> Result<Vec<ResultDebugCall>, Web3Error> {
         self.current_method().set_block_id(block_id);
+        if matches!(block_id, BlockId::Number(BlockNumber::Pending)) {
+            // See `EthNamespace::get_block_impl()` for an explanation why this check is needed.
+            return Ok(vec![]);
+        }
 
         let only_top_call = options
             .map(|options| options.tracer_config.only_top_call)


### PR DESCRIPTION
## What ❔

Fixes getting data for the pending block in `eth_getBlockByNumber` and a couple of other methods.

## Why ❔

Getting a pending block should always return `null`, but right now it actually doesn't. Caused by non-atomic reads from Postgres in the method implementation: first, a pending block number is resolved, and then a block with this number is fetched. Between these two reads, a block with this number may be inserted to Postgres.

While it's somewhat unlikely that anyone will query a pending block, it's still a correctness issue.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.