### PR TITLE
fix(en): Initialize SyncState in OutputHandler

### DIFF
--- a/core/bin/external_node/src/node_builder.rs
+++ b/core/bin/external_node/src/node_builder.rs
@@ -216,8 +216,8 @@ impl ExternalNodeBuilder {
             rocksdb_options,
         );
         self.node
-            .add_layer(persistence_layer)
             .add_layer(io_layer)
+            .add_layer(persistence_layer)
             .add_layer(main_node_batch_executor_builder_layer)
             .add_layer(state_keeper_layer);
         Ok(self)


### PR DESCRIPTION
## What ❔

OutputHandler must be added after ExternalIO, because the latter is adding SyncStateResource

## Why ❔

Bug

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
