### PR TITLE
fix(en): Fix reorg detection in presence of tree data fetcher

### DIFF
--- a/core/node/node_sync/src/tree_data_fetcher/metrics.rs
+++ b/core/node/node_sync/src/tree_data_fetcher/metrics.rs
@@ -40,6 +40,7 @@ pub(super) enum StepOutcomeLabel {
     UpdatedBatch,
     NoProgress,
     RemoteHashMissing,
+    PossibleReorg,
     TransientError,
 }
 
@@ -91,6 +92,7 @@ impl TreeDataFetcherMetrics {
             }
             Ok(StepOutcome::NoProgress) => StepOutcomeLabel::NoProgress,
             Ok(StepOutcome::RemoteHashMissing) => StepOutcomeLabel::RemoteHashMissing,
+            Ok(StepOutcome::PossibleReorg) => StepOutcomeLabel::PossibleReorg,
             Err(err) if err.is_transient() => StepOutcomeLabel::TransientError,
             Err(_) => return, // fatal error; the node will exit soon anyway
         };

--- a/core/node/node_sync/src/tree_data_fetcher/mod.rs
+++ b/core/node/node_sync/src/tree_data_fetcher/mod.rs
@@ -298,8 +298,8 @@ impl TreeDataFetcher {
                 }
                 Ok(StepOutcome::PossibleReorg) => {
                     tracing::info!("Potential chain reorg detected by tree data fetcher; not updating tree data");
-                    // Since we don't 100% trust the reorg logic in the tree data fetcher, we let it continue working,
-                    // so that, if there's a false positive, the whole node isn't brought down.
+                    // Since we don't trust the reorg logic in the tree data fetcher, we let it continue working
+                    // so that, if there's a false positive, the whole node doesn't crash (or is in a crash loop in the worst-case scenario).
                     let health = TreeDataFetcherHealth::Affected {
                         error: "Potential chain reorg".to_string(),
                     };

--- a/core/node/node_sync/src/tree_data_fetcher/provider/tests.rs
+++ b/core/node/node_sync/src/tree_data_fetcher/provider/tests.rs
@@ -5,6 +5,8 @@ use once_cell::sync::Lazy;
 use test_casing::test_casing;
 use zksync_dal::{ConnectionPool, Core};
 use zksync_node_genesis::{insert_genesis_batch, GenesisParams};
+use zksync_node_test_utils::create_l2_block;
+use zksync_types::{api, L2BlockNumber, ProtocolVersionId};
 use zksync_web3_decl::client::MockClient;
 
 use super::*;
@@ -20,6 +22,100 @@ static BLOCK_COMMIT_SIGNATURE: Lazy<H256> = Lazy::new(|| {
         .expect("missing `BlockCommit` event")
         .signature()
 });
+
+fn mock_block_details_base(number: u32, hash: Option<H256>) -> api::BlockDetailsBase {
+    api::BlockDetailsBase {
+        timestamp: number.into(),
+        root_hash: hash,
+        // The fields below are not read.
+        l1_tx_count: 0,
+        l2_tx_count: 1,
+        status: api::BlockStatus::Sealed,
+        commit_tx_hash: None,
+        committed_at: None,
+        prove_tx_hash: None,
+        proven_at: None,
+        execute_tx_hash: None,
+        executed_at: None,
+        l1_gas_price: 10,
+        l2_fair_gas_price: 100,
+        base_system_contracts_hashes: Default::default(),
+    }
+}
+
+#[derive(Debug)]
+struct L2Parameters {
+    l2_block_hashes: Vec<H256>,
+    l1_batch_root_hashes: Vec<H256>,
+}
+
+impl L2Parameters {
+    fn mock_client(self) -> MockClient<L2> {
+        let block_number = U64::from(self.l2_block_hashes.len());
+
+        MockClient::builder(L2::default())
+            .method("eth_blockNumber", move || Ok(block_number))
+            .method("zks_getL1BatchDetails", move |number: L1BatchNumber| {
+                let root_hash = self.l1_batch_root_hashes.get(number.0 as usize);
+                Ok(root_hash.map(|&hash| api::L1BatchDetails {
+                    number,
+                    base: mock_block_details_base(number.0, Some(hash)),
+                }))
+            })
+            .method("zks_getBlockDetails", move |number: L2BlockNumber| {
+                let hash = self.l2_block_hashes.get(number.0 as usize);
+                Ok(hash.map(|&hash| api::BlockDetails {
+                    number,
+                    l1_batch_number: L1BatchNumber(number.0),
+                    operator_address: Address::zero(),
+                    protocol_version: Some(ProtocolVersionId::latest()),
+                    base: mock_block_details_base(number.0, Some(hash)),
+                }))
+            })
+            .build()
+    }
+}
+
+#[tokio::test]
+async fn rpc_data_provider_basics() {
+    let last_l2_block = create_l2_block(1);
+    let l2_parameters = L2Parameters {
+        l2_block_hashes: vec![H256::zero(), last_l2_block.hash],
+        l1_batch_root_hashes: vec![H256::zero(), H256::from_low_u64_be(1)],
+    };
+    let mut client: Box<DynClient<L2>> = Box::new(l2_parameters.mock_client());
+
+    let output = client
+        .batch_details(L1BatchNumber(1), &last_l2_block)
+        .await
+        .unwrap()
+        .expect("missing block");
+    assert_eq!(output.root_hash, H256::from_low_u64_be(1));
+    assert_matches!(output.source, TreeDataProviderSource::BatchDetailsRpc);
+
+    // Query a future L1 batch.
+    let output = client
+        .batch_details(L1BatchNumber(2), &create_l2_block(2))
+        .await
+        .unwrap();
+    assert_matches!(output, Err(MissingData::Batch));
+}
+
+#[tokio::test]
+async fn rpc_data_provider_with_block_hash_divergence() {
+    let last_l2_block = create_l2_block(1);
+    let l2_parameters = L2Parameters {
+        l2_block_hashes: vec![H256::zero(), H256::repeat_byte(1)], // Hash for block #1 differs from the local one
+        l1_batch_root_hashes: vec![H256::zero(), H256::from_low_u64_be(1)],
+    };
+    let mut client: Box<DynClient<L2>> = Box::new(l2_parameters.mock_client());
+
+    let output = client
+        .batch_details(L1BatchNumber(1), &last_l2_block)
+        .await
+        .unwrap();
+    assert_matches!(output, Err(MissingData::PossibleReorg));
+}
 
 struct EthereumParameters {
     block_number: U64,
@@ -46,40 +142,6 @@ impl EthereumParameters {
         self.l1_blocks_for_commits.push(l1_block_number);
     }
 
-    fn filter_logs(logs: &[web3::Log], filter: web3::Filter) -> Vec<web3::Log> {
-        let Some(web3::BlockNumber::Number(filter_from)) = filter.from_block else {
-            panic!("Unexpected filter: {filter:?}");
-        };
-        let Some(web3::BlockNumber::Number(filter_to)) = filter.to_block else {
-            panic!("Unexpected filter: {filter:?}");
-        };
-        let filter_block_range = filter_from..=filter_to;
-
-        let filter_addresses = filter.address.unwrap().flatten();
-        let filter_topics = filter.topics.unwrap();
-        let filter_topics: Vec<_> = filter_topics
-            .into_iter()
-            .map(|topic| topic.map(web3::ValueOrArray::flatten))
-            .collect();
-
-        let filtered_logs = logs.iter().filter(|log| {
-            if !filter_addresses.contains(&log.address) {
-                return false;
-            }
-            if !filter_block_range.contains(&log.block_number.unwrap()) {
-                return false;
-            }
-            filter_topics
-                .iter()
-                .zip(&log.topics)
-                .all(|(filter_topics, actual_topic)| match filter_topics {
-                    Some(topics) => topics.contains(actual_topic),
-                    None => true,
-                })
-        });
-        filtered_logs.cloned().collect()
-    }
-
     fn client(&self) -> MockClient<L1> {
         let logs = self
             .l1_blocks_for_commits
@@ -101,36 +163,72 @@ impl EthereumParameters {
                 }
             });
         let logs: Vec<_> = logs.collect();
-        let block_number = self.block_number;
-
-        MockClient::builder(L1::default())
-            .method("eth_blockNumber", move || Ok(block_number))
-            .method(
-                "eth_getBlockByNumber",
-                move |number: web3::BlockNumber, with_txs: bool| {
-                    assert!(!with_txs);
-
-                    let number = match number {
-                        web3::BlockNumber::Number(number) => number,
-                        web3::BlockNumber::Latest => block_number,
-                        web3::BlockNumber::Earliest => U64::zero(),
-                        _ => panic!("Unexpected number: {number:?}"),
-                    };
-                    if number > block_number {
-                        return Ok(None);
-                    }
-                    Ok(Some(web3::Block::<H256> {
-                        number: Some(number),
-                        timestamp: U256::from(number.as_u64()), // timestamp == number
-                        ..web3::Block::default()
-                    }))
-                },
-            )
-            .method("eth_getLogs", move |filter: web3::Filter| {
-                Ok(Self::filter_logs(&logs, filter))
-            })
-            .build()
+        mock_l1_client(self.block_number, logs)
     }
