### PR TITLE
feat(prover): Add bellman_cuda_path to FriProofCompressor

### DIFF
--- a/core/lib/config/src/configs/fri_proof_compressor.rs
+++ b/core/lib/config/src/configs/fri_proof_compressor.rs
@@ -23,8 +23,12 @@ pub struct FriProofCompressorConfig {
     /// https://storage.googleapis.com/matterlabs-setup-keys-us/setup-keys/setup_2\^24.key
     pub universal_setup_download_url: String,
 
-    // Whether to verify wrapper proof or not.
+    /// Whether to verify wrapper proof or not.
     pub verify_wrapper_proof: bool,
+
+    /// Path to bellman cuda
+    /// https://github.com/matter-labs/era-bellman-cuda
+    pub bellman_cuda_path: Option<String>,
 }
 
 impl FriProofCompressorConfig {

--- a/core/lib/config/src/testonly.rs
+++ b/core/lib/config/src/testonly.rs
@@ -422,6 +422,7 @@ impl Distribution<configs::FriProofCompressorConfig> for EncodeDist {
             universal_setup_path: self.sample(rng),
             universal_setup_download_url: self.sample(rng),
             verify_wrapper_proof: self.sample(rng),
+            bellman_cuda_path: self.sample(rng),
         }
     }
 }

--- a/core/lib/env_config/src/fri_proof_compressor.rs
+++ b/core/lib/env_config/src/fri_proof_compressor.rs
@@ -28,6 +28,7 @@ mod tests {
                 "https://storage.googleapis.com/matterlabs-setup-keys-us/setup-keys/setup_2^26.key"
                     .to_string(),
             verify_wrapper_proof: false,
+            bellman_cuda_path: Some("era-bellman-cuda".to_string()),
         }
     }
 
@@ -44,6 +45,7 @@ mod tests {
             FRI_PROOF_COMPRESSOR_UNIVERSAL_SETUP_PATH="keys/setup/setup_2^26.key"
             FRI_PROOF_COMPRESSOR_UNIVERSAL_SETUP_DOWNLOAD_URL="https://storage.googleapis.com/matterlabs-setup-keys-us/setup-keys/setup_2^26.key"
             FRI_PROOF_COMPRESSOR_VERIFY_WRAPPER_PROOF=false
+            FRI_PROOF_COMPRESSOR_BELLMAN_CUDA_PATH="era-bellman-cuda"
         "#;
         lock.set_env(config);
 

--- a/core/lib/protobuf_config/src/proto/config/prover.proto
+++ b/core/lib/protobuf_config/src/proto/config/prover.proto
@@ -14,6 +14,7 @@ message ProofCompressor {
   optional string universal_setup_path = 7; // required; fs path
   optional string universal_setup_download_url = 8; // required
   optional bool verify_wrapper_proof = 9; // required
+  optional string bellman_cuda_path = 10; // optional
 }
 
 enum SetupLoadMode {

--- a/core/lib/protobuf_config/src/prover.rs
+++ b/core/lib/protobuf_config/src/prover.rs
@@ -33,6 +33,7 @@ impl ProtoRepr for proto::ProofCompressor {
                 .clone(),
             verify_wrapper_proof: *required(&self.verify_wrapper_proof)
                 .context("verify_wrapper_proof")?,
+            bellman_cuda_path: self.bellman_cuda_path.clone(),
         })
     }
 
@@ -47,6 +48,7 @@ impl ProtoRepr for proto::ProofCompressor {
             universal_setup_path: Some(this.universal_setup_path.clone()),
             universal_setup_download_url: Some(this.universal_setup_download_url.clone()),
             verify_wrapper_proof: Some(this.verify_wrapper_proof),
+            bellman_cuda_path: this.bellman_cuda_path.clone(),
         }
     }
 }

--- a/prover/proof_fri_compressor/src/main.rs
+++ b/prover/proof_fri_compressor/src/main.rs
@@ -115,6 +115,10 @@ async fn main() -> anyhow::Result<()> {
     );
     env::set_var("CRS_FILE", config.universal_setup_path.clone());
 
+    if let Some(bellman_cuda_path) = config.bellman_cuda_path {
+        env::set_var("BELLMAN_CUDA_DIR", bellman_cuda_path);
+    }
+
     tracing::info!("Starting proof compressor");
 
     let prometheus_config = PrometheusExporterConfig::push(


### PR DESCRIPTION
## What ❔

Add bellman_cuda_path to FriProofCompressor

## Why ❔

To support file based config for gpu feature
