### PR TITLE
feat: remove TEE from tree

### DIFF
--- a/core/lib/dal/src/tee_verifier_input_producer_dal.rs
+++ b/core/lib/dal/src/tee_verifier_input_producer_dal.rs
@@ -89,8 +89,12 @@ impl TeeVerifierInputProducerDal<'_, '_> {
         .report_latency()
         .fetch_one(self.storage)
         .await?
-        .number
-        .unwrap();
+        .number;
+
+        let row_high = match row_high {
+            Some(number) => number,
+            None => return Ok(None),
+        };
 
         let row_low = sqlx::query!(
             r#"

--- a/core/lib/dal/src/tee_verifier_input_producer_dal.rs
+++ b/core/lib/dal/src/tee_verifier_input_producer_dal.rs
@@ -72,9 +72,57 @@ impl TeeVerifierInputProducerDal<'_, '_> {
         Ok(())
     }
 
+    // Returns inclusive range, i.e. [low,high]
+    pub async fn get_new_l1_batches(
+        &mut self,
+    ) -> DalResult<Option<(L1BatchNumber, L1BatchNumber)>> {
+        // COALESCE(1, ...) covers the case where the table is initially empty. NB: We start from batch 1, since genesis batch 0 has no proof.
+        let row_low = sqlx::query!(
+            r#"
+            SELECT
+                COALESCE(1, MAX(l1_batch_number) + 1) AS "number"
+            FROM
+                tee_verifier_input_producer_jobs
+            "#
+        )
+        .instrument("get_latest_tee_job_l1_batch_number")
+        .report_latency()
+        .fetch_one(self.storage)
+        .await?;
+
+        // Since we depend on Merkle paths, we use the proof_generation_details table to inform us of newly available to-be-proven batches.
+        let row_high = sqlx::query!(
+            r#"
+            SELECT
+                MAX(l1_batch_number) AS "number"
+            FROM
+                proof_generation_details
+            "#
+        )
+        .instrument("get_sealed_l1_batch_number")
+        .report_latency()
+        .fetch_one(self.storage)
+        .await?;
+
+        match (row_low.number, row_high.number) {
+            (Some(low), Some(high)) => Ok(Some((
+                L1BatchNumber(low as u32),
+                L1BatchNumber(high as u32),
+            ))),
+            _ => Ok(None),
+        }
+    }
+
     pub async fn get_next_tee_verifier_input_producer_job(
         &mut self,
     ) -> DalResult<Option<L1BatchNumber>> {
+        if let Some((low, high)) = self.get_new_l1_batches().await? {
+            for i in low.0..=high.0 {
+                self.create_tee_verifier_input_producer_job(L1BatchNumber(i))
+                    .await?
+            }
+        }
+
         let l1_batch_number = sqlx::query!(
             r#"
             UPDATE tee_verifier_input_producer_jobs

--- a/core/node/metadata_calculator/src/updater.rs
+++ b/core/node/metadata_calculator/src/updater.rs
@@ -152,10 +152,6 @@ impl TreeUpdater {
             // right away without having to implement dedicated code.
 
             if let Some(object_key) = &object_key {
-                storage
-                    .tee_verifier_input_producer_dal()
-                    .create_tee_verifier_input_producer_job(l1_batch_number)
-                    .await?;
                 // Save the proof generation details to Postgres
                 storage
                     .proof_generation_dal()


### PR DESCRIPTION
TEE input producer jobs are now created by monitoring the db instead of hooking directly into the tree logic.

## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
