### PR TITLE
fix(node): respect namespaces configuration

### DIFF
--- a/core/bin/zksync_server/src/node_builder.rs
+++ b/core/bin/zksync_server/src/node_builder.rs
@@ -325,7 +325,14 @@ impl MainNodeBuilder {
         let state_keeper_config = try_load_config!(self.configs.state_keeper_config);
         let with_debug_namespace = state_keeper_config.save_call_traces;
 
-        let mut namespaces = Namespace::DEFAULT.to_vec();
+        let mut namespaces = if let Some(namespaces) = &rpc_config.api_namespaces {
+            namespaces
+                .iter()
+                .map(|a| a.parse())
+                .collect::<Result<_, _>>()?
+        } else {
+            Namespace::DEFAULT.to_vec()
+        };
         if with_debug_namespace {
             namespaces.push(Namespace::Debug)
         }


### PR DESCRIPTION
## What ❔

Respect the configuration of namespaces when building the HTTP Web3 API layer.

## Why ❔

This commit fixes a bug found when trying to run the node server with the following configuration:
```
API_WEB3_JSON_RPC_API_NAMESPACES=eth,web3,net,pubsub,zks,en,debug,unstable
```
This was added to the `etc/env/target/dev.env` file to test PR #2474. It turned out that the `unstable` namespace works fine for the WebSocket API but not for the HTTP API.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