+}
+
+fn filter_logs(logs: &[web3::Log], filter: web3::Filter) -> Vec<web3::Log> {
+    let Some(web3::BlockNumber::Number(filter_from)) = filter.from_block else {
+        panic!("Unexpected filter: {filter:?}");
+    };
+    let Some(web3::BlockNumber::Number(filter_to)) = filter.to_block else {
+        panic!("Unexpected filter: {filter:?}");
+    };
+    let filter_block_range = filter_from..=filter_to;
+
+    let filter_addresses = filter.address.unwrap().flatten();
+    let filter_topics = filter.topics.unwrap();
+    let filter_topics: Vec<_> = filter_topics
+        .into_iter()
+        .map(|topic| topic.map(web3::ValueOrArray::flatten))
+        .collect();
+
+    let filtered_logs = logs.iter().filter(|log| {
+        if !filter_addresses.contains(&log.address) {
+            return false;
+        }
+        if !filter_block_range.contains(&log.block_number.unwrap()) {
+            return false;
+        }
+        filter_topics
+            .iter()
+            .zip(&log.topics)
+            .all(|(filter_topics, actual_topic)| match filter_topics {
+                Some(topics) => topics.contains(actual_topic),
+                None => true,
+            })
+    });
+    filtered_logs.cloned().collect()
+}
+
+fn mock_l1_client(block_number: U64, logs: Vec<web3::Log>) -> MockClient<L1> {
+    MockClient::builder(L1::default())
+        .method("eth_blockNumber", move || Ok(block_number))
+        .method(
+            "eth_getBlockByNumber",
+            move |number: web3::BlockNumber, with_txs: bool| {
+                assert!(!with_txs);
+
+                let number = match number {
+                    web3::BlockNumber::Number(number) => number,
+                    web3::BlockNumber::Latest => block_number,
+                    web3::BlockNumber::Earliest => U64::zero(),
+                    _ => panic!("Unexpected number: {number:?}"),
+                };
+                if number > block_number {
+                    return Ok(None);
+                }
+                Ok(Some(web3::Block::<H256> {
+                    number: Some(number),
+                    timestamp: U256::from(number.as_u64()), // timestamp == number
+                    ..web3::Block::default()
+                }))
+            },
+        )
+        .method("eth_getLogs", move |filter: web3::Filter| {
+            Ok(filter_logs(&logs, filter))
+        })
+        .build()
 }
 
 #[tokio::test]
