### PR TITLE
feat: added test checking that eth_syncing response is reasonable

### DIFF
--- a/core/tests/ts-integration/tests/api/web3.test.ts
+++ b/core/tests/ts-integration/tests/api/web3.test.ts
@@ -164,8 +164,8 @@ describe('web3 API compatibility tests', () => {
                 if (response.highestBlock > BigInt(0) && response.currentBlock > BigInt(0)) {
                     break;
                 }
-                await zksync.utils.sleep(alice.provider.pollingInterval);
             }
+            await zksync.utils.sleep(alice.provider.pollingInterval);
         }
     });
 

--- a/core/tests/ts-integration/tests/api/web3.test.ts
+++ b/core/tests/ts-integration/tests/api/web3.test.ts
@@ -150,16 +150,21 @@ describe('web3 API compatibility tests', () => {
     });
 
     test('Should check the syncing status', async () => {
-        // We can't know whether the node is synced (in EN case), so we just check the validity of the response.
-        const response = await alice.provider.send('eth_syncing', []);
-        // Sync status is either `false` or an object with the following fields.
-        if (response !== false) {
-            const expectedObject = {
-                currentBlock: expect.stringMatching(HEX_VALUE_REGEX),
-                highestBlock: expect.stringMatching(HEX_VALUE_REGEX),
-                startingBlock: expect.stringMatching(HEX_VALUE_REGEX)
-            };
-            expect(response).toMatchObject(expectedObject);
+        while (true) {
+            // We can't know whether the node is synced (in EN case), so we just check the validity of the response.
+            const response = await alice.provider.send('eth_syncing', []);
+            // Sync status is either `false` or an object with the following fields.
+            if (response !== false) {
+                const expectedObject = {
+                    currentBlock: expect.stringMatching(HEX_VALUE_REGEX),
+                    highestBlock: expect.stringMatching(HEX_VALUE_REGEX),
+                    startingBlock: expect.stringMatching(HEX_VALUE_REGEX)
+                };
+                expect(response).toMatchObject(expectedObject);
+            }
+            if (response.highestBlock > BigInt(0) && response.currentBlock > BigInt(0)) {
+                break;
+            }
         }
     });
 

--- a/core/tests/ts-integration/tests/api/web3.test.ts
+++ b/core/tests/ts-integration/tests/api/web3.test.ts
@@ -164,6 +164,7 @@ describe('web3 API compatibility tests', () => {
                 if (response.highestBlock > BigInt(0) && response.currentBlock > BigInt(0)) {
                     break;
                 }
+                await zksync.utils.sleep(alice.provider.pollingInterval);
             }
         }
     });

--- a/core/tests/ts-integration/tests/api/web3.test.ts
+++ b/core/tests/ts-integration/tests/api/web3.test.ts
@@ -161,9 +161,9 @@ describe('web3 API compatibility tests', () => {
                     startingBlock: expect.stringMatching(HEX_VALUE_REGEX)
                 };
                 expect(response).toMatchObject(expectedObject);
-            }
-            if (response.highestBlock > BigInt(0) && response.currentBlock > BigInt(0)) {
-                break;
+                if (response.highestBlock > BigInt(0) && response.currentBlock > BigInt(0)) {
+                    break;
+                }
             }
         }
     });


### PR DESCRIPTION
To detect a situation in which the syncstate is not populated at all.