### PR TITLE
fix: shrink enclave size of `zksync-tee-prover`

### DIFF
--- a/etc/nix/container-tee_prover.nix
+++ b/etc/nix/container-tee_prover.nix
@@ -41,7 +41,7 @@ nixsgxLib.mkSGXContainer {
 
     sgx = {
       edmm_enable = false;
-      enclave_size = "32G";
+      enclave_size = "8G";
       max_threads = 128;
     };
   };


### PR DESCRIPTION
## What ❔

Shrink the enclave size of `zksync-tee-prover`.

## Why ❔

32G was a bit of safe guard while testing. 8G seems to be enough and will fit better the memory size of the Azure nodes.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
