### PR TITLE
test(api): Fix latency of API server unit tests

### DIFF
--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -486,10 +486,9 @@ async fn run_api(
         .build(
             fee_params_fetcher,
             Arc::new(vm_concurrency_limiter),
-            ApiContracts::load_from_disk(), // TODO (BFT-138): Allow to dynamically reload API contracts
+            ApiContracts::load_from_disk().await?, // TODO (BFT-138): Allow to dynamically reload API contracts
             storage_caches,
-        )
-        .await;
+        );
 
     let mempool_cache = MempoolCache::new(config.optional.mempool_cache_size);
     let mempool_cache_update_task = mempool_cache.update_task(

--- a/core/bin/zksync_server/src/node_builder.rs
+++ b/core/bin/zksync_server/src/node_builder.rs
@@ -239,7 +239,7 @@ impl MainNodeBuilder {
             ),
             postgres_storage_caches_config,
             rpc_config.vm_concurrency_limit(),
-            ApiContracts::load_from_disk(), // TODO (BFT-138): Allow to dynamically reload API contracts
+            ApiContracts::load_from_disk_blocking(), // TODO (BFT-138): Allow to dynamically reload API contracts
         ));
         Ok(self)
     }

--- a/core/lib/contracts/src/lib.rs
+++ b/core/lib/contracts/src/lib.rs
@@ -6,6 +6,7 @@
 
 use std::{
     fs::{self, File},
+    io::BufReader,
     path::{Path, PathBuf},
 };
 
