### PR TITLE
feat(prover): Add file based config support for vk-setup-data-generator-server-fri

### DIFF
--- a/prover/vk_setup_data_generator_server_fri/src/commitment_utils.rs
+++ b/prover/vk_setup_data_generator_server_fri/src/commitment_utils.rs
@@ -102,9 +102,9 @@ pub fn generate_commitments(keystore: &Keystore) -> anyhow::Result<VkCommitments
     Ok(result)
 }
 
-pub fn get_cached_commitments(setup_data_generator: Option<String>) -> L1VerifierConfig {
-    if let Some(setup_data_generator) = setup_data_generator {
-        let keystore = Keystore::new_with_setup_data_path(setup_data_generator);
+pub fn get_cached_commitments(setup_data_path: Option<String>) -> L1VerifierConfig {
+    if let Some(setup_data_path) = setup_data_path {
+        let keystore = Keystore::new_with_setup_data_path(setup_data_path);
         let mut keystore_lock = KEYSTORE.lock().unwrap();
         *keystore_lock = Some(keystore);
     }

--- a/prover/vk_setup_data_generator_server_fri/src/commitment_utils.rs
+++ b/prover/vk_setup_data_generator_server_fri/src/commitment_utils.rs
@@ -27,7 +27,7 @@ static KEYSTORE: Lazy<Mutex<Option<Keystore>>> = Lazy::new(|| Mutex::new(None));
 lazy_static! {
     // TODO: do not initialize a static const with data read in runtime.
     static ref COMMITMENTS: Lazy<L1VerifierConfig> = Lazy::new(|| {
-        let keystore = KEYSTORE.lock().unwrap().clone().unwrap_or_else(Keystore::default);
+        let keystore = KEYSTORE.lock().unwrap().clone().unwrap_or_default();
         circuit_commitments(&keystore).unwrap()
     });
 }

--- a/prover/vk_setup_data_generator_server_fri/src/commitment_utils.rs
+++ b/prover/vk_setup_data_generator_server_fri/src/commitment_utils.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{str::FromStr, sync::Mutex};
 
 use anyhow::Context as _;
 use hex::ToHex;
@@ -22,9 +22,14 @@ use crate::{
     VkCommitments,
 };
 
+static KEYSTORE: Lazy<Mutex<Option<Keystore>>> = Lazy::new(|| Mutex::new(None));
+
 lazy_static! {
     // TODO: do not initialize a static const with data read in runtime.
-    static ref COMMITMENTS: Lazy<L1VerifierConfig> = Lazy::new(|| { circuit_commitments(&Keystore::default()).unwrap() });
+    static ref COMMITMENTS: Lazy<L1VerifierConfig> = Lazy::new(|| {
+        let keystore = KEYSTORE.lock().unwrap().clone().unwrap_or_else(Keystore::default);
+        circuit_commitments(&keystore).unwrap()
+    });
 }
 
 fn circuit_commitments(keystore: &Keystore) -> anyhow::Result<L1VerifierConfig> {
@@ -97,14 +102,19 @@ pub fn generate_commitments(keystore: &Keystore) -> anyhow::Result<VkCommitments
     Ok(result)
 }
 
-pub fn get_cached_commitments() -> L1VerifierConfig {
+pub fn get_cached_commitments(setup_data_generator: Option<String>) -> L1VerifierConfig {
+    if let Some(setup_data_generator) = setup_data_generator {
+        let keystore = Keystore::new_with_setup_data_path(setup_data_generator);
+        let mut keystore_lock = KEYSTORE.lock().unwrap();
+        *keystore_lock = Some(keystore);
+    }
     tracing::info!("Using cached commitments {:?}", **COMMITMENTS);
     **COMMITMENTS
 }
 
 #[test]
 fn test_get_cached_commitments() {
-    let commitments = get_cached_commitments();
+    let commitments = get_cached_commitments(None);
     assert_eq!(
         H256::zero(),
         commitments.params.recursion_circuits_set_vks_hash

--- a/prover/vk_setup_data_generator_server_fri/src/keystore.rs
+++ b/prover/vk_setup_data_generator_server_fri/src/keystore.rs
@@ -36,6 +36,7 @@ pub enum ProverServiceDataType {
 /// There are 2 types:
 /// - small verification, finalization keys (used only during verification)
 /// - large setup keys, used during proving.
+#[derive(Clone)]
 pub struct Keystore {
     /// Directory to store all the small keys.
     basedir: PathBuf,
@@ -80,10 +81,18 @@ impl Keystore {
             setup_data_path: Some(setup_data_path),
         }
     }
+
     pub fn new_with_optional_setup_path(basedir: PathBuf, setup_data_path: Option<String>) -> Self {
         Keystore {
             basedir,
             setup_data_path,
+        }
+    }
+
+    pub fn new_with_setup_data_path(setup_data_path: String) -> Self {
+        Keystore {
+            basedir: get_base_path(),
+            setup_data_path: Some(setup_data_path),
         }
     }
 

--- a/prover/witness_generator/src/main.rs
+++ b/prover/witness_generator/src/main.rs
@@ -111,12 +111,12 @@ async fn main() -> anyhow::Result<()> {
     let started_at = Instant::now();
     let use_push_gateway = opt.batch_size.is_some();
 
+    let prover_config = general_config.prover_config.context("prover config")?;
     let object_store_config = ProverObjectStoreConfig(
-        general_config
-            .prover_config
-            .context("prover config")?
+        prover_config
             .prover_object_store
-            .context("object store")?,
+            .context("object store")?
+            .clone(),
     );
     let store_factory = ObjectStoreFactory::new(object_store_config.0);
     let config = general_config
@@ -202,7 +202,8 @@ async fn main() -> anyhow::Result<()> {
 
         let witness_generator_task = match round {
             AggregationRound::BasicCircuits => {
-                let vk_commitments = get_cached_commitments();
+                let setup_data_path = prover_config.setup_data_path.clone();
+                let vk_commitments = get_cached_commitments(Some(setup_data_path));
                 assert_eq!(
                     vk_commitments,
                     vk_commitments_in_db,


### PR DESCRIPTION
## What ❔
Add file based config support for vk-setup-data-generator-server-fri

## Why

`KeyStore::default()` uses `FriProverConfig::from_env()` which panics when config is provided via files