### PR TITLE
chore(docs): adds instructions for `Cannot read properties of undefined (reading 'compilerPath')` error resolution

### DIFF
--- a/docs/guides/launch.md
+++ b/docs/guides/launch.md
@@ -331,7 +331,9 @@ Error: Cannot read properties of undefined (reading 'compilerPath')
 error Command failed with exit code 1.
 ```
 
-**Description**. The compiler downloader [could not verify](https://github.com/NomicFoundation/hardhat/blob/0d850d021f3ab33b59b1ea2ae70d1e659e579e40/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts#L336-L383) that the Solidity compiler it downloaded actually works.
+**Description**. The compiler downloader
+[could not verify](https://github.com/NomicFoundation/hardhat/blob/0d850d021f3ab33b59b1ea2ae70d1e659e579e40/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts#L336-L383)
+that the Solidity compiler it downloaded actually works.
 
 **Solution**. Delete the cached `*.does.not.work` file to run the check again:
 

--- a/docs/guides/launch.md
+++ b/docs/guides/launch.md
@@ -320,3 +320,22 @@ to:
 ```
     "@matterlabs/hardhat-zksync-solc": "^0.3.15",
 ```
+
+### Error: Cannot read properties of undefined (reading 'compilerPath')
+
+**Problem**. `zk init` fails with an error similar to the following:
+
+```text
+Yarn project directory: /Users/<user>/Projects/zksync-era/contracts/system-contracts
+Error: Cannot read properties of undefined (reading 'compilerPath')
+error Command failed with exit code 1.
+```
+
+**Description**. The compiler downloader [could not verify](https://github.com/NomicFoundation/hardhat/blob/0d850d021f3ab33b59b1ea2ae70d1e659e579e40/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts#L336-L383) that the Solidity compiler it downloaded actually works.
+
+**Solution**. Delete the cached `*.does.not.work` file to run the check again:
+
+```sh
+# NOTE: Compiler version, commit hash may differ.
+rm $HOME/Library/Caches/hardhat-nodejs/compilers-v2/macosx-amd64/solc-macosx-amd64-v0.8.20+commit.a1b79de6.does.not.work
+```


### PR DESCRIPTION
Encountered an issue when setting up new development environment: when running `zk init`, it would fail with the following error:

```text
Creating Typechain artifacts in directory typechain for target ethers-v5
Successfully generated Typechain artifacts!
$ ts-node scripts/compile-yul.ts compile-precompiles
Using zksolc from https://github.com/matter-labs/era-compiler-solidity/releases/download/prerelease-a167aa3-code4rena/zksolc-macosx-arm64-v1.5.0
Yarn project directory: /Users/jacob/Projects/zksync-era/contracts/system-contracts
Error: Cannot read properties of undefined (reading 'compilerPath')
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed.
Exit code: 1
```

Thus, this PR updates the "Troubleshooting" section of `docs/guides/launch.md` with the resolution instructions.
