### PR TITLE
feat(merkle-tree): Rework tree rollback

### DIFF
--- a/core/lib/merkle_tree/src/domain.rs
+++ b/core/lib/merkle_tree/src/domain.rs
@@ -166,6 +166,12 @@ impl ZkSyncTree {
         self.tree.latest_root_hash()
     }
 
+    /// Returns the root hash and leaf count at the specified L1 batch.
+    pub fn root_info(&self, l1_batch_number: L1BatchNumber) -> Option<(ValueHash, u64)> {
+        let root = self.tree.root(l1_batch_number.0.into())?;
+        Some((root.hash(&Blake2Hasher), root.leaf_count()))
+    }
+
     /// Checks whether this tree is empty.
     pub fn is_empty(&self) -> bool {
         let Some(version) = self.tree.latest_version() else {

--- a/core/lib/snapshots_applier/src/tests/utils.rs
+++ b/core/lib/snapshots_applier/src/tests/utils.rs
@@ -332,12 +332,12 @@ impl ObjectStore for HangingObjectStore {
         let mut should_proceed = true;
         self.count_sender.send_modify(|count| {
             *count += 1;
-            if dbg!(*count) > self.stop_after_count {
+            if *count > self.stop_after_count {
                 should_proceed = false;
             }
         });
 
-        if dbg!(should_proceed) {
+        if should_proceed {
             self.inner.get_raw(bucket, key).await
         } else {
             future::pending().await // Hang up the snapshot applier task

--- a/core/node/metadata_calculator/src/helpers.rs
+++ b/core/node/metadata_calculator/src/helpers.rs
@@ -245,10 +245,10 @@ impl AsyncTree {
     }
 
     pub fn data_for_l1_batch(&self, l1_batch_number: L1BatchNumber) -> Option<L1BatchTreeData> {
-        let (hash, rollup_last_leaf_index) = self.as_ref().root_info(l1_batch_number)?;
+        let (hash, leaf_count) = self.as_ref().root_info(l1_batch_number)?;
         Some(L1BatchTreeData {
             hash,
-            rollup_last_leaf_index,
+            rollup_last_leaf_index: leaf_count + 1,
         })
     }
 

--- a/core/node/metadata_calculator/src/updater.rs
+++ b/core/node/metadata_calculator/src/updater.rs
@@ -307,7 +307,7 @@ impl AsyncTree {
 
         anyhow::ensure!(
             self.l1_batch_matches(&mut storage, min_tree_l1_batch).await?,
-            "Diverging min L1 batch in the tree #{min_tree_l1_batch}; the tree cannot recover from this"
+            "diverging min L1 batch in the tree #{min_tree_l1_batch}; the tree cannot recover from this"
         );
 
         let mut left = min_tree_l1_batch.0;

--- a/core/node/metadata_calculator/src/updater.rs
+++ b/core/node/metadata_calculator/src/updater.rs
@@ -336,6 +336,7 @@ impl AsyncTree {
         storage: &mut Connection<'_, Core>,
         l1_batch: L1BatchNumber,
     ) -> anyhow::Result<bool> {
+        dbg!(l1_batch);
         if l1_batch == L1BatchNumber(0) {
             // Corner case: root hash for L1 batch #0 persisted in Postgres is fictive (set to `H256::zero()`).
             return Ok(true);
@@ -354,7 +355,8 @@ impl AsyncTree {
             return Ok(true);
         };
 
-        let data_matches = tree_data == tree_data_from_postgres;
+        let data_matches = dbg!(tree_data) == dbg!(tree_data_from_postgres);
+        dbg!(data_matches);
         if !data_matches {
             tracing::warn!(
                 "Detected diverging tree data for L1 batch #{l1_batch}; data in tree is: {tree_data:?}, \
@@ -380,6 +382,7 @@ impl AsyncTree {
 
         self.ensure_genesis(&mut storage, earliest_l1_batch).await?;
         let next_l1_batch_to_seal = self.next_l1_batch_number();
+        dbg!(next_l1_batch_to_seal);
 
         let current_db_batch = storage.blocks_dal().get_sealed_l1_batch_number().await?;
         let last_l1_batch_with_tree_data = storage
@@ -392,6 +395,7 @@ impl AsyncTree {
             "Next L1 batch for Merkle tree: {next_l1_batch_to_seal}, current Postgres L1 batch: {current_db_batch:?}, \
              last L1 batch with metadata: {last_l1_batch_with_tree_data:?}"
         );
+        dbg!(last_l1_batch_with_tree_data);
 
         // It may be the case that we don't have any L1 batches with metadata in Postgres, e.g. after
         // recovering from a snapshot. We cannot wait for such a batch to appear (*this* is the component

--- a/core/node/metadata_calculator/src/updater.rs
+++ b/core/node/metadata_calculator/src/updater.rs
@@ -198,92 +198,6 @@ impl TreeUpdater {
         Ok(())
     }
 
-    /// Invariant: the tree is not ahead of Postgres.
-    async fn ensure_no_l1_batch_divergence(
-        pool: &ConnectionPool<Core>,
-        tree: &mut AsyncTree,
-    ) -> anyhow::Result<()> {
-        let Some(last_tree_l1_batch) = tree.next_l1_batch_number().checked_sub(1) else {
-            // No L1 batches in the tree means no divergence.
-            return Ok(());
-        };
-        let last_tree_l1_batch = L1BatchNumber(last_tree_l1_batch);
-
-        let mut storage = pool.connection_tagged("metadata_calculator").await?;
-        if Self::l1_batch_matches(&mut storage, tree, last_tree_l1_batch).await? {
-            tracing::debug!(
-                "Last l1 batch in tree #{last_tree_l1_batch} has same data in tree and Postgres"
-            );
-            return Ok(());
-        }
-
-        tracing::debug!("Last l1 batch in tree #{last_tree_l1_batch} has diverging data in tree and Postgres; searching for the last common L1 batch");
-        let min_tree_l1_batch = tree
-            .min_l1_batch_number()
-            .context("tree shouldn't be empty at this point")?;
-        anyhow::ensure!(
-            min_tree_l1_batch <= last_tree_l1_batch,
-            "potential Merkle tree corruption: minimum L1 batch number ({min_tree_l1_batch}) exceeds the last L1 batch ({last_tree_l1_batch})"
-        );
-
-        anyhow::ensure!(
-            Self::l1_batch_matches(&mut storage, tree, min_tree_l1_batch).await?,
-            "Diverging min L1 batch in the tree #{min_tree_l1_batch}; the tree cannot recover from this"
-        );
-
-        let mut left = min_tree_l1_batch.0;
-        let mut right = last_tree_l1_batch.0;
-        while left + 1 < right {
-            let middle = (left + right) / 2;
-            let batch_matches =
-                Self::l1_batch_matches(&mut storage, tree, L1BatchNumber(middle)).await?;
-            if batch_matches {
-                left = middle;
-            } else {
-                right = middle;
-            }
-        }
-        let last_common_l1_batch_number = L1BatchNumber(left);
-        tracing::info!("Found last common L1 batch between tree and Postgres: #{last_common_l1_batch_number}; will revert tree to it");
-
-        tree.roll_back_logs(last_common_l1_batch_number)?;
-        tree.save().await?;
-        Ok(())
-    }
-
-    async fn l1_batch_matches(
-        storage: &mut Connection<'_, Core>,
-        tree: &AsyncTree,
-        l1_batch: L1BatchNumber,
-    ) -> anyhow::Result<bool> {
-        if l1_batch == L1BatchNumber(0) {
-            // Corner case: root hash for L1 batch #0 persisted in Postgres is fictive (set to `H256::zero()`).
-            return Ok(true);
-        }
-
-        let Some(tree_data) = tree.data_for_l1_batch(l1_batch) else {
-            // Corner case: the L1 batch was pruned in the tree.
-            return Ok(true);
-        };
-        let Some(tree_data_from_postgres) = storage
-            .blocks_dal()
-            .get_l1_batch_tree_data(l1_batch)
-            .await?
-        else {
-            // Corner case: the L1 batch was pruned in Postgres (including initial snapshot recovery).
-            return Ok(true);
-        };
-
-        let data_matches = tree_data == tree_data_from_postgres;
-        if !data_matches {
-            tracing::warn!(
-                "Detected diverging tree data for L1 batch #{l1_batch}; data in tree is: {tree_data:?}, \
-                data in Postgres is: {tree_data_from_postgres:?}"
-            );
-        }
-        Ok(data_matches)
-    }
-
     /// The processing loop for this updater.
     pub async fn loop_updating_tree(
         mut self,
@@ -291,68 +205,13 @@ impl TreeUpdater {
         pool: &ConnectionPool<Core>,
         mut stop_receiver: watch::Receiver<bool>,
     ) -> anyhow::Result<()> {
-        let Some(earliest_l1_batch) =
-            wait_for_l1_batch(pool, delayer.delay_interval(), &mut stop_receiver).await?
-        else {
-            return Ok(()); // Stop signal received
-        };
-        let mut storage = pool.connection_tagged("metadata_calculator").await?;
-
-        // Ensure genesis creation
         let tree = &mut self.tree;
-        if tree.is_empty() {
-            anyhow::ensure!(
-                earliest_l1_batch == L1BatchNumber(0),
-                "Non-zero earliest L1 batch #{earliest_l1_batch} is not supported without previous tree recovery"
-            );
-            let batch = L1BatchWithLogs::new(&mut storage, earliest_l1_batch, tree.mode())
-                .await
-                .with_context(|| {
-                    format!("failed fetching tree input for L1 batch #{earliest_l1_batch}")
-                })?
-                .context("Missing storage logs for the genesis L1 batch")?;
-            tree.process_l1_batch(batch).await?;
-            tree.save().await?;
-        }
         let mut next_l1_batch_to_seal = tree.next_l1_batch_number();
-
-        let current_db_batch = storage.blocks_dal().get_sealed_l1_batch_number().await?;
-        let last_l1_batch_with_tree_data = storage
-            .blocks_dal()
-            .get_last_l1_batch_number_with_tree_data()
-            .await?;
-        drop(storage);
-
         tracing::info!(
             "Initialized metadata calculator with {max_batches_per_iter} max L1 batches per iteration. \
-             Next L1 batch for Merkle tree: {next_l1_batch_to_seal}, current Postgres L1 batch: {current_db_batch:?}, \
-             last L1 batch with metadata: {last_l1_batch_with_tree_data:?}",
+             Next L1 batch for Merkle tree: {next_l1_batch_to_seal}",
             max_batches_per_iter = self.max_l1_batches_per_iter
         );
-
-        // It may be the case that we don't have any L1 batches with metadata in Postgres, e.g. after
-        // recovering from a snapshot. We cannot wait for such a batch to appear (*this* is the component
-        // responsible for their appearance!), but fortunately most of the updater doesn't depend on it.
-        if let Some(last_l1_batch_with_tree_data) = last_l1_batch_with_tree_data {
-            let backup_lag =
-                (last_l1_batch_with_tree_data.0 + 1).saturating_sub(next_l1_batch_to_seal.0);
-            METRICS.backup_lag.set(backup_lag.into());
-
-            if next_l1_batch_to_seal > last_l1_batch_with_tree_data + 1 {
-                tracing::warn!(
-                    "Next L1 batch of the tree ({next_l1_batch_to_seal}) is greater than last L1 batch with metadata in Postgres \
-                     ({last_l1_batch_with_tree_data}); this may be a result of restoring Postgres from a snapshot. \
-                     Truncating Merkle tree versions so that this mismatch is fixed..."
-                );
-                tree.roll_back_logs(last_l1_batch_with_tree_data)?;
-                tree.save().await?;
-                tracing::info!("Truncated Merkle tree to L1 batch #{next_l1_batch_to_seal}");
-            }
-
-            // FIXME: move to before the tree is fully initialized
-            Self::ensure_no_l1_batch_divergence(pool, tree).await?;
-            next_l1_batch_to_seal = tree.next_l1_batch_number();
-        }
 
         loop {
             if *stop_receiver.borrow_and_update() {
@@ -385,6 +244,175 @@ impl TreeUpdater {
                 }
                 () = delay => { /* The delay has passed */ }
             }
+        }
+        Ok(())
+    }
+}
+
+impl AsyncTree {
+    async fn ensure_genesis(
+        &mut self,
+        storage: &mut Connection<'_, Core>,
+        earliest_l1_batch: L1BatchNumber,
+    ) -> anyhow::Result<()> {
+        if !self.is_empty() {
+            return Ok(());
+        }
+
+        anyhow::ensure!(
+            earliest_l1_batch == L1BatchNumber(0),
+            "Non-zero earliest L1 batch #{earliest_l1_batch} is not supported without previous tree recovery"
+        );
+        let batch = L1BatchWithLogs::new(storage, earliest_l1_batch, self.mode())
+            .await
+            .with_context(|| {
+                format!("failed fetching tree input for L1 batch #{earliest_l1_batch}")
+            })?
+            .context("Missing storage logs for the genesis L1 batch")?;
+        self.process_l1_batch(batch).await?;
+        self.save().await?;
+        Ok(())
+    }
+
+    /// Invariant: the tree is not ahead of Postgres.
+    async fn ensure_no_l1_batch_divergence(
+        &mut self,
+        pool: &ConnectionPool<Core>,
+    ) -> anyhow::Result<()> {
+        let Some(last_tree_l1_batch) = self.next_l1_batch_number().checked_sub(1) else {
+            // No L1 batches in the tree means no divergence.
+            return Ok(());
+        };
+        let last_tree_l1_batch = L1BatchNumber(last_tree_l1_batch);
+
+        let mut storage = pool.connection_tagged("metadata_calculator").await?;
+        if self
+            .l1_batch_matches(&mut storage, last_tree_l1_batch)
+            .await?
+        {
+            tracing::debug!(
+                "Last l1 batch in tree #{last_tree_l1_batch} has same data in tree and Postgres"
+            );
+            return Ok(());
+        }
+
+        tracing::debug!("Last l1 batch in tree #{last_tree_l1_batch} has diverging data in tree and Postgres; searching for the last common L1 batch");
+        let min_tree_l1_batch = self
+            .min_l1_batch_number()
+            .context("tree shouldn't be empty at this point")?;
+        anyhow::ensure!(
+            min_tree_l1_batch <= last_tree_l1_batch,
+            "potential Merkle tree corruption: minimum L1 batch number ({min_tree_l1_batch}) exceeds the last L1 batch ({last_tree_l1_batch})"
+        );
+
+        anyhow::ensure!(
+            self.l1_batch_matches(&mut storage, min_tree_l1_batch).await?,
+            "Diverging min L1 batch in the tree #{min_tree_l1_batch}; the tree cannot recover from this"
+        );
+
+        let mut left = min_tree_l1_batch.0;
+        let mut right = last_tree_l1_batch.0;
+        while left + 1 < right {
+            let middle = (left + right) / 2;
+            let batch_matches = self
+                .l1_batch_matches(&mut storage, L1BatchNumber(middle))
+                .await?;
+            if batch_matches {
+                left = middle;
+            } else {
+                right = middle;
+            }
+        }
+        let last_common_l1_batch_number = L1BatchNumber(left);
+        tracing::info!("Found last common L1 batch between tree and Postgres: #{last_common_l1_batch_number}; will revert tree to it");
+
+        self.roll_back_logs(last_common_l1_batch_number)?;
+        self.save().await?;
+        Ok(())
+    }
+
+    async fn l1_batch_matches(
+        &self,
+        storage: &mut Connection<'_, Core>,
+        l1_batch: L1BatchNumber,
+    ) -> anyhow::Result<bool> {
+        if l1_batch == L1BatchNumber(0) {
+            // Corner case: root hash for L1 batch #0 persisted in Postgres is fictive (set to `H256::zero()`).
+            return Ok(true);
+        }
+
+        let Some(tree_data) = self.data_for_l1_batch(l1_batch) else {
+            // Corner case: the L1 batch was pruned in the tree.
+            return Ok(true);
+        };
+        let Some(tree_data_from_postgres) = storage
+            .blocks_dal()
+            .get_l1_batch_tree_data(l1_batch)
+            .await?
+        else {
+            // Corner case: the L1 batch was pruned in Postgres (including initial snapshot recovery).
+            return Ok(true);
+        };
+
+        let data_matches = tree_data == tree_data_from_postgres;
+        if !data_matches {
+            tracing::warn!(
+                "Detected diverging tree data for L1 batch #{l1_batch}; data in tree is: {tree_data:?}, \
+                data in Postgres is: {tree_data_from_postgres:?}"
+            );
+        }
+        Ok(data_matches)
+    }
+
+    /// Ensures that the tree is consistent with Postgres, truncating the tree if necessary.
+    pub(crate) async fn ensure_consistency(
+        &mut self,
+        delayer: &Delayer,
+        pool: &ConnectionPool<Core>,
+        stop_receiver: &mut watch::Receiver<bool>,
+    ) -> anyhow::Result<()> {
+        let Some(earliest_l1_batch) =
+            wait_for_l1_batch(pool, delayer.delay_interval(), stop_receiver).await?
+        else {
+            return Ok(()); // Stop signal received
+        };
+        let mut storage = pool.connection_tagged("metadata_calculator").await?;
+
+        self.ensure_genesis(&mut storage, earliest_l1_batch).await?;
+        let next_l1_batch_to_seal = self.next_l1_batch_number();
+
+        let current_db_batch = storage.blocks_dal().get_sealed_l1_batch_number().await?;
+        let last_l1_batch_with_tree_data = storage
+            .blocks_dal()
+            .get_last_l1_batch_number_with_tree_data()
+            .await?;
+        drop(storage);
+
+        tracing::info!(
+            "Next L1 batch for Merkle tree: {next_l1_batch_to_seal}, current Postgres L1 batch: {current_db_batch:?}, \
+             last L1 batch with metadata: {last_l1_batch_with_tree_data:?}"
+        );
+
+        // It may be the case that we don't have any L1 batches with metadata in Postgres, e.g. after
+        // recovering from a snapshot. We cannot wait for such a batch to appear (*this* is the component
+        // responsible for their appearance!), but fortunately most of the updater doesn't depend on it.
+        if let Some(last_l1_batch_with_tree_data) = last_l1_batch_with_tree_data {
+            let backup_lag =
+                (last_l1_batch_with_tree_data.0 + 1).saturating_sub(next_l1_batch_to_seal.0);
+            METRICS.backup_lag.set(backup_lag.into());
+
+            if next_l1_batch_to_seal > last_l1_batch_with_tree_data + 1 {
+                tracing::warn!(
+                    "Next L1 batch of the tree ({next_l1_batch_to_seal}) is greater than last L1 batch with metadata in Postgres \
+                     ({last_l1_batch_with_tree_data}); this may be a result of restoring Postgres from a snapshot. \
+                     Truncating Merkle tree versions so that this mismatch is fixed..."
+                );
+                self.roll_back_logs(last_l1_batch_with_tree_data)?;
+                self.save().await?;
+                tracing::info!("Truncated Merkle tree to L1 batch #{next_l1_batch_to_seal}");
+            }
+
+            self.ensure_no_l1_batch_divergence(pool).await?;
         }
         Ok(())
     }


### PR DESCRIPTION
## What ❔

Reworks tree rollback so that it's supported on the distributed external node, including the case when a node runs multiple trees.

- Desync with Postgres is now detected on metadata calculator initialization, and the tree is truncated correspondingly.
- The old approach is left intact as a safety guard.

## Why ❔

Right now, reorg logic on EN relies on a node running a single tree, and block reverter being a singleton. Both these assumptions are bogus in case of a distributed EN.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.