### PR TITLE
fix: Fix rustls setup for jsonrpsee clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9742,6 +9742,7 @@ dependencies = [
  "pin-project-lite",
  "rand 0.8.5",
  "rlp",
+ "rustls",
  "serde",
  "serde_json",
  "test-casing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ reqwest = "0.12"
 rlp = "0.5"
 rocksdb = "0.21.0"
 rustc_version = "0.4.0"
+rustls = "0.23"
 secp256k1 = { version = "0.27.0", features = ["recovery", "global-context"] }
 secrecy = "0.8.0"
 semver = "1"

--- a/core/lib/eth_client/src/clients/http/query.rs
+++ b/core/lib/eth_client/src/clients/http/query.rs
@@ -353,3 +353,18 @@ where
         Ok(block)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use zksync_web3_decl::client::{Client, L1};
+
+    /// This test makes sure that we can instantiate a client with an HTTPS provider.
+    /// The need for this test was caused by feature collisions for `rustls` in our dependency graph,
+    /// which caused this test to panic.
+    #[tokio::test]
+    async fn test_https_provider() {
+        let url = "https://rpc.flashbots.net/";
+        let _client = Client::<L1>::http(url.parse().unwrap()).unwrap().build();
+        // No need to do anything; if the client was created and we didn't panic, we're good.
+    }
+}

--- a/core/lib/web3_decl/Cargo.toml
+++ b/core/lib/web3_decl/Cargo.toml
@@ -27,6 +27,7 @@ serde_json.workspace = true
 tokio = { workspace = true, features = ["time"] }
 tracing.workspace = true
 vise.workspace = true
+rustls.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/core/lib/web3_decl/src/client/mod.rs
+++ b/core/lib/web3_decl/src/client/mod.rs
@@ -46,6 +46,7 @@ mod boxed;
 mod metrics;
 mod mock;
 mod network;
+mod rustls;
 mod shared;
 #[cfg(test)]
 mod tests;
@@ -140,6 +141,8 @@ impl<Net: fmt::Debug, C: 'static> fmt::Debug for Client<Net, C> {
 impl<Net: Network> Client<Net> {
     /// Creates an HTTP-backed client.
     pub fn http(url: SensitiveUrl) -> anyhow::Result<ClientBuilder<Net>> {
+        crate::client::rustls::set_rustls_backend_if_required();
+
         let client = HttpClientBuilder::default().build(url.expose_str())?;
         Ok(ClientBuilder::new(client, url))
     }
@@ -150,6 +153,8 @@ impl<Net: Network> WsClient<Net> {
     pub async fn ws(
         url: SensitiveUrl,
     ) -> anyhow::Result<ClientBuilder<Net, Shared<ws_client::WsClient>>> {
+        crate::client::rustls::set_rustls_backend_if_required();
+
         let client = ws_client::WsClientBuilder::default()
             .build(url.expose_str())
             .await?;

--- a/core/lib/web3_decl/src/client/rustls.rs
+++ b/core/lib/web3_decl/src/client/rustls.rs
@@ -1,0 +1,10 @@
+/// Makes sure that `rustls` crypto backend is set before we instantiate
+/// a `Web3` client. `jsonrpsee` doesn't explicitly set it, and when
+/// multiple crypto backends are enabled, `rustls` can't choose one and panics.
+/// See [this issue](https://github.com/rustls/rustls/issues/1877) for more detail.
+///
+/// The problem is on `jsonrpsee` side, but until it's fixed we have to patch it.
+pub(super) fn set_rustls_backend_if_required() {
+    // Function returns an error if the provider is already installed, and we're fine with it.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -260,6 +260,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a47f2fb521b70c11ce7369a6c5fa4bd6af7e5d62ec06303875bafe7c6ba245"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2927c7af777b460b7ccd95f8b67acd7b4c04ec8896bf0c8e80ba30523cffc057"
+dependencies = [
+ "bindgen 0.69.4",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +1711,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
 name = "ecdsa"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,6 +2169,12 @@ dependencies = [
  "splitmut",
  "tiny-keccak 1.5.0",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -3532,6 +3571,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "multimap"
@@ -5056,6 +5101,7 @@ version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -5136,6 +5182,7 @@ version = "0.102.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -8460,6 +8507,7 @@ dependencies = [
  "jsonrpsee",
  "pin-project-lite",
  "rlp",
+ "rustls",
  "serde",
  "serde_json",
  "thiserror",


### PR DESCRIPTION
## What ❔

`jsonrpsee` client expects `rustls` to use the default crypto provider, but `rustls` cannot choose and panics if there are multiple providers available. See [this issue](https://github.com/rustls/rustls/issues/1877) for more detail.
Recently `rustls` changed the default backend, so now some (older) of crates use `ring` backend, while some (newer) use `aws-lc-rs`.
Until the issue is fixed on `jsonrpsee` side, we're making sure that the provider is installed before we create any `jsonrpsee` client.

Added test used to fail before the change and passes now.

## Why ❔

Panics are bad.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
