### PR TITLE
fix(vm): Fix missing experimental VM config

### DIFF
--- a/core/bin/zksync_server/src/node_builder.rs
+++ b/core/bin/zksync_server/src/node_builder.rs
@@ -249,7 +249,11 @@ impl MainNodeBuilder {
             try_load_config!(wallets.state_keeper),
         );
         let db_config = try_load_config!(self.configs.db_config);
-        let experimental_vm_config = try_load_config!(self.configs.experimental_vm_config);
+        let experimental_vm_config = self
+            .configs
+            .experimental_vm_config
+            .clone()
+            .unwrap_or_default();
         let main_node_batch_executor_builder_layer =
             MainBatchExecutorLayer::new(sk_config.save_call_traces, OPTIONAL_BYTECODE_COMPRESSION)
                 .with_fast_vm_mode(experimental_vm_config.state_keeper_fast_vm_mode);


### PR DESCRIPTION
## What ❔

Uses default experimental VM config if one is not supplied when initializing the state keeper.

## Why ❔

Otherwise, the state keeper will panic on start if the config is missing. Logically, this config shouldn't be required for it to work (unlike for the VM playground).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `zk fmt` and `zk lint`.