### PR TITLE
feat(): tidy up base token oracle

### DIFF
--- a/core/bin/zksync_server/src/node_builder.rs
+++ b/core/bin/zksync_server/src/node_builder.rs
@@ -146,6 +146,7 @@ impl MainNodeBuilder {
             state_keeper_config,
             try_load_config!(eth_sender_config.sender).pubdata_sending_mode,
             base_token_adjuster_config,
+            self.contracts_config.clone(),
         );
         self.node.add_layer(sequencer_l1_gas_layer);
         Ok(self)

--- a/core/lib/config/src/configs/base_token_adjuster.rs
+++ b/core/lib/config/src/configs/base_token_adjuster.rs
@@ -9,16 +9,12 @@ pub const DEFAULT_INTERVAL_MS: u64 = 30_000;
 pub struct BaseTokenAdjusterConfig {
     /// How often to poll external APIs for a new ETH<->Base-Token price.
     pub price_polling_interval_ms: Option<u64>,
-
-    /// Base token symbol.
-    pub base_token: Option<String>,
 }
 
 impl BaseTokenAdjusterConfig {
     pub fn for_tests() -> Self {
         Self {
             price_polling_interval_ms: Some(DEFAULT_INTERVAL_MS),
-            base_token: Option::from("ETH".to_string()),
         }
     }
 

--- a/core/lib/constants/src/contracts.rs
+++ b/core/lib/constants/src/contracts.rs
@@ -152,3 +152,9 @@ pub const SHARED_BRIDGE_ETHER_TOKEN_ADDRESS: Address = H160([
 /// Default `ERA_CHAIN_ID`. All hyperchains start with this chain id and later on during their registration
 /// an "initial upgrade" transaction overrides it with the correct value.
 pub const DEFAULT_ERA_CHAIN_ID: u32 = 270;
+
+/// Value of the base token contract if ETH is used
+pub const L1_ETH_BASE_TOKEN: Address = H160([
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x01,
+]);

--- a/core/lib/constants/src/contracts.rs
+++ b/core/lib/constants/src/contracts.rs
@@ -153,8 +153,8 @@ pub const SHARED_BRIDGE_ETHER_TOKEN_ADDRESS: Address = H160([
 /// an "initial upgrade" transaction overrides it with the correct value.
 pub const DEFAULT_ERA_CHAIN_ID: u32 = 270;
 
-/// Value of the base token contract if ETH is used
-pub const L1_ETH_BASE_TOKEN: Address = H160([
+/// Value of the l1 contract address if ETH is used as base token
+pub const L1_ETH_CONTRACT_ADDRESS: Address = H160([
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x01,
 ]);

--- a/core/lib/dal/src/base_token_dal.rs
+++ b/core/lib/dal/src/base_token_dal.rs
@@ -18,9 +18,9 @@ impl BaseTokenDal<'_, '_> {
         let row = sqlx::query!(
             r#"
             INSERT INTO
-                base_token_prices (numerator, denominator, ratio_timestamp)
+                base_token_prices (numerator, denominator, ratio_timestamp, created_at, updated_at)
             VALUES
-                ($1, $2, $3)
+                ($1, $2, $3, NOW(), NOW())
             RETURNING
                 id
             "#,

--- a/core/lib/protobuf_config/src/base_token_adjuster.rs
+++ b/core/lib/protobuf_config/src/base_token_adjuster.rs
@@ -9,14 +9,12 @@ impl ProtoRepr for proto::BaseTokenAdjuster {
     fn read(&self) -> anyhow::Result<Self::Type> {
         Ok(configs::base_token_adjuster::BaseTokenAdjusterConfig {
             price_polling_interval_ms: self.price_polling_interval_ms.clone(),
-            base_token: self.base_token.clone(),
         })
     }
 
     fn build(this: &Self::Type) -> Self {
         Self {
             price_polling_interval_ms: this.price_polling_interval_ms.clone(),
-            base_token: this.base_token.clone(),
         }
     }
 }

--- a/core/lib/protobuf_config/src/proto/config/base_token_adjuster.proto
+++ b/core/lib/protobuf_config/src/proto/config/base_token_adjuster.proto
@@ -4,5 +4,4 @@ package zksync.config.base_token_adjuster;
 
 message BaseTokenAdjuster {
   optional uint64 price_polling_interval_ms = 1;
-  optional string base_token = 2;
 }

--- a/core/lib/zksync_core_leftovers/src/lib.rs
+++ b/core/lib/zksync_core_leftovers/src/lib.rs
@@ -73,7 +73,7 @@ use zksync_state_keeper::{
     AsyncRocksdbCache, MempoolFetcher, MempoolGuard, OutputHandler, StateKeeperPersistence,
     TreeWritesPersistence,
 };
-use zksync_system_constants::L1_ETH_BASE_TOKEN;
+use zksync_system_constants::L1_ETH_CONTRACT_ADDRESS;
 use zksync_tee_verifier_input_producer::TeeVerifierInputProducer;
 use zksync_types::{ethabi::Contract, fee_model::FeeModelConfig, Address, L2ChainId};
 use zksync_web3_decl::client::{Client, DynClient, L1};
@@ -301,7 +301,7 @@ pub async fn initialize_components(
     // check if the base token is ETH, if not, we need to use the real adjuster
     // otherwise, this is not needed
     if let Some(base_token_addr) = contracts_config.base_token_addr {
-        if base_token_addr != L1_ETH_BASE_TOKEN {
+        if base_token_addr != L1_ETH_CONTRACT_ADDRESS {
             arc_base_token_adjuster = Some(Arc::new(MainNodeBaseTokenAdjuster::new(
                 connection_pool.clone(),
                 configs
@@ -806,7 +806,7 @@ pub async fn initialize_components(
     }
 
     if let Some(base_token_addr) = contracts_config.base_token_addr {
-        if base_token_addr != L1_ETH_BASE_TOKEN {
+        if base_token_addr != L1_ETH_CONTRACT_ADDRESS {
             if components.contains(&Component::BaseTokenAdjuster) {
                 // the native token is not ETH, we need the base token adjuster
                 tracing::info!("initializing base token adjuster");

--- a/core/node/base_token_adjuster/README.md
+++ b/core/node/base_token_adjuster/README.md
@@ -1,11 +1,11 @@
 # Base Token Adjuster
 
-This crate contains an implementation of
+This crate contains an implementation of the base token adjuster
 
 ## Overview
 
 The Base Token Adjuster has 3 roles:
 
-1. bla
-2. bli
-3. blue
+1. Update the exchange-rate between the base token against ETH in DB
+2. Update the exchange-rate between the base token against ETH in L1 for the L1->L2 transactions
+3. Provide an interface for the server to poll the latest exchange-rate

--- a/core/node/node_framework/src/implementations/layers/base_token_adjuster.rs
+++ b/core/node/node_framework/src/implementations/layers/base_token_adjuster.rs
@@ -53,7 +53,7 @@ impl Task for BaseTokenAdjusterTask {
     }
 
     async fn run(self: Box<Self>, stop_receiver: StopReceiver) -> anyhow::Result<()> {
-        let mut adjuster =
+        let adjuster =
             zksync_base_token_adjuster::MainNodeBaseTokenAdjuster::new(self.main_pool, self.config);
 
         adjuster.run(stop_receiver.0).await

--- a/core/node/node_framework/src/implementations/layers/l1_gas.rs
+++ b/core/node/node_framework/src/implementations/layers/l1_gas.rs
@@ -7,7 +7,7 @@ use zksync_config::{
     BaseTokenAdjusterConfig, ContractsConfig, GasAdjusterConfig, GenesisConfig,
 };
 use zksync_node_fee_model::{l1_gas_price::GasAdjuster, MainNodeFeeInputProvider};
-use zksync_types::{fee_model::FeeModelConfig, Address, L1_ETH_BASE_TOKEN};
+use zksync_types::{fee_model::FeeModelConfig, Address, L1_ETH_CONTRACT_ADDRESS};
 
 use crate::{
     implementations::resources::{
@@ -77,7 +77,7 @@ impl WiringLayer for SequencerL1GasLayer {
         // check if the base token is ETH, if not, we need to use the real adjuster
         // otherwise, this is not needed
         if let Some(base_token_addr) = self.contracts_config.base_token_addr {
-            if base_token_addr != L1_ETH_BASE_TOKEN {
+            if base_token_addr != L1_ETH_CONTRACT_ADDRESS {
                 let main_node_base_token_adjuster = MainNodeBaseTokenAdjuster::new(
                     replica_pool.clone(),
                     self.base_token_adjuster_config,

--- a/etc/env/base/base_token_adjuster.toml
+++ b/etc/env/base/base_token_adjuster.toml
@@ -1,0 +1,2 @@
+[base_token_adjuster]
+price_polling_interval_ms=30000

--- a/etc/env/base/rust.toml
+++ b/etc/env/base/rust.toml
@@ -57,6 +57,7 @@ zksync_health_check=debug,\
 zksync_proof_fri_compressor=info,\
 vise_exporter=debug,\
 snapshots_creator=debug,\
+zksync_base_token_adjuster=info,\
 """
 
 # `RUST_BACKTRACE` variable

--- a/etc/env/configs/dev.toml
+++ b/etc/env/configs/dev.toml
@@ -1,3 +1,4 @@
 __imports__ = [ "base", "l1-inits/.init.env", "l2-inits/dev.init.env" ]
 
 ETH_SENDER_SENDER_PUBDATA_SENDING_MODE = "Blobs"
+CHAIN_STATE_KEEPER_FEE_MODEL_VERSION="V2"

--- a/etc/env/dev.toml
+++ b/etc/env/dev.toml
@@ -1,6 +1,7 @@
 [_metadata]
 base = [
     'base/api.toml',
+    'base/base_token_adjuster.toml',
     'base/chain.toml',
     'base/contract_verifier.toml',
     'base/contracts.toml',

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -8392,6 +8392,7 @@ name = "zksync_base_token_adjuster"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "rand 0.8.5",
  "tokio",


### PR DESCRIPTION
Changes: 

- Complete the flow by allowing to run the base-token-adjuster component to zk core builder if BaseTokenAdjuster component is specified in the component list. This will effectively run a component that update the exchange rate in DB at polling interval.

- Remove unnecessary `base_token` in config. we will use the common config `base_token_addr` in contract configs instead to avoid introducing redundancy

- fix DB query
