### PR TITLE
chore(eth-sender): extact abstract l1 interface and all fee-related code

### DIFF
--- a/core/node/eth_sender/src/abstract_l1_interface.rs
+++ b/core/node/eth_sender/src/abstract_l1_interface.rs
@@ -12,13 +12,25 @@ use zksync_types::{
     aggregated_operations::AggregatedActionType,
     eth_sender::{EthTx, EthTxBlobSidecar},
     web3::{BlockId, BlockNumber},
-    Address, EIP_1559_TX_TYPE, EIP_4844_TX_TYPE, H256, U256,
+    Address, L1BlockNumber, Nonce, EIP_1559_TX_TYPE, EIP_4844_TX_TYPE, H256, U256,
 };
 
-use crate::{
-    eth_tx_manager::{L1BlockNumbers, OperatorNonce},
-    EthSenderError,
-};
+use crate::EthSenderError;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct OperatorNonce {
+    // Nonce on finalized block
+    pub finalized: Nonce,
+    // Nonce on latest block
+    pub latest: Nonce,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct L1BlockNumbers {
+    pub safe: L1BlockNumber,
+    pub finalized: L1BlockNumber,
+    pub latest: L1BlockNumber,
+}
 
 #[async_trait]
 pub(super) trait AbstractL1Interface: 'static + Sync + Send + fmt::Debug {

--- a/core/node/eth_sender/src/abstract_l1_interface.rs
+++ b/core/node/eth_sender/src/abstract_l1_interface.rs
@@ -38,13 +38,16 @@ pub(super) trait AbstractL1Interface: 'static + Sync + Send + fmt::Debug {
 
     #[cfg(test)]
     async fn get_tx(&self, tx_hash: H256) -> EnrichedClientResult<Option<web3::Transaction>>;
+
     async fn get_tx_status(
         &self,
         tx_hash: H256,
     ) -> Result<Option<ExecutedTxStatus>, EthSenderError>;
 
     async fn send_raw_tx(&self, tx_bytes: RawTransactionBytes) -> EnrichedClientResult<H256>;
+
     fn get_blobs_operator_account(&self) -> Option<Address>;
+
     async fn get_operator_nonce(
         &self,
         block_numbers: L1BlockNumbers,
@@ -67,6 +70,7 @@ pub(super) trait AbstractL1Interface: 'static + Sync + Send + fmt::Debug {
     async fn get_l1_block_numbers(&self) -> Result<L1BlockNumbers, EthSenderError>;
 
     fn ethereum_gateway(&self) -> &dyn BoundEthInterface;
+
     fn ethereum_gateway_blobs(&self) -> Option<&dyn BoundEthInterface>;
 }
 
@@ -108,6 +112,7 @@ impl AbstractL1Interface for RealL1Interface {
     async fn send_raw_tx(&self, tx_bytes: RawTransactionBytes) -> EnrichedClientResult<H256> {
         self.query_client().send_raw_tx(tx_bytes).await
     }
+
     fn get_blobs_operator_account(&self) -> Option<Address> {
         self.ethereum_gateway_blobs()
             .as_ref()

--- a/core/node/eth_sender/src/abstract_l1_interface.rs
+++ b/core/node/eth_sender/src/abstract_l1_interface.rs
@@ -1,0 +1,244 @@
+use std::fmt;
+
+use async_trait::async_trait;
+use zksync_eth_client::{
+    clients::{DynClient, L1},
+    BoundEthInterface, EnrichedClientResult, EthInterface, ExecutedTxStatus, FailureInfo, Options,
+    RawTransactionBytes, SignedCallResult,
+};
+#[cfg(test)]
+use zksync_types::web3;
+use zksync_types::{
+    aggregated_operations::AggregatedActionType,
+    eth_sender::{EthTx, EthTxBlobSidecar},
+    web3::{BlockId, BlockNumber},
+    Address, EIP_1559_TX_TYPE, EIP_4844_TX_TYPE, H256, U256,
+};
+
+use crate::{
+    eth_tx_manager::{L1BlockNumbers, OperatorNonce},
+    EthSenderError,
+};
+
+#[async_trait]
+pub(super) trait AbstractL1Interface: 'static + Sync + Send + fmt::Debug {
+    async fn failure_reason(&self, tx_hash: H256) -> Option<FailureInfo>;
+
+    #[cfg(test)]
+    async fn get_tx(&self, tx_hash: H256) -> EnrichedClientResult<Option<web3::Transaction>>;
+    async fn get_tx_status(
+        &self,
+        tx_hash: H256,
+    ) -> Result<Option<ExecutedTxStatus>, EthSenderError>;
+
+    async fn send_raw_tx(&self, tx_bytes: RawTransactionBytes) -> EnrichedClientResult<H256>;
+    fn get_blobs_operator_account(&self) -> Option<Address>;
+    async fn get_operator_nonce(
+        &self,
+        block_numbers: L1BlockNumbers,
+    ) -> Result<OperatorNonce, EthSenderError>;
+
+    async fn get_blobs_operator_nonce(
+        &self,
+        block_numbers: L1BlockNumbers,
+    ) -> Result<Option<OperatorNonce>, EthSenderError>;
+
+    async fn sign_tx(
+        &self,
+        tx: &EthTx,
+        base_fee_per_gas: u64,
+        priority_fee_per_gas: u64,
+        blob_gas_price: Option<U256>,
+        max_aggregated_tx_gas: U256,
+    ) -> SignedCallResult;
+
+    async fn get_l1_block_numbers(&self) -> Result<L1BlockNumbers, EthSenderError>;
+
+    fn ethereum_gateway(&self) -> &dyn BoundEthInterface;
+    fn ethereum_gateway_blobs(&self) -> Option<&dyn BoundEthInterface>;
+}
+
+#[derive(Debug)]
+pub(super) struct RealL1Interface {
+    pub ethereum_gateway: Box<dyn BoundEthInterface>,
+    pub ethereum_gateway_blobs: Option<Box<dyn BoundEthInterface>>,
+    pub wait_confirmations: Option<u64>,
+}
+
+impl RealL1Interface {
+    pub(crate) fn query_client(&self) -> &DynClient<L1> {
+        self.ethereum_gateway().as_ref()
+    }
+}
+#[async_trait]
+impl AbstractL1Interface for RealL1Interface {
+    async fn failure_reason(&self, tx_hash: H256) -> Option<FailureInfo> {
+        self.query_client().failure_reason(tx_hash).await.expect(
+            "Tx is already failed, it's safe to fail here and apply the status on the next run",
+        )
+    }
+
+    #[cfg(test)]
+    async fn get_tx(&self, tx_hash: H256) -> EnrichedClientResult<Option<web3::Transaction>> {
+        self.query_client().get_tx(tx_hash).await
+    }
+
+    async fn get_tx_status(
+        &self,
+        tx_hash: H256,
+    ) -> Result<Option<ExecutedTxStatus>, EthSenderError> {
+        self.query_client()
+            .get_tx_status(tx_hash)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn send_raw_tx(&self, tx_bytes: RawTransactionBytes) -> EnrichedClientResult<H256> {
+        self.query_client().send_raw_tx(tx_bytes).await
+    }
+    fn get_blobs_operator_account(&self) -> Option<Address> {
+        self.ethereum_gateway_blobs()
+            .as_ref()
+            .map(|s| s.sender_account())
+    }
+
+    async fn get_operator_nonce(
+        &self,
+        block_numbers: L1BlockNumbers,
+    ) -> Result<OperatorNonce, EthSenderError> {
+        let finalized = self
+            .ethereum_gateway()
+            .nonce_at(block_numbers.finalized.0.into())
+            .await?
+            .as_u32()
+            .into();
+
+        let latest = self
+            .ethereum_gateway()
+            .nonce_at(block_numbers.latest.0.into())
+            .await?
+            .as_u32()
+            .into();
+        Ok(OperatorNonce { finalized, latest })
+    }
+
+    async fn get_blobs_operator_nonce(
+        &self,
+        block_numbers: L1BlockNumbers,
+    ) -> Result<Option<OperatorNonce>, EthSenderError> {
+        match &self.ethereum_gateway_blobs() {
+            None => Ok(None),
+            Some(gateway) => {
+                let finalized = gateway
+                    .nonce_at(block_numbers.finalized.0.into())
+                    .await?
+                    .as_u32()
+                    .into();
+
+                let latest = gateway
+                    .nonce_at(block_numbers.latest.0.into())
+                    .await?
+                    .as_u32()
+                    .into();
+                Ok(Some(OperatorNonce { finalized, latest }))
+            }
+        }
+    }
+
+    async fn sign_tx(
+        &self,
+        tx: &EthTx,
+        base_fee_per_gas: u64,
+        priority_fee_per_gas: u64,
+        blob_gas_price: Option<U256>,
+        max_aggregated_tx_gas: U256,
+    ) -> SignedCallResult {
+        // Chose the signing gateway. Use a custom one in case
+        // the operator is in 4844 mode and the operation at hand is Commit.
+        // then the optional gateway is used to send this transaction from a
+        // custom sender account.
+        let signing_gateway = if let Some(blobs_gateway) = self.ethereum_gateway_blobs() {
+            if tx.tx_type == AggregatedActionType::Commit {
+                blobs_gateway
+            } else {
+                self.ethereum_gateway()
+            }
+        } else {
+            self.ethereum_gateway()
+        };
+
+        signing_gateway
+            .sign_prepared_tx_for_addr(
+                tx.raw_tx.clone(),
+                tx.contract_address,
+                Options::with(|opt| {
+                    // TODO Calculate gas for every operation SMA-1436
+                    opt.gas = Some(max_aggregated_tx_gas);
+                    opt.max_fee_per_gas = Some(U256::from(base_fee_per_gas + priority_fee_per_gas));
+                    opt.max_priority_fee_per_gas = Some(U256::from(priority_fee_per_gas));
+                    opt.nonce = Some(tx.nonce.0.into());
+                    opt.transaction_type = if tx.blob_sidecar.is_some() {
+                        opt.max_fee_per_blob_gas = blob_gas_price;
+                        Some(EIP_4844_TX_TYPE.into())
+                    } else {
+                        Some(EIP_1559_TX_TYPE.into())
+                    };
+                    opt.blob_versioned_hashes = tx.blob_sidecar.as_ref().map(|s| match s {
+                        EthTxBlobSidecar::EthTxBlobSidecarV1(s) => s
+                            .blobs
+                            .iter()
+                            .map(|blob| H256::from_slice(&blob.versioned_hash))
+                            .collect(),
+                    });
+                }),
+            )
+            .await
+            .expect("Failed to sign transaction")
+    }
+
+    async fn get_l1_block_numbers(&self) -> Result<L1BlockNumbers, EthSenderError> {
+        let (finalized, safe) = if let Some(confirmations) = self.wait_confirmations {
+            let latest_block_number = self.query_client().block_number().await?.as_u64();
+
+            let finalized = (latest_block_number.saturating_sub(confirmations) as u32).into();
+            (finalized, finalized)
+        } else {
+            let finalized = self
+                .query_client()
+                .block(BlockId::Number(BlockNumber::Finalized))
+                .await?
+                .expect("Finalized block must be present on L1")
+                .number
+                .expect("Finalized block must contain number")
+                .as_u32()
+                .into();
+
+            let safe = self
+                .query_client()
+                .block(BlockId::Number(BlockNumber::Safe))
+                .await?
+                .expect("Safe block must be present on L1")
+                .number
+                .expect("Safe block must contain number")
+                .as_u32()
+                .into();
+            (finalized, safe)
+        };
+
+        let latest = self.query_client().block_number().await?.as_u32().into();
+
+        Ok(L1BlockNumbers {
+            finalized,
+            latest,
+            safe,
+        })
+    }
+
+    fn ethereum_gateway(&self) -> &dyn BoundEthInterface {
+        self.ethereum_gateway.as_ref()
+    }
+
+    fn ethereum_gateway_blobs(&self) -> Option<&dyn BoundEthInterface> {
+        self.ethereum_gateway_blobs.as_deref()
+    }
+}

--- a/core/node/eth_sender/src/eth_fees_oracle.rs
+++ b/core/node/eth_sender/src/eth_fees_oracle.rs
@@ -1,0 +1,148 @@
+use std::{
+    cmp::{max, min},
+    fmt,
+    sync::Arc,
+};
+
+use zksync_eth_client::{ClientError, EnrichedClientError};
+use zksync_node_fee_model::l1_gas_price::L1TxParamsProvider;
+use zksync_types::eth_sender::TxHistory;
+
+use crate::EthSenderError;
+
+#[derive(Debug)]
+pub(crate) struct EthFees {
+    pub(crate) base_fee_per_gas: u64,
+    pub(crate) priority_fee_per_gas: u64,
+    pub(crate) blob_base_fee_per_gas: Option<u64>,
+}
+
+pub(crate) trait EthFeesOracle: 'static + Sync + Send + fmt::Debug {
+    fn calculate_fees(
+        &self,
+        previous_sent_tx: &Option<TxHistory>,
+        has_blob_sidecar: bool,
+        time_in_mempool: u32,
+    ) -> Result<EthFees, EthSenderError>;
+}
+
+#[derive(Debug)]
+pub(crate) struct GasAdjusterFeesOracle {
+    pub gas_adjuster: Arc<dyn L1TxParamsProvider>,
+    pub max_acceptable_priority_fee_in_gwei: u64,
+}
+
+impl GasAdjusterFeesOracle {
+    fn calculate_fees_with_blob_sidecar(
+        &self,
+        previous_sent_tx: &Option<TxHistory>,
+    ) -> Result<EthFees, EthSenderError> {
+        let base_fee_per_gas = self.gas_adjuster.get_base_fee(0);
+        let priority_fee_per_gas = self.gas_adjuster.get_priority_fee();
+        let blob_base_fee_per_gas = Some(self.gas_adjuster.get_blob_base_fee());
+
+        if let Some(previous_sent_tx) = previous_sent_tx {
+            // for blob transactions on re-sending need to double all gas prices
+            return Ok(EthFees {
+                base_fee_per_gas: max(previous_sent_tx.base_fee_per_gas * 2, base_fee_per_gas),
+                priority_fee_per_gas: max(
+                    previous_sent_tx.priority_fee_per_gas * 2,
+                    priority_fee_per_gas,
+                ),
+                blob_base_fee_per_gas: max(
+                    previous_sent_tx.blob_base_fee_per_gas.map(|v| v * 2),
+                    blob_base_fee_per_gas,
+                ),
+            });
+        }
+        Ok(EthFees {
+            base_fee_per_gas,
+            priority_fee_per_gas,
+            blob_base_fee_per_gas,
+        })
+    }
+
+    fn calculate_fees_no_blob_sidecar(
+        &self,
+        previous_sent_tx: &Option<TxHistory>,
+        time_in_mempool: u32,
+    ) -> Result<EthFees, EthSenderError> {
+        let base_fee_per_gas = self.gas_adjuster.get_base_fee(time_in_mempool);
+        if let Some(previous_sent_tx) = previous_sent_tx {
+            self.verify_base_fee_not_too_low_on_resend(
+                previous_sent_tx.id,
+                previous_sent_tx.base_fee_per_gas,
+                base_fee_per_gas,
+            )?;
+        }
+
+        let mut priority_fee_per_gas = self.gas_adjuster.get_priority_fee();
+
+        if let Some(previous_sent_tx) = previous_sent_tx {
+            // Increase `priority_fee_per_gas` by at least 20% to prevent "replacement transaction under-priced" error.
+            priority_fee_per_gas = max(
+                priority_fee_per_gas,
+                (previous_sent_tx.priority_fee_per_gas * 6) / 5 + 1,
+            );
+        }
+
+        // Extra check to prevent sending transaction will extremely high priority fee.
+        if priority_fee_per_gas > self.max_acceptable_priority_fee_in_gwei {
+            panic!(
+                "Extremely high value of priority_fee_per_gas is suggested: {}, while max acceptable is {}",
+                priority_fee_per_gas,
+                self.max_acceptable_priority_fee_in_gwei
+            );
+        }
+
+        Ok(EthFees {
+            base_fee_per_gas,
+            blob_base_fee_per_gas: None,
+            priority_fee_per_gas,
+        })
+    }
+
+    fn verify_base_fee_not_too_low_on_resend(
+        &self,
+        tx_id: u32,
+        previous_base_fee: u64,
+        base_fee_to_use: u64,
+    ) -> Result<(), EthSenderError> {
+        let next_block_minimal_base_fee = self.gas_adjuster.get_next_block_minimal_base_fee();
+        if base_fee_to_use <= min(next_block_minimal_base_fee, previous_base_fee) {
+            // If the base fee is lower than the previous used one
+            // or is lower than the minimal possible value for the next block, sending is skipped.
+            tracing::info!(
+                "Base fee too low for resend detected for tx {}, \
+                 suggested base_fee_per_gas {:?}, \
+                 previous_base_fee {:?}, \
+                 next_block_minimal_base_fee {:?}",
+                tx_id,
+                base_fee_to_use,
+                previous_base_fee,
+                next_block_minimal_base_fee
+            );
+            let err = ClientError::Custom("base_fee_per_gas is too low".into());
+            let err = EnrichedClientError::new(err, "increase_priority_fee")
+                .with_arg("base_fee_to_use", &base_fee_to_use)
+                .with_arg("previous_base_fee", &previous_base_fee)
+                .with_arg("next_block_minimal_base_fee", &next_block_minimal_base_fee);
+            return Err(err.into());
+        }
+        Ok(())
+    }
+}
+
+impl EthFeesOracle for GasAdjusterFeesOracle {
+    fn calculate_fees(
+        &self,
+        previous_sent_tx: &Option<TxHistory>,
+        has_blob_sidecar: bool,
+        time_in_mempool: u32,
+    ) -> Result<EthFees, EthSenderError> {
+        match has_blob_sidecar {
+            true => self.calculate_fees_with_blob_sidecar(previous_sent_tx),
+            false => self.calculate_fees_no_blob_sidecar(previous_sent_tx, time_in_mempool),
+        }
+    }
+}

--- a/core/node/eth_sender/src/eth_fees_oracle.rs
+++ b/core/node/eth_sender/src/eth_fees_oracle.rs
@@ -140,9 +140,10 @@ impl EthFeesOracle for GasAdjusterFeesOracle {
         has_blob_sidecar: bool,
         time_in_mempool: u32,
     ) -> Result<EthFees, EthSenderError> {
-        match has_blob_sidecar {
-            true => self.calculate_fees_with_blob_sidecar(previous_sent_tx),
-            false => self.calculate_fees_no_blob_sidecar(previous_sent_tx, time_in_mempool),
+        if has_blob_sidecar {
+            self.calculate_fees_with_blob_sidecar(previous_sent_tx)
+        } else {
+            self.calculate_fees_no_blob_sidecar(previous_sent_tx, time_in_mempool)
         }
     }
 }

--- a/core/node/eth_sender/src/lib.rs
+++ b/core/node/eth_sender/src/lib.rs
@@ -9,6 +9,8 @@ mod utils;
 mod zksync_functions;
 
 mod abstract_l1_interface;
+
+mod eth_fees_oracle;
 #[cfg(test)]
 mod tests;
 

--- a/core/node/eth_sender/src/lib.rs
+++ b/core/node/eth_sender/src/lib.rs
@@ -8,6 +8,7 @@ mod publish_criterion;
 mod utils;
 mod zksync_functions;
 
+mod abstract_l1_interface;
 #[cfg(test)]
 mod tests;
 

--- a/core/node/eth_sender/src/metrics.rs
+++ b/core/node/eth_sender/src/metrics.rs
@@ -8,7 +8,7 @@ use zksync_shared_metrics::{BlockL1Stage, BlockStage, APP_METRICS};
 use zksync_types::{aggregated_operations::AggregatedActionType, eth_sender::EthTx};
 use zksync_utils::time::seconds_since_epoch;
 
-use crate::eth_tx_manager::L1BlockNumbers;
+use crate::abstract_l1_interface::L1BlockNumbers;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelSet, EncodeLabelValue)]
 #[metrics(label = "kind", rename_all = "snake_case")]

