### PR TITLE
fix(nix): make devShells.default `pure` again

### DIFF
--- a/docs/guides/setup-dev.md
+++ b/docs/guides/setup-dev.md
@@ -258,8 +258,7 @@ Install `nix`. Enable the nix command and flakes.
 Install docker, rustup and use rust to install SQLx CLI like described above. If you are on NixOS, you also need to
 enable nix-ld.
 
-Go to the zksync folder and run `nix develop --impure`. After it finishes, you are in a shell that has all the
-dependencies.
+Go to the zksync folder and run `nix develop`. After it finishes, you are in a shell that has all the dependencies.
 
 ## Foundry
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 # $ nix build .#zksync_server.block_reverter
 #
 # To enter the development shell, run:
-# $ nix develop --impure
+# $ nix develop
 #
 # To vendor the dependencies manually, run:
 # $ nix shell .#cargo-vendor -c cargo vendor --no-merge-sources
@@ -212,7 +212,7 @@
               export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="clang"
 
               if [ "x$NIX_LD" = "x" ]; then
-                export NIX_LD="$ZK_NIX_LD"
+                export NIX_LD="$(<${clangStdenv.cc}/nix-support/dynamic-linker)"
               fi
               if [ "x$NIX_LD_LIBRARY_PATH" = "x" ]; then
                 export NIX_LD_LIBRARY_PATH="$ZK_NIX_LD_LIBRARY_PATH"
@@ -222,7 +222,6 @@
             '';
 
             ZK_NIX_LD_LIBRARY_PATH = lib.makeLibraryPath [ ];
-            ZK_NIX_LD = builtins.readFile "${clangStdenv.cc}/nix-support/dynamic-linker";
           };
         };
       });


### PR DESCRIPTION
no need for `--impure` anymore

## What ❔

this removes the need to call `nix develop` with the `--impure` flag

## Why ❔

This removes an inconvenience.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
- [ ] Spellcheck has been run via `zk spellcheck`.
