### PR TITLE
feat(docs): Add documentation for subset of wiring layer implementations, used by Main node

### DIFF
--- a/core/node/node_framework/src/implementations/layers/circuit_breaker_checker.rs
+++ b/core/node/node_framework/src/implementations/layers/circuit_breaker_checker.rs
@@ -8,6 +8,17 @@ use crate::{
     wiring_layer::{WiringError, WiringLayer},
 };
 
+/// Wiring layer for circuit breaker checker
+///
+/// Expects other layers to insert different components' circuit breakers into
+/// [`zksync_circuit_breaker::CircuitBreakers`] collection using [`CircuitBreakersResource`].
+/// The added task periodically runs checks for all inserted circuit breakers.
+///
+/// ## Adds resources
+/// - [`CircuitBreakersResource`]
+///
+/// ## Adds tasks
+/// - [`CircuitBreakerCheckerTask`] (as [`UnconstrainedTask`])
 #[derive(Debug)]
 pub struct CircuitBreakerCheckerLayer(pub CircuitBreakerConfig);
 

--- a/core/node/node_framework/src/implementations/layers/commitment_generator.rs
+++ b/core/node/node_framework/src/implementations/layers/commitment_generator.rs
@@ -13,6 +13,16 @@ use crate::{
     wiring_layer::{WiringError, WiringLayer},
 };
 
