### PR TITLE
docs(prover): Improve default configuration for prover binaries

### DIFF
--- a/etc/env/base/fri_witness_generator.toml
+++ b/etc/env/base/fri_witness_generator.toml
@@ -7,3 +7,4 @@ recursion_tip_generation_timeout_in_secs = 900
 scheduler_generation_timeout_in_secs = 900
 max_attempts = 10
 shall_save_to_public_bucket = true
+prometheus_listener_port = 3116

--- a/etc/env/base/fri_witness_vector_generator.toml
+++ b/etc/env/base/fri_witness_vector_generator.toml
@@ -1,7 +1,7 @@
 [fri_witness_vector_generator]
 prover_instance_wait_timeout_in_secs=200
 prover_instance_poll_time_in_milli_secs=250
-prometheus_listener_port=3314
+prometheus_listener_port=3420
 prometheus_pushgateway_url="http://127.0.0.1:9091"
 prometheus_push_interval_ms=100
 specialized_group_id=100

--- a/prover/docs/03_launch.md
+++ b/prover/docs/03_launch.md
@@ -62,7 +62,7 @@ until it happens, witness generators will panic and won't be able to start.
 Once a job is created, start witness generators:
 
 ```
-API_PROMETHEUS_LISTENER_PORT=3116 zk f cargo run --release --bin zksync_witness_generator -- --all_rounds
+zk f cargo run --release --bin zksync_witness_generator -- --all_rounds
 ```
 
 `--all_rounds` means that witness generator will produce witnesses of all kinds. You can run a witness generator for
@@ -71,11 +71,11 @@ each round separately, but it's mostly useful in production environments.
 ### Witness vector generator
 
 ```
-FRI_WITNESS_VECTOR_GENERATOR_PROMETHEUS_LISTENER_PORT=3420 zk f cargo run --release --bin zksync_witness_vector_generator
+zk f cargo run --release --bin zksync_witness_vector_generator -- --threads 10
 ```
 
-WVG prepares inputs for prover, and it's a single-threaded time-consuming operation. You may run several instances (make
-sure to use different ports). The exact amount of WVGs needed to "feed" one prover depends on CPU/GPU specs, but a
+WVG prepares inputs for prover, and it's a single-threaded time-consuming operation. You may run several jobs by
+changing the `threads` parameter. The exact amount of WVGs needed to "feed" one prover depends on CPU/GPU specs, but a
 ballpark estimate (useful for local development) is 10 WVGs per prover.
 
 ### Prover


### PR DESCRIPTION
## What ❔

Changes the default prometheus ports for prover binaries so that there is no need to override them when running together.
Updates the docs accordingly. Also mentions that you can run WVG with multiple threads.

## Why ❔

Convenience.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
