### PR TITLE
fix(object-store): Consider some token source errors transient

### DIFF
--- a/core/lib/object_store/src/gcs.rs
+++ b/core/lib/object_store/src/gcs.rs
@@ -112,10 +112,7 @@ fn get_source<'a, T: StdError + 'static>(mut err: &'a (dyn StdError + 'static)) 
         if let Some(err) = err.downcast_ref::<T>() {
             return Some(err);
         }
-        err = match err.source() {
-            Some(source) => source,
-            None => return None,
-        };
+        err = err.source()?;
     }
 }
 


### PR DESCRIPTION
## What ❔

Considers some token source GCS errors transient.

## Why ❔

Considering errors as transient leads to less abnormal application terminations.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.