### PR TITLE
feat(contract-verifier): Adjust contract verifier for zksolc 1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8307,6 +8307,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "regex",
+ "semver",
  "serde",
  "serde_json",
  "tempfile",

--- a/core/lib/contract_verifier/Cargo.toml
+++ b/core/lib/contract_verifier/Cargo.toml
@@ -31,3 +31,4 @@ lazy_static.workspace = true
 tempfile.workspace = true
 regex.workspace = true
 tracing.workspace = true
+semver.workspace = true

--- a/core/lib/contract_verifier/src/lib.rs
+++ b/core/lib/contract_verifier/src/lib.rs
@@ -153,7 +153,11 @@ impl ContractVerifier {
             ));
         }
 
-        let zksolc = ZkSolc::new(zksolc_path, solc_path);
+        let zksolc = ZkSolc::new(
+            zksolc_path,
+            solc_path,
+            request.req.compiler_versions.zk_compiler_version(),
+        );
 
         let output = time::timeout(config.compilation_timeout(), zksolc.async_compile(input))
             .await

--- a/core/lib/contract_verifier/src/zksolc_utils.rs
+++ b/core/lib/contract_verifier/src/zksolc_utils.rs
@@ -113,7 +113,7 @@ impl ZkSolc {
                     }
                 }
 
-                command.arg("--solc").arg(self.solc_path.to_str().unwrap())
+                command.arg("--solc").arg(self.solc_path.to_str().unwrap());
             }
             ZkSolcInput::YulSingleFile { is_system, .. } => {
                 if self.is_post_1_5_0() {

--- a/core/lib/contract_verifier/src/zksolc_utils.rs
+++ b/core/lib/contract_verifier/src/zksolc_utils.rs
@@ -102,6 +102,7 @@ impl ZkSolc {
         let mut command = tokio::process::Command::new(&self.zksolc_path);
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
+        dbg!(&input);
         match &input {
             ZkSolcInput::StandardJson(input) => {
                 if !self.is_post_1_5_0() {
@@ -202,13 +203,13 @@ impl ZkSolc {
             false
         } else {
             let re =
-                Regex::new(r"^(?<MAJOR>(?:0|(?:[1-9]\d*)))\.(?<MINOR>(?:0|(?:[1-9]\d*)))\.(?<PATCH>(?:0|(?:[1-9]\d*)))")
+                Regex::new(r"^v(?<MAJOR>(?:0|(?:[1-9]\d*)))\.(?<MINOR>(?:0|(?:[1-9]\d*)))\.(?<PATCH>(?:0|(?:[1-9]\d*)))")
                     .unwrap();
             if let Some(caps) = re.captures(&self.zksolc_version) {
                 (caps["MAJOR"].len() > 1 || &caps["MAJOR"] > "1")
                     || (&caps["MAJOR"] == "1" && (caps["MINOR"].len() > 1 || &caps["MINOR"] >= "5"))
             } else {
-                false
+                true
             }
         }
     }
@@ -224,22 +225,22 @@ mod tests {
         let mut zksolc = ZkSolc::new(".", ".", "vm-1.5.0-a167aa3".to_string());
         assert!(!zksolc.is_post_1_5_0(), "vm-1.5.0-a167aa3");
 
-        zksolc.zksolc_version = "1.5.0".to_string();
-        assert!(zksolc.is_post_1_5_0(), "1.5.0");
+        zksolc.zksolc_version = "v1.5.0".to_string();
+        assert!(zksolc.is_post_1_5_0(), "v1.5.0");
 
-        zksolc.zksolc_version = "1.5.1".to_string();
-        assert!(zksolc.is_post_1_5_0(), "1.5.1");
+        zksolc.zksolc_version = "v1.5.1".to_string();
+        assert!(zksolc.is_post_1_5_0(), "v1.5.1");
 
-        zksolc.zksolc_version = "1.10.1".to_string();
-        assert!(zksolc.is_post_1_5_0(), "1.10.1");
+        zksolc.zksolc_version = "v1.10.1".to_string();
+        assert!(zksolc.is_post_1_5_0(), "v1.10.1");
 
-        zksolc.zksolc_version = "2.0.0".to_string();
-        assert!(zksolc.is_post_1_5_0(), "2.0.0");
+        zksolc.zksolc_version = "v2.0.0".to_string();
+        assert!(zksolc.is_post_1_5_0(), "v2.0.0");
 
-        zksolc.zksolc_version = "1.4.15".to_string();
-        assert!(!zksolc.is_post_1_5_0(), "1.4.15");
+        zksolc.zksolc_version = "v1.4.15".to_string();
+        assert!(!zksolc.is_post_1_5_0(), "v1.4.15");
 
-        zksolc.zksolc_version = "0.5.1".to_string();
-        assert!(!zksolc.is_post_1_5_0(), "0.5.1");
+        zksolc.zksolc_version = "v0.5.1".to_string();
+        assert!(!zksolc.is_post_1_5_0(), "v0.5.1");
     }
 }

--- a/core/lib/contract_verifier/src/zksolc_utils.rs
+++ b/core/lib/contract_verifier/src/zksolc_utils.rs
@@ -102,7 +102,6 @@ impl ZkSolc {
         let mut command = tokio::process::Command::new(&self.zksolc_path);
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
-        dbg!(&input);
         match &input {
             ZkSolcInput::StandardJson(input) => {
                 if !self.is_post_1_5_0() {
@@ -113,6 +112,8 @@ impl ZkSolc {
                         command.arg("--force-evmla");
                     }
                 }
+
+                command.arg("--solc").arg(self.solc_path.to_str().unwrap())
             }
             ZkSolcInput::YulSingleFile { is_system, .. } => {
                 if self.is_post_1_5_0() {
@@ -239,6 +240,9 @@ mod tests {
 
         zksolc.zksolc_version = "v1.4.15".to_string();
         assert!(!zksolc.is_post_1_5_0(), "v1.4.15");
+
+        zksolc.zksolc_version = "v1.3.21".to_string();
+        assert!(!zksolc.is_post_1_5_0(), "v1.3.21");
 
         zksolc.zksolc_version = "v0.5.1".to_string();
         assert!(!zksolc.is_post_1_5_0(), "v0.5.1");

--- a/core/lib/types/src/contract_verification_api.rs
+++ b/core/lib/types/src/contract_verification_api.rs
@@ -140,7 +140,7 @@ pub struct VerificationIncomingRequest {
     pub optimizer_mode: Option<String>,
     #[serde(default)]
     pub constructor_arguments: Bytes,
-    #[serde(default)]
+    #[serde(default, alias = "enableEraVMExtensions")]
     pub is_system: bool,
     #[serde(default)]
     pub force_evmla: bool,


### PR DESCRIPTION
## What ❔

- `system-mode`, `force-evmla` flag are not provided for zksolc post v1.5.0 compilations
- `solc-path` is not provided for system yul post v1.5.0 compilations 

## Why ❔

Changes in compiler interface

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
