### PR TITLE
refactor(en): Fetch old L1 batch hashes from L1 – improve metrics / logging

### DIFF
--- a/core/node/node_sync/src/tree_data_fetcher/metrics.rs
+++ b/core/node/node_sync/src/tree_data_fetcher/metrics.rs
@@ -7,7 +7,7 @@ use vise::{
     Info, Metrics, Unit,
 };
 
-use super::{provider::TreeDataProviderSource, StepOutcome, TreeDataFetcher, TreeDataFetcherError};
+use super::{StepOutcome, TreeDataFetcher, TreeDataFetcherError};
 
 #[derive(Debug, EncodeLabelSet)]
 struct TreeDataFetcherInfo {
@@ -42,6 +42,14 @@ pub(super) enum StepOutcomeLabel {
     RemoteHashMissing,
     PossibleReorg,
     TransientError,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, EncodeLabelSet)]
+#[metrics(label = "source", rename_all = "snake_case")]
+#[allow(dead_code)] // FIXME
+pub(super) enum TreeDataProviderSource {
+    L1CommitEvent,
+    BatchDetailsRpc,
 }
 
 const BLOCK_DIFF_BUCKETS: Buckets = Buckets::values(&[

--- a/core/node/node_sync/src/tree_data_fetcher/metrics.rs
+++ b/core/node/node_sync/src/tree_data_fetcher/metrics.rs
@@ -30,6 +30,9 @@ impl From<&TreeDataFetcher> for TreeDataFetcherInfo {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, EncodeLabelSet)]
 #[metrics(label = "stage", rename_all = "snake_case")]
 pub(super) enum ProcessingStage {
+    FetchL1CommitEvent,
+    FetchBatchDetailsRpc,
+    /// Total latency for all clients.
     Fetch,
     Persistence,
 }
@@ -46,7 +49,6 @@ pub(super) enum StepOutcomeLabel {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, EncodeLabelSet)]
 #[metrics(label = "source", rename_all = "snake_case")]
