### PR TITLE
feat(configs): Do not panic if config is only partially filled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9294,6 +9294,7 @@ dependencies = [
  "secrecy",
  "serde_json",
  "serde_yaml",
+ "tracing",
  "zksync_basic_types",
  "zksync_config",
  "zksync_protobuf",

--- a/core/lib/protobuf_config/Cargo.toml
+++ b/core/lib/protobuf_config/Cargo.toml
@@ -25,6 +25,7 @@ prost.workspace = true
 rand.workspace = true
 hex.workspace = true
 secrecy.workspace = true
+tracing.workspace = true
 
 [build-dependencies]
 zksync_protobuf_build.workspace = true

--- a/core/lib/protobuf_config/src/consensus.rs
+++ b/core/lib/protobuf_config/src/consensus.rs
@@ -139,8 +139,8 @@ impl ProtoRepr for proto::Config {
                 .enumerate()
                 .map(|(i, e)| read_addr(e).context(i))
                 .collect::<Result<_, _>>()?,
-            genesis_spec: read_optional_repr(&self.genesis_spec).context("genesis_spec")?,
-            rpc: read_optional_repr(&self.rpc_config).context("rpc_config")?,
+            genesis_spec: read_optional_repr(&self.genesis_spec),
+            rpc: read_optional_repr(&self.rpc_config),
         })
     }
 

--- a/core/lib/protobuf_config/src/eth.rs
+++ b/core/lib/protobuf_config/src/eth.rs
@@ -49,9 +49,9 @@ impl ProtoRepr for proto::Eth {
 
     fn read(&self) -> anyhow::Result<Self::Type> {
         Ok(Self::Type {
-            sender: read_optional_repr(&self.sender).context("sender")?,
-            gas_adjuster: read_optional_repr(&self.gas_adjuster).context("gas_adjuster")?,
-            watcher: read_optional_repr(&self.watcher).context("watcher")?,
+            sender: read_optional_repr(&self.sender),
+            gas_adjuster: read_optional_repr(&self.gas_adjuster),
+            watcher: read_optional_repr(&self.watcher),
         })
     }
 

--- a/core/lib/protobuf_config/src/general.rs
+++ b/core/lib/protobuf_config/src/general.rs
@@ -1,4 +1,3 @@
-use anyhow::Context as _;
 use zksync_config::configs::GeneralConfig;
 use zksync_protobuf::ProtoRepr;
 
@@ -9,54 +8,38 @@ impl ProtoRepr for proto::GeneralConfig {
 
     fn read(&self) -> anyhow::Result<Self::Type> {
         Ok(Self::Type {
-            postgres_config: read_optional_repr(&self.postgres).context("postgres")?,
-            contract_verifier: read_optional_repr(&self.contract_verifier).context("postgres")?,
-            circuit_breaker_config: read_optional_repr(&self.circuit_breaker)
-                .context("circuit_breaker")?,
-            mempool_config: read_optional_repr(&self.mempool).context("mempool")?,
-            operations_manager_config: read_optional_repr(&self.operations_manager)
-                .context("operations_manager")?,
-            state_keeper_config: read_optional_repr(&self.state_keeper).context("state_keeper")?,
-            house_keeper_config: read_optional_repr(&self.house_keeper).context("house_keeper")?,
-            proof_compressor_config: read_optional_repr(&self.proof_compressor)
-                .context("proof_compressor_config")?,
-            prover_config: read_optional_repr(&self.prover).context("prover_config")?,
-            prover_gateway: read_optional_repr(&self.prover_gateway).context("prover_gateway")?,
-            witness_vector_generator: read_optional_repr(&self.witness_vector_generator)
-                .context("witness_vector_generator")?,
-            prover_group_config: read_optional_repr(&self.prover_group)
-                .context("prover_group_config")?,
-            prometheus_config: read_optional_repr(&self.prometheus).context("prometheus")?,
-            proof_data_handler_config: read_optional_repr(&self.data_handler)
-                .context("proof_data_handler")?,
-            witness_generator: read_optional_repr(&self.witness_generator)
-                .context("witness_generator")?,
-            api_config: read_optional_repr(&self.api).context("api")?,
-            db_config: read_optional_repr(&self.db).context("db")?,
-            eth: read_optional_repr(&self.eth).context("eth")?,
-            snapshot_creator: read_optional_repr(&self.snapshot_creator)
-                .context("snapshot_creator")?,
-            observability: read_optional_repr(&self.observability).context("observability")?,
-            da_dispatcher_config: read_optional_repr(&self.da_dispatcher)
-                .context("da_dispatcher")?,
-            protective_reads_writer_config: read_optional_repr(&self.protective_reads_writer)
-                .context("protective_reads_writer")?,
+            postgres_config: read_optional_repr(&self.postgres),
+            contract_verifier: read_optional_repr(&self.contract_verifier),
+            circuit_breaker_config: read_optional_repr(&self.circuit_breaker),
+            mempool_config: read_optional_repr(&self.mempool),
+            operations_manager_config: read_optional_repr(&self.operations_manager),
+            state_keeper_config: read_optional_repr(&self.state_keeper),
+            house_keeper_config: read_optional_repr(&self.house_keeper),
+            proof_compressor_config: read_optional_repr(&self.proof_compressor),
+            prover_config: read_optional_repr(&self.prover),
+            prover_gateway: read_optional_repr(&self.prover_gateway),
+            witness_vector_generator: read_optional_repr(&self.witness_vector_generator),
+            prover_group_config: read_optional_repr(&self.prover_group),
+            prometheus_config: read_optional_repr(&self.prometheus),
+            proof_data_handler_config: read_optional_repr(&self.data_handler),
+            witness_generator: read_optional_repr(&self.witness_generator),
+            api_config: read_optional_repr(&self.api),
+            db_config: read_optional_repr(&self.db),
+            eth: read_optional_repr(&self.eth),
+            snapshot_creator: read_optional_repr(&self.snapshot_creator),
+            observability: read_optional_repr(&self.observability),
+            da_dispatcher_config: read_optional_repr(&self.da_dispatcher),
+            protective_reads_writer_config: read_optional_repr(&self.protective_reads_writer),
             basic_witness_input_producer_config: read_optional_repr(
                 &self.basic_witness_input_producer,
-            )
-            .context("basic_witness_input_producer")?,
-            core_object_store: read_optional_repr(&self.core_object_store)
-                .context("core_object_store")?,
-            base_token_adjuster: read_optional_repr(&self.base_token_adjuster)
-                .context("base_token_adjuster")?,
-            commitment_generator: read_optional_repr(&self.commitment_generator)
-                .context("commitment_generator")?,
-            pruning: read_optional_repr(&self.pruning).context("pruning")?,
-            snapshot_recovery: read_optional_repr(&self.snapshot_recovery)
-                .context("snapshot_recovery")?,
-            external_price_api_client_config: read_optional_repr(&self.external_price_api_client)
-                .context("external_price_api_client")?,
-            consensus_config: read_optional_repr(&self.consensus).context("consensus")?,
+            ),
+            core_object_store: read_optional_repr(&self.core_object_store),
+            base_token_adjuster: read_optional_repr(&self.base_token_adjuster),
+            commitment_generator: read_optional_repr(&self.commitment_generator),
+            pruning: read_optional_repr(&self.pruning),
+            snapshot_recovery: read_optional_repr(&self.snapshot_recovery),
+            external_price_api_client_config: read_optional_repr(&self.external_price_api_client),
+            consensus_config: read_optional_repr(&self.consensus),
         })
     }
 

--- a/core/lib/protobuf_config/src/lib.rs
+++ b/core/lib/protobuf_config/src/lib.rs
@@ -54,8 +54,18 @@ fn parse_h160(bytes: &str) -> anyhow::Result<H160> {
     Ok(H160::from_str(bytes)?)
 }
 
-pub fn read_optional_repr<P: ProtoRepr>(field: &Option<P>) -> anyhow::Result<Option<P::Type>> {
-    field.as_ref().map(|x| x.read()).transpose()
+pub fn read_optional_repr<P: ProtoRepr>(field: &Option<P>) -> Option<P::Type> {
+    field
+        .as_ref()
+        .map(|x| x.read())
+        .transpose()
+        // This error will printed, only if the config partially filled, allows to debug config issues easier
+        .map_err(|err| {
+            tracing::error!("Failed to serialize config: {err}");
+            err
+        })
+        .ok()
+        .flatten()
 }
 
 pub fn decode_yaml_repr<T: ProtoRepr>(

--- a/core/lib/protobuf_config/src/secrets.rs
+++ b/core/lib/protobuf_config/src/secrets.rs
@@ -17,9 +17,9 @@ impl ProtoRepr for proto::Secrets {
 
     fn read(&self) -> anyhow::Result<Self::Type> {
         Ok(Self::Type {
-            consensus: read_optional_repr(&self.consensus).context("consensus")?,
-            database: read_optional_repr(&self.database).context("database")?,
-            l1: read_optional_repr(&self.l1).context("l1")?,
+            consensus: read_optional_repr(&self.consensus),
+            database: read_optional_repr(&self.database),
+            l1: read_optional_repr(&self.l1),
         })
     }
 

--- a/core/lib/protobuf_config/src/snapshot_recovery.rs
+++ b/core/lib/protobuf_config/src/snapshot_recovery.rs
@@ -1,6 +1,5 @@
 use std::num::NonZeroUsize;
 
-use anyhow::Context;
 use zksync_basic_types::L1BatchNumber;
 use zksync_config::configs::{
     snapshot_recovery::{PostgresRecoveryConfig, TreeRecoveryConfig},
@@ -55,11 +54,9 @@ impl ProtoRepr for proto::SnapshotRecovery {
         Ok(Self::Type {
             enabled: self.enabled.unwrap_or_default(),
             tree,
-            postgres: read_optional_repr(&self.postgres)
-                .context("postgres")?
-                .unwrap_or_default(),
+            postgres: read_optional_repr(&self.postgres).unwrap_or_default(),
             l1_batch: self.l1_batch.map(L1BatchNumber),
-            object_store: read_optional_repr(&self.object_store).context("object store")?,
+            object_store: read_optional_repr(&self.object_store),
             drop_storage_key_preimages: self
                 .experimental
                 .as_ref()

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -8168,6 +8168,7 @@ dependencies = [
  "secrecy",
  "serde_json",
  "serde_yaml",
+ "tracing",
  "zksync_basic_types",
  "zksync_config",
  "zksync_protobuf",

--- a/zk_toolbox/Cargo.lock
+++ b/zk_toolbox/Cargo.lock
@@ -6456,6 +6456,7 @@ dependencies = [
  "secrecy",
  "serde_json",
  "serde_yaml",
+ "tracing",
  "zksync_basic_types",
  "zksync_config",
  "zksync_protobuf",


### PR DESCRIPTION
## What ❔

If config is partially serialized, do not throw an error just print it and the app, for which part the config is required will panic by itself 

##  Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
