### PR TITLE
perf: writing tx to bootloader memory is no longer quadratic

### DIFF
--- a/core/lib/multivm/src/versions/vm_latest/bootloader_state/l2_block.rs
+++ b/core/lib/multivm/src/versions/vm_latest/bootloader_state/l2_block.rs
@@ -56,12 +56,6 @@ impl BootloaderL2Block {
         self.txs_rolling_hash = concat_and_hash(self.txs_rolling_hash, tx_hash)
     }
 
-    pub(crate) fn interim_version(&self) -> BootloaderL2Block {
-        let mut interim = self.clone();
-        interim.max_virtual_blocks_to_create = 0;
-        interim
-    }
-
     pub(crate) fn make_snapshot(&self) -> L2BlockSnapshot {
         L2BlockSnapshot {
             txs_rolling_hash: self.txs_rolling_hash,

--- a/core/lib/multivm/src/versions/vm_latest/bootloader_state/l2_block.rs
+++ b/core/lib/multivm/src/versions/vm_latest/bootloader_state/l2_block.rs
@@ -13,7 +13,7 @@ use crate::{
 
 const EMPTY_TXS_ROLLING_HASH: H256 = H256::zero();
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct BootloaderL2Block {
     pub(crate) number: u32,
     pub(crate) timestamp: u64,

--- a/core/lib/multivm/src/versions/vm_latest/bootloader_state/state.rs
+++ b/core/lib/multivm/src/versions/vm_latest/bootloader_state/state.rs
@@ -29,7 +29,7 @@ use crate::{
 /// Serves two purposes:
 /// - Tracks where next tx should be pushed to in the bootloader memory.
 /// - Tracks which transaction should be executed next.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct BootloaderState {
     /// ID of the next transaction to be executed.
     /// See the structure doc-comment for a better explanation of purpose.

--- a/core/lib/multivm/src/versions/vm_latest/bootloader_state/utils.rs
+++ b/core/lib/multivm/src/versions/vm_latest/bootloader_state/utils.rs
@@ -67,12 +67,7 @@ pub(super) fn apply_tx_to_memory(
             .zip(bootloader_tx.encoded.clone()),
     );
 
-    let bootloader_l2_block = if start_new_l2_block {
-        bootloader_l2_block.clone()
-    } else {
-        bootloader_l2_block.interim_version()
-    };
-    apply_l2_block(memory, &bootloader_l2_block, tx_index);
+    apply_l2_block_inner(memory, bootloader_l2_block, tx_index, start_new_l2_block);
 
     // Note, +1 is moving for pointer
     let compressed_bytecodes_offset = COMPRESSED_BYTECODES_OFFSET + 1 + compressed_bytecodes_size;
@@ -94,6 +89,15 @@ pub(crate) fn apply_l2_block(
     bootloader_l2_block: &BootloaderL2Block,
     txs_index: usize,
 ) {
+    apply_l2_block_inner(memory, bootloader_l2_block, txs_index, true)
+}
+
+fn apply_l2_block_inner(
+    memory: &mut BootloaderMemory,
+    bootloader_l2_block: &BootloaderL2Block,
+    txs_index: usize,
+    start_new_l2_block: bool,
+) {
     // Since L2 block information start from the `TX_OPERATOR_L2_BLOCK_INFO_OFFSET` and each
     // L2 block info takes `TX_OPERATOR_SLOTS_PER_L2_BLOCK_INFO` slots, the position where the L2 block info
     // for this transaction needs to be written is:
@@ -110,7 +114,12 @@ pub(crate) fn apply_l2_block(
         ),
         (
             block_position + 3,
-            bootloader_l2_block.max_virtual_blocks_to_create.into(),
+            if start_new_l2_block {
+                bootloader_l2_block.max_virtual_blocks_to_create
+            } else {
+                0
+            }
+            .into(),
         ),
     ])
 }

--- a/core/lib/multivm/src/versions/vm_latest/bootloader_state/utils.rs
+++ b/core/lib/multivm/src/versions/vm_latest/bootloader_state/utils.rs
@@ -115,11 +115,10 @@ fn apply_l2_block_inner(
         (
             block_position + 3,
             if start_new_l2_block {
-                bootloader_l2_block.max_virtual_blocks_to_create
+                bootloader_l2_block.max_virtual_blocks_to_create.into()
             } else {
-                0
-            }
-            .into(),
+                U256::zero()
+            },
         ),
     ])
 }


### PR DESCRIPTION
It used to grow proportionally to the number of transactions in the L2 block squared.