### PR TITLE
refactor(external_price_api): force erc20 in coingecko's api query

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ prost = "0.12.1"
 rand = "0.8"
 rayon = "1.3.1"
 regex = "1"
-reqwest = "0.12"
+reqwest = { version = "0.12", features = ["json"] }
 rlp = "0.5"
 rocksdb = "0.21.0"
 rustc_version = "0.4.0"

--- a/core/lib/config/src/configs/external_price_api_client.rs
+++ b/core/lib/config/src/configs/external_price_api_client.rs
@@ -14,6 +14,7 @@ pub struct ExternalPriceApiClientConfig {
     /// Forced conversion ratio. Only used with the ForcedPriceClient.
     pub forced_numerator: Option<u64>,
     pub forced_denominator: Option<u64>,
+    pub forced_ethereum_erc20_address: Option<String>,
 }
 
 impl ExternalPriceApiClientConfig {

--- a/core/lib/env_config/src/external_price_api_client.rs
+++ b/core/lib/env_config/src/external_price_api_client.rs
@@ -27,6 +27,9 @@ mod tests {
             client_timeout_ms: DEFAULT_TIMEOUT_MS,
             forced_numerator: Some(100),
             forced_denominator: Some(1),
+            forced_ethereum_erc20_address: Some(
+                "0xdac17f958d2ee523a2206206994597c13d831ec7".to_string(),
+            ),
         }
     }
 
@@ -39,6 +42,7 @@ mod tests {
             EXTERNAL_PRICE_API_CLIENT_API_KEY=qwerty12345
             EXTERNAL_PRICE_API_CLIENT_FORCED_NUMERATOR=100
             EXTERNAL_PRICE_API_CLIENT_FORCED_DENOMINATOR=1
+            EXTERNAL_PRICE_API_CLIENT_FORCED_ETHEREUM_ERC20_ADDRESS=0xdac17f958d2ee523a2206206994597c13d831ec7
         "#;
         lock.set_env(config);
 

--- a/core/lib/external_price_api/src/coingecko_api.rs
+++ b/core/lib/external_price_api/src/coingecko_api.rs
@@ -132,17 +132,13 @@ impl CoinGeckoPriceResponse {
             .and_then(|price| price.get(currency))
     }
 }