@@ -64,10 +65,10 @@ fn home_path() -> &'static Path {
 fn read_file_to_json_value(path: impl AsRef<Path> + std::fmt::Debug) -> serde_json::Value {
     let zksync_home = home_path();
     let path = Path::new(&zksync_home).join(path);
-    serde_json::from_reader(
-        File::open(&path).unwrap_or_else(|e| panic!("Failed to open file {:?}: {}", path, e)),
-    )
-    .unwrap_or_else(|e| panic!("Failed to parse file {:?}: {}", path, e))
+    let file =
+        File::open(&path).unwrap_or_else(|e| panic!("Failed to open file {:?}: {}", path, e));
+    serde_json::from_reader(BufReader::new(file))
+        .unwrap_or_else(|e| panic!("Failed to parse file {:?}: {}", path, e))
 }
 
 fn load_contract_if_present<P: AsRef<Path> + std::fmt::Debug>(path: P) -> Option<Contract> {

--- a/core/lib/zksync_core_leftovers/src/lib.rs
+++ b/core/lib/zksync_core_leftovers/src/lib.rs
@@ -1256,7 +1256,7 @@ async fn run_http_api(
         batch_fee_model_input_provider,
         storage_caches,
     )
-    .await;
+    .await?;
 
     let mut namespaces = Namespace::DEFAULT.to_vec();
     if with_debug_namespace {
@@ -1321,7 +1321,7 @@ async fn run_ws_api(
         batch_fee_model_input_provider,
         storage_caches,
     )
-    .await;
+    .await?;
     let updaters_pool = ConnectionPool::<Core>::singleton(database_secrets.replica_url()?)
         .build()
         .await

--- a/core/node/api_server/src/execution_sandbox/tests.rs
+++ b/core/node/api_server/src/execution_sandbox/tests.rs
@@ -185,11 +185,11 @@ async fn test_instantiating_vm(pool: ConnectionPool<Core>, block_args: BlockArgs
     let (vm_concurrency_limiter, _) = VmConcurrencyLimiter::new(1);
     let vm_permit = vm_concurrency_limiter.acquire().await.unwrap();
     let transaction = create_l2_transaction(10, 100).into();
-
+    let estimate_gas_contracts = ApiContracts::load_from_disk().await.unwrap().estimate_gas;
     tokio::task::spawn_blocking(move || {
         apply_vm_in_sandbox(
             vm_permit,
-            TxSharedArgs::mock(ApiContracts::load_from_disk().estimate_gas),
+            TxSharedArgs::mock(estimate_gas_contracts),
             true,
             &TxExecutionArgs::for_gas_estimate(None, &transaction, 123),
             &pool,

--- a/core/node/api_server/src/tx_sender/mod.rs
+++ b/core/node/api_server/src/tx_sender/mod.rs
@@ -61,7 +61,7 @@ pub async fn build_tx_sender(
     master_pool: ConnectionPool<Core>,
     batch_fee_model_input_provider: Arc<dyn BatchFeeModelInputProvider>,
     storage_caches: PostgresStorageCaches,
-) -> (TxSender, VmConcurrencyBarrier) {
+) -> anyhow::Result<(TxSender, VmConcurrencyBarrier)> {
     let sequencer_sealer = SequencerSealer::new(state_keeper_config.clone());
     let master_pool_sink = MasterPoolSink::new(master_pool);
     let tx_sender_builder = TxSenderBuilder::new(
@@ -77,15 +77,13 @@ pub async fn build_tx_sender(
     let batch_fee_input_provider =
         ApiFeeInputProvider::new(batch_fee_model_input_provider, replica_pool);
 
-    let tx_sender = tx_sender_builder
-        .build(
-            Arc::new(batch_fee_input_provider),
-            Arc::new(vm_concurrency_limiter),
-            ApiContracts::load_from_disk(),
-            storage_caches,
-        )
-        .await;
-    (tx_sender, vm_barrier)
+    let tx_sender = tx_sender_builder.build(
+        Arc::new(batch_fee_input_provider),
+        Arc::new(vm_concurrency_limiter),
+        ApiContracts::load_from_disk().await?,
+        storage_caches,
+    );
+    Ok((tx_sender, vm_barrier))
 }
 
 #[derive(Debug, Clone)]
@@ -161,7 +159,14 @@ impl ApiContracts {
     /// Loads the contracts from the local file system.
     /// This method is *currently* preferred to be used in all contexts,
     /// given that there is no way to fetch "playground" contracts from the main node.
-    pub fn load_from_disk() -> Self {
+    pub async fn load_from_disk() -> anyhow::Result<Self> {
+        tokio::task::spawn_blocking(Self::load_from_disk_blocking)
+            .await
+            .context("loading `ApiContracts` panicked")
+    }
+
+    /// Blocking version of [`Self::load_from_disk()`].
+    pub fn load_from_disk_blocking() -> Self {
         Self {
             estimate_gas: MultiVMBaseSystemContracts {
                 pre_virtual_blocks: BaseSystemContracts::estimate_gas_pre_virtual_blocks(),
@@ -233,7 +238,7 @@ impl TxSenderBuilder {
         self
     }
 
-    pub async fn build(
+    pub fn build(
         self,
         batch_fee_input_provider: Arc<dyn BatchFeeModelInputProvider>,
         vm_concurrency_limiter: Arc<VmConcurrencyLimiter>,

--- a/core/node/api_server/src/web3/namespaces/debug.rs
+++ b/core/node/api_server/src/web3/namespaces/debug.rs
@@ -31,7 +31,7 @@ pub(crate) struct DebugNamespace {
 
 impl DebugNamespace {
     pub async fn new(state: RpcState) -> anyhow::Result<Self> {
-        let api_contracts = ApiContracts::load_from_disk();
+        let api_contracts = ApiContracts::load_from_disk().await?;
         let fee_input_provider = &state.tx_sender.0.batch_fee_input_provider;
         let batch_fee_input = fee_input_provider
             .get_batch_fee_input_scaled(

--- a/core/node/api_server/src/web3/testonly.rs
+++ b/core/node/api_server/src/web3/testonly.rs
@@ -45,7 +45,8 @@ pub(crate) async fn create_test_tx_sender(
         batch_fee_model_input_provider,
         storage_caches,
     )
-    .await;
+    .await
+    .expect("failed building transaction sender");
 
     Arc::get_mut(&mut tx_sender.0).unwrap().executor = tx_executor;
     (tx_sender, vm_barrier)

--- a/core/node/node_framework/examples/main_node.rs
+++ b/core/node/node_framework/examples/main_node.rs
@@ -211,7 +211,7 @@ impl MainNodeBuilder {
             ),
             postgres_storage_caches_config,
             rpc_config.vm_concurrency_limit(),
-            ApiContracts::load_from_disk(), // TODO (BFT-138): Allow to dynamically reload API contracts
+            ApiContracts::load_from_disk_blocking(), // TODO (BFT-138): Allow to dynamically reload API contracts
         ));
         Ok(self)
     }

--- a/core/node/node_framework/src/implementations/layers/web3_api/tx_sender.rs
+++ b/core/node/node_framework/src/implementations/layers/web3_api/tx_sender.rs
@@ -96,14 +96,12 @@ impl WiringLayer for TxSenderLayer {
         if let Some(sealer) = sealer {
             tx_sender = tx_sender.with_sealer(sealer);
         }
-        let tx_sender = tx_sender
-            .build(
-                fee_input,
-                Arc::new(vm_concurrency_limiter),
-                self.api_contracts,
-                storage_caches,
-            )
-            .await;
+        let tx_sender = tx_sender.build(
+            fee_input,
+            Arc::new(vm_concurrency_limiter),
+            self.api_contracts,
+            storage_caches,
+        );
         context.insert_resource(TxSenderResource(tx_sender))?;
 
         Ok(())


### PR DESCRIPTION
## What ❔

Fixes the latency of API server unit tests caused by the lack of buffering when reading contracts.

## Why ❔

Lack of buffering is a logical error on its own. In this case, it leads t slow test runs, i.e., degrades DevEx.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.