--- a/core/node/eth_sender/src/tests.rs
+++ b/core/node/eth_sender/src/tests.rs
@@ -28,7 +28,7 @@ use zksync_types::{
 };
 
 use crate::{
-    aggregated_operations::AggregatedOperation, eth_tx_manager::L1BlockNumbers, Aggregator,
+    abstract_l1_interface::L1BlockNumbers, aggregated_operations::AggregatedOperation, Aggregator,
     EthSenderError, EthTxAggregator, EthTxManager,
 };
 

--- a/core/node/eth_sender/src/tests.rs
+++ b/core/node/eth_sender/src/tests.rs
@@ -9,7 +9,7 @@ use zksync_config::{
 };
 use zksync_contracts::BaseSystemContractsHashes;
 use zksync_dal::{Connection, ConnectionPool, Core, CoreDal};
-use zksync_eth_client::{clients::MockEthereum, EthInterface};
+use zksync_eth_client::clients::MockEthereum;
 use zksync_l1_contract_interface::i_executor::methods::{ExecuteBatches, ProveBatches};
 use zksync_node_fee_model::l1_gas_price::GasAdjuster;
 use zksync_node_test_utils::{create_l1_batch, l1_batch_metadata_to_commitment_artifacts};
@@ -210,12 +210,11 @@ impl EthSenderTester {
     async fn get_block_numbers(&self) -> L1BlockNumbers {
         let latest = self
             .manager
-            .query_client()
-            .block_number()
+            .l1_interface()
+            .get_l1_block_numbers()
             .await
             .unwrap()
-            .as_u32()
-            .into();
+            .latest;
         let finalized = latest - Self::WAIT_CONFIRMATIONS as u32;
         L1BlockNumbers {
             finalized,
@@ -432,7 +431,7 @@ async fn resend_each_block(commitment_mode: L1BatchCommitmentMode) -> anyhow::Re
 
     let sent_tx = tester
         .manager
-        .query_client()
+        .l1_interface()
         .get_tx(hash)
         .await
         .unwrap()
@@ -481,7 +480,7 @@ async fn resend_each_block(commitment_mode: L1BatchCommitmentMode) -> anyhow::Re
 
     let resent_tx = tester
         .manager
-        .query_client()
+        .l1_interface()
         .get_tx(resent_hash)
         .await
         .unwrap()


### PR DESCRIPTION
This PR deliberately only moves the code around without refactoring the logic itself to decrease the risk of error. More PRs will most likely follow 