-#[allow(dead_code)] // FIXME
 pub(super) enum TreeDataProviderSource {
     L1CommitEvent,
     BatchDetailsRpc,

--- a/core/node/node_sync/src/tree_data_fetcher/mod.rs
+++ b/core/node/node_sync/src/tree_data_fetcher/mod.rs
@@ -30,7 +30,7 @@ mod tests;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum TreeDataFetcherError {
-    #[error("error fetching data from main node")]
+    #[error("error fetching data")]
     Rpc(#[from] EnrichedClientError),
     #[error("internal error")]
     Internal(#[from] anyhow::Error),

--- a/core/node/node_sync/src/tree_data_fetcher/mod.rs
+++ b/core/node/node_sync/src/tree_data_fetcher/mod.rs
@@ -22,6 +22,7 @@ use self::{
     metrics::{ProcessingStage, TreeDataFetcherMetrics, METRICS},
     provider::{L1DataProvider, MissingData, TreeDataProvider},
 };
+use crate::tree_data_fetcher::provider::CombinedDataProvider;
 
 mod metrics;
 mod provider;
@@ -95,7 +96,7 @@ enum StepOutcome {
 /// by Consistency checker.
 #[derive(Debug)]
 pub struct TreeDataFetcher {
-    data_provider: Box<dyn TreeDataProvider>,
+    data_provider: CombinedDataProvider,
     // Used in the Info metric
     diamond_proxy_address: Option<Address>,
     pool: ConnectionPool<Core>,
@@ -112,7 +113,7 @@ impl TreeDataFetcher {
     /// Creates a new fetcher connected to the main node.
     pub fn new(client: Box<DynClient<L2>>, pool: ConnectionPool<Core>) -> Self {
         Self {
-            data_provider: Box::new(client.for_component("tree_data_fetcher")),
+            data_provider: CombinedDataProvider::new(client.for_component("tree_data_fetcher")),
             diamond_proxy_address: None,
             pool,
             metrics: &METRICS,
@@ -140,7 +141,7 @@ impl TreeDataFetcher {
             eth_client.for_component("tree_data_fetcher"),
             diamond_proxy_address,
         )?;
-        self.data_provider = Box::new(l1_provider.with_fallback(self.data_provider));
+        self.data_provider.set_l1(l1_provider);
         self.diamond_proxy_address = Some(diamond_proxy_address);
         Ok(self)
     }
@@ -212,14 +213,11 @@ impl TreeDataFetcher {
             .await?;
         stage_latency.observe();
         let root_hash = match root_hash_result {
-            Ok(output) => {
+            Ok(root_hash) => {
                 tracing::debug!(
-                    "Received root hash for L1 batch #{l1_batch_to_fetch} from {source:?}: {root_hash:?}",
-                    source = output.source,
-                    root_hash = output.root_hash
+                    "Received root hash for L1 batch #{l1_batch_to_fetch}: {root_hash:?}"
                 );
-                self.metrics.root_hash_sources[&output.source].inc();
-                output.root_hash
+                root_hash
             }
             Err(MissingData::Batch) => {
                 let err = anyhow::anyhow!(

--- a/core/node/node_sync/src/tree_data_fetcher/provider/tests.rs
+++ b/core/node/node_sync/src/tree_data_fetcher/provider/tests.rs
@@ -85,13 +85,12 @@ async fn rpc_data_provider_basics() {
     };
     let mut client: Box<DynClient<L2>> = Box::new(l2_parameters.mock_client());
 
-    let output = client
+    let root_hash = client
         .batch_details(L1BatchNumber(1), &last_l2_block)
         .await
         .unwrap()
         .expect("missing block");
-    assert_eq!(output.root_hash, H256::from_low_u64_be(1));
-    assert_matches!(output.source, TreeDataProviderSource::BatchDetailsRpc);
+    assert_eq!(root_hash, H256::from_low_u64_be(1));
 
     // Query a future L1 batch.
     let output = client
@@ -269,13 +268,12 @@ async fn test_using_l1_data_provider(l1_batch_timestamps: &[u64]) {
         L1DataProvider::new(Box::new(eth_params.client()), DIAMOND_PROXY_ADDRESS).unwrap();
     for i in 0..l1_batch_timestamps.len() {
         let number = L1BatchNumber(i as u32 + 1);
-        let output = provider
+        let root_hash = provider
             .batch_details(number, &get_last_l2_block(&mut storage, number).await)
             .await
             .unwrap()
             .expect("no root hash");
-        assert_eq!(output.root_hash, H256::repeat_byte(number.0 as u8));
-        assert_matches!(output.source, TreeDataProviderSource::L1CommitEvent);
+        assert_eq!(root_hash, H256::repeat_byte(number.0 as u8));
 
         let past_l1_batch = provider.past_l1_batch.unwrap();
         assert_eq!(past_l1_batch.number, number);
@@ -351,12 +349,13 @@ async fn combined_data_provider_errors() {
 
     let mut main_node_client = MockMainNodeClient::default();
     main_node_client.insert_batch(L1BatchNumber(2), H256::repeat_byte(2));
-    let mut provider = L1DataProvider::new(Box::new(eth_params.client()), DIAMOND_PROXY_ADDRESS)
-        .unwrap()
-        .with_fallback(Box::new(main_node_client));
+    let mut provider = CombinedDataProvider::new(main_node_client);
+    let l1_provider =
+        L1DataProvider::new(Box::new(eth_params.client()), DIAMOND_PROXY_ADDRESS).unwrap();
+    provider.set_l1(l1_provider);
 
     // L1 batch #1 should be obtained from L1
-    let output = provider
+    let root_hash = provider
         .batch_details(
             L1BatchNumber(1),
             &get_last_l2_block(&mut storage, L1BatchNumber(1)).await,
@@ -364,12 +363,11 @@ async fn combined_data_provider_errors() {
         .await
         .unwrap()
         .expect("no root hash");
-    assert_eq!(output.root_hash, H256::repeat_byte(1));
-    assert_matches!(output.source, TreeDataProviderSource::L1CommitEvent);
+    assert_eq!(root_hash, H256::repeat_byte(1));
     assert!(provider.l1.is_some());
 
     // L1 batch #2 should be obtained from L2
-    let output = provider
+    let root_hash = provider
         .batch_details(
             L1BatchNumber(2),
             &get_last_l2_block(&mut storage, L1BatchNumber(2)).await,
@@ -377,7 +375,6 @@ async fn combined_data_provider_errors() {
         .await
         .unwrap()
         .expect("no root hash");
-    assert_eq!(output.root_hash, H256::repeat_byte(2));
-    assert_matches!(output.source, TreeDataProviderSource::BatchDetailsRpc);
+    assert_eq!(root_hash, H256::repeat_byte(2));
     assert!(provider.l1.is_none());
 }


### PR DESCRIPTION
## What ❔

Improves logging and metrics for the tree data fetcher.

## Why ❔

Currently, some errors don't have their context logged, and some metrics are defined suboptimally.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.