+
+#[cfg(test)]
 mod test {
-    use std::str::FromStr;
-
-    use zksync_config::configs::ExternalPriceApiClientConfig;
-    use zksync_types::Address;
-
-    use super::CoinGeckoPriceAPIClient;
+    use super::*;
 
     #[tokio::test]
-    // This is not a proper test, as it requires user input and prints information.
-    // It serves as a quick check to verify if the CoinGecko api_key is working correctly.
+    #[ignore = "This is not a proper test, as it requires user input and prints information.\nIt serves as a quick check to verify if the CoinGecko api_key is working correctly."]
     async fn test_coingecko_api() {
         let config = ExternalPriceApiClientConfig {
             source: "coingecko".to_string(),

--- a/core/lib/external_price_api/src/coingecko_api.rs
+++ b/core/lib/external_price_api/src/coingecko_api.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, str::FromStr};
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -14,18 +14,31 @@ use crate::{address_to_string, utils::get_fraction, PriceAPIClient};
 pub struct CoinGeckoPriceAPIClient {
     base_url: Url,
     client: reqwest::Client,
+    forced_ethereum_erc20_address: Option<Address>,
 }
 
-const DEFAULT_COINGECKO_API_URL: &str = "https://pro-api.coingecko.com";
-const COINGECKO_AUTH_HEADER: &str = "x-cg-pro-api-key";
+const PRO_COINGECKO_API_URL: &str = "https://pro-api.coingecko.com";
+const DEMO_COINGECKO_API_URL: &str = "https://api.coingecko.com";
+const PRO_COINGECKO_AUTH_HEADER: &str = "x-cg-pro-api-key";
+const DEMO_AUTH_HEADER: &str = "x-cg-demo-api-key";
 const ETH_ID: &str = "eth";
 
 impl CoinGeckoPriceAPIClient {
     pub fn new(config: ExternalPriceApiClientConfig) -> Self {
+        let base_url = config
+            .base_url
+            .clone()
+            .unwrap_or(PRO_COINGECKO_API_URL.to_string());
         let client = if let Some(api_key) = &config.api_key {
+            let header = match base_url.as_str() {
+                PRO_COINGECKO_API_URL => PRO_COINGECKO_AUTH_HEADER,
+                DEMO_COINGECKO_API_URL => DEMO_AUTH_HEADER,
+                _ => PRO_COINGECKO_API_URL,
+            };
+
             let mut headers = reqwest::header::HeaderMap::new();
             headers.insert(
-                reqwest::header::HeaderName::from_static(COINGECKO_AUTH_HEADER),
+                reqwest::header::HeaderName::from_static(header),
                 reqwest::header::HeaderValue::from_str(api_key)
                     .expect("Failed to create header value"),
             );
@@ -39,18 +52,27 @@ impl CoinGeckoPriceAPIClient {
             reqwest::Client::new()
         };
 
-        let base_url = config
-            .base_url
-            .unwrap_or(DEFAULT_COINGECKO_API_URL.to_string());
+        let erc20 = config.forced_ethereum_erc20_address;
+        let forced_ethereum_erc20_address: Option<Address> = match erc20 {
+            Some(erc20) => match Address::from_str(erc20.as_str()) {
+                Ok(address) => Some(address),
+                Err(_) => None,
+            },
+            None => None,
+        };
 
         Self {
             base_url: Url::parse(&base_url).expect("Failed to parse CoinGecko URL"),
             client,
+            forced_ethereum_erc20_address,
         }
     }
 
     async fn get_token_price_by_address(&self, address: Address) -> anyhow::Result<f64> {
-        let address_str = address_to_string(&address);
+        let address_str: String = match self.forced_ethereum_erc20_address {
+            Some(erc20) => address_to_string(&erc20),
+            None => address_to_string(&address),
+        };
         let price_url = self
             .base_url
             .join(
@@ -108,5 +130,40 @@ impl CoinGeckoPriceResponse {
         self.prices
             .get(address)
             .and_then(|price| price.get(currency))
+    }
+}
+mod test {
+    use std::str::FromStr;
+
+    use zksync_config::configs::ExternalPriceApiClientConfig;
+    use zksync_types::Address;
+
+    use super::CoinGeckoPriceAPIClient;
+
+    #[tokio::test]
+    // This is not a proper test, as it requires user input and prints information.
+    // It serves as a quick check to verify if the CoinGecko api_key is working correctly.
+    async fn test_coingecko_api() {
+        let config = ExternalPriceApiClientConfig {
+            source: "coingecko".to_string(),
+            base_url: Some("https://api.coingecko.com".to_string()),
+            api_key: Some("insert_your_api".to_string()),
+            client_timeout_ms: 30000,
+            forced_numerator: Some(100),
+            forced_denominator: Some(1),
+            // If the below address is set the `get_token_price_by_address` will ommit the address passed as parameter
+            //forced_ethereum_erc20_address: Some("0xdac17f958d2ee523a2206206994597c13d831ec7".to_string()),
+            forced_ethereum_erc20_address: None,
+        };
+        let api = CoinGeckoPriceAPIClient::new(config);
+
+        println!(
+            "{:?}",
+            api.get_token_price_by_address(
+                Address::from_str("0x1f9840a85d5af5bf1d1762f925bdaddc4201f984").unwrap()
+            )
+            .await
+            .unwrap()
+        );
     }
 }

--- a/core/lib/protobuf_config/src/external_price_api_client.rs
+++ b/core/lib/protobuf_config/src/external_price_api_client.rs
@@ -15,6 +15,7 @@ impl ProtoRepr for proto::ExternalPriceApiClient {
                 api_key: self.api_key.clone(),
                 forced_numerator: self.forced_numerator,
                 forced_denominator: self.forced_denominator,
+                forced_ethereum_erc20_address: self.forced_ethereum_erc20_address.clone(),
             },
         )
     }
@@ -27,6 +28,7 @@ impl ProtoRepr for proto::ExternalPriceApiClient {
             client_timeout_ms: Some(this.client_timeout_ms),
             forced_numerator: this.forced_numerator,
             forced_denominator: this.forced_denominator,
+            forced_ethereum_erc20_address: this.forced_ethereum_erc20_address.clone(),
         }
     }
 }

--- a/core/lib/protobuf_config/src/proto/config/external_price_api_client.proto
+++ b/core/lib/protobuf_config/src/proto/config/external_price_api_client.proto
@@ -9,4 +9,5 @@ message ExternalPriceApiClient {
   optional uint64 client_timeout_ms = 4;
   optional uint64 forced_numerator = 5;
   optional uint64 forced_denominator = 6;
+  optional string forced_ethereum_erc20_address = 7;
 }

--- a/core/lib/types/src/fee_model.rs
+++ b/core/lib/types/src/fee_model.rs
@@ -282,7 +282,7 @@ impl FeeParamsV2 {
     fn convert_to_base_token(&self, price_in_wei: u64) -> u64 {
         let conversion_ratio = BigDecimal::from(self.conversion_ratio.numerator.get())
             / BigDecimal::from(self.conversion_ratio.denominator.get());
-        let converted_price_bd = BigDecimal::from(price_in_wei) * conversion_ratio;
+        let converted_price_bd = BigDecimal::from(price_in_wei) / conversion_ratio;
 
         // Match on the converted price to ensure it can be represented as a u64
         match converted_price_bd.to_u64() {

--- a/etc/env/base/external_price_api.toml
+++ b/etc/env/base/external_price_api.toml
@@ -6,3 +6,7 @@
 source = "no-op"
 
 client_timeout_ms = 10000
+
+# The below configuration is used for dev purposes
+# It will override the base-token address used to calculate the conversion rate
+# forced_ethereum_erc20_address = "0xdac17f958d2ee523a2206206994597c13d831ec7"


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Integrate the `external_price_api` with a dev environment, such as `dev` config or even a different L1 like `sepolia`.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

Provide a workaround and a possible solution.

## Proposed solution

### Provide a way to force the desired token to calculate the conversion rate.

```toml
[external_price_api_client]
forced_ethereum_erc20_address = "forced_token"
```

And in `core/lib/config/src/configs/external_price_api_client.rs`:

```rust
pub struct ExternalPriceApiClientConfig {
    // [...]
    pub forced_ethereum_erc20_address: Option<String>,
}
```

### Change header if the coingecko api is using the `demo` base_url.

In `core/lib/external_price_api/src/coingecko_api.rs`:

```rust
const PRO_COINGECKO_API_URL: &str = "https://pro-api.coingecko.com";
const DEMO_COINGECKO_API_URL: &str = "https://api.coingecko.com";
const PRO_COINGECKO_AUTH_HEADER: &str = "x-cg-pro-api-key";
const DEMO_AUTH_HEADER: &str = "x-cg-demo-api-key";
//[...]
impl CoinGeckoPriceAPIClient {
    pub fn new(config: ExternalPriceApiClientConfig) -> Self {
        //[...]
        let header = match base_url.as_str() {
            PRO_COINGECKO_API_URL => PRO_COINGECKO_AUTH_HEADER,
            DEMO_COINGECKO_API_URL => DEMO_AUTH_HEADER,
            _ => PRO_COINGECKO_API_URL,
        };
//[...]
```

### Provide according gasprice

In `core/lib/types/src/fee_model.rs`:

```rust
    fn convert_to_base_token(&self, price_in_wei: u64) -> u64 {
        let conversion_ratio = BigDecimal::from(self.conversion_ratio.numerator.get())
            / BigDecimal::from(self.conversion_ratio.denominator.get());
        let converted_price_bd = BigDecimal::from(price_in_wei) / conversion_ratio;
```

Before, the `converted_price_bd` was:

```rust
let converted_price_bd = BigDecimal::from(price_in_wei) * conversion_ratio;
```

Offering a lower gas price compared to an `ETH_BASED` chain, resulting in negligible gas deductions.

## How to reproduce

Using the `etc/env/configs/dev.toml` config as example:

1. Set the `base_token_addr`

The dev `zk init` automatically deploys some ERC20 contracts, the addresses are written in `etc/tokens/localhost.json`.

It uses `create2` so the addresses persist.

If we use `DAI` as example:

```toml
__imports__ = [ "base", "l1-inits/.init.env", "l2-inits/dev.init.env" ]

ETH_SENDER_SENDER_PUBDATA_SENDING_MODE = "Blobs"

# DAI ERC20 address
BASE_TOKEN_ADDR = "0x70a0F165d6f8054d0d0CF8dFd4DD2005f0AF6B55"

[external_price_api_client]
source = "coingecko"
base_url = "https://api.coingecko.com"
api_key = "your_api"
# Since the coingecko api only works for ethereum mainnet and with the dev config we run a reth instance as L1,
# we can force the erc20 address used to get the conversion_rate, the address below is the DAI contract of ethereum mainnet
forced_ethereum_erc20_address = "0x6b175474e89094c44da98b954eedeac495271d0f"
```

2. Setup the environment:

```sh
export ZKSYNC_HOME=$(pwd)
export PATH=$ZKSYNC_HOME/bin:$PATH
```

3. Now we can launch the `zk server`:

```sh
zk && zk clean --all && zk env dev && zk init --base-token-name DAI && zk server --components=api,eth,tree,state_keeper,housekeeper,commitment_generator,proof_data_handler,base_token_ratio_persister
```

4. Try it out
   1. If using the `dev config`, we will have to mint some tokens, and transfer the `ERC20` from L1 to L2. Proposed
      script: [GIST](https://gist.github.com/fborello-lambda/3804938f2b43705b34715cd610e30d2d)
   2. Then we can do a transfer to test that the gasprice is according to the `ERC20` used.

The output of the transaction using the `zksync-ethers` sdk:

```
ZK Network URL: http://127.0.0.1:3050
ZK Network ChainID: 270
(from) balance before tx: 2.000062297325
  (to) balance before tx: 0.00060582619375
Send 1 token
(from): 0x36615Cf349d7F6344891B1e7CA7C72883F5dc049
  (to): 0xde03a0B5963f75f1C8485B355fF6D30f3093BDE7
#####################################################
Tx hash: 0x11df0add38b5ed8276c9652b8405f2ce0b3a507445e3504c955e159c42eae66a
#####################################################
(from) balance after tx: 0.953929033219829376
  (to) balance after tx: 1.00060582619375
#####################################################
```

1 base_token (`DAI`) is being transferred, with a fee of 0.05 `DAI` deducted.

## Note

The ERC20 token must be defined in `etc/tokens/<L1>.json` after executing `zk init`. This limits the default availability of tokens that can be used. Users should be informed about these required steps because failing to define the token could lead to contract deployment failures and `unintended additional costs`.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
