### PR TITLE
chore(vm): Update VM revision and TODOs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7301,12 +7301,12 @@ dependencies = [
 [[package]]
 name = "vm2"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/vm2.git?rev=a0cf04b03ac1c486a48e5f2e32422a00c27a1b9d#a0cf04b03ac1c486a48e5f2e32422a00c27a1b9d"
+source = "git+https://github.com/matter-labs/vm2.git?rev=9a38900d7af9b1d72b47ce3be980e77c1239a61d#9a38900d7af9b1d72b47ce3be980e77c1239a61d"
 dependencies = [
  "enum_dispatch",
  "primitive-types",
- "zk_evm_abstractions 1.5.0",
- "zkevm_opcode_defs 1.5.0",
+ "zk_evm_abstractions 0.150.0",
+ "zkevm_opcode_defs 0.150.0",
 ]
 
 [[package]]
@@ -7935,18 +7935,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zk_evm_abstractions"
-version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-zk_evm_abstractions.git?branch=v1.5.0#e464b2cf2b146d883be80e7d690c752bf670ff05"
-dependencies = [
- "anyhow",
- "num_enum 0.6.1",
- "serde",
- "static_assertions",
- "zkevm_opcode_defs 1.5.0",
-]
-
-[[package]]
 name = "zkevm_circuits"
 version = "0.140.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8057,22 +8045,6 @@ name = "zkevm_opcode_defs"
 version = "0.150.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3328c012d444bdbfadb754a72c01a56879eb66584efc71eac457e89e7843608"
-dependencies = [
- "bitflags 2.6.0",
- "blake2 0.10.6",
- "ethereum-types",
- "k256 0.13.3",
- "lazy_static",
- "p256",
- "serde",
- "sha2 0.10.8",
- "sha3 0.10.8",
-]
-
-[[package]]
-name = "zkevm_opcode_defs"
-version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-zkevm_opcode_defs.git?branch=v1.5.0#28d2edabf902ea9b08f6a26a4506831fd89346b9"
 dependencies = [
  "bitflags 2.6.0",
  "blake2 0.10.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,6 +215,9 @@ zk_evm_1_4_0 = { package = "zk_evm", version = "0.140.0" }
 zk_evm_1_4_1 = { package = "zk_evm", version = "0.141.0" }
 zk_evm_1_5_0 = { package = "zk_evm", version = "=0.150.0" }
 
+# New VM; pinned to a specific commit because of instability
+vm2 = { git = "https://github.com/matter-labs/vm2.git", rev = "9a38900d7af9b1d72b47ce3be980e77c1239a61d" }
+
 # Consensus dependencies.
 zksync_concurrency = "=0.1.0-rc.8"
 zksync_consensus_bft = "=0.1.0-rc.8"

--- a/core/bin/zksync_server/src/node_builder.rs
+++ b/core/bin/zksync_server/src/node_builder.rs
@@ -476,7 +476,6 @@ impl MainNodeBuilder {
         Ok(self)
     }
 
-    #[allow(dead_code)] // FIXME: doesn't work with the new VM
     fn add_tee_verifier_input_producer_layer(mut self) -> anyhow::Result<Self> {
         self.node.add_layer(TeeVerifierInputProducerLayer::new(
             self.genesis_config.l2_chain_id,
@@ -692,7 +691,7 @@ impl MainNodeBuilder {
                     self = self.add_eth_tx_manager_layer()?;
                 }
                 Component::TeeVerifierInputProducer => {
-                    // FIXME: self = self.add_tee_verifier_input_producer_layer()?;
+                    self = self.add_tee_verifier_input_producer_layer()?;
                 }
                 Component::Housekeeper => {
                     self = self

--- a/core/lib/multivm/Cargo.toml
+++ b/core/lib/multivm/Cargo.toml
@@ -16,7 +16,7 @@ zk_evm_1_4_1.workspace = true
 zk_evm_1_4_0.workspace = true
 zk_evm_1_3_3.workspace = true
 zk_evm_1_3_1.workspace = true
-vm2 = { git = "https://github.com/matter-labs/vm2.git", rev = "a0cf04b03ac1c486a48e5f2e32422a00c27a1b9d" }
+vm2.workspace = true
 
 circuit_sequencer_api_1_3_3.workspace = true
 circuit_sequencer_api_1_4_0.workspace = true

--- a/core/lib/multivm/src/versions/shadow.rs
+++ b/core/lib/multivm/src/versions/shadow.rs
@@ -64,7 +64,6 @@ where
         main_result
     }
 
-    // FIXME: this should show a divergence when validating transactions, but there are no tests covering it.
     fn inspect(
         &mut self,
         dispatcher: Self::TracerDispatcher,
@@ -139,7 +138,6 @@ where
         main_result
     }
 
-    // FIXME: this should show a divergence when validating transactions, but there are no tests covering it.
     fn inspect_transaction_with_bytecode_compression(
         &mut self,
         tracer: Self::TracerDispatcher,

--- a/core/lib/multivm/src/versions/vm_fast/tests/gas_limit.rs
+++ b/core/lib/multivm/src/versions/vm_fast/tests/gas_limit.rs
@@ -30,7 +30,7 @@ fn test_tx_gas_limit_offset() {
     assert!(vm.vm.inner.state.previous_frames.is_empty());
     let gas_limit_from_memory = vm
         .vm
-        .read_heap_word(TX_DESCRIPTION_OFFSET + TX_GAS_LIMIT_OFFSET);
+        .read_word_from_bootloader_heap(TX_DESCRIPTION_OFFSET + TX_GAS_LIMIT_OFFSET);
 
     assert_eq!(gas_limit_from_memory, gas_limit);
 }

--- a/core/lib/multivm/src/versions/vm_fast/vm.rs
+++ b/core/lib/multivm/src/versions/vm_fast/vm.rs
@@ -108,28 +108,16 @@ impl<S: ReadStorage> Vm<S> {
                 }
             };
 
-            use Hook::*;
             match Hook::from_u32(hook) {
-                AccountValidationEntered => {
-                    /*
-                    if self.run_account_validation().is_err() {
-                        break ExecutionResult::Halt {
-                            reason: Halt::ValidationOutOfGas,
-                        };
-                    }
-                    */
+                Hook::AccountValidationEntered | Hook::AccountValidationExited => {
+                    // TODO (PLA-908): implement account validation
                 }
-                AccountValidationExited => {
-                    /*
-                    panic!("must enter account validation before exiting");
-                    */
-                }
-                TxHasEnded => {
+                Hook::TxHasEnded => {
                     if let VmExecutionMode::OneTx = execution_mode {
                         break last_tx_result.take().unwrap();
                     }
                 }
-                AskOperatorForRefund => {
+                Hook::AskOperatorForRefund => {
                     if track_refunds {
                         let [bootloader_refund, gas_spent_on_pubdata, gas_per_pubdata_byte] =
                             self.get_hook_params();
@@ -168,17 +156,16 @@ impl<S: ReadStorage> Vm<S> {
                             .set_refund_for_current_tx(refund_value);
                     }
                 }
-                NotifyAboutRefund => {
+                Hook::NotifyAboutRefund => {
                     if track_refunds {
                         refunds.gas_refunded = self.get_hook_params()[0].low_u64()
                     }
                 }
-                PostResult => {
+                Hook::PostResult => {
                     let result = self.get_hook_params()[0];
                     let value = self.get_hook_params()[1];
                     let fp = FatPointer::from(value);
-
-                    assert!(fp.offset == 0);
+                    assert_eq!(fp.offset, 0);
 
                     let return_data = self.inner.state.heaps[fp.memory_page]
                         .read_range_big_endian(fp.start..fp.start + fp.length);
@@ -193,7 +180,7 @@ impl<S: ReadStorage> Vm<S> {
                         }
                     });
                 }
-                FinalBatchInfo => {
+                Hook::FinalBatchInfo => {
                     // set fictive l2 block
                     let txs_index = self.bootloader_state.free_tx_index();
                     let l2_block = self.bootloader_state.insert_fictive_l2_block();
@@ -201,10 +188,9 @@ impl<S: ReadStorage> Vm<S> {
                     apply_l2_block(&mut memory, l2_block, txs_index);
                     self.write_to_bootloader_heap(memory);
                 }
-                PubdataRequested => {
+                Hook::PubdataRequested => {
                     if !matches!(execution_mode, VmExecutionMode::Batch) {
-                        // We do not provide the pubdata when executing the block tip or a single transaction
-                        todo!("I have no idea what exit status to return here");
+                        unreachable!("We do not provide the pubdata when executing the block tip or a single transaction");
                     }
 
                     let events =
@@ -250,53 +236,14 @@ impl<S: ReadStorage> Vm<S> {
                     self.write_to_bootloader_heap(memory_to_apply);
                 }
 
-                PaymasterValidationEntered | ValidationStepEnded => {} // unused
-                DebugLog | DebugReturnData | NearCallCatch => {} // these are for debug purposes only
+                Hook::PaymasterValidationEntered | Hook::ValidationStepEnded => { /* unused */ }
+                Hook::DebugLog | Hook::DebugReturnData | Hook::NearCallCatch => {
+                    // These hooks are for debug purposes only
+                }
             }
         };
 
         (result, refunds)
-    }
-
-    #[allow(dead_code)] // FIXME: enable validation
-    fn run_account_validation(&mut self) -> Result<(), ()> {
-        loop {
-            match self.inner.resume_with_additional_gas_limit(
-                self.suspended_at,
-                &mut self.world,
-                self.gas_for_account_validation,
-            ) {
-                None => {
-                    // Used too much gas
-                    return Err(());
-                }
-                Some((
-                    validation_gas_left,
-                    ExecutionEnd::SuspendedOnHook {
-                        hook,
-                        pc_to_resume_from,
-                    },
-                )) => {
-                    self.suspended_at = pc_to_resume_from;
-                    self.gas_for_account_validation = validation_gas_left;
-
-                    let hook = Hook::from_u32(hook);
-                    match hook {
-                        Hook::AccountValidationExited => {
-                            return Ok(());
-                        }
-                        Hook::DebugLog => {}
-                        _ => {
-                            panic!("Unexpected {:?} hook while in account validation", hook);
-                        }
-                    }
-                }
-                _ => {
-                    // Exited normally without ending account validation, panicked or reverted.
-                    panic!("unexpected exit from account validation")
-                }
-            }
-        }
     }
 
     fn get_hook_params(&self) -> [U256; 3] {
@@ -548,7 +495,7 @@ impl<S: ReadStorage> VmInterface for Vm<S> {
         VmExecutionResultAndLogs {
             result,
             logs,
-            // FIXME (PLA-936): Fill statistics; investigate whether they should be zeroed on `Halt`
+            // TODO (PLA-936): Fill statistics; investigate whether they should be zeroed on `Halt`
             statistics: VmExecutionStatistics {
                 contracts_used: 0,
                 cycles_used: 0,
@@ -630,7 +577,7 @@ impl<S: ReadStorage> VmInterface for Vm<S> {
     }
 
     fn record_vm_memory_metrics(&self) -> crate::vm_latest::VmMemoryMetrics {
-        todo!()
+        todo!("Unused during batch execution")
     }
 
     fn gas_remaining(&self) -> u32 {
@@ -725,11 +672,10 @@ impl<S: fmt::Debug> fmt::Debug for Vm<S> {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct World<S> {
     pub(crate) storage: S,
-
-    // TODO: It would be nice to store an LRU cache elsewhere.
-    // This one is cleared on change of batch unfortunately.
+    // TODO (PLA-1008): Store `Program`s in an LRU cache
     program_cache: HashMap<U256, Program>,
     pub(crate) bytecode_cache: HashMap<U256, Vec<u8>>,
 }
@@ -798,9 +744,6 @@ impl<S: ReadStorage> vm2::World for World<S> {
         // For value compression, we use a metadata byte which holds the length of the value and the operation from the
         // previous state to the new state, and the compressed value. The maximum for this is 33 bytes.
         // Total bytes for initial writes then becomes 65 bytes and repeated writes becomes 38 bytes.
-        // TODO (SMA-1702): take into account the content of the log query, i.e. values that contain mostly zeroes
-        // should cost less.
-
         let compressed_value_size =
             compress_with_best_strategy(initial_value, new_value).len() as u32;
 

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -6930,12 +6930,12 @@ dependencies = [
 [[package]]
 name = "vm2"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/vm2.git?rev=a0cf04b03ac1c486a48e5f2e32422a00c27a1b9d#a0cf04b03ac1c486a48e5f2e32422a00c27a1b9d"
+source = "git+https://github.com/matter-labs/vm2.git?rev=9a38900d7af9b1d72b47ce3be980e77c1239a61d#9a38900d7af9b1d72b47ce3be980e77c1239a61d"
 dependencies = [
  "enum_dispatch",
  "primitive-types",
- "zk_evm_abstractions 1.5.0",
- "zkevm_opcode_defs 1.5.0",
+ "zk_evm_abstractions 0.150.0",
+ "zkevm_opcode_defs 0.150.0",
 ]
 
 [[package]]
@@ -7492,18 +7492,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zk_evm_abstractions"
-version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-zk_evm_abstractions.git?branch=v1.5.0#e464b2cf2b146d883be80e7d690c752bf670ff05"
-dependencies = [
- "anyhow",
- "num_enum 0.6.1",
- "serde",
- "static_assertions",
- "zkevm_opcode_defs 1.5.0",
-]
-
-[[package]]
 name = "zkevm-assembly"
 version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7654,22 +7642,6 @@ name = "zkevm_opcode_defs"
 version = "0.150.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3328c012d444bdbfadb754a72c01a56879eb66584efc71eac457e89e7843608"
-dependencies = [
- "bitflags 2.5.0",
- "blake2 0.10.6",
- "ethereum-types",
- "k256 0.13.3",
- "lazy_static",
- "p256",
- "serde",
- "sha2 0.10.8",
- "sha3 0.10.8",
-]
-
-[[package]]
-name = "zkevm_opcode_defs"
-version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-zkevm_opcode_defs.git?branch=v1.5.0#28d2edabf902ea9b08f6a26a4506831fd89346b9"
 dependencies = [
  "bitflags 2.5.0",
  "blake2 0.10.6",


### PR DESCRIPTION
## What ❔

- Bumps the `vm2` revision and moves it to the workspace manifest.
- Brushes up TODOs in the new VM code.
- Re-enables the TEE input producer.

## Why ❔

Part of preparations to merge the feature branch into `main`.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.