### PR TITLE
feat: Remove cached commitments, add BWIP to docs

### DIFF
--- a/prover/prover_fri/README.md
+++ b/prover/prover_fri/README.md
@@ -55,7 +55,7 @@ installation as a pre-requisite, alongside these machine specs:
 2. Run the server. In the root of the repository:
 
    ```console
-   zk server --components=api,eth,tree,state_keeper,housekeeper,commitment_generator,proof_data_handler
+   zk server --components=api,eth,tree,state_keeper,housekeeper,commitment_generator,proof_data_handler,vm_runner_bwip
    ```
 
    Note that it will produce a first l1 batch that can be proven (should be batch 0).


### PR DESCRIPTION
## What ❔

Remove lazy loading of commitments in BWG
Add BWIP to docs

## Why ❔

It is not needed, because it is called only once

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
