### PR TITLE
fix(db): Optimize `get_l2_blocks_to_execute_for_l1_batch`

### DIFF
--- a/core/lib/dal/.sqlx/query-f023e5fa599b279acd6ac02dffb7a33a8fea8ab7fdefb7d9210673245a2a6f6c.json
+++ b/core/lib/dal/.sqlx/query-f023e5fa599b279acd6ac02dffb7a33a8fea8ab7fdefb7d9210673245a2a6f6c.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                *\n            FROM\n                transactions\n            WHERE\n                l1_batch_number = $1\n            ORDER BY\n                miniblock_number,\n                index_in_block\n            ",
+  "query": "\n            SELECT\n                *\n            FROM\n                transactions\n            WHERE\n                miniblock_number BETWEEN (\n                    SELECT\n                        MIN(number)\n                    FROM\n                        miniblocks\n                    WHERE\n                        miniblocks.l1_batch_number = $1\n                ) AND (\n                    SELECT\n                        MAX(number)\n                    FROM\n                        miniblocks\n                    WHERE\n                        miniblocks.l1_batch_number = $1\n                )\n            ORDER BY\n                miniblock_number,\n                index_in_block\n            ",
   "describe": {
     "columns": [
       {
@@ -228,5 +228,5 @@
       true
     ]
   },
-  "hash": "f63586d59264eab7388ad1de823227ecaa45d76d1ba260074898fe57c059a15a"
+  "hash": "f023e5fa599b279acd6ac02dffb7a33a8fea8ab7fdefb7d9210673245a2a6f6c"
 }

--- a/core/lib/dal/src/transactions_dal.rs
+++ b/core/lib/dal/src/transactions_dal.rs
@@ -1927,7 +1927,21 @@ impl TransactionsDal<'_, '_> {
             FROM
                 transactions
             WHERE
-                l1_batch_number = $1
+                miniblock_number BETWEEN (
+                    SELECT
+                        MIN(number)
+                    FROM
+                        miniblocks
+                    WHERE
+                        miniblocks.l1_batch_number = $1
+                ) AND (
+                    SELECT
+                        MAX(number)
+                    FROM
+                        miniblocks
+                    WHERE
+                        miniblocks.l1_batch_number = $1
+                )
             ORDER BY
                 miniblock_number,
                 index_in_block


### PR DESCRIPTION
## What ❔

Optimize `get_l2_blocks_to_execute_for_l1_batch`

## Why ❔

`transactions.l1_batch_number` is not indexed

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
