### PR TITLE
fix: impossible to run zk_inception containers command

### DIFF
--- a/zk_toolbox/crates/zk_inception/src/main.rs
+++ b/zk_toolbox/crates/zk_inception/src/main.rs
@@ -48,7 +48,7 @@ pub enum InceptionSubcommands {
     #[command(subcommand, alias = "en")]
     ExternalNode(ExternalNodeCommands),
     /// Run containers for local development
-    #[command(subcommand, alias = "up")]
+    #[command(alias = "up")]
     Containers,
     /// Run contract verifier
     #[command(subcommand)]


### PR DESCRIPTION
## What ❔

Fixes a bug for which it is impossible to run `zk_inception containers`.
The command required an impossible to supply subcommand due to the `#[command(subcommand,...` attribute.

```
❯ zk_inception containers

┌   ZKsync toolbox 
│
Run containers for local development

Usage: zk_inception containers [OPTIONS]

Options:
  -h, --help  Print help

Global options:
  -v, --verbose               Verbose mode
      --chain <CHAIN>         Chain to use
      --ignore-prerequisites  Ignores prerequisites checks
```

```
❯ zk_inception containers  -v

┌   ZKsync toolbox 
│
error: 'zk_inception containers' requires a subcommand but one was not provided

Usage: zk_inception containers [OPTIONS]

For more information, try '--help'.
```
## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->
Bug

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