@@ -198,6 +296,44 @@ async fn test_using_l1_data_provider(l1_batch_timestamps: &[u64]) {
 async fn using_l1_data_provider(batch_spacing: u64) {
     let l1_batch_timestamps: Vec<_> = (0..10).map(|i| 50_000 + batch_spacing * i).collect();
     test_using_l1_data_provider(&l1_batch_timestamps).await;
+}
+
+#[tokio::test]
+async fn detecting_reorg_in_l1_data_provider() {
+    let l1_batch_number = H256::from_low_u64_be(1);
+    // Generate two logs for the same L1 batch #1
+    let logs = vec![
+        web3::Log {
+            address: DIAMOND_PROXY_ADDRESS,
+            topics: vec![
+                *BLOCK_COMMIT_SIGNATURE,
+                l1_batch_number,
+                H256::repeat_byte(1),
+                H256::zero(), // commitment hash; not used
+            ],
+            block_number: Some(1.into()),
+            ..web3::Log::default()
+        },
+        web3::Log {
+            address: DIAMOND_PROXY_ADDRESS,
+            topics: vec![
+                *BLOCK_COMMIT_SIGNATURE,
+                l1_batch_number,
+                H256::repeat_byte(2),
+                H256::zero(), // commitment hash; not used
+            ],
+            block_number: Some(100.into()),
+            ..web3::Log::default()
+        },
+    ];
+    let l1_client = mock_l1_client(200.into(), logs);
+
+    let mut provider = L1DataProvider::new(Box::new(l1_client), DIAMOND_PROXY_ADDRESS).unwrap();
+    let output = provider
+        .batch_details(L1BatchNumber(1), &create_l2_block(1))
+        .await
+        .unwrap();
+    assert_matches!(output, Err(MissingData::PossibleReorg));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What ❔

Fixes reorg detection logic so that it accounts for the tree data fetcher:

- **In tree data fetcher:** Tries to detect reorgs, so that root hashes are not written for diverging L1 batches.
- **In reorg detector:** Checks last L2 block correspondence during binary searching a diverging L1 batch.

## Why ❔

Reorg detection may be broken if tree data fetcher is enabled:

- The tree data fetcher doesn't check that fetched L1 batch root hashes correspond to local L1 batches, i.e. it can fetch a root hash after a revert.
- Hence, the logic in reorg detector which binary-searches the diverged L1 batch is broken because the latest L1 batch isn't guaranteed to diverge if there's a divergence.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.