### PR TITLE
refactor(pruning): Improve pruning metrics and logs

### DIFF
--- a/core/lib/merkle_tree/src/metrics.rs
+++ b/core/lib/merkle_tree/src/metrics.rs
@@ -309,6 +309,21 @@ enum Bound {
     End,
 }
 
+const LARGE_NODE_COUNT_BUCKETS: Buckets = Buckets::values(&[
+    1_000.0,
+    2_000.0,
+    5_000.0,
+    10_000.0,
+    20_000.0,
+    50_000.0,
+    100_000.0,
+    200_000.0,
+    500_000.0,
+    1_000_000.0,
+    2_000_000.0,
+    5_000_000.0,
+]);
+
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "merkle_tree_pruning")]
 struct PruningMetrics {
@@ -316,7 +331,7 @@ struct PruningMetrics {
     /// may not remove all stale keys to this version if there are too many.
     target_retained_version: Gauge<u64>,
     /// Number of pruned node keys on a specific pruning iteration.
-    #[metrics(buckets = NODE_COUNT_BUCKETS)]
+    #[metrics(buckets = LARGE_NODE_COUNT_BUCKETS)]
     key_count: Histogram<usize>,
     /// Lower and upper boundaries on the new stale key versions deleted
     /// during a pruning iteration. The lower boundary is inclusive, the upper one is exclusive.
@@ -368,26 +383,11 @@ pub(crate) enum RecoveryStage {
     ParallelPersistence,
 }
 
-const CHUNK_SIZE_BUCKETS: Buckets = Buckets::values(&[
-    1_000.0,
-    2_000.0,
-    5_000.0,
-    10_000.0,
-    20_000.0,
-    50_000.0,
-    100_000.0,
-    200_000.0,
-    500_000.0,
-    1_000_000.0,
-    2_000_000.0,
-    5_000_000.0,
-]);
-
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "merkle_tree_recovery")]
 pub(crate) struct RecoveryMetrics {
     /// Number of entries in a recovered chunk.
-    #[metrics(buckets = CHUNK_SIZE_BUCKETS)]
+    #[metrics(buckets = LARGE_NODE_COUNT_BUCKETS)]
     pub chunk_size: Histogram<usize>,
     /// Latency of a specific stage of recovery for a single chunk.
     #[metrics(buckets = Buckets::LATENCIES, unit = Unit::Seconds)]

--- a/core/node/db_pruner/src/metrics.rs
+++ b/core/node/db_pruner/src/metrics.rs
@@ -5,7 +5,8 @@ use zksync_dal::pruning_dal::HardPruningStats;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, EncodeLabelSet)]
 #[metrics(label = "prune_type", rename_all = "snake_case")]
-pub(super) enum MetricPruneType {
+pub(super) enum PruneType {
+    NoOp,
     Soft,
     Hard,
 }
@@ -30,7 +31,7 @@ const ENTITY_COUNT_BUCKETS: Buckets = Buckets::values(&[
 pub(super) struct DbPrunerMetrics {
     /// Total latency of pruning chunk of L1 batches.
     #[metrics(buckets = Buckets::LATENCIES, unit = Unit::Seconds)]
-    pub pruning_chunk_duration: Family<MetricPruneType, Histogram<Duration>>,
+    pub pruning_chunk_duration: Family<PruneType, Histogram<Duration>>,
     /// Number of not-pruned L1 batches.
     pub not_pruned_l1_batches_count: Gauge<u64>,
     /// Number of entities deleted during a single hard pruning iteration, grouped by entity type.

--- a/core/node/db_pruner/src/metrics.rs
+++ b/core/node/db_pruner/src/metrics.rs
@@ -24,6 +24,7 @@ enum PrunedEntityType {
 
 const ENTITY_COUNT_BUCKETS: Buckets = Buckets::values(&[
     1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0, 200.0, 500.0, 1_000.0, 2_000.0, 5_000.0, 10_000.0,
+    20_000.0, 50_000.0, 100_000.0,
 ]);
 
 #[derive(Debug, Metrics)]

--- a/core/node/db_pruner/src/prune_conditions.rs
+++ b/core/node/db_pruner/src/prune_conditions.rs
@@ -7,6 +7,8 @@ use zksync_types::L1BatchNumber;
 
 #[async_trait]
 pub(crate) trait PruneCondition: fmt::Debug + fmt::Display + Send + Sync + 'static {
+    fn metric_label(&self) -> &'static str;
+
     async fn is_batch_prunable(&self, l1_batch_number: L1BatchNumber) -> anyhow::Result<bool>;
 }
 
@@ -24,6 +26,10 @@ impl fmt::Display for L1BatchOlderThanPruneCondition {
 
 #[async_trait]
 impl PruneCondition for L1BatchOlderThanPruneCondition {
+    fn metric_label(&self) -> &'static str {
+        "l1_batch_older_than_minimum_age"
+    }
+
     async fn is_batch_prunable(&self, l1_batch_number: L1BatchNumber) -> anyhow::Result<bool> {
         let mut storage = self.pool.connection_tagged("db_pruner").await?;
         let l1_batch_header = storage
@@ -50,6 +56,10 @@ impl fmt::Display for NextL1BatchWasExecutedCondition {
 
 #[async_trait]
 impl PruneCondition for NextL1BatchWasExecutedCondition {
+    fn metric_label(&self) -> &'static str {
+        "next_l1_batch_was_executed"
+    }
+
     async fn is_batch_prunable(&self, l1_batch_number: L1BatchNumber) -> anyhow::Result<bool> {
         let mut storage = self.pool.connection_tagged("db_pruner").await?;
         let next_l1_batch_number = L1BatchNumber(l1_batch_number.0 + 1);
@@ -76,6 +86,10 @@ impl fmt::Display for NextL1BatchHasMetadataCondition {
 
 #[async_trait]
 impl PruneCondition for NextL1BatchHasMetadataCondition {
+    fn metric_label(&self) -> &'static str {
+        "next_l1_batch_has_metadata"
+    }
+
     async fn is_batch_prunable(&self, l1_batch_number: L1BatchNumber) -> anyhow::Result<bool> {
         let mut storage = self.pool.connection_tagged("db_pruner").await?;
         let next_l1_batch_number = L1BatchNumber(l1_batch_number.0 + 1);
@@ -117,6 +131,10 @@ impl fmt::Display for L1BatchExistsCondition {
 
 #[async_trait]
 impl PruneCondition for L1BatchExistsCondition {
+    fn metric_label(&self) -> &'static str {
+        "l1_batch_exists"
+    }
+
     async fn is_batch_prunable(&self, l1_batch_number: L1BatchNumber) -> anyhow::Result<bool> {
         let mut storage = self.pool.connection_tagged("db_pruner").await?;
         let l1_batch_header = storage
@@ -140,6 +158,10 @@ impl fmt::Display for ConsistencyCheckerProcessedBatch {
 
 #[async_trait]
 impl PruneCondition for ConsistencyCheckerProcessedBatch {
+    fn metric_label(&self) -> &'static str {
+        "l1_batch_consistency_checked"
+    }
+
     async fn is_batch_prunable(&self, l1_batch_number: L1BatchNumber) -> anyhow::Result<bool> {
         let mut storage = self.pool.connection_tagged("db_pruner").await?;
         let last_processed_l1_batch = storage

--- a/core/node/db_pruner/src/tests.rs
+++ b/core/node/db_pruner/src/tests.rs
@@ -47,10 +47,14 @@ impl fmt::Display for ConditionMock {
 
 #[async_trait]
 impl PruneCondition for ConditionMock {
+    fn metric_label(&self) -> &'static str {
+        "mock"
+    }
+
     async fn is_batch_prunable(&self, l1_batch_number: L1BatchNumber) -> anyhow::Result<bool> {
         self.is_batch_prunable_responses
             .get(&l1_batch_number)
-            .cloned()
+            .copied()
             .context("error!")
     }
 }


### PR DESCRIPTION
## What ❔

- Adds counters for outcomes (success, failure, error) for all pruning conditions.
- Distinguishes between no-op and soft pruning latency.
- Logs latencies and stats in tree pruning.
- Other misc improvements.

## Why ❔

Improves pruning observability.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.