### PR TITLE
fix: restrictive genesis parsing

### DIFF
--- a/core/lib/dal/src/consensus_dal.rs
+++ b/core/lib/dal/src/consensus_dal.rs
@@ -7,6 +7,7 @@ use zksync_db_connection::{
     error::{DalError, DalResult, SqlxContext},
     instrument::{InstrumentExt, Instrumented},
 };
+use zksync_protobuf::ProtoFmt as _;
 use zksync_types::L2BlockNumber;
 
 pub use crate::consensus::{AttestationStatus, Payload};
@@ -48,9 +49,20 @@ impl ConsensusDal<'_, '_> {
             let Some(genesis) = row.genesis else {
                 return Ok(None);
             };
-            let genesis: validator::GenesisRaw =
-                zksync_protobuf::serde::deserialize(genesis).decode_column("genesis")?;
-            Ok(Some(genesis.with_hash()))
+            // Deserialize the json, but don't allow for unknown fields.
+            // We might encounter an unknown fields here in case if support for the previous
+            // consensus protocol version is removed before the migration to a new version
+            // is performed. The node should NOT operate in such a state.
+            Ok(Some(
+                validator::GenesisRaw::read(
+                    &zksync_protobuf::serde::deserialize_proto_with_options(
+                        &genesis, /*deny_unknown_fields=*/ true,
+                    )
+                    .decode_column("genesis")?,
+                )
+                .decode_column("genesis")?
+                .with_hash(),
+            ))
         })
         .instrument("genesis")
         .fetch_optional(self.storage)

--- a/core/node/consensus/src/en.rs
+++ b/core/node/consensus/src/en.rs
@@ -11,6 +11,7 @@ use zksync_dal::consensus_dal;
 use zksync_node_sync::{
     fetcher::FetchedBlock, sync_action::ActionQueueSender, MainNodeClient, SyncState,
 };
+use zksync_protobuf::ProtoFmt as _;
 use zksync_types::L2BlockNumber;
 use zksync_web3_decl::client::{DynClient, L2};
 
@@ -203,12 +204,13 @@ impl EN {
         // Deserialize the json, but don't allow for unknown fields.
         // We need to compute the hash of the Genesis, so simply ignoring the unknown fields won't
         // do.
-        Ok(validator::Genesis::read(
+        Ok(validator::GenesisRaw::read(
             &zksync_protobuf::serde::deserialize_proto_with_options(
                 &genesis.0, /*deny_unknown_fields=*/ true,
             )
             .context("deserialize")?,
-        )?)
+        )?
+        .with_hash())
     }
 
     /// Fetches (with retries) the given block from the main node.


### PR DESCRIPTION
The error about receiving an unsupported consensus genesis was unnecessarily delayed. I've disallowed unknown fields in genesis to fix that.