### PR TITLE
fix(db): Fix / extend transaction isolation levels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8128,6 +8128,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "test-casing",
  "thiserror",
  "tokio",
  "tracing",

--- a/core/lib/dal/src/lib.rs
+++ b/core/lib/dal/src/lib.rs
@@ -6,7 +6,7 @@
 pub use sqlx::{types::BigDecimal, Error as SqlxError};
 use zksync_db_connection::connection::DbMarker;
 pub use zksync_db_connection::{
-    connection::Connection,
+    connection::{Connection, IsolationLevel},
     connection_pool::{ConnectionPool, ConnectionPoolBuilder},
     error::{DalError, DalResult},
 };

--- a/core/lib/db_connection/Cargo.toml
+++ b/core/lib/db_connection/Cargo.toml
@@ -36,3 +36,4 @@ tracing.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
+test-casing.workspace = true


### PR DESCRIPTION
## What ❔

- Makes readonly Postgres transaction have "repeatable read" isolation level by default.
- Allows specifying an isolation level in the transaction builder.

## Why ❔

Readonly transactions usually expect a consistent DB view, hence the "repeatable read" isolation level.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.