### PR TITLE
feat(vm-runner): add basic metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9441,6 +9441,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "vise",
  "vm_utils",
  "zksync_contracts",
  "zksync_dal",

--- a/core/node/vm_runner/Cargo.toml
+++ b/core/node/vm_runner/Cargo.toml
@@ -26,6 +26,7 @@ async-trait.workspace = true
 once_cell.workspace = true
 tracing.workspace = true
 dashmap.workspace = true
+vise.workspace = true
 
 [dev-dependencies]
 zksync_node_test_utils.workspace = true

--- a/core/node/vm_runner/src/lib.rs
+++ b/core/node/vm_runner/src/lib.rs
@@ -9,6 +9,7 @@ mod output_handler;
 mod process;
 mod storage;
 
+mod metrics;
 #[cfg(test)]
 mod tests;
 

--- a/core/node/vm_runner/src/metrics.rs
+++ b/core/node/vm_runner/src/metrics.rs
@@ -1,0 +1,28 @@
+//! Metrics for `VmRunner`.
+
+use std::time::Duration;
+
+use vise::{Buckets, Gauge, Histogram, Metrics};
+
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "vm_runner")]
+pub(super) struct VmRunnerMetrics {
+    /// Last batch that has been marked as processed.
+    pub last_processed_batch: Gauge<u64>,
+    /// Last batch that is ready to be processed.
+    pub last_ready_batch: Gauge<u64>,
+    /// Current amount of batches that are being processed.
+    pub in_progress_l1_batches: Gauge<u64>,
+    /// Total latency of loading an L1 batch (RocksDB mode only).
+    #[metrics(buckets = Buckets::LATENCIES)]
+    pub storage_load_time: Histogram<Duration>,
+    /// Total latency of running VM on an L1 batch.
+    #[metrics(buckets = Buckets::LATENCIES)]
+    pub run_vm_time: Histogram<Duration>,
+    /// Total latency of handling output of an L1 batch.
+    #[metrics(buckets = Buckets::LATENCIES)]
+    pub output_handle_time: Histogram<Duration>,
+}
+
+#[vise::register]
+pub(super) static METRICS: vise::Global<VmRunnerMetrics> = vise::Global::new();

--- a/core/node/vm_runner/src/output_handler.rs
+++ b/core/node/vm_runner/src/output_handler.rs
@@ -2,7 +2,7 @@ use std::{
     fmt::{Debug, Formatter},
     mem,
     sync::Arc,
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use anyhow::Context;
@@ -12,7 +12,6 @@ use tokio::{
     sync::{oneshot, watch},
     task::JoinHandle,
 };
-use vise::Histogram;
 use zksync_dal::{ConnectionPool, Core};
 use zksync_state_keeper::{StateKeeperOutputHandler, UpdatesManager};
 use zksync_types::L1BatchNumber;

--- a/core/node/vm_runner/src/process.rs
+++ b/core/node/vm_runner/src/process.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{sync::Arc, time::Duration};
 
 use anyhow::Context;
 use multivm::interface::L2BlockEnv;
@@ -155,7 +152,7 @@ impl VmRunner {
             task_handles = retained_handles;
             METRICS
                 .in_progress_l1_batches
-                .set(task_handles.len().into());
+                .set(task_handles.len() as u64);
 
             let last_ready_batch = self
                 .io

--- a/core/node/vm_runner/src/storage.rs
+++ b/core/node/vm_runner/src/storage.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     fmt::Debug,
     sync::Arc,
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use anyhow::Context as _;

--- a/core/node/vm_runner/src/storage.rs
+++ b/core/node/vm_runner/src/storage.rs
@@ -338,7 +338,7 @@ impl<Io: VmRunnerIo> StorageSyncTask<Io> {
             drop(state);
             let max_desired = self.io.last_ready_to_be_loaded_batch(&mut conn).await?;
             for l1_batch_number in max_present.0 + 1..=max_desired.0 {
-                let started_at = Instant::now();
+                let latency = METRICS.storage_load_time.start();
                 let l1_batch_number = L1BatchNumber(l1_batch_number);
                 let Some(execute_data) = Self::load_batch_execute_data(
                     &mut conn,
@@ -375,7 +375,7 @@ impl<Io: VmRunnerIo> StorageSyncTask<Io> {
                     .storage
                     .insert(l1_batch_number, BatchData { execute_data, diff });
                 drop(state);
-                METRICS.storage_load_time.observe(started_at.elapsed());
+                latency.observe();
             }
             drop(conn);
         }

--- a/core/node/vm_runner/src/storage.rs
+++ b/core/node/vm_runner/src/storage.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     fmt::Debug,
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use anyhow::Context as _;
@@ -19,7 +19,7 @@ use zksync_state::{
 use zksync_storage::RocksDB;
 use zksync_types::{block::L2BlockExecutionData, L1BatchNumber, L2ChainId};
 
-use crate::VmRunnerIo;
+use crate::{metrics::METRICS, VmRunnerIo};
 
 #[async_trait]
 pub trait StorageLoader: ReadStorageFactory {
@@ -338,6 +338,7 @@ impl<Io: VmRunnerIo> StorageSyncTask<Io> {
             drop(state);
             let max_desired = self.io.last_ready_to_be_loaded_batch(&mut conn).await?;
             for l1_batch_number in max_present.0 + 1..=max_desired.0 {
+                let started_at = Instant::now();
                 let l1_batch_number = L1BatchNumber(l1_batch_number);
                 let Some(execute_data) = Self::load_batch_execute_data(
                     &mut conn,
@@ -374,6 +375,7 @@ impl<Io: VmRunnerIo> StorageSyncTask<Io> {
                     .storage
                     .insert(l1_batch_number, BatchData { execute_data, diff });
                 drop(state);
+                METRICS.storage_load_time.observe(started_at.elapsed());
             }
             drop(conn);
         }


### PR DESCRIPTION
## What ❔

This PR just adds some basic VM runner-specific metrics. Note that VM runner already inherits VM-related metrics from state keeper.

I decided to split `storage_load`/`vm_run`/`output_handle` into 3 different metrics as opposed to a single metric with 3 stages as the stages happen asynchronously and don't represent a continuous execution. Lmk if you disagree though.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
