### PR TITLE
chore: Publish fix-ups

### DIFF
--- a/core/lib/vlog/Cargo.toml
+++ b/core/lib/vlog/Cargo.toml
@@ -9,7 +9,6 @@ repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
-publish = false
 
 [dependencies]
 anyhow.workspace = true

--- a/core/tests/test_account/Cargo.toml
+++ b/core/tests/test_account/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zksync_test_account"
-version = "0.1.0"
+description = "ZKsync test account for writing unit tests"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
@@ -8,7 +9,6 @@ repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
-publish = false
 
 [dependencies]
 zksync_types.workspace = true


### PR DESCRIPTION
## What ❔

A few more fixes that were required to publish packages.
Core workspace crates are already published under `crates.io-v0.1.0` tag.

## Why ❔

Publishing on crates.io

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
