### PR TITLE
feat(proof_data_handler): add a health check endpoint to the proof data handler

### DIFF
--- a/core/node/proof_data_handler/src/lib.rs
+++ b/core/node/proof_data_handler/src/lib.rs
@@ -1,7 +1,11 @@
 use std::{net::SocketAddr, sync::Arc};
 
 use anyhow::Context as _;
-use axum::{extract::Path, routing::post, Json, Router};
+use axum::{
+    extract::{Extension, Path},
+    routing::{get, post},
+    Json, Router,
+};
 use request_processor::RequestProcessor;
 use tee_request_processor::TeeRequestProcessor;
 use tokio::sync::watch;
@@ -81,6 +85,10 @@ fn create_proof_processing_router(
                         .await
                 },
             ),
+        )
+        .route(
+            "/health",
+            get(|_: Extension<()>| async { Ok::<_, ()>("Service is up and running") }),
         );
 
     if config.tee_support {


### PR DESCRIPTION
## What ❔

Add `/health` endpoint to the `proof_data_handler` introduced in eca98cceeb74a979040279caaf1d05d1fdf1b90c (#1993).

## Why ❔

The DevOps team asked for a health check endpoint so the in-cluster load balancer can use it. Details: https://matter-labs-workspace.slack.com/archives/C05MZ0ZUB6Z/p1718801741282109?thread_ts=1718191882.611349&cid=C05MZ0ZUB6Z

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
- [x] Spellcheck has been run via `zk spellcheck`.
