### PR TITLE
[EVM-Equivalence-YUL] Fix zksolc changes

### DIFF
--- a/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm_simulator.rs
@@ -4238,7 +4238,6 @@ fn test_basic_environment4_vectors() {
 }
 
 #[test]
-#[ignore = "Ignored because the current compared values don't match"]
 fn test_basic_extcodehash_vectors() {
     // extcodehash
     let evm_output = test_evm_vector(

--- a/recompile_interpreter.sh
+++ b/recompile_interpreter.sh
@@ -2,7 +2,7 @@
 set -e
 
 VERSION_OUTPUT=$(zksolc --version)
-if [[ $VERSION_OUTPUT == *"1.4.1"*  ||  $VERSION_OUTPUT == *"1.5.0"* ]]; then
+if [[ $VERSION_OUTPUT == *"1.4.1"* ]]; then
     JUMP_TABLE_FLAG="--jump-table-density-threshold 5"
 else
     JUMP_TABLE_FLAG=
@@ -10,6 +10,11 @@ fi
 
 preprocess -f contracts/system-contracts/contracts/EvmInterpreter.template.yul -d contracts/system-contracts/contracts/EvmInterpreterPreprocessed.yul
 zksolc contracts/system-contracts/contracts/EvmInterpreterPreprocessed.yul --optimization 3 $JUMP_TABLE_FLAG --yul --bin --overwrite -o contracts/system-contracts/contracts-preprocessed/artifacts/
+
+VERSION_OUTPUT=$(zksolc --version)
+if [[ $VERSION_OUTPUT == *"1.5.0"* ]]; then
+    mv -f contracts/system-contracts/contracts-preprocessed/artifacts/contracts/EvmInterpreterPreprocessed.yul.zbin contracts/system-contracts/contracts-preprocessed/artifacts/EvmInterpreterPreprocessed.yul.zbin
+fi
 
 VERSION_OUTPUT=$(zksolc --version)
 if [[ $VERSION_OUTPUT == *"1.4.1"* ||  $VERSION_OUTPUT == *"1.5.0"* ]]; then


### PR DESCRIPTION
## What ❔

This PR fixes recompile_interpreter.sh for zksolc 1.5.0, which now puts the compiled interpreter on another folder, it also does not use the jump table (apparently)
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
