### PR TITLE
Adding SLChainID

### DIFF
--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -31,7 +31,7 @@ use zksync_protobuf_config::proto;
 use zksync_snapshots_applier::SnapshotsApplierConfig;
 use zksync_types::{
     api::BridgeAddresses, commitment::L1BatchCommitmentMode, url::SensitiveUrl, Address,
-    L1BatchNumber, L2ChainId, SLChainId, ETHEREUM_ADDRESS,
+    L1BatchNumber, L1ChainId, L2ChainId, SLChainId, ETHEREUM_ADDRESS,
 };
 use zksync_web3_decl::{
     client::{DynClient, L2},
@@ -908,9 +908,11 @@ impl OptionalENConfig {
 /// This part of the external node config is required for its operation.
 #[derive(Debug, Deserialize)]
 pub(crate) struct RequiredENConfig {
-    /// The chain ID of the settlement layer (e.g., 9 for Ethereum mainnet). This ID will be checked against the `eth_client_url` RPC provider on initialization
-    /// to ensure that there's no mismatch between the expected and actual L1 network.
-    pub l1_chain_id: SLChainId,
+    /// The chain ID of the L1 network (e.g., 1 for Ethereum mainnet). In the future, it may be different from the settlement layer.
+    pub l1_chain_id: L1ChainId,
+    /// The chain ID of the settlement layer (e.g., 1 for Ethereum mainnet). This ID will be checked against the `eth_client_url` RPC provider on initialization
+    /// to ensure that there's no mismatch between the expected and actual settlement layer network.
+    pub sl_chain_id: Option<SLChainId>,
     /// L2 chain ID (e.g., 270 for ZKsync Era mainnet). This ID will be checked against the `main_node_url` RPC provider on initialization
     /// to ensure that there's no mismatch between the expected and actual L2 network.
     pub l2_chain_id: L2ChainId,
@@ -932,6 +934,10 @@ pub(crate) struct RequiredENConfig {
 }
 
 impl RequiredENConfig {
+    pub fn get_settlement_layer_id(&self) -> SLChainId {
+        self.sl_chain_id.unwrap_or(self.l1_chain_id.into())
+    }
+
     fn from_env() -> anyhow::Result<Self> {
         envy::prefixed("EN_")
             .from_env()
@@ -953,6 +959,7 @@ impl RequiredENConfig {
             .context("Database config is required")?;
         Ok(RequiredENConfig {
             l1_chain_id: en_config.l1_chain_id,
+            sl_chain_id: None,
             l2_chain_id: en_config.l2_chain_id,
             http_port: api_config.web3_json_rpc.http_port,
             ws_port: api_config.web3_json_rpc.ws_port,
@@ -972,7 +979,8 @@ impl RequiredENConfig {
     #[cfg(test)]
     fn mock(temp_dir: &tempfile::TempDir) -> Self {
         Self {
-            l1_chain_id: SLChainId(9),
+            l1_chain_id: L1ChainId(9),
+            sl_chain_id: None,
             l2_chain_id: L2ChainId::default(),
             http_port: 0,
             ws_port: 0,

--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -31,7 +31,7 @@ use zksync_protobuf_config::proto;
 use zksync_snapshots_applier::SnapshotsApplierConfig;
 use zksync_types::{
     api::BridgeAddresses, commitment::L1BatchCommitmentMode, url::SensitiveUrl, Address,
-    L1BatchNumber, L1ChainId, L2ChainId, ETHEREUM_ADDRESS,
+    L1BatchNumber, L2ChainId, SLChainId, ETHEREUM_ADDRESS,
 };
 use zksync_web3_decl::{
     client::{DynClient, L2},
@@ -908,9 +908,9 @@ impl OptionalENConfig {
 /// This part of the external node config is required for its operation.
 #[derive(Debug, Deserialize)]
 pub(crate) struct RequiredENConfig {
-    /// L1 chain ID (e.g., 9 for Ethereum mainnet). This ID will be checked against the `eth_client_url` RPC provider on initialization
+    /// The chain ID of the settlement layer (e.g., 9 for Ethereum mainnet). This ID will be checked against the `eth_client_url` RPC provider on initialization
     /// to ensure that there's no mismatch between the expected and actual L1 network.
-    pub l1_chain_id: L1ChainId,
+    pub l1_chain_id: SLChainId,
     /// L2 chain ID (e.g., 270 for ZKsync Era mainnet). This ID will be checked against the `main_node_url` RPC provider on initialization
     /// to ensure that there's no mismatch between the expected and actual L2 network.
     pub l2_chain_id: L2ChainId,
@@ -972,7 +972,7 @@ impl RequiredENConfig {
     #[cfg(test)]
     fn mock(temp_dir: &tempfile::TempDir) -> Self {
         Self {
-            l1_chain_id: L1ChainId(9),
+            l1_chain_id: SLChainId(9),
             l2_chain_id: L2ChainId::default(),
             http_port: 0,
             ws_port: 0,

--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -841,7 +841,7 @@ async fn main() -> anyhow::Result<()> {
     let eth_client_url = &config.required.eth_client_url;
     let eth_client = Client::http(eth_client_url.clone())
         .context("failed creating JSON-RPC client for Ethereum")?
-        .for_network(config.required.l1_chain_id.into())
+        .for_network(config.required.get_settlement_layer_id().into())
         .build();
     let eth_client = Box::new(eth_client);
 
@@ -879,7 +879,7 @@ async fn main() -> anyhow::Result<()> {
 
     RUST_METRICS.initialize();
     EN_METRICS.observe_config(
-        config.required.l1_chain_id,
+        config.required.get_settlement_layer_id(),
         config.required.l2_chain_id,
         config.postgres.max_connections,
     );
@@ -985,7 +985,7 @@ async fn run_node(
     });
 
     let validate_chain_ids_task = ValidateChainIdsTask::new(
-        config.required.l1_chain_id,
+        config.required.get_settlement_layer_id(),
         config.required.l2_chain_id,
         eth_client.clone(),
         main_node_client.clone(),

--- a/core/bin/external_node/src/metrics/framework.rs
+++ b/core/bin/external_node/src/metrics/framework.rs
@@ -6,13 +6,13 @@ use zksync_node_framework::{
     FromContext, IntoContext, StopReceiver, Task, TaskId, WiringError, WiringLayer,
 };
 use zksync_shared_metrics::rustc::RUST_METRICS;
-use zksync_types::{L1ChainId, L2ChainId};
+use zksync_types::{L2ChainId, SLChainId};
 
 use super::EN_METRICS;
 
 #[derive(Debug)]
 pub struct ExternalNodeMetricsLayer {
-    pub l1_chain_id: L1ChainId,
+    pub l1_chain_id: SLChainId,
     pub l2_chain_id: L2ChainId,
     pub postgres_pool_size: u32,
 }

--- a/core/bin/external_node/src/metrics/framework.rs
+++ b/core/bin/external_node/src/metrics/framework.rs
@@ -12,7 +12,7 @@ use super::EN_METRICS;
 
 #[derive(Debug)]
 pub struct ExternalNodeMetricsLayer {
-    pub l1_chain_id: SLChainId,
+    pub sl_chain_id: SLChainId,
     pub l2_chain_id: L2ChainId,
     pub postgres_pool_size: u32,
 }
@@ -39,7 +39,7 @@ impl WiringLayer for ExternalNodeMetricsLayer {
 
     async fn wire(self, input: Self::Input) -> Result<Self::Output, WiringError> {
         RUST_METRICS.initialize();
-        EN_METRICS.observe_config(self.l1_chain_id, self.l2_chain_id, self.postgres_pool_size);
+        EN_METRICS.observe_config(self.sl_chain_id, self.l2_chain_id, self.postgres_pool_size);
 
         let pool = input.master_pool.get_singleton().await?;
         let task = ProtocolVersionMetricsTask { pool };

--- a/core/bin/external_node/src/metrics/mod.rs
+++ b/core/bin/external_node/src/metrics/mod.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use tokio::sync::watch;
 use vise::{EncodeLabelSet, Gauge, Info, Metrics};
 use zksync_dal::{ConnectionPool, Core, CoreDal};
-use zksync_types::{L1ChainId, L2ChainId};
+use zksync_types::{L2ChainId, SLChainId};
 
 use crate::metadata::SERVER_VERSION;
 
@@ -31,7 +31,7 @@ pub(crate) struct ExternalNodeMetrics {
 impl ExternalNodeMetrics {
     pub(crate) fn observe_config(
         &self,
-        l1_chain_id: L1ChainId,
+        l1_chain_id: SLChainId,
         l2_chain_id: L2ChainId,
         postgres_pool_size: u32,
     ) {

--- a/core/bin/external_node/src/metrics/mod.rs
+++ b/core/bin/external_node/src/metrics/mod.rs
@@ -31,13 +31,13 @@ pub(crate) struct ExternalNodeMetrics {
 impl ExternalNodeMetrics {
     pub(crate) fn observe_config(
         &self,
-        l1_chain_id: SLChainId,
+        sl_chain_id: SLChainId,
         l2_chain_id: L2ChainId,
         postgres_pool_size: u32,
     ) {
         let info = ExternalNodeInfo {
             server_version: SERVER_VERSION,
-            l1_chain_id: l1_chain_id.0,
+            l1_chain_id: sl_chain_id.0,
             l2_chain_id: l2_chain_id.as_u64(),
             postgres_pool_size,
         };

--- a/core/bin/external_node/src/node_builder.rs
+++ b/core/bin/external_node/src/node_builder.rs
@@ -120,7 +120,7 @@ impl ExternalNodeBuilder {
 
     fn add_external_node_metrics_layer(mut self) -> anyhow::Result<Self> {
         self.node.add_layer(ExternalNodeMetricsLayer {
-            l1_chain_id: self.config.required.l1_chain_id,
+            sl_chain_id: self.config.required.get_settlement_layer_id(),
             l2_chain_id: self.config.required.l2_chain_id,
             postgres_pool_size: self.config.postgres.max_connections,
         });
@@ -166,7 +166,7 @@ impl ExternalNodeBuilder {
 
     fn add_query_eth_client_layer(mut self) -> anyhow::Result<Self> {
         let query_eth_client_layer = QueryEthClientLayer::new(
-            self.config.required.l1_chain_id,
+            self.config.required.get_settlement_layer_id(),
             self.config.required.eth_client_url.clone(),
         );
         self.node.add_layer(query_eth_client_layer);
@@ -256,7 +256,7 @@ impl ExternalNodeBuilder {
 
     fn add_validate_chain_ids_layer(mut self) -> anyhow::Result<Self> {
         let layer = ValidateChainIdsLayer::new(
-            self.config.required.l1_chain_id,
+            self.config.required.get_settlement_layer_id(),
             self.config.required.l2_chain_id,
         );
         self.node.add_layer(layer);

--- a/core/bin/external_node/src/tests/framework.rs
+++ b/core/bin/external_node/src/tests/framework.rs
@@ -17,7 +17,7 @@ use zksync_node_framework::{
     task::TaskKind,
     FromContext, IntoContext, StopReceiver, Task, TaskId, WiringError, WiringLayer,
 };
-use zksync_types::{L1ChainId, L2ChainId};
+use zksync_types::{L2ChainId, SLChainId};
 use zksync_web3_decl::client::{MockClient, L1, L2};
 
 use super::ExternalNodeBuilder;
@@ -127,7 +127,7 @@ impl WiringLayer for MockL1ClientLayer {
 
     fn layer_name(&self) -> &'static str {
         // We don't care about values, we just want to hijack the layer name.
-        QueryEthClientLayer::new(L1ChainId(1), "https://example.com".parse().unwrap()).layer_name()
+        QueryEthClientLayer::new(SLChainId(1), "https://example.com".parse().unwrap()).layer_name()
     }
 
     async fn wire(self, _: Self::Input) -> Result<Self::Output, WiringError> {

--- a/core/bin/zksync_server/src/node_builder.rs
+++ b/core/bin/zksync_server/src/node_builder.rs
@@ -142,7 +142,7 @@ impl MainNodeBuilder {
         self.node.add_layer(PKSigningEthClientLayer::new(
             eth_config,
             self.contracts_config.clone(),
-            self.genesis_config.l1_chain_id,
+            self.genesis_config.get_settlement_layer_id(),
             wallets,
         ));
         Ok(self)
@@ -152,7 +152,7 @@ impl MainNodeBuilder {
         let genesis = self.genesis_config.clone();
         let eth_config = try_load_config!(self.secrets.l1);
         let query_eth_client_layer =
-            QueryEthClientLayer::new(genesis.l1_chain_id, eth_config.l1_rpc_url);
+            QueryEthClientLayer::new(genesis.get_settlement_layer_id(), eth_config.l1_rpc_url);
         self.node.add_layer(query_eth_client_layer);
         Ok(self)
     }

--- a/core/lib/basic_types/src/lib.rs
+++ b/core/lib/basic_types/src/lib.rs
@@ -214,10 +214,26 @@ basic_type!(
 );
 
 basic_type!(
+    /// ChainId of a settlement layer.
+    SLChainId,
+    u64
+);
+
+basic_type!(
     /// ChainId in the Ethereum network.
+    /// IMPORTANT: Please, use this method when exactly the L1 chain id is required.
+    /// Note, that typically this is not the case and the majority of methods need to work
+    /// with *settlement layer* chain id, which is represented by `SLChainId`.
     L1ChainId,
     u64
 );
+
+// Every L1 can be a settlement layer.
+impl From<L1ChainId> for SLChainId {
+    fn from(value: L1ChainId) -> Self {
+        SLChainId(value.0)
+    }
+}
 
 #[allow(clippy::derivable_impls)]
 impl Default for L2BlockNumber {

--- a/core/lib/basic_types/src/network.rs
+++ b/core/lib/basic_types/src/network.rs
@@ -8,7 +8,7 @@ use std::{fmt, str::FromStr};
 use serde::{Deserialize, Serialize};
 
 // Workspace uses
-use crate::L1ChainId;
+use crate::SLChainId;
 
 // Local uses
 
@@ -28,6 +28,8 @@ pub enum Network {
     Sepolia,
     /// Self-hosted Ethereum network.
     Localhost,
+    /// Self-hosted L2 network.
+    LocalhostL2,
     /// Unknown network type.
     Unknown,
     /// Test network for testkit purposes
@@ -44,6 +46,7 @@ impl FromStr for Network {
             "ropsten" => Self::Ropsten,
             "goerli" => Self::Goerli,
             "localhost" => Self::Localhost,
+            "localhostL2" => Self::LocalhostL2,
             "sepolia" => Self::Sepolia,
             "test" => Self::Test,
             another => return Err(another.to_owned()),
@@ -59,6 +62,7 @@ impl fmt::Display for Network {
             Self::Ropsten => write!(f, "ropsten"),
             Self::Goerli => write!(f, "goerli"),
             Self::Localhost => write!(f, "localhost"),
+            Self::LocalhostL2 => write!(f, "localhostL2"),
             Self::Sepolia => write!(f, "sepolia"),
             Self::Unknown => write!(f, "unknown"),
             Self::Test => write!(f, "test"),
@@ -68,7 +72,7 @@ impl fmt::Display for Network {
 
 impl Network {
     /// Returns the network chain ID on the Ethereum side.
-    pub fn from_chain_id(chain_id: L1ChainId) -> Self {
+    pub fn from_chain_id(chain_id: SLChainId) -> Self {
         match *chain_id {
             1 => Self::Mainnet,
             3 => Self::Ropsten,
@@ -76,19 +80,21 @@ impl Network {
             5 => Self::Goerli,
             9 => Self::Localhost,
             11155111 => Self::Sepolia,
+            270 => Self::LocalhostL2,
             _ => Self::Unknown,
         }
     }
 
     /// Returns the network chain ID on the Ethereum side.
-    pub fn chain_id(self) -> L1ChainId {
+    pub fn chain_id(self) -> SLChainId {
         match self {
-            Self::Mainnet => L1ChainId(1),
-            Self::Ropsten => L1ChainId(3),
-            Self::Rinkeby => L1ChainId(4),
-            Self::Goerli => L1ChainId(5),
-            Self::Localhost => L1ChainId(9),
-            Self::Sepolia => L1ChainId(11155111),
+            Self::Mainnet => SLChainId(1),
+            Self::Ropsten => SLChainId(3),
+            Self::Rinkeby => SLChainId(4),
+            Self::Goerli => SLChainId(5),
+            Self::Localhost => SLChainId(9),
+            Self::Sepolia => SLChainId(11155111),
+            Self::LocalhostL2 => SLChainId(270),
             Self::Unknown => panic!("Unknown chain ID"),
             Self::Test => panic!("Test chain ID"),
         }

--- a/core/lib/config/src/configs/en_config.rs
+++ b/core/lib/config/src/configs/en_config.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroUsize;
 
 use serde::Deserialize;
 use zksync_basic_types::{
-    commitment::L1BatchCommitmentMode, url::SensitiveUrl, L1ChainId, L2ChainId,
+    commitment::L1BatchCommitmentMode, url::SensitiveUrl, L2ChainId, SLChainId,
 };
 
 /// Temporary config for initializing external node, will be completely replaced by consensus config later
@@ -10,7 +10,7 @@ use zksync_basic_types::{
 pub struct ENConfig {
     // Genesis
     pub l2_chain_id: L2ChainId,
-    pub l1_chain_id: L1ChainId,
+    pub l1_chain_id: SLChainId,
     pub l1_batch_commit_data_generator_mode: L1BatchCommitmentMode,
 
     // Main node configuration

--- a/core/lib/config/src/configs/en_config.rs
+++ b/core/lib/config/src/configs/en_config.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroUsize;
 
 use serde::Deserialize;
 use zksync_basic_types::{
-    commitment::L1BatchCommitmentMode, url::SensitiveUrl, L2ChainId, SLChainId,
+    commitment::L1BatchCommitmentMode, url::SensitiveUrl, L1ChainId, L2ChainId, SLChainId,
 };
 
 /// Temporary config for initializing external node, will be completely replaced by consensus config later
@@ -10,7 +10,8 @@ use zksync_basic_types::{
 pub struct ENConfig {
     // Genesis
     pub l2_chain_id: L2ChainId,
-    pub l1_chain_id: SLChainId,
+    pub sl_chain_id: Option<SLChainId>,
+    pub l1_chain_id: L1ChainId,
     pub l1_batch_commit_data_generator_mode: L1BatchCommitmentMode,
 
     // Main node configuration

--- a/core/lib/config/src/configs/genesis.rs
+++ b/core/lib/config/src/configs/genesis.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use zksync_basic_types::{
     commitment::L1BatchCommitmentMode,
     protocol_version::{ProtocolSemanticVersion, ProtocolVersionId},
-    Address, L1ChainId, L2ChainId, H256,
+    Address, L1ChainId, L2ChainId, SLChainId, H256,
 };
 
 /// This config represents the genesis state of the chain.
@@ -18,11 +18,18 @@ pub struct GenesisConfig {
     pub bootloader_hash: Option<H256>,
     pub default_aa_hash: Option<H256>,
     pub l1_chain_id: L1ChainId,
+    pub sl_chain_id: Option<SLChainId>,
     pub l2_chain_id: L2ChainId,
     pub recursion_scheduler_level_vk_hash: H256,
     pub fee_account: Address,
     pub dummy_verifier: bool,
     pub l1_batch_commit_data_generator_mode: L1BatchCommitmentMode,
+}
+
+impl GenesisConfig {
+    pub fn get_settlement_layer_id(&self) -> SLChainId {
+        self.sl_chain_id.unwrap_or(self.l1_chain_id.into())
+    }
 }
 
 impl GenesisConfig {
@@ -36,6 +43,7 @@ impl GenesisConfig {
             bootloader_hash: Default::default(),
             default_aa_hash: Default::default(),
             l1_chain_id: L1ChainId(9),
+            sl_chain_id: None,
             protocol_version: Some(ProtocolSemanticVersion {
                 minor: ProtocolVersionId::latest(),
                 patch: 0.into(),

--- a/core/lib/config/src/testonly.rs
+++ b/core/lib/config/src/testonly.rs
@@ -6,7 +6,7 @@ use zksync_basic_types::{
     commitment::L1BatchCommitmentMode,
     network::Network,
     protocol_version::{ProtocolSemanticVersion, ProtocolVersionId, VersionPatch},
-    L1BatchNumber, L1ChainId, L2ChainId,
+    L1BatchNumber, L2ChainId, SLChainId,
 };
 use zksync_consensus_utils::EncodeDist;
 use zksync_crypto_primitives::K256PrivateKey;
@@ -701,7 +701,7 @@ impl Distribution<configs::GenesisConfig> for EncodeDist {
             bootloader_hash: Some(rng.gen()),
             default_aa_hash: Some(rng.gen()),
             fee_account: rng.gen(),
-            l1_chain_id: L1ChainId(self.sample(rng)),
+            l1_chain_id: SLChainId(self.sample(rng)),
             l2_chain_id: L2ChainId::default(),
             recursion_scheduler_level_vk_hash: rng.gen(),
             dummy_verifier: rng.gen(),
@@ -873,7 +873,7 @@ impl Distribution<configs::en_config::ENConfig> for EncodeDist {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> configs::en_config::ENConfig {
         configs::en_config::ENConfig {
             l2_chain_id: L2ChainId::default(),
-            l1_chain_id: L1ChainId(rng.gen()),
+            l1_chain_id: SLChainId(rng.gen()),
             main_node_url: format!("localhost:{}", rng.gen::<u16>()).parse().unwrap(),
             l1_batch_commit_data_generator_mode: match rng.gen_range(0..2) {
                 0 => L1BatchCommitmentMode::Rollup,

--- a/core/lib/config/src/testonly.rs
+++ b/core/lib/config/src/testonly.rs
@@ -6,7 +6,7 @@ use zksync_basic_types::{
     commitment::L1BatchCommitmentMode,
     network::Network,
     protocol_version::{ProtocolSemanticVersion, ProtocolVersionId, VersionPatch},
-    L1BatchNumber, L2ChainId, SLChainId,
+    L1BatchNumber, L1ChainId, L2ChainId, SLChainId,
 };
 use zksync_consensus_utils::EncodeDist;
 use zksync_crypto_primitives::K256PrivateKey;
@@ -701,7 +701,8 @@ impl Distribution<configs::GenesisConfig> for EncodeDist {
             bootloader_hash: Some(rng.gen()),
             default_aa_hash: Some(rng.gen()),
             fee_account: rng.gen(),
-            l1_chain_id: SLChainId(self.sample(rng)),
+            l1_chain_id: L1ChainId(self.sample(rng)),
+            sl_chain_id: None,
             l2_chain_id: L2ChainId::default(),
             recursion_scheduler_level_vk_hash: rng.gen(),
             dummy_verifier: rng.gen(),
@@ -873,7 +874,8 @@ impl Distribution<configs::en_config::ENConfig> for EncodeDist {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> configs::en_config::ENConfig {
         configs::en_config::ENConfig {
             l2_chain_id: L2ChainId::default(),
-            l1_chain_id: SLChainId(rng.gen()),
+            l1_chain_id: L1ChainId(rng.gen()),
+            sl_chain_id: Some(SLChainId(rng.gen())),
             main_node_url: format!("localhost:{}", rng.gen::<u16>()).parse().unwrap(),
             l1_batch_commit_data_generator_mode: match rng.gen_range(0..2) {
                 0 => L1BatchCommitmentMode::Rollup,

--- a/core/lib/env_config/src/genesis.rs
+++ b/core/lib/env_config/src/genesis.rs
@@ -68,8 +68,8 @@ impl FromEnv for GenesisConfig {
             genesis_commitment: contracts_config.genesis_batch_commitment,
             bootloader_hash: state_keeper.bootloader_hash,
             default_aa_hash: state_keeper.default_aa_hash,
-            // FIXME: double check whether we can remove it
-            l1_chain_id: L1ChainId(9),
+            // TODO(X): for now, the settlement layer is always the same as the L1 network
+            l1_chain_id: L1ChainId(network_config.network.chain_id().0),
             sl_chain_id: Some(network_config.network.chain_id()),
             l2_chain_id: network_config.zksync_network_id,
             recursion_scheduler_level_vk_hash: contracts_config.snark_wrapper_vk_hash,

--- a/core/lib/env_config/src/genesis.rs
+++ b/core/lib/env_config/src/genesis.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
-use zksync_basic_types::{protocol_version::ProtocolSemanticVersion, Address, H256};
+use zksync_basic_types::{protocol_version::ProtocolSemanticVersion, Address, L1ChainId, H256};
 use zksync_config::{
     configs::chain::{NetworkConfig, StateKeeperConfig},
     GenesisConfig,
@@ -68,7 +68,9 @@ impl FromEnv for GenesisConfig {
             genesis_commitment: contracts_config.genesis_batch_commitment,
             bootloader_hash: state_keeper.bootloader_hash,
             default_aa_hash: state_keeper.default_aa_hash,
-            l1_chain_id: network_config.network.chain_id(),
+            // FIXME: double check whether we can remove it
+            l1_chain_id: L1ChainId(9),
+            sl_chain_id: Some(network_config.network.chain_id()),
             l2_chain_id: network_config.zksync_network_id,
             recursion_scheduler_level_vk_hash: contracts_config.snark_wrapper_vk_hash,
             fee_account: state_keeper

--- a/core/lib/eth_client/src/clients/http/query.rs
+++ b/core/lib/eth_client/src/clients/http/query.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use async_trait::async_trait;
 use jsonrpsee::core::ClientError;
-use zksync_types::{web3, Address, L1ChainId, H256, U256, U64};
+use zksync_types::{web3, Address, SLChainId, H256, U256, U64};
 use zksync_web3_decl::error::{ClientRpcContext, EnrichedClientError, EnrichedClientResult};
 
 use super::{decl::L1EthNamespaceClient, Method, COUNTERS, LATENCIES};
@@ -16,7 +16,7 @@ impl<T> EthInterface for T
 where
     T: L1EthNamespaceClient + fmt::Debug + Send + Sync,
 {
-    async fn fetch_chain_id(&self) -> EnrichedClientResult<L1ChainId> {
+    async fn fetch_chain_id(&self) -> EnrichedClientResult<SLChainId> {
         COUNTERS.call[&(Method::ChainId, self.component())].inc();
         let latency = LATENCIES.direct[&Method::ChainId].start();
         let raw_chain_id = self.chain_id().rpc_context("chain_id").await?;
@@ -25,7 +25,7 @@ where
             let err = ClientError::Custom(format!("invalid chainId: {err}"));
             EnrichedClientError::new(err, "chain_id").with_arg("chain_id", &raw_chain_id)
         })?;
-        Ok(L1ChainId(chain_id))
+        Ok(SLChainId(chain_id))
     }
 
     async fn nonce_at_for_account(

--- a/core/lib/eth_client/src/clients/http/signing.rs
+++ b/core/lib/eth_client/src/clients/http/signing.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use zksync_contracts::hyperchain_contract;
 use zksync_eth_signer::{EthereumSigner, PrivateKeySigner, TransactionParameters};
 use zksync_types::{
-    ethabi, web3, Address, K256PrivateKey, L1ChainId, EIP_4844_TX_TYPE, H160, U256,
+    ethabi, web3, Address, K256PrivateKey, SLChainId, EIP_4844_TX_TYPE, H160, U256,
 };
 use zksync_web3_decl::client::{DynClient, L1};
 
@@ -22,7 +22,7 @@ impl PKSigningClient {
         operator_private_key: K256PrivateKey,
         diamond_proxy_addr: Address,
         default_priority_fee_per_gas: u64,
-        l1_chain_id: L1ChainId,
+        l1_chain_id: SLChainId,
         query_client: Box<DynClient<L1>>,
     ) -> Self {
         let operator_address = operator_private_key.address();
@@ -58,7 +58,7 @@ struct EthDirectClientInner<S: EthereumSigner> {
     sender_account: Address,
     contract_addr: H160,
     contract: ethabi::Contract,
-    chain_id: L1ChainId,
+    chain_id: SLChainId,
     default_priority_fee_per_gas: U256,
 }
 
@@ -101,7 +101,7 @@ impl<S: EthereumSigner> BoundEthInterface for SigningClient<S> {
         self.inner.contract_addr
     }
 
-    fn chain_id(&self) -> L1ChainId {
+    fn chain_id(&self) -> SLChainId {
         self.inner.chain_id
     }
 
@@ -217,7 +217,7 @@ impl<S: EthereumSigner> SigningClient<S> {
         eth_signer: S,
         contract_eth_addr: H160,
         default_priority_fee_per_gas: U256,
-        chain_id: L1ChainId,
+        chain_id: SLChainId,
     ) -> Self {
         Self {
             inner: Arc::new(EthDirectClientInner {

--- a/core/lib/eth_client/src/clients/http/signing.rs
+++ b/core/lib/eth_client/src/clients/http/signing.rs
@@ -22,7 +22,7 @@ impl PKSigningClient {
         operator_private_key: K256PrivateKey,
         diamond_proxy_addr: Address,
         default_priority_fee_per_gas: u64,
-        l1_chain_id: SLChainId,
+        chain_id: SLChainId,
         query_client: Box<DynClient<L1>>,
     ) -> Self {
         let operator_address = operator_private_key.address();
@@ -35,7 +35,7 @@ impl PKSigningClient {
             signer,
             diamond_proxy_addr,
             default_priority_fee_per_gas.into(),
-            l1_chain_id,
+            chain_id,
         )
     }
 }

--- a/core/lib/eth_client/src/clients/mock.rs
+++ b/core/lib/eth_client/src/clients/mock.rs
@@ -8,7 +8,7 @@ use jsonrpsee::{core::ClientError, types::ErrorObject};
 use zksync_types::{
     ethabi,
     web3::{self, contract::Tokenize, BlockId},
-    Address, L1ChainId, H160, H256, U256, U64,
+    Address, SLChainId, H160, H256, U256, U64,
 };
 use zksync_web3_decl::client::{DynClient, MockClient, L1};
 
@@ -315,7 +315,7 @@ impl MockEthereumBuilder {
     }
 
     fn build_client(self) -> MockClient<L1> {
-        const CHAIN_ID: L1ChainId = L1ChainId(9);
+        const CHAIN_ID: SLChainId = SLChainId(9);
 
         let base_fee_history = self.base_fee_history.clone();
         let call_handler = self.call_handler;
@@ -540,7 +540,7 @@ impl BoundEthInterface for MockEthereum {
         H160::repeat_byte(0x22)
     }
 
-    fn chain_id(&self) -> L1ChainId {
+    fn chain_id(&self) -> SLChainId {
         unimplemented!("Not needed right now")
     }
 
@@ -617,7 +617,7 @@ mod tests {
     async fn getting_chain_id() {
         let mock = MockEthereum::builder().build();
         let chain_id = mock.client.fetch_chain_id().await.unwrap();
-        assert_eq!(chain_id, L1ChainId(9));
+        assert_eq!(chain_id, SLChainId(9));
     }
 
     #[tokio::test]

--- a/core/lib/eth_client/src/lib.rs
+++ b/core/lib/eth_client/src/lib.rs
@@ -8,7 +8,7 @@ use zksync_types::{
         AccessList, Block, BlockId, BlockNumber, Filter, Log, Transaction, TransactionCondition,
         TransactionReceipt,
     },
-    Address, L1ChainId, H160, H256, U256, U64,
+    Address, SLChainId, H160, H256, U256, U64,
 };
 use zksync_web3_decl::client::{DynClient, L1};
 pub use zksync_web3_decl::{
@@ -86,7 +86,7 @@ pub struct BaseFees {
 pub trait EthInterface: Sync + Send {
     /// Fetches the L1 chain ID (in contrast to [`BoundEthInterface::chain_id()`] which returns
     /// the *expected* L1 chain ID).
-    async fn fetch_chain_id(&self) -> EnrichedClientResult<L1ChainId>;
+    async fn fetch_chain_id(&self) -> EnrichedClientResult<SLChainId>;
 
     /// Returns the nonce of the provided account at the specified block.
     async fn nonce_at_for_account(
@@ -186,7 +186,7 @@ pub trait BoundEthInterface: AsRef<DynClient<L1>> + 'static + Sync + Send + fmt:
     ///
     /// This value should be externally provided by the user rather than requested from the network
     /// to avoid accidental network mismatch.
-    fn chain_id(&self) -> L1ChainId;
+    fn chain_id(&self) -> SLChainId;
 
     /// Address of the account associated with the object implementing the trait.
     fn sender_account(&self) -> Address;

--- a/core/lib/protobuf_config/src/en.rs
+++ b/core/lib/protobuf_config/src/en.rs
@@ -4,6 +4,7 @@ use anyhow::Context;
 use zksync_basic_types::{url::SensitiveUrl, L2ChainId, SLChainId};
 use zksync_config::configs::en_config::ENConfig;
 use zksync_protobuf::{required, ProtoRepr};
+use zksync_types::L1ChainId;
 
 use crate::proto::en as proto;
 
@@ -16,8 +17,14 @@ impl ProtoRepr for proto::ExternalNode {
                 required(&self.main_node_url).context("main_node_url")?,
             )?,
             l1_chain_id: required(&self.l1_chain_id)
-                .map(|x| SLChainId(*x))
+                .map(|x| L1ChainId(*x))
                 .context("l1_chain_id")?,
+            // For now, the settlement layer is always the same as the L1 network
+            sl_chain_id: Some(
+                required(&self.l1_chain_id)
+                    .map(|x| SLChainId(*x))
+                    .context("l1_chain_id")?,
+            ),
             l2_chain_id: required(&self.l2_chain_id)
                 .and_then(|x| L2ChainId::try_from(*x).map_err(|a| anyhow::anyhow!(a)))
                 .context("l2_chain_id")?,

--- a/core/lib/protobuf_config/src/en.rs
+++ b/core/lib/protobuf_config/src/en.rs
@@ -1,7 +1,7 @@
 use std::{num::NonZeroUsize, str::FromStr};
 
 use anyhow::Context;
-use zksync_basic_types::{url::SensitiveUrl, L1ChainId, L2ChainId};
+use zksync_basic_types::{url::SensitiveUrl, L2ChainId, SLChainId};
 use zksync_config::configs::en_config::ENConfig;
 use zksync_protobuf::{required, ProtoRepr};
 
@@ -16,7 +16,7 @@ impl ProtoRepr for proto::ExternalNode {
                 required(&self.main_node_url).context("main_node_url")?,
             )?,
             l1_chain_id: required(&self.l1_chain_id)
-                .map(|x| L1ChainId(*x))
+                .map(|x| SLChainId(*x))
                 .context("l1_chain_id")?,
             l2_chain_id: required(&self.l2_chain_id)
                 .and_then(|x| L2ChainId::try_from(*x).map_err(|a| anyhow::anyhow!(a)))

--- a/core/lib/protobuf_config/src/en.rs
+++ b/core/lib/protobuf_config/src/en.rs
@@ -19,7 +19,7 @@ impl ProtoRepr for proto::ExternalNode {
             l1_chain_id: required(&self.l1_chain_id)
                 .map(|x| L1ChainId(*x))
                 .context("l1_chain_id")?,
-            // For now, the settlement layer is always the same as the L1 network
+            // TODO(X): for now, the settlement layer is always the same as the L1 network
             sl_chain_id: Some(
                 required(&self.l1_chain_id)
                     .map(|x| SLChainId(*x))

--- a/core/lib/protobuf_config/src/genesis.rs
+++ b/core/lib/protobuf_config/src/genesis.rs
@@ -72,7 +72,7 @@ impl ProtoRepr for proto::Genesis {
             l1_chain_id: required(&self.l1_chain_id)
                 .map(|x| L1ChainId(*x))
                 .context("l1_chain_id")?,
-            // For now, the settlement layer is always the same as the L1 network
+            // TODO(X): for now, the settlement layer is always the same as the L1 network
             sl_chain_id: Some(
                 required(&self.l1_chain_id)
                     .map(|x| SLChainId(*x))

--- a/core/lib/protobuf_config/src/genesis.rs
+++ b/core/lib/protobuf_config/src/genesis.rs
@@ -7,6 +7,7 @@ use zksync_basic_types::{
 };
 use zksync_config::configs;
 use zksync_protobuf::{repr::ProtoRepr, required};
+use zksync_types::L1ChainId;
 
 use crate::{parse_h160, parse_h256, proto::genesis as proto};
 
@@ -69,8 +70,14 @@ impl ProtoRepr for proto::Genesis {
                     .context("default_aa_hash")?,
             ),
             l1_chain_id: required(&self.l1_chain_id)
-                .map(|x| SLChainId(*x))
+                .map(|x| L1ChainId(*x))
                 .context("l1_chain_id")?,
+            // For now, the settlement layer is always the same as the L1 network
+            sl_chain_id: Some(
+                required(&self.l1_chain_id)
+                    .map(|x| SLChainId(*x))
+                    .context("l1_chain_id")?,
+            ),
             l2_chain_id: required(&self.l2_chain_id)
                 .and_then(|x| L2ChainId::try_from(*x).map_err(|a| anyhow::anyhow!(a)))
                 .context("l2_chain_id")?,

--- a/core/lib/protobuf_config/src/genesis.rs
+++ b/core/lib/protobuf_config/src/genesis.rs
@@ -2,8 +2,8 @@ use std::str::FromStr;
 
 use anyhow::Context as _;
 use zksync_basic_types::{
-    commitment::L1BatchCommitmentMode, protocol_version::ProtocolSemanticVersion, L1ChainId,
-    L2ChainId,
+    commitment::L1BatchCommitmentMode, protocol_version::ProtocolSemanticVersion, L2ChainId,
+    SLChainId,
 };
 use zksync_config::configs;
 use zksync_protobuf::{repr::ProtoRepr, required};
@@ -69,7 +69,7 @@ impl ProtoRepr for proto::Genesis {
                     .context("default_aa_hash")?,
             ),
             l1_chain_id: required(&self.l1_chain_id)
-                .map(|x| L1ChainId(*x))
+                .map(|x| SLChainId(*x))
                 .context("l1_chain_id")?,
             l2_chain_id: required(&self.l2_chain_id)
                 .and_then(|x| L2ChainId::try_from(*x).map_err(|a| anyhow::anyhow!(a)))

--- a/core/lib/web3_decl/src/client/network.rs
+++ b/core/lib/web3_decl/src/client/network.rs
@@ -12,7 +12,8 @@ pub trait Network: 'static + Copy + Default + Sync + Send + fmt::Debug {
     fn metric_label(&self) -> String;
 }
 
-/// L1 (i.e., Ethereum) network.
+/// L1-compatible (e.g., Ethereum) network.
+/// Note, that this network does not have to be an L1. It can be any network that is compatible with Ethereum JSON-RPC.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct L1(Option<SLChainId>);
 

--- a/core/lib/web3_decl/src/client/network.rs
+++ b/core/lib/web3_decl/src/client/network.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use zksync_types::{L1ChainId, L2ChainId};
+use zksync_types::{L2ChainId, SLChainId};
 
 /// Marker trait for networks. Two standard network kinds are [`L1`] and [`L2`].
 ///
@@ -14,7 +14,7 @@ pub trait Network: 'static + Copy + Default + Sync + Send + fmt::Debug {
 
 /// L1 (i.e., Ethereum) network.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct L1(Option<L1ChainId>);
+pub struct L1(Option<SLChainId>);
 
 impl Network for L1 {
     fn metric_label(&self) -> String {
@@ -26,8 +26,8 @@ impl Network for L1 {
     }
 }
 
-impl From<L1ChainId> for L1 {
-    fn from(chain_id: L1ChainId) -> Self {
+impl From<SLChainId> for L1 {
+    fn from(chain_id: SLChainId) -> Self {
         Self(Some(chain_id))
     }
 }

--- a/core/node/api_server/src/web3/namespaces/en.rs
+++ b/core/node/api_server/src/web3/namespaces/en.rs
@@ -150,6 +150,7 @@ impl EnNamespace {
             bootloader_hash: Some(genesis_batch.header.base_system_contracts_hashes.bootloader),
             default_aa_hash: Some(genesis_batch.header.base_system_contracts_hashes.default_aa),
             l1_chain_id: self.state.api_config.l1_chain_id,
+            sl_chain_id: Some(self.state.api_config.l1_chain_id.into()),
             l2_chain_id: self.state.api_config.l2_chain_id,
             recursion_scheduler_level_vk_hash: verifier_config.recursion_scheduler_level_vk_hash,
             fee_account,

--- a/core/node/api_server/src/web3/state.rs
+++ b/core/node/api_server/src/web3/state.rs
@@ -21,7 +21,7 @@ use zksync_metadata_calculator::api_server::TreeApiClient;
 use zksync_node_sync::SyncState;
 use zksync_types::{
     api, commitment::L1BatchCommitmentMode, l2::L2Tx, transaction_request::CallRequest, Address,
-    L1BatchNumber, L1ChainId, L2BlockNumber, L2ChainId, H256, U256, U64,
+    L1BatchNumber, L1ChainId, L2BlockNumber, L2ChainId, SLChainId, H256, U256, U64,
 };
 use zksync_web3_decl::{error::Web3Error, types::Filter};
 
@@ -95,6 +95,7 @@ impl BlockStartInfo {
 /// The intention is to only keep the actually used information here.
 #[derive(Debug, Clone)]
 pub struct InternalApiConfig {
+    /// Chain ID of the L1 network. Note, that it may be different from the chain id of the settlement layer.
     pub l1_chain_id: L1ChainId,
     pub l2_chain_id: L2ChainId,
     pub max_tx_size: usize,

--- a/core/node/fee_model/src/l1_gas_price/singleton.rs
+++ b/core/node/fee_model/src/l1_gas_price/singleton.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::Context as _;
 use tokio::{sync::watch, task::JoinHandle};
 use zksync_config::{configs::eth_sender::PubdataSendingMode, GasAdjusterConfig};
-use zksync_types::{commitment::L1BatchCommitmentMode, url::SensitiveUrl, L1ChainId};
+use zksync_types::{commitment::L1BatchCommitmentMode, url::SensitiveUrl, SLChainId};
 use zksync_web3_decl::client::Client;
 
 use crate::l1_gas_price::GasAdjuster;
@@ -12,7 +12,7 @@ use crate::l1_gas_price::GasAdjuster;
 /// This is needed only for running the server.
 #[derive(Debug)]
 pub struct GasAdjusterSingleton {
-    chain_id: L1ChainId,
+    chain_id: SLChainId,
     web3_url: SensitiveUrl,
     gas_adjuster_config: GasAdjusterConfig,
     pubdata_sending_mode: PubdataSendingMode,
@@ -22,7 +22,7 @@ pub struct GasAdjusterSingleton {
 
 impl GasAdjusterSingleton {
     pub fn new(
-        chain_id: L1ChainId,
+        chain_id: SLChainId,
         web3_url: SensitiveUrl,
         gas_adjuster_config: GasAdjusterConfig,
         pubdata_sending_mode: PubdataSendingMode,

--- a/core/node/genesis/src/lib.rs
+++ b/core/node/genesis/src/lib.rs
@@ -159,7 +159,7 @@ pub struct GenesisBatchParams {
 }
 
 pub fn mock_genesis_config() -> GenesisConfig {
-    use zksync_types::L1ChainId;
+    use zksync_types::SLChainId;
 
     let base_system_contracts_hashes = BaseSystemContracts::load_from_disk().hashes();
     let first_l1_verifier_config = L1VerifierConfig::default();
@@ -174,7 +174,7 @@ pub fn mock_genesis_config() -> GenesisConfig {
         genesis_commitment: Some(H256::default()),
         bootloader_hash: Some(base_system_contracts_hashes.bootloader),
         default_aa_hash: Some(base_system_contracts_hashes.default_aa),
-        l1_chain_id: L1ChainId(9),
+        l1_chain_id: SLChainId(9),
         l2_chain_id: L2ChainId::default(),
         recursion_scheduler_level_vk_hash: first_l1_verifier_config
             .recursion_scheduler_level_vk_hash,

--- a/core/node/genesis/src/lib.rs
+++ b/core/node/genesis/src/lib.rs
@@ -20,7 +20,7 @@ use zksync_types::{
     protocol_version::{L1VerifierConfig, ProtocolSemanticVersion},
     system_contracts::get_system_smart_contracts,
     web3::{BlockNumber, FilterBuilder},
-    AccountTreeId, Address, L1BatchNumber, L2BlockNumber, L2ChainId, ProtocolVersion,
+    AccountTreeId, Address, L1BatchNumber, L1ChainId, L2BlockNumber, L2ChainId, ProtocolVersion,
     ProtocolVersionId, StorageKey, H256,
 };
 use zksync_utils::{bytecode::hash_bytecode, u256_to_h256};
@@ -174,7 +174,8 @@ pub fn mock_genesis_config() -> GenesisConfig {
         genesis_commitment: Some(H256::default()),
         bootloader_hash: Some(base_system_contracts_hashes.bootloader),
         default_aa_hash: Some(base_system_contracts_hashes.default_aa),
-        l1_chain_id: SLChainId(9),
+        l1_chain_id: L1ChainId(9),
+        sl_chain_id: None,
         l2_chain_id: L2ChainId::default(),
         recursion_scheduler_level_vk_hash: first_l1_verifier_config
             .recursion_scheduler_level_vk_hash,

--- a/core/node/node_framework/src/implementations/layers/pk_signing_eth_client.rs
+++ b/core/node/node_framework/src/implementations/layers/pk_signing_eth_client.rs
@@ -19,7 +19,7 @@ use crate::{
 pub struct PKSigningEthClientLayer {
     eth_sender_config: EthConfig,
     contracts_config: ContractsConfig,
-    l1_chain_id: SLChainId,
+    sl_chain_id: SLChainId,
     wallets: wallets::EthSender,
 }
 
@@ -41,13 +41,13 @@ impl PKSigningEthClientLayer {
     pub fn new(
         eth_sender_config: EthConfig,
         contracts_config: ContractsConfig,
-        l1_chain_id: SLChainId,
+        sl_chain_id: SLChainId,
         wallets: wallets::EthSender,
     ) -> Self {
         Self {
             eth_sender_config,
             contracts_config,
-            l1_chain_id,
+            sl_chain_id,
             wallets,
         }
     }
@@ -75,7 +75,7 @@ impl WiringLayer for PKSigningEthClientLayer {
             private_key.clone(),
             self.contracts_config.diamond_proxy_addr,
             gas_adjuster_config.default_priority_fee_per_gas,
-            self.l1_chain_id,
+            self.sl_chain_id,
             query_client.clone(),
         );
         let signing_client = BoundEthInterfaceResource(Box::new(signing_client));
@@ -86,7 +86,7 @@ impl WiringLayer for PKSigningEthClientLayer {
                 private_key.clone(),
                 self.contracts_config.diamond_proxy_addr,
                 gas_adjuster_config.default_priority_fee_per_gas,
-                self.l1_chain_id,
+                self.sl_chain_id,
                 query_client,
             );
             BoundEthInterfaceForBlobsResource(Box::new(signing_client_for_blobs))

--- a/core/node/node_framework/src/implementations/layers/pk_signing_eth_client.rs
+++ b/core/node/node_framework/src/implementations/layers/pk_signing_eth_client.rs
@@ -4,7 +4,7 @@ use zksync_config::{
     EthConfig,
 };
 use zksync_eth_client::clients::PKSigningClient;
-use zksync_types::L1ChainId;
+use zksync_types::SLChainId;
 
 use crate::{
     implementations::resources::eth_interface::{
@@ -19,7 +19,7 @@ use crate::{
 pub struct PKSigningEthClientLayer {
     eth_sender_config: EthConfig,
     contracts_config: ContractsConfig,
-    l1_chain_id: L1ChainId,
+    l1_chain_id: SLChainId,
     wallets: wallets::EthSender,
 }
 
@@ -41,7 +41,7 @@ impl PKSigningEthClientLayer {
     pub fn new(
         eth_sender_config: EthConfig,
         contracts_config: ContractsConfig,
-        l1_chain_id: L1ChainId,
+        l1_chain_id: SLChainId,
         wallets: wallets::EthSender,
     ) -> Self {
         Self {

--- a/core/node/node_framework/src/implementations/layers/query_eth_client.rs
+++ b/core/node/node_framework/src/implementations/layers/query_eth_client.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use zksync_types::{url::SensitiveUrl, L1ChainId};
+use zksync_types::{url::SensitiveUrl, SLChainId};
 use zksync_web3_decl::client::Client;
 
 use crate::{
@@ -10,12 +10,12 @@ use crate::{
 /// Wiring layer for Ethereum client.
 #[derive(Debug)]
 pub struct QueryEthClientLayer {
-    chain_id: L1ChainId,
+    chain_id: SLChainId,
     web3_url: SensitiveUrl,
 }
 
 impl QueryEthClientLayer {
-    pub fn new(chain_id: L1ChainId, web3_url: SensitiveUrl) -> Self {
+    pub fn new(chain_id: SLChainId, web3_url: SensitiveUrl) -> Self {
         Self { chain_id, web3_url }
     }
 }

--- a/core/node/node_framework/src/implementations/layers/validate_chain_ids.rs
+++ b/core/node/node_framework/src/implementations/layers/validate_chain_ids.rs
@@ -1,5 +1,5 @@
 use zksync_node_sync::validate_chain_ids_task::ValidateChainIdsTask;
-use zksync_types::{L1ChainId, L2ChainId};
+use zksync_types::{L2ChainId, SLChainId};
 
 use crate::{
     implementations::resources::{
@@ -24,7 +24,7 @@ use crate::{
 /// - `ValidateChainIdsTask`
 #[derive(Debug)]
 pub struct ValidateChainIdsLayer {
-    l1_chain_id: L1ChainId,
+    l1_chain_id: SLChainId,
     l2_chain_id: L2ChainId,
 }
 
@@ -43,7 +43,7 @@ pub struct Output {
 }
 
 impl ValidateChainIdsLayer {
-    pub fn new(l1_chain_id: L1ChainId, l2_chain_id: L2ChainId) -> Self {
+    pub fn new(l1_chain_id: SLChainId, l2_chain_id: L2ChainId) -> Self {
         Self {
             l1_chain_id,
             l2_chain_id,

--- a/core/node/node_framework/src/implementations/layers/validate_chain_ids.rs
+++ b/core/node/node_framework/src/implementations/layers/validate_chain_ids.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// Wiring layer for chain ID validation precondition for external node.
-/// Ensures that chain IDs are consistent locally, on main node, and on L1.
+/// Ensures that chain IDs are consistent locally, on main node, and on the settlement layer.
 ///
 /// ## Requests resources
 ///
@@ -24,7 +24,7 @@ use crate::{
 /// - `ValidateChainIdsTask`
 #[derive(Debug)]
 pub struct ValidateChainIdsLayer {
-    l1_chain_id: SLChainId,
+    sl_chain_id: SLChainId,
     l2_chain_id: L2ChainId,
 }
 
@@ -43,9 +43,9 @@ pub struct Output {
 }
 
 impl ValidateChainIdsLayer {
-    pub fn new(l1_chain_id: SLChainId, l2_chain_id: L2ChainId) -> Self {
+    pub fn new(sl_chain_id: SLChainId, l2_chain_id: L2ChainId) -> Self {
         Self {
-            l1_chain_id,
+            sl_chain_id,
             l2_chain_id,
         }
     }
@@ -65,7 +65,7 @@ impl WiringLayer for ValidateChainIdsLayer {
         let MainNodeClientResource(main_node_client) = input.main_node_client;
 
         let task = ValidateChainIdsTask::new(
-            self.l1_chain_id,
+            self.sl_chain_id,
             self.l2_chain_id,
             query_client,
             main_node_client,

--- a/core/node/node_sync/src/validate_chain_ids_task.rs
+++ b/core/node/node_sync/src/validate_chain_ids_task.rs
@@ -15,7 +15,7 @@ use zksync_web3_decl::{
 /// Task that validates chain IDs using main node and Ethereum clients.
 #[derive(Debug)]
 pub struct ValidateChainIdsTask {
-    l1_chain_id: SLChainId,
+    sl_chain_id: SLChainId,
     l2_chain_id: L2ChainId,
     eth_client: Box<DynClient<L1>>,
     main_node_client: Box<DynClient<L2>>,
@@ -25,13 +25,13 @@ impl ValidateChainIdsTask {
     const BACKOFF_INTERVAL: Duration = Duration::from_secs(5);
 
     pub fn new(
-        l1_chain_id: SLChainId,
+        sl_chain_id: SLChainId,
         l2_chain_id: L2ChainId,
         eth_client: Box<DynClient<L1>>,
         main_node_client: Box<DynClient<L2>>,
     ) -> Self {
         Self {
-            l1_chain_id,
+            sl_chain_id,
             l2_chain_id,
             eth_client: eth_client.for_component("chain_ids_validation"),
             main_node_client: main_node_client.for_component("chain_ids_validation"),
@@ -140,9 +140,9 @@ impl ValidateChainIdsTask {
 
     /// Runs the task once, exiting either when all the checks are performed or when the stop signal is received.
     pub async fn run_once(self, mut stop_receiver: watch::Receiver<bool>) -> anyhow::Result<()> {
-        let eth_client_check = Self::check_eth_client(self.eth_client, self.l1_chain_id);
+        let eth_client_check = Self::check_eth_client(self.eth_client, self.sl_chain_id);
         let main_node_l1_check =
-            Self::check_l1_chain_using_main_node(self.main_node_client.clone(), self.l1_chain_id);
+            Self::check_l1_chain_using_main_node(self.main_node_client.clone(), self.sl_chain_id);
         let main_node_l2_check =
             Self::check_l2_chain_using_main_node(self.main_node_client, self.l2_chain_id);
         let joined_futures =
@@ -158,9 +158,9 @@ impl ValidateChainIdsTask {
     pub async fn run(self, mut stop_receiver: watch::Receiver<bool>) -> anyhow::Result<()> {
         // Since check futures are fused, they are safe to poll after getting resolved; they will never resolve again,
         // so we'll just wait for another check or a stop signal.
-        let eth_client_check = Self::check_eth_client(self.eth_client, self.l1_chain_id).fuse();
+        let eth_client_check = Self::check_eth_client(self.eth_client, self.sl_chain_id).fuse();
         let main_node_l1_check =
-            Self::check_l1_chain_using_main_node(self.main_node_client.clone(), self.l1_chain_id)
+            Self::check_l1_chain_using_main_node(self.main_node_client.clone(), self.sl_chain_id)
                 .fuse();
         let main_node_l2_check =
             Self::check_l2_chain_using_main_node(self.main_node_client, self.l2_chain_id).fuse();

--- a/core/node/node_sync/src/validate_chain_ids_task.rs
+++ b/core/node/node_sync/src/validate_chain_ids_task.rs
@@ -187,7 +187,7 @@ mod tests {
             .build();
         let main_node_client = MockClient::builder(L2::default())
             .method("eth_chainId", || Ok(U64::from(270)))
-            .method("zks_SLChainId", || Ok(U64::from(3)))
+            .method("zks_L1ChainId", || Ok(U64::from(3)))
             .build();
 
         let validation_task = ValidateChainIdsTask::new(
@@ -225,7 +225,7 @@ mod tests {
 
         let main_node_client = MockClient::builder(L2::default())
             .method("eth_chainId", || Ok(U64::from(270)))
-            .method("zks_SLChainId", || Ok(U64::from(9)))
+            .method("zks_L1ChainId", || Ok(U64::from(9)))
             .build();
 
         let validation_task = ValidateChainIdsTask::new(
@@ -252,7 +252,7 @@ mod tests {
             .build();
         let main_node_client = MockClient::builder(L2::default())
             .method("eth_chainId", || Ok(U64::from(270)))
-            .method("zks_SLChainId", || Ok(U64::from(9)))
+            .method("zks_L1ChainId", || Ok(U64::from(9)))
             .build();
 
         let validation_task = ValidateChainIdsTask::new(

--- a/core/tests/loadnext/src/sdk/ethereum/mod.rs
+++ b/core/tests/loadnext/src/sdk/ethereum/mod.rs
@@ -15,7 +15,7 @@ use zksync_types::{
     network::Network,
     url::SensitiveUrl,
     web3::{contract::Tokenize, TransactionReceipt},
-    Address, L1ChainId, L1TxCommonData, H160, H256, REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, U256,
+    Address, L1TxCommonData, SLChainId, H160, H256, REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, U256,
 };
 use zksync_web3_decl::{
     client::{Client, DynClient, L1},
@@ -87,7 +87,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
                 "Chain id overflow - Expected chain id to be in range 0..2^64".to_owned(),
             )
         })?;
-        let l1_chain_id = L1ChainId(l1_chain_id);
+        let l1_chain_id = SLChainId(l1_chain_id);
 
         let contract_address = provider.get_main_contract().await?;
         let default_bridges = provider

--- a/core/tests/loadnext/src/sdk/ethereum/mod.rs
+++ b/core/tests/loadnext/src/sdk/ethereum/mod.rs
@@ -87,7 +87,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
                 "Chain id overflow - Expected chain id to be in range 0..2^64".to_owned(),
             )
         })?;
-        let l1_chain_id = SLChainId(l1_chain_id);
+        let sl_chain_id = SLChainId(l1_chain_id);
 
         let contract_address = provider.get_main_contract().await?;
         let default_bridges = provider
@@ -101,7 +101,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
             .map_err(|err| ClientError::NetworkError(err.to_string()))?;
         let query_client = Client::http(eth_web3_url)
             .map_err(|err| ClientError::NetworkError(err.to_string()))?
-            .for_network(l1_chain_id.into())
+            .for_network(sl_chain_id.into())
             .build();
         let query_client: Box<DynClient<L1>> = Box::new(query_client);
         let eth_client = SigningClient::new(
@@ -111,7 +111,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
             eth_signer,
             contract_address,
             DEFAULT_PRIORITY_FEE.into(),
-            l1_chain_id,
+            sl_chain_id,
         );
         let erc20_abi = ierc20_contract();
         let l1_erc20_bridge_abi = l1_erc20_bridge_contract();

--- a/core/tests/ts-integration/tests/api/web3.test.ts
+++ b/core/tests/ts-integration/tests/api/web3.test.ts
@@ -118,7 +118,7 @@ describe('web3 API compatibility tests', () => {
             const tokenBalance = await alice.getBalance(l2Token);
             expect(balances[l2Token.toLowerCase()] == tokenBalance);
         }
-        // zks_SLChainId
+        // zks_L1ChainId
         const l1ChainId = (await alice.providerL1!.getNetwork()).chainId;
         const l1ChainIdFromL2Provider = BigInt(await alice.provider.l1ChainId());
         expect(l1ChainId).toEqual(l1ChainIdFromL2Provider);

--- a/core/tests/ts-integration/tests/api/web3.test.ts
+++ b/core/tests/ts-integration/tests/api/web3.test.ts
@@ -118,7 +118,7 @@ describe('web3 API compatibility tests', () => {
             const tokenBalance = await alice.getBalance(l2Token);
             expect(balances[l2Token.toLowerCase()] == tokenBalance);
         }
-        // zks_L1ChainId
+        // zks_SLChainId
         const l1ChainId = (await alice.providerL1!.getNetwork()).chainId;
         const l1ChainIdFromL2Provider = BigInt(await alice.provider.l1ChainId());
         expect(l1ChainId).toEqual(l1ChainIdFromL2Provider);

--- a/zk_toolbox/crates/config/src/genesis.rs
+++ b/zk_toolbox/crates/config/src/genesis.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use xshell::Shell;
-use zksync_basic_types::L1ChainId;
+use zksync_basic_types::SLChainId;
 pub use zksync_config::GenesisConfig;
 use zksync_protobuf_config::{decode_yaml_repr, encode_yaml_repr};
 
@@ -13,7 +13,7 @@ use crate::{
 
 pub fn update_from_chain_config(genesis: &mut GenesisConfig, config: &ChainConfig) {
     genesis.l2_chain_id = config.chain_id;
-    genesis.l1_chain_id = L1ChainId(config.l1_network.chain_id());
+    genesis.l1_chain_id = SLChainId(config.l1_network.chain_id());
     genesis.l1_batch_commit_data_generator_mode = config.l1_batch_commit_data_generator_mode;
 }
 


### PR DESCRIPTION
## What ❔

Adding settlement layer chain id. Note, that in the future zkSync may settle onto other instances of Era. This PR does not introduce any legacy-inducing changes (e.g. amending configs) in case we'll need to change something.

I also did not rename components / structs that mention "Eth", e.g. `QueryEthClientLayer`. For now, we can say that everything that says Eth means "Eth-compatible".

With this PR:
- L1ChainId should not be used only when *exactly* L1 is meant and not settlement layer.
- SLChainId should be used otherwise.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
