### PR TITLE
feat(): tidy up base token bare bones

### DIFF
--- a/core/bin/zksync_server/src/node_builder.rs
+++ b/core/bin/zksync_server/src/node_builder.rs
@@ -153,6 +153,7 @@ impl MainNodeBuilder {
             state_keeper_config,
             try_load_config!(eth_sender_config.sender).pubdata_sending_mode,
             base_token_adjuster_config,
+            self.contracts_config.clone(),
         );
         self.node.add_layer(sequencer_l1_gas_layer);
         Ok(self)
@@ -449,7 +450,10 @@ impl MainNodeBuilder {
 
     fn add_base_token_adjuster_layer(mut self) -> anyhow::Result<Self> {
         let config = try_load_config!(self.configs.base_token_adjuster);
-        self.node.add_layer(BaseTokenAdjusterLayer::new(config));
+        self.node.add_layer(BaseTokenAdjusterLayer::new(
+            config,
+            self.contracts_config.clone(),
+        ));
 
         Ok(self)
     }

--- a/core/lib/config/src/configs/base_token_adjuster.rs
+++ b/core/lib/config/src/configs/base_token_adjuster.rs
@@ -2,23 +2,19 @@ use std::time::Duration;
 
 use serde::Deserialize;
 
-// By default external APIs shall be polled every 30 seconds for a new price.
+// By default, external APIs shall be polled every 30 seconds for a new price.
 pub const DEFAULT_INTERVAL_MS: u64 = 30_000;
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct BaseTokenAdjusterConfig {
     /// How often to fetch external APIs for a new ETH<->Base-Token price.
     pub price_polling_interval_ms: Option<u64>,
-
-    /// Base token symbol. If none, an assumption of ETH is made.
-    pub base_token: Option<String>,
 }
 
 impl BaseTokenAdjusterConfig {
     pub fn for_tests() -> Self {
         Self {
             price_polling_interval_ms: Some(DEFAULT_INTERVAL_MS),
-            base_token: Option::from("ETH".to_string()),
         }
     }
 

--- a/core/lib/constants/src/contracts.rs
+++ b/core/lib/constants/src/contracts.rs
@@ -152,3 +152,9 @@ pub const SHARED_BRIDGE_ETHER_TOKEN_ADDRESS: Address = H160([
 /// Default `ERA_CHAIN_ID`. All hyperchains start with this chain id and later on during their registration
 /// an "initial upgrade" transaction overrides it with the correct value.
 pub const DEFAULT_ERA_CHAIN_ID: u32 = 270;
+
+/// Value of the l1 contract address if ETH is used as base token
+pub const L1_ETH_CONTRACT_ADDRESS: Address = H160([
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x01,
+]);

--- a/core/lib/protobuf_config/src/base_token_adjuster.rs
+++ b/core/lib/protobuf_config/src/base_token_adjuster.rs
@@ -9,14 +9,12 @@ impl ProtoRepr for proto::BaseTokenAdjuster {
     fn read(&self) -> anyhow::Result<Self::Type> {
         Ok(configs::base_token_adjuster::BaseTokenAdjusterConfig {
             price_polling_interval_ms: self.price_polling_interval_ms,
-            base_token: self.base_token.clone(),
         })
     }
 
     fn build(this: &Self::Type) -> Self {
         Self {
             price_polling_interval_ms: this.price_polling_interval_ms,
-            base_token: this.base_token.clone(),
         }
     }
 }

--- a/core/lib/protobuf_config/src/proto/config/base_token_adjuster.proto
+++ b/core/lib/protobuf_config/src/proto/config/base_token_adjuster.proto
@@ -4,5 +4,4 @@ package zksync.config.base_token_adjuster;
 
 message BaseTokenAdjuster {
   optional uint64 price_polling_interval_ms = 1;
-  optional string base_token = 2;
 }

--- a/core/lib/zksync_core_leftovers/src/lib.rs
+++ b/core/lib/zksync_core_leftovers/src/lib.rs
@@ -88,7 +88,7 @@ pub enum Component {
     CommitmentGenerator,
     /// VM runner-based component that saves protective reads to Postgres.
     VmRunnerProtectiveReads,
-    /// A component to handle anything related to a chain's custom base token.
+    /// A component that handle the base token exchange rate conversion (non ETH chain).
     BaseTokenAdjuster,
 }
 

--- a/core/node/fee_model/src/l1_gas_price/main_node_fetcher.rs
+++ b/core/node/fee_model/src/l1_gas_price/main_node_fetcher.rs
@@ -77,10 +77,7 @@ impl BatchFeeModelInputProvider for MainNodeFeeParamsFetcher {
         Ok(*self.main_node_fee_params.read().unwrap())
     }
 
-    async fn maybe_convert_params_to_base_token(
-        &self,
-        _params: FeeParams,
-    ) -> anyhow::Result<FeeParams> {
+    async fn adjust_params_to_base_token(&self, _params: FeeParams) -> anyhow::Result<FeeParams> {
         Ok(_params)
     }
 }

--- a/core/node/node_framework/examples/main_node.rs
+++ b/core/node/node_framework/examples/main_node.rs
@@ -113,6 +113,7 @@ impl MainNodeBuilder {
         let genesis_config = GenesisConfig::from_env()?;
         let eth_sender_config = EthConfig::from_env()?;
         let base_token_adjuster_config = BaseTokenAdjusterConfig::from_env()?;
+        let contracts_config = ContractsConfig::from_env()?;
         let sequencer_l1_gas_layer = SequencerL1GasLayer::new(
             gas_adjuster_config,
             genesis_config,
@@ -122,6 +123,7 @@ impl MainNodeBuilder {
                 .context("eth_sender")?
                 .pubdata_sending_mode,
             base_token_adjuster_config,
+            contracts_config,
         );
         self.node.add_layer(sequencer_l1_gas_layer);
         Ok(self)

--- a/core/node/node_framework/src/implementations/layers/base_token_adjuster.rs
+++ b/core/node/node_framework/src/implementations/layers/base_token_adjuster.rs
@@ -1,6 +1,7 @@
-use zksync_config::configs::base_token_adjuster::BaseTokenAdjusterConfig;
+use zksync_config::{configs::base_token_adjuster::BaseTokenAdjusterConfig, ContractsConfig};
 use zksync_dal::Core;
 use zksync_db_connection::connection_pool::ConnectionPool;
+use zksync_types::L1_ETH_CONTRACT_ADDRESS;
 
 use crate::{
     implementations::resources::pools::{MasterPool, PoolResource},
@@ -13,11 +14,15 @@ use crate::{
 #[derive(Debug)]
 pub struct BaseTokenAdjusterLayer {
     config: BaseTokenAdjusterConfig,
+    contracts_config: ContractsConfig,
 }
 
 impl BaseTokenAdjusterLayer {
-    pub fn new(config: BaseTokenAdjusterConfig) -> Self {
-        Self { config }
+    pub fn new(config: BaseTokenAdjusterConfig, contracts_config: ContractsConfig) -> Self {
+        Self {
+            config,
+            contracts_config,
+        }
     }
 }
 
@@ -34,6 +39,7 @@ impl WiringLayer for BaseTokenAdjusterLayer {
         context.add_task(Box::new(BaseTokenAdjusterTask {
             main_pool: master_pool,
             config: self.config,
+            contracts_config: self.contracts_config,
         }));
 
         Ok(())
@@ -44,6 +50,7 @@ impl WiringLayer for BaseTokenAdjusterLayer {
 struct BaseTokenAdjusterTask {
     main_pool: ConnectionPool<Core>,
     config: BaseTokenAdjusterConfig,
+    contracts_config: ContractsConfig,
 }
 
 #[async_trait::async_trait]
@@ -53,8 +60,18 @@ impl Task for BaseTokenAdjusterTask {
     }
 
     async fn run(self: Box<Self>, stop_receiver: StopReceiver) -> anyhow::Result<()> {
-        let mut adjuster =
-            zksync_base_token_adjuster::MainNodeBaseTokenAdjuster::new(self.main_pool, self.config);
+        let mut is_eth = true;
+        if let Some(base_token_addr) = self.contracts_config.base_token_addr {
+            if base_token_addr != L1_ETH_CONTRACT_ADDRESS {
+                is_eth = false;
+            }
+        }
+
+        let mut adjuster = zksync_base_token_adjuster::MainNodeBaseTokenAdjuster::new(
+            self.main_pool,
+            self.config,
+            is_eth,
+        );
 
         adjuster.run(stop_receiver.0).await
     }

--- a/etc/env/base/base_token_adjuster.toml
+++ b/etc/env/base/base_token_adjuster.toml
@@ -1,0 +1,2 @@
+[base_token_adjuster]
+price_polling_interval_ms=30000

--- a/etc/env/base/rust.toml
+++ b/etc/env/base/rust.toml
@@ -57,6 +57,7 @@ zksync_health_check=debug,\
 zksync_proof_fri_compressor=info,\
 vise_exporter=debug,\
 snapshots_creator=debug,\
+zksync_base_token_adjuster=info,\
 """
 
 # `RUST_BACKTRACE` variable

--- a/etc/env/configs/dev.toml
+++ b/etc/env/configs/dev.toml
@@ -1,3 +1,4 @@
 __imports__ = [ "base", "l1-inits/.init.env", "l2-inits/dev.init.env" ]
 
 ETH_SENDER_SENDER_PUBDATA_SENDING_MODE = "Blobs"
+CHAIN_STATE_KEEPER_FEE_MODEL_VERSION="V2"

--- a/etc/env/dev.toml
+++ b/etc/env/dev.toml
@@ -21,4 +21,5 @@ base = [
     'base/fri_witness_vector_generator.toml',
     'base/fri_prover_gateway.toml',
     'base/fri_proof_compressor.toml',
+    'base/base_token_adjuster.toml',
 ]


### PR DESCRIPTION
- Remove unnecessary base_token in config. we will use the common config base_token_addr in contract configs instead to avoid introducing redundancy 

- Rename some methods

- add some missing config file to make it work with zk init

