### PR TITLE
fix(merkle-tree): Change `LazyAsyncTreeReader::wait()` signature

### DIFF
--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -191,6 +191,9 @@ async fn run_tree(
             } else {
                 // Tree is dropped before initialized, e.g. because the node is getting shut down.
                 // We don't want to treat this as an error since it could mask the real shutdown cause in logs etc.
+                tracing::warn!(
+                    "Tree is dropped before initialized, not starting the tree API server"
+                );
                 stop_receiver.changed().await?;
                 Ok(())
             }

--- a/core/node/node_framework/src/implementations/layers/metadata_calculator.rs
+++ b/core/node/node_framework/src/implementations/layers/metadata_calculator.rs
@@ -167,6 +167,7 @@ impl Task for TreeApiTask {
         } else {
             // Tree is dropped before initialized, e.g. because the node is getting shut down.
             // We don't want to treat this as an error since it could mask the real shutdown cause in logs etc.
+            tracing::warn!("Tree is dropped before initialized, not starting the tree API server");
             stop_receiver.0.changed().await?;
             Ok(())
         }


### PR DESCRIPTION
## What ❔

Makes `LazyAsyncTreeReader::wait()` return an `Option` to make it clearer that not initializing is not necessarily an error (this decision is up to the caller).

## Why ❔

Recent errors on ENs were caused by unwrapping `LazyAsyncTreeReader::wait()`. They partially masked the real error cause (not related to this task).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.