### PR TITLE
fix(object-store): Consider more GCS errors transient

### DIFF
--- a/core/lib/object_store/src/gcs.rs
+++ b/core/lib/object_store/src/gcs.rs
@@ -87,13 +87,24 @@ impl From<AuthError> for ObjectStoreError {
     fn from(err: AuthError) -> Self {
         let is_transient = matches!(
             &err,
-            AuthError::HttpError(err) if err.is_timeout() || err.is_connect() || has_transient_io_source(err) || upstream_unavailable(err)
+            AuthError::HttpError(err) if is_transient_http_error(err)
         );
         Self::Initialization {
             source: err.into(),
             is_transient,
         }
     }
+}
+
+fn is_transient_http_error(err: &reqwest::Error) -> bool {
+    err.is_timeout()
+        || err.is_connect()
+        // Not all request errors are logically transient, but a significant part of them are (e.g.,
+        // `hyper` protocol-level errors), and it's safer to consider an error transient.
+        || err.is_request()
+        || has_transient_io_source(err)
+        || err.status() == Some(StatusCode::BAD_GATEWAY)
+        || err.status() == Some(StatusCode::SERVICE_UNAVAILABLE)
 }
 
 fn has_transient_io_source(mut err: &(dyn StdError + 'static)) -> bool {
@@ -111,11 +122,6 @@ fn has_transient_io_source(mut err: &(dyn StdError + 'static)) -> bool {
     }
 }
 
-fn upstream_unavailable(err: &reqwest::Error) -> bool {
-    err.status() == Some(StatusCode::BAD_GATEWAY)
-        || err.status() == Some(StatusCode::SERVICE_UNAVAILABLE)
-}
-
 impl From<HttpError> for ObjectStoreError {
     fn from(err: HttpError) -> Self {
         let is_not_found = match &err {
@@ -131,7 +137,7 @@ impl From<HttpError> for ObjectStoreError {
         } else {
             let is_transient = matches!(
                 &err,
-                HttpError::HttpClient(err) if err.is_timeout() || err.is_connect() || has_transient_io_source(err) || upstream_unavailable(err)
+                HttpError::HttpClient(err) if is_transient_http_error(err)
             );
             ObjectStoreError::Other {
                 is_transient,


### PR DESCRIPTION
## What ❔

Considers `reqwest::Error`s with "request" kind transient for the object store logic.

## Why ❔

Similar to some other kinds of `reqwest::Error`s, not all "request" errors are truly transient, but considering them as such is a safer option.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.