### PR TITLE
ci: Relax TPS for CI loadtest

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Loadtest configuration
         run: |
-          echo EXPECTED_TX_COUNT=${{ matrix.vm_mode == 'new' && 24000 || 18000 }} >> .env
+          echo EXPECTED_TX_COUNT=${{ matrix.vm_mode == 'new' && 22000 || 16000 }} >> .env
           echo ACCOUNTS_AMOUNT="150" >> .env
           echo FAIL_FAST=true >> .env
           echo IN_DOCKER=1 >> .env


### PR DESCRIPTION
## What ❔

Relax expected TPS for CI load tests.

## Why ❔

The current expected TPS values are chosen too aggressively, leading to sporadic CI failures.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).