### PR TITLE
fix: consensus secrets generator

### DIFF
--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -1136,11 +1136,11 @@ pub fn generate_consensus_secrets() {
     let attester_key = roles::attester::SecretKey::generate();
     let node_key = roles::node::SecretKey::generate();
     println!("# {}", validator_key.public().encode());
-    println!("- validator_key: {}", validator_key.encode());
+    println!("validator_key: {}", validator_key.encode());
     println!("# {}", attester_key.public().encode());
-    println!("- attester_key: {}", attester_key.encode());
+    println!("attester_key: {}", attester_key.encode());
     println!("# {}", node_key.public().encode());
-    println!("- node_key: {}", node_key.encode());
+    println!("node_key: {}", node_key.encode());
 }
 
 pub(crate) fn read_consensus_secrets() -> anyhow::Result<Option<ConsensusSecrets>> {


### PR DESCRIPTION
the output format didn't match the expected consensus_secrets.yaml format.