### PR TITLE
fix(vm-runner): change `processing_started_at` column type to `timestamp`

### DIFF
--- a/core/lib/dal/migrations/20240708194915_vm_runner_processing_started_at_timestamp.down.sql
+++ b/core/lib/dal/migrations/20240708194915_vm_runner_processing_started_at_timestamp.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE vm_runner_protective_reads ALTER COLUMN processing_started_at TYPE TIME USING (null);
+ALTER TABLE vm_runner_bwip ALTER COLUMN processing_started_at TYPE TIME USING (null);

--- a/core/lib/dal/migrations/20240708194915_vm_runner_processing_started_at_timestamp.up.sql
+++ b/core/lib/dal/migrations/20240708194915_vm_runner_processing_started_at_timestamp.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE vm_runner_protective_reads ALTER COLUMN processing_started_at TYPE TIMESTAMP USING (null);
+ALTER TABLE vm_runner_bwip ALTER COLUMN processing_started_at TYPE TIMESTAMP USING (null);


### PR DESCRIPTION
## What ❔



## Why ❔


## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
