### PR TITLE
feat(prover): Make it possible to run prover out of GCP

### DIFF
--- a/core/lib/config/src/configs/fri_prover.rs
+++ b/core/lib/config/src/configs/fri_prover.rs
@@ -10,6 +10,18 @@ pub enum SetupLoadMode {
     FromMemory,
 }
 
+/// Kind of cloud environment prover subsystem runs in.
+///
+/// Currently will only affect how the prover zone is chosen.
+#[derive(Debug, Default, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum CloudType {
+    /// Assumes that the prover runs in GCP.
+    #[default]
+    GCP,
+    /// Assumes that the prover runs locally.
+    Local,
+}
+
 /// Configuration for the fri prover application
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct FriProverConfig {
@@ -28,6 +40,8 @@ pub struct FriProverConfig {
     pub shall_save_to_public_bucket: bool,
     pub prover_object_store: Option<ObjectStoreConfig>,
     pub public_object_store: Option<ObjectStoreConfig>,
+    #[serde(default)]
+    pub cloud_type: CloudType,
 }
 
 impl FriProverConfig {

--- a/core/lib/config/src/testonly.rs
+++ b/core/lib/config/src/testonly.rs
@@ -438,6 +438,16 @@ impl Distribution<configs::fri_prover::SetupLoadMode> for EncodeDist {
     }
 }
 
+impl Distribution<configs::fri_prover::CloudType> for EncodeDist {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> configs::fri_prover::CloudType {
+        type T = configs::fri_prover::CloudType;
+        match rng.gen_range(0..1) {
+            0 => T::GCP,
+            _ => T::Local,
+        }
+    }
+}
+
 impl Distribution<configs::FriProverConfig> for EncodeDist {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> configs::FriProverConfig {
         configs::FriProverConfig {
@@ -454,6 +464,7 @@ impl Distribution<configs::FriProverConfig> for EncodeDist {
             availability_check_interval_in_secs: self.sample(rng),
             prover_object_store: self.sample(rng),
             public_object_store: self.sample(rng),
+            cloud_type: self.sample(rng),
         }
     }
 }

--- a/core/lib/env_config/src/fri_prover.rs
+++ b/core/lib/env_config/src/fri_prover.rs
@@ -18,7 +18,10 @@ impl FromEnv for FriProverConfig {
 #[cfg(test)]
 mod tests {
     use zksync_config::{
-        configs::{fri_prover::SetupLoadMode, object_store::ObjectStoreMode},
+        configs::{
+            fri_prover::{CloudType, SetupLoadMode},
+            object_store::ObjectStoreMode,
+        },
         ObjectStoreConfig,
     };
 
@@ -57,6 +60,7 @@ mod tests {
                 local_mirror_path: None,
             }),
             availability_check_interval_in_secs: Some(1_800),
+            cloud_type: CloudType::GCP,
         }
     }
 

--- a/core/lib/protobuf_config/src/proto/config/prover.proto
+++ b/core/lib/protobuf_config/src/proto/config/prover.proto
@@ -21,6 +21,11 @@ enum SetupLoadMode {
   FROM_MEMORY = 1;
 }
 
+enum CloudType {
+  GCP = 0;
+  LOCAL = 1;
+}
+
 message Prover {
   optional string setup_data_path = 1; // required; fs path?
   optional uint32 prometheus_port = 2; // required; u16
@@ -35,6 +40,7 @@ message Prover {
   optional bool shall_save_to_public_bucket = 13; // required
   optional config.object_store.ObjectStore public_object_store = 22;
   optional config.object_store.ObjectStore prover_object_store = 23;
+  optional CloudType cloud_type = 24; // optional
   reserved 5, 6, 9; reserved "base_layer_circuit_ids_to_be_verified", "recursive_layer_circuit_ids_to_be_verified", "witness_vector_generator_thread_count";
 }
 

--- a/prover/proof_fri_compressor/Cargo.toml
+++ b/prover/proof_fri_compressor/Cargo.toml
@@ -41,5 +41,6 @@ serde = { workspace = true, features = ["derive"] }
 wrapper_prover = { workspace = true, optional = true }
 
 [features]
+default = []
 gpu = ["wrapper_prover"]
 

--- a/prover/prover_fri/src/gpu_prover_availability_checker.rs
+++ b/prover/prover_fri/src/gpu_prover_availability_checker.rs
@@ -4,6 +4,7 @@ pub mod availability_checker {
 
     use tokio::sync::Notify;
     use zksync_prover_dal::{ConnectionPool, Prover, ProverDal};
+    use zksync_prover_fri_utils::region_fetcher::Zone;
     use zksync_types::prover_dal::{GpuProverInstanceStatus, SocketAddress};
 
     use crate::metrics::{KillingReason, METRICS};
@@ -12,7 +13,7 @@ pub mod availability_checker {
     /// If the prover instance is not found in the database or marked as dead, the availability checker will shut down the prover.
     pub struct AvailabilityChecker {
         address: SocketAddress,
-        zone: String,
+        zone: Zone,
         polling_interval: Duration,
         pool: ConnectionPool<Prover>,
     }
@@ -20,7 +21,7 @@ pub mod availability_checker {
     impl AvailabilityChecker {
         pub fn new(
             address: SocketAddress,
-            zone: String,
+            zone: Zone,
             polling_interval_secs: u32,
             pool: ConnectionPool<Prover>,
         ) -> Self {
@@ -46,7 +47,7 @@ pub mod availability_checker {
                     .await
                     .unwrap()
                     .fri_gpu_prover_queue_dal()
-                    .get_prover_instance_status(self.address.clone(), self.zone.clone())
+                    .get_prover_instance_status(self.address.clone(), self.zone.to_string())
                     .await;
 
                 // If the prover instance is not found in the database or marked as dead, we should shut down the prover

--- a/prover/prover_fri/src/gpu_prover_job_processor.rs
+++ b/prover/prover_fri/src/gpu_prover_job_processor.rs
@@ -28,6 +28,7 @@ pub mod gpu_prover {
         },
         CircuitWrapper, FriProofWrapper, ProverServiceDataKey, WitnessVectorArtifacts,
     };
+    use zksync_prover_fri_utils::region_fetcher::Zone;
     use zksync_queued_job_processor::{async_trait, JobProcessor};
     use zksync_types::{
         basic_fri_types::CircuitIdRoundTuple, protocol_version::ProtocolSemanticVersion,
@@ -64,7 +65,7 @@ pub mod gpu_prover {
         witness_vector_queue: SharedWitnessVectorQueue,
         prover_context: ProverContext,
         address: SocketAddress,
-        zone: String,
+        zone: Zone,
         protocol_version: ProtocolSemanticVersion,
     }
 
@@ -79,7 +80,7 @@ pub mod gpu_prover {
             circuit_ids_for_round_to_be_proven: Vec<CircuitIdRoundTuple>,
             witness_vector_queue: SharedWitnessVectorQueue,
             address: SocketAddress,
-            zone: String,
+            zone: Zone,
             protocol_version: ProtocolSemanticVersion,
         ) -> Self {
             Prover {
@@ -230,7 +231,7 @@ pub mod gpu_prover {
                             .fri_gpu_prover_queue_dal()
                             .update_prover_instance_from_full_to_available(
                                 self.address.clone(),
-                                self.zone.clone(),
+                                self.zone.to_string(),
                             )
                             .await;
                     }

--- a/prover/prover_fri/src/socket_listener.rs
+++ b/prover/prover_fri/src/socket_listener.rs
@@ -11,6 +11,7 @@ pub mod gpu_socket_listener {
     use zksync_object_store::bincode;
     use zksync_prover_dal::{ConnectionPool, Prover, ProverDal};
     use zksync_prover_fri_types::WitnessVectorArtifacts;
+    use zksync_prover_fri_utils::region_fetcher::Zone;
     use zksync_types::{
         protocol_version::ProtocolSemanticVersion,
         prover_dal::{GpuProverInstanceStatus, SocketAddress},
@@ -26,7 +27,7 @@ pub mod gpu_socket_listener {
         queue: SharedWitnessVectorQueue,
         pool: ConnectionPool<Prover>,
         specialized_prover_group_id: u8,
-        zone: String,
+        zone: Zone,
         protocol_version: ProtocolSemanticVersion,
     }
 
@@ -36,7 +37,7 @@ pub mod gpu_socket_listener {
             queue: SharedWitnessVectorQueue,
             pool: ConnectionPool<Prover>,
             specialized_prover_group_id: u8,
-            zone: String,
+            zone: Zone,
             protocol_version: ProtocolSemanticVersion,
         ) -> Self {
             Self {
@@ -68,7 +69,7 @@ pub mod gpu_socket_listener {
                 .insert_prover_instance(
                     self.address.clone(),
                     self.specialized_prover_group_id,
-                    self.zone.clone(),
+                    self.zone.to_string(),
                     self.protocol_version,
                 )
                 .await;
@@ -154,7 +155,7 @@ pub mod gpu_socket_listener {
                 .await
                 .unwrap()
                 .fri_gpu_prover_queue_dal()
-                .update_prover_instance_status(self.address.clone(), status, self.zone.clone())
+                .update_prover_instance_status(self.address.clone(), status, self.zone.to_string())
                 .await;
             tracing::info!(
                 "Marked prover as {:?} after {:?}",

--- a/prover/prover_fri_utils/src/region_fetcher.rs
+++ b/prover/prover_fri_utils/src/region_fetcher.rs
@@ -1,4 +1,4 @@
-use std::net::ToSocketAddrs;
+use core::fmt;
 
 use anyhow::Context;
 use regex::Regex;
@@ -6,54 +6,93 @@ use reqwest::{
     header::{HeaderMap, HeaderValue},
     Method,
 };
+use zksync_config::configs::fri_prover::CloudType;
 use zksync_utils::http_with_retries::send_request_with_retries;
 
-pub async fn get_zone(zone_url: &str) -> anyhow::Result<String> {
-    // Check if zone URL can be resolved. If not, we assume that we're running locally.
-    if zone_url.to_socket_addrs().is_err() {
-        tracing::error!("Unable to resolve zone URL, assuming local environment");
-        return Ok("local".to_string());
-    }
-
-    let data = fetch_from_url(zone_url).await.context("fetch_from_url()")?;
-    parse_zone(&data).context("parse_zone")
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegionFetcher {
+    cloud_type: CloudType,
+    zone_url: String,
 }
 
-async fn fetch_from_url(url: &str) -> anyhow::Result<String> {
-    let mut headers = HeaderMap::new();
-    headers.insert("Metadata-Flavor", HeaderValue::from_static("Google"));
-    let response = send_request_with_retries(url, 5, Method::GET, Some(headers), None).await;
-    response
-        .map_err(|err| anyhow::anyhow!("Failed fetching response from url: {url}: {err:?}"))?
-        .text()
-        .await
-        .context("Failed to read response as text")
+impl RegionFetcher {
+    pub fn new(cloud_type: CloudType, zone_url: String) -> Self {
+        Self {
+            cloud_type,
+            zone_url,
+        }
+    }
+
+    pub async fn get_zone(&self) -> anyhow::Result<Zone> {
+        match self.cloud_type {
+            CloudType::GCP => GcpZoneFetcher::get_zone(&self.zone_url).await,
+            CloudType::Local => Ok(Zone("local".to_string())),
+        }
+    }
 }
 
-fn parse_zone(data: &str) -> anyhow::Result<String> {
-    // Statically provided Regex should always compile.
-    let re = Regex::new(r"^projects/\d+/zones/(\w+-\w+-\w+)$").unwrap();
-    if let Some(caps) = re.captures(data) {
-        let zone = &caps[1];
-        return Ok(zone.to_string());
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Zone(String);
+
+impl fmt::Display for Zone {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
-    anyhow::bail!("failed to extract zone from: {data}");
+}
+
+impl Zone {
+    pub fn new<T: ToString>(zone: T) -> Self {
+        Self(zone.to_string())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct GcpZoneFetcher;
+
+impl GcpZoneFetcher {
+    pub async fn get_zone(zone_url: &str) -> anyhow::Result<Zone> {
+        let data = Self::fetch_from_url(zone_url)
+            .await
+            .context("fetch_from_url()")?;
+        Self::parse_zone(&data).context("parse_zone")
+    }
+
+    async fn fetch_from_url(url: &str) -> anyhow::Result<String> {
+        let mut headers = HeaderMap::new();
+        headers.insert("Metadata-Flavor", HeaderValue::from_static("Google"));
+        let response = send_request_with_retries(url, 5, Method::GET, Some(headers), None).await;
+        response
+            .map_err(|err| anyhow::anyhow!("Failed fetching response from url: {url}: {err:?}"))?
+            .text()
+            .await
+            .context("Failed to read response as text")
+    }
+
+    fn parse_zone(data: &str) -> anyhow::Result<Zone> {
+        // Statically provided Regex should always compile.
+        let re = Regex::new(r"^projects/\d+/zones/(\w+-\w+-\w+)$").unwrap();
+        if let Some(caps) = re.captures(data) {
+            let zone = &caps[1];
+            return Ok(Zone(zone.to_string()));
+        }
+        anyhow::bail!("failed to extract zone from: {data}");
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::region_fetcher::parse_zone;
+    use super::*;
 
     #[test]
     fn test_parse_zone() {
         let data = "projects/295056426491/zones/us-central1-a";
-        let zone = parse_zone(data).unwrap();
-        assert_eq!(zone, "us-central1-a");
+        let zone = GcpZoneFetcher::parse_zone(data).unwrap();
+        assert_eq!(zone, Zone::new("us-central1-a"));
     }
 
     #[test]
     fn test_parse_zone_panic() {
         let data = "invalid data";
-        assert!(parse_zone(data).is_err());
+        assert!(GcpZoneFetcher::parse_zone(data).is_err());
     }
 }

--- a/prover/prover_fri_utils/src/region_fetcher.rs
+++ b/prover/prover_fri_utils/src/region_fetcher.rs
@@ -1,3 +1,5 @@
+use std::net::ToSocketAddrs;
+
 use anyhow::Context;
 use regex::Regex;
 use reqwest::{
@@ -7,6 +9,12 @@ use reqwest::{
 use zksync_utils::http_with_retries::send_request_with_retries;
 
 pub async fn get_zone(zone_url: &str) -> anyhow::Result<String> {
+    // Check if zone URL can be resolved. If not, we assume that we're running locally.
+    if zone_url.to_socket_addrs().is_err() {
+        tracing::error!("Unable to resolve zone URL, assuming local environment");
+        return Ok("local".to_string());
+    }
+
     let data = fetch_from_url(zone_url).await.context("fetch_from_url()")?;
     parse_zone(&data).context("parse_zone")
 }


### PR DESCRIPTION
## What ❔

~~When zone read domain name cannot be resolved, assumes local environment and uses `local` zone.~~

- Introduces a new config to choose cloud type, either GCP or local.
- Creates `RegionFetcher` structure that can fetch the zone based on configuration.
- Introduces strong typing for zone.

## Why ❔

Makes it possible to run prover locally.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
