### PR TITLE
feat(consensus): add tracing instrumentation to consensus store

### DIFF
--- a/core/node/consensus/src/storage/connection.rs
+++ b/core/node/consensus/src/storage/connection.rs
@@ -106,6 +106,7 @@ impl<'a> Connection<'a> {
     }
 
     /// Wrapper for `consensus_dal().insert_block_certificate()`.
+    #[tracing::instrument(skip_all, fields(block_number = %cert.message.proposal.number))]
     pub async fn insert_block_certificate(
         &mut self,
         ctx: &ctx::Ctx,
@@ -118,6 +119,7 @@ impl<'a> Connection<'a> {
 
     /// Wrapper for `consensus_dal().insert_batch_certificate()`,
     /// which additionally verifies that the batch hash matches the stored batch.
+    #[tracing::instrument(skip_all, fields(batch_number = %cert.message.number))]
     pub async fn insert_batch_certificate(
         &mut self,
         ctx: &ctx::Ctx,
@@ -223,11 +225,13 @@ impl<'a> Connection<'a> {
     }
 
     /// Wrapper for `consensus_dal().next_block()`.
+    #[tracing::instrument(skip_all)]
     async fn next_block(&mut self, ctx: &ctx::Ctx) -> ctx::Result<validator::BlockNumber> {
         Ok(ctx.wait(self.0.consensus_dal().next_block()).await??)
     }
 
     /// Wrapper for `consensus_dal().block_certificates_range()`.
+    #[tracing::instrument(skip_all)]
     pub(crate) async fn block_certificates_range(
         &mut self,
         ctx: &ctx::Ctx,
@@ -305,6 +309,7 @@ impl<'a> Connection<'a> {
     }
 
     /// Wrapper for `blocks_dal().get_sealed_l1_batch_number()`.
+    #[tracing::instrument(skip_all)]
     pub async fn get_last_batch_number(
         &mut self,
         ctx: &ctx::Ctx,
@@ -390,6 +395,7 @@ impl<'a> Connection<'a> {
     }
 
     /// Construct the [storage::BatchStoreState] which contains the earliest batch and the last available [attester::SyncBatch].
+    #[tracing::instrument(skip_all)]
     pub async fn batches_range(&mut self, ctx: &ctx::Ctx) -> ctx::Result<storage::BatchStoreState> {
         let first = self
             .0


### PR DESCRIPTION
## What ❔

This PR adds instrumentation to consensus store layer which should serve as a good starting point. Most other layers are heavily intertwined with the `era-consensus` codebase so we will need to introduce instrumentation there first.

## Why ❔

Better visibility of what we spend our time on, including waiting time

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
