### PR TITLE
test(vm): Fix fast VM unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7352,7 +7352,7 @@ dependencies = [
 [[package]]
 name = "vm2"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/vm2.git?rev=28770597a3f150dbe4373cb57929bd8db82e884f#28770597a3f150dbe4373cb57929bd8db82e884f"
+source = "git+https://github.com/matter-labs/vm2.git?rev=a0cf04b03ac1c486a48e5f2e32422a00c27a1b9d#a0cf04b03ac1c486a48e5f2e32422a00c27a1b9d"
 dependencies = [
  "enum_dispatch",
  "primitive-types",

--- a/core/lib/multivm/Cargo.toml
+++ b/core/lib/multivm/Cargo.toml
@@ -16,7 +16,7 @@ zk_evm_1_4_1.workspace = true
 zk_evm_1_4_0.workspace = true
 zk_evm_1_3_3.workspace = true
 zk_evm_1_3_1.workspace = true
-vm2 = { git = "https://github.com/matter-labs/vm2.git", rev = "28770597a3f150dbe4373cb57929bd8db82e884f" }
+vm2 = { git = "https://github.com/matter-labs/vm2.git", rev = "a0cf04b03ac1c486a48e5f2e32422a00c27a1b9d" }
 
 circuit_sequencer_api_1_3_3.workspace = true
 circuit_sequencer_api_1_4_0.workspace = true

--- a/core/lib/multivm/src/versions/vm_fast/tests/rollbacks.rs
+++ b/core/lib/multivm/src/versions/vm_fast/tests/rollbacks.rs
@@ -10,7 +10,6 @@ use crate::{
     },
 };
 
-#[ignore] // FIXME(PLA-1002): VM state assertion in `execute_tx_and_verify` fails
 #[test]
 fn test_vm_rollbacks() {
     let mut vm = VmTesterBuilder::new()
@@ -60,7 +59,6 @@ fn test_vm_rollbacks() {
     assert_eq!(result_without_rollbacks, result_with_rollbacks);
 }
 
-#[ignore] // FIXME(PLA-1002): VM state assertion in `execute_tx_and_verify` fails
 #[test]
 fn test_vm_loadnext_rollbacks() {
     let mut vm = VmTesterBuilder::new()

--- a/core/lib/multivm/src/versions/vm_fast/tests/tracing_execution_error.rs
+++ b/core/lib/multivm/src/versions/vm_fast/tests/tracing_execution_error.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 
 #[test]
-#[ignore] // FIXME(PLA-1002): VM state assertion in `execute_tx_and_verify` fails
 fn test_tracing_of_execution_errors() {
     let contract_address = H160::random();
     let mut vm = VmTesterBuilder::new()

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -6946,7 +6946,7 @@ dependencies = [
 [[package]]
 name = "vm2"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/vm2.git?rev=28770597a3f150dbe4373cb57929bd8db82e884f#28770597a3f150dbe4373cb57929bd8db82e884f"
+source = "git+https://github.com/matter-labs/vm2.git?rev=a0cf04b03ac1c486a48e5f2e32422a00c27a1b9d#a0cf04b03ac1c486a48e5f2e32422a00c27a1b9d"
 dependencies = [
  "enum_dispatch",
  "primitive-types",


### PR DESCRIPTION
## What ❔

Fixes unit tests that previously failed because of incorrect `Heap` comparisons.

## Why ❔

Better test coverage.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.