+/// Wiring layer for l1 batches commitment generation
+///
+/// Responsible for initialization and running [`CommitmentGenerator`].
+///
+/// ## Requests resources
+/// - [`PoolResource`] for [`MasterPool`]
+/// - [`AppHealthCheckResource`] (to add new health check)
+///
+/// ## Adds tasks
+/// - [`CommitmentGeneratorTask`] (as [`Task`])
 #[derive(Debug)]
 pub struct CommitmentGeneratorLayer {
     mode: L1BatchCommitmentMode,

--- a/core/node/node_framework/src/implementations/layers/contract_verification_api.rs
+++ b/core/node/node_framework/src/implementations/layers/contract_verification_api.rs
@@ -8,6 +8,16 @@ use crate::{
     wiring_layer::{WiringError, WiringLayer},
 };
 
+/// Wiring layer for contract verification
+///
+/// Responsible for initialization of the contract verification server.
+///
+/// ## Requests resources
+/// - [`PoolResource`] for [`MasterPool`]
+/// - [`PoolResource`] for [`ReplicaPool`]
+///
+/// ## Adds tasks
+/// - [`ContractVerificationApiTask`] (as [`Task`])
 #[derive(Debug)]
 pub struct ContractVerificationApiLayer(pub ContractVerifierConfig);
 

--- a/core/node/node_framework/src/implementations/layers/eth_sender.rs
+++ b/core/node/node_framework/src/implementations/layers/eth_sender.rs
@@ -18,6 +18,21 @@ use crate::{
     wiring_layer::{WiringError, WiringLayer},
 };
 
+/// Wiring layer for `eth_txs` managing
+///
+/// Responsible for initialization and running [`EthTxManager`] component, that manages sending
+/// of `eth_txs`(such as `CommitBlocks`, `PublishProofBlocksOnchain` or `ExecuteBlock` ) to L1.
+///
+/// ## Requests resources
+/// - [`PoolResource`] for [`MasterPool`]
+/// - [`PoolResource`] for [`ReplicaPool`]
+/// - [`BoundEthInterfaceResource`]
+/// - [`BoundEthInterfaceForBlobsResource`]
+/// - [`L1TxParamsResource`]
+/// - [`CircuitBreakersResource`] (to add new circuit breaker)
+///
+/// ## Adds tasks
+/// - [`EthTxManagerTask`] (as [`Task`])
 #[derive(Debug)]
 pub struct EthTxManagerLayer {
     eth_sender_config: EthConfig,
@@ -78,6 +93,22 @@ impl WiringLayer for EthTxManagerLayer {
     }
 }
 
+/// Wiring layer for aggregating l1 batches into `eth_txs`
+///
+/// Responsible for initialization and running of [`EthTxAggregator`], that aggregates L1 batches
+/// into `eth_txs`(such as `CommitBlocks`, `PublishProofBlocksOnchain` or `ExecuteBlock`).
+/// These `eth_txs` will be used as a queue for generating signed txs and will be sent later on L1.
+///
+/// ## Requests resources
+/// - [`PoolResource`] for [`MasterPool`]
+/// - [`PoolResource`] for [`ReplicaPool`]
+/// - [`BoundEthInterfaceResource`]
+/// - [`BoundEthInterfaceForBlobsResource`]
+/// - [`ObjectStoreResource`]
+/// - [`CircuitBreakersResource`] (to add new circuit breaker)
+///
+/// ## Adds tasks
+/// - [`EthTxAggregatorTask`] (as [`Task`])
 #[derive(Debug)]
 pub struct EthTxAggregatorLayer {
     eth_sender_config: EthConfig,

--- a/core/node/node_framework/src/implementations/layers/eth_watch.rs
+++ b/core/node/node_framework/src/implementations/layers/eth_watch.rs
@@ -16,6 +16,17 @@ use crate::{
     wiring_layer::{WiringError, WiringLayer},
 };
 
+/// Wiring layer for ethereum watcher
+///
+/// Responsible for initializing and running of [`EthWatch`] component, that polls the Ethereum node for the relevant events,
+/// such as priority operations (aka L1 transactions), protocol upgrades etc.
+///
+/// ## Requests resources
+/// - [`PoolResource`] for [`MasterPool`]
+/// - [`EthInterfaceResource`]
+///
+/// ## Adds tasks
+/// - [`EthWatchTask`] (as [`Task`])
 #[derive(Debug)]
 pub struct EthWatchLayer {
     eth_watch_config: EthWatchConfig,

--- a/core/node/node_framework/src/implementations/layers/healtcheck_server.rs
+++ b/core/node/node_framework/src/implementations/layers/healtcheck_server.rs
@@ -11,17 +11,17 @@ use crate::{
     wiring_layer::{WiringError, WiringLayer},
 };
 
-/// Builder for a health check server.
+/// Wiring layer for health check server
 ///
-/// Spawned task collects all the health checks added by different tasks to the
-/// corresponding resource collection and spawns an HTTP server exposing them.
+/// Expects other layers to insert different components' health checks
+/// into [`AppHealthCheck`] aggregating heath using [`AppHealthCheckResource`].
+/// The added task spawns a health check server that only exposes the state provided by other tasks.
 ///
-/// This layer expects other tasks to add health checks to the `ResourceCollection<HealthCheckResource>`.
+/// ## Adds resources
+/// - [`AppHealthCheckResource`]
 ///
-/// ## Effects
-///
-/// - Resolves `ResourceCollection<HealthCheckResource>`.
-/// - Adds `healthcheck_server` to the node.
+/// ## Adds tasks
+/// - [`HealthCheckTask`] (as [`UnconstrainedTask`])
 #[derive(Debug)]
 pub struct HealthCheckLayer(pub HealthCheckConfig);
 
@@ -39,7 +39,6 @@ impl WiringLayer for HealthCheckLayer {
             app_health_check,
         };
 
-        // Healthcheck server only exposes the state provided by other tasks, and also it has to start as soon as possible.
         node.add_unconstrained_task(Box::new(task));
         Ok(())
     }


### PR DESCRIPTION
This is the first PR in the queue.

## What ❔

Adds a description for the next wiring layers:
- `CircuitBreakerCheckerLayer`
- `CommitmentGeneratorLayer`
- `ContractVerificationApiLayer`
- `EthTxManagerLayer`
- `EthTxAggregatorLayer`
- `EthWatchLayer`
- `HealthCheckLayer` 
