### PR TITLE
perf(db): Improve storage switching for state keeper cache

### DIFF
--- a/core/lib/state/src/catchup.rs
+++ b/core/lib/state/src/catchup.rs
@@ -131,14 +131,17 @@ impl AsyncCatchupTask {
     /// Propagates RocksDB and Postgres errors.
     pub async fn run(self, stop_receiver: watch::Receiver<bool>) -> anyhow::Result<()> {
         let started_at = Instant::now();
-        tracing::debug!("Catching up RocksDB asynchronously");
+        tracing::debug!(
+            "Catching up RocksDB asynchronously to L1 batch #{:?}",
+            self.to_l1_batch_number
+        );
 
-        let mut rocksdb_builder = dbg!(RocksdbStorage::builder_with_options(
+        let mut rocksdb_builder = RocksdbStorage::builder_with_options(
             self.state_keeper_db_path.as_ref(),
             self.state_keeper_db_options,
         )
         .await
-        .context("Failed creating RocksDB storage builder"))?;
+        .context("Failed creating RocksDB storage builder")?;
 
         let initial_state = InitialRocksdbState {
             l1_batch_number: rocksdb_builder.l1_batch_number().await,

--- a/core/lib/state/src/catchup.rs
+++ b/core/lib/state/src/catchup.rs
@@ -139,12 +139,10 @@ impl AsyncCatchupTask {
     /// # Errors
     ///
     /// Propagates RocksDB and Postgres errors.
+    #[tracing::instrument(name = "catch_up", skip_all, fields(target_l1_batch = ?self.to_l1_batch_number))]
     pub async fn run(self, stop_receiver: watch::Receiver<bool>) -> anyhow::Result<()> {
         let started_at = Instant::now();
-        tracing::debug!(
-            "Catching up RocksDB asynchronously to L1 batch #{:?}",
-            self.to_l1_batch_number
-        );
+        tracing::info!("Catching up RocksDB asynchronously");
 
         let mut rocksdb_builder = RocksdbStorage::builder_with_options(
             self.state_keeper_db_path.as_ref(),

--- a/core/lib/state/src/lib.rs
+++ b/core/lib/state/src/lib.rs
@@ -30,7 +30,7 @@ mod test_utils;
 
 pub use self::{
     cache::sequential_cache::SequentialCache,
-    catchup::AsyncCatchupTask,
+    catchup::{AsyncCatchupTask, RocksdbCell},
     in_memory::InMemoryStorage,
     // Note, that `test_infra` of the bootloader tests relies on this value to be exposed
     in_memory::IN_MEMORY_STORAGE_DEFAULT_NETWORK_ID,

--- a/core/lib/state/src/storage_factory.rs
+++ b/core/lib/state/src/storage_factory.rs
@@ -186,7 +186,7 @@ impl ReadStorage for RocksdbWithMemory {
 }
 
 impl ReadStorage for PgOrRocksdbStorage<'_> {
-    fn read_value(&mut self, key: &StorageKey) -> zksync_types::StorageValue {
+    fn read_value(&mut self, key: &StorageKey) -> StorageValue {
         match self {
             Self::Postgres(postgres) => postgres.read_value(key),
             Self::Rocksdb(rocksdb) => rocksdb.read_value(key),

--- a/core/node/state_keeper/src/state_keeper_storage.rs
+++ b/core/node/state_keeper/src/state_keeper_storage.rs
@@ -69,13 +69,11 @@ impl AsyncRocksdbCache {
         state_keeper_db_path: String,
         state_keeper_db_options: RocksdbStorageOptions,
     ) -> (Self, AsyncCatchupTask) {
-        let (task, rocksdb_cell) = AsyncCatchupTask::new(
-            pool.clone(),
-            state_keeper_db_path,
-            state_keeper_db_options,
-            None,
-        );
-        (Self { pool, rocksdb_cell }, task)
+        let (task, rocksdb_cell) = AsyncCatchupTask::new(pool.clone(), state_keeper_db_path);
+        (
+            Self { pool, rocksdb_cell },
+            task.with_db_options(state_keeper_db_options),
+        )
     }
 }
 


### PR DESCRIPTION
## What ❔

Improves switching logic between Postgres and RocksDB for SK cache. With these changes, RocksDB is guaranteed to be used if it's up to date when it's opened.

## Why ❔

Previously, Postgres could be used after node start (primarily if there's a pending L1 batch) even if RocksDB is up to date. This is caused by potential delays when opening RocksDB. This behavior was observed in the wild, e.g. for a mainnet full node with pruning enabled.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.