### PR TITLE
feat(db): Allow creating owned Postgres connections

### DIFF
--- a/core/lib/db_connection/src/connection_pool.rs
+++ b/core/lib/db_connection/src/connection_pool.rs
@@ -347,7 +347,7 @@ impl<DB: DbMarker> ConnectionPool<DB> {
     ///
     /// This method is intended to be used in crucial contexts, where the
     /// database access is must-have (e.g. block committer).
-    pub async fn connection(&self) -> DalResult<Connection<'_, DB>> {
+    pub async fn connection(&self) -> DalResult<Connection<'static, DB>> {
         self.connection_inner(None).await
     }
 
@@ -361,7 +361,7 @@ impl<DB: DbMarker> ConnectionPool<DB> {
     pub fn connection_tagged(
         &self,
         requester: &'static str,
-    ) -> impl Future<Output = DalResult<Connection<'_, DB>>> + '_ {
+    ) -> impl Future<Output = DalResult<Connection<'static, DB>>> + '_ {
         let location = Location::caller();
         async move {
             let tags = ConnectionTags {
@@ -375,7 +375,7 @@ impl<DB: DbMarker> ConnectionPool<DB> {
     async fn connection_inner(
         &self,
         tags: Option<ConnectionTags>,
-    ) -> DalResult<Connection<'_, DB>> {
+    ) -> DalResult<Connection<'static, DB>> {
         let acquire_latency = CONNECTION_METRICS.acquire.start();
         let conn = self.acquire_connection_retried(tags.as_ref()).await?;
         let elapsed = acquire_latency.observe();
@@ -386,7 +386,7 @@ impl<DB: DbMarker> ConnectionPool<DB> {
         Ok(Connection::<DB>::from_pool(
             conn,
             tags,
-            self.traced_connections.as_deref(),
+            self.traced_connections.as_ref(),
         ))
     }
 

--- a/core/lib/state/src/lib.rs
+++ b/core/lib/state/src/lib.rs
@@ -20,8 +20,7 @@ pub use self::{
     },
     shadow_storage::ShadowStorage,
     storage_factory::{
-        BatchDiff, OwnedPostgresStorage, OwnedStorage, PgOrRocksdbStorage, ReadStorageFactory,
-        RocksdbWithMemory,
+        BatchDiff, OwnedStorage, PgOrRocksdbStorage, ReadStorageFactory, RocksdbWithMemory,
     },
 };
 

--- a/core/lib/state/src/storage_factory.rs
+++ b/core/lib/state/src/storage_factory.rs
@@ -10,6 +10,9 @@ use zksync_vm_interface::storage::ReadStorage;
 
 use crate::{PostgresStorage, RocksdbStorage, RocksdbStorageBuilder, StateKeeperColumnFamily};
 
+/// Storage with a static lifetime that can be sent to Tokio tasks etc.
+pub type OwnedStorage = PgOrRocksdbStorage<'static>;
+
 /// Factory that can produce storage instances on demand. The storage type is encapsulated as a type param
 /// (mostly for testing purposes); the default is [`OwnedStorage`].
 #[async_trait]
@@ -35,8 +38,9 @@ impl ReadStorageFactory for ConnectionPool<Core> {
         _stop_receiver: &watch::Receiver<bool>,
         l1_batch_number: L1BatchNumber,
     ) -> anyhow::Result<Option<OwnedStorage>> {
-        let storage = OwnedPostgresStorage::new(self.clone(), l1_batch_number);
-        Ok(Some(storage.into()))
+        let connection = self.connection().await?;
+        let storage = OwnedStorage::postgres(connection, l1_batch_number).await?;
+        Ok(Some(storage))
     }
 }
 
@@ -61,31 +65,29 @@ pub struct RocksdbWithMemory {
     pub batch_diffs: Vec<BatchDiff>,
 }
 
-/// Owned Postgres-backed VM storage for a certain L1 batch.
+/// A [`ReadStorage`] implementation that uses either [`PostgresStorage`] or [`RocksdbStorage`]
+/// underneath.
 #[derive(Debug)]
-pub struct OwnedPostgresStorage {
-    connection_pool: ConnectionPool<Core>,
-    l1_batch_number: L1BatchNumber,
+pub enum PgOrRocksdbStorage<'a> {
+    /// Implementation over a Postgres connection.
+    Postgres(PostgresStorage<'a>),
+    /// Implementation over a RocksDB cache instance.
+    Rocksdb(RocksdbStorage),
+    /// Implementation over a RocksDB cache instance with in-memory DB diffs.
+    RocksdbWithMemory(RocksdbWithMemory),
 }
 
-impl OwnedPostgresStorage {
-    /// Creates a VM storage for the specified batch number.
-    pub fn new(connection_pool: ConnectionPool<Core>, l1_batch_number: L1BatchNumber) -> Self {
-        Self {
-            connection_pool,
-            l1_batch_number,
-        }
-    }
-
-    /// Returns a [`ReadStorage`] implementation backed by Postgres
+impl PgOrRocksdbStorage<'static> {
+    /// Creates a Postgres-based storage. Because of the `'static` lifetime requirement, `connection` must be
+    /// non-transactional.
     ///
     /// # Errors
     ///
-    /// Propagates Postgres errors.
-    pub async fn borrow(&self) -> anyhow::Result<PgOrRocksdbStorage<'_>> {
-        let l1_batch_number = self.l1_batch_number;
-        let mut connection = self.connection_pool.connection().await?;
-
+    /// Propagates Postgres I/O errors.
+    pub async fn postgres(
+        mut connection: Connection<'static, Core>,
+        l1_batch_number: L1BatchNumber,
+    ) -> anyhow::Result<Self> {
         let l2_block_number = if let Some((_, l2_block_number)) = connection
             .blocks_dal()
             .get_l2_block_range_of_l1_batch(l1_batch_number)
@@ -114,42 +116,7 @@ impl OwnedPostgresStorage {
                 .into(),
         )
     }
-}
 
-/// Owned version of [`PgOrRocksdbStorage`]. It is thus possible to send to blocking tasks for VM execution.
-#[derive(Debug)]
-pub enum OwnedStorage {
-    /// Readily initialized storage with a static lifetime.
-    Static(PgOrRocksdbStorage<'static>),
-    /// Storage that must be `borrow()`ed from.
-    Lending(OwnedPostgresStorage),
-}
-
-impl From<OwnedPostgresStorage> for OwnedStorage {
-    fn from(storage: OwnedPostgresStorage) -> Self {
-        Self::Lending(storage)
-    }
-}
-
-impl From<PgOrRocksdbStorage<'static>> for OwnedStorage {
-    fn from(storage: PgOrRocksdbStorage<'static>) -> Self {
-        Self::Static(storage)
-    }
-}
-
-/// A [`ReadStorage`] implementation that uses either [`PostgresStorage`] or [`RocksdbStorage`]
-/// underneath.
-#[derive(Debug)]
-pub enum PgOrRocksdbStorage<'a> {
-    /// Implementation over a Postgres connection.
-    Postgres(PostgresStorage<'a>),
-    /// Implementation over a RocksDB cache instance.
-    Rocksdb(RocksdbStorage),
-    /// Implementation over a RocksDB cache instance with in-memory DB diffs.
-    RocksdbWithMemory(RocksdbWithMemory),
-}
-
-impl PgOrRocksdbStorage<'static> {
     /// Catches up RocksDB synchronously (i.e. assumes the gap is small) and
     /// returns a [`ReadStorage`] implementation backed by caught-up RocksDB.
     ///

--- a/core/node/api_server/src/web3/state.rs
+++ b/core/node/api_server/src/web3/state.rs
@@ -287,7 +287,7 @@ impl RpcState {
     #[track_caller]
     pub(crate) fn acquire_connection(
         &self,
-    ) -> impl Future<Output = Result<Connection<'_, Core>, Web3Error>> + '_ {
+    ) -> impl Future<Output = Result<Connection<'static, Core>, Web3Error>> + '_ {
         self.connection_pool
             .connection_tagged("api")
             .map_err(|err| err.generalize().into())

--- a/core/node/state_keeper/src/batch_executor/main_executor.rs
+++ b/core/node/state_keeper/src/batch_executor/main_executor.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use anyhow::Context as _;
 use once_cell::sync::OnceCell;
 use tokio::sync::mpsc;
 use zksync_multivm::{
@@ -13,7 +14,6 @@ use zksync_multivm::{
     MultiVMTracer, VmInstance,
 };
 use zksync_shared_metrics::{InteractionType, TxStage, APP_METRICS};
-use zksync_state::OwnedStorage;
 use zksync_types::{vm::FastVmMode, vm_trace::Call, Transaction};
 use zksync_utils::bytecode::CompressedBytecodeInfo;
 
@@ -57,10 +57,10 @@ impl MainBatchExecutor {
     }
 }
 
-impl BatchExecutor<OwnedStorage> for MainBatchExecutor {
+impl<S: ReadStorage + Send + 'static> BatchExecutor<S> for MainBatchExecutor {
     fn init_batch(
         &mut self,
-        storage: OwnedStorage,
+        storage: S,
         l1_batch_params: L1BatchEnv,
         system_env: SystemEnv,
     ) -> BatchExecutorHandle {
@@ -74,12 +74,17 @@ impl BatchExecutor<OwnedStorage> for MainBatchExecutor {
             commands: commands_receiver,
         };
 
-        let handle = tokio::task::spawn_blocking(move || {
-            executor.run(storage, l1_batch_params, system_env);
-            anyhow::Ok(())
-        });
+        let handle =
+            tokio::task::spawn_blocking(move || executor.run(storage, l1_batch_params, system_env));
         BatchExecutorHandle::from_raw(handle, commands_sender)
     }
+}
+
+#[derive(Debug)]
+struct TransactionOutput {
+    tx_result: VmExecutionResultAndLogs,
+    compressed_bytecodes: Vec<CompressedBytecodeInfo>,
+    calls: Vec<Call>,
 }
 
 /// Implementation of the "primary" (non-test) batch executor.
@@ -99,13 +104,13 @@ struct CommandReceiver {
 impl CommandReceiver {
     pub(super) fn run<S: ReadStorage>(
         mut self,
-        secondary_storage: S,
+        storage: S,
         l1_batch_params: L1BatchEnv,
         system_env: SystemEnv,
-    ) {
+    ) -> anyhow::Result<()> {
         tracing::info!("Starting executing L1 batch #{}", &l1_batch_params.number);
 
-        let storage_view = StorageView::new(secondary_storage).to_rc_ptr();
+        let storage_view = StorageView::new(storage).to_rc_ptr();
         let mut vm = VmInstance::maybe_fast(
             l1_batch_params,
             system_env,
@@ -116,7 +121,9 @@ impl CommandReceiver {
         while let Some(cmd) = self.commands.blocking_recv() {
             match cmd {
                 Command::ExecuteTx(tx, resp) => {
-                    let result = self.execute_tx(&tx, &mut vm);
+                    let result = self
+                        .execute_tx(&tx, &mut vm)
+                        .with_context(|| format!("fatal error executing transaction {tx:?}"))?;
                     if resp.send(result).is_err() {
                         break;
                     }
@@ -134,7 +141,7 @@ impl CommandReceiver {
                     }
                 }
                 Command::FinishBatch(resp) => {
-                    let vm_block_result = self.finish_batch(&mut vm);
+                    let vm_block_result = self.finish_batch(&mut vm)?;
                     if resp.send(vm_block_result).is_err() {
                         break;
                     }
@@ -146,28 +153,28 @@ impl CommandReceiver {
                         .observe(metrics.time_spent_on_get_value);
                     EXECUTOR_METRICS.batch_storage_interaction_duration[&InteractionType::SetValue]
                         .observe(metrics.time_spent_on_set_value);
-                    return;
+                    return Ok(());
                 }
                 Command::FinishBatchWithCache(resp) => {
-                    let vm_block_result = self.finish_batch(&mut vm);
+                    let vm_block_result = self.finish_batch(&mut vm)?;
                     let cache = (*storage_view).borrow().cache();
                     if resp.send((vm_block_result, cache)).is_err() {
                         break;
                     }
-
-                    return;
+                    return Ok(());
                 }
             }
         }
         // State keeper can exit because of stop signal, so it's OK to exit mid-batch.
         tracing::info!("State keeper exited with an unfinished L1 batch");
+        Ok(())
     }
 
     fn execute_tx<S: ReadStorage>(
         &self,
         tx: &Transaction,
         vm: &mut VmInstance<S, HistoryEnabled>,
-    ) -> TxExecutionResult {
+    ) -> anyhow::Result<TxExecutionResult> {
         // Executing a next transaction means that a previous transaction was either rolled back (in which case its snapshot
         // was already removed), or that we build on top of it (in which case, it can be removed now).
         vm.pop_snapshot_no_rollback();
@@ -176,33 +183,38 @@ impl CommandReceiver {
 
         // Execute the transaction.
         let latency = KEEPER_METRICS.tx_execution_time[&TxExecutionStage::Execution].start();
-        let (tx_result, compressed_bytecodes, call_tracer_result) =
-            if self.optional_bytecode_compression {
-                self.execute_tx_in_vm_with_optional_compression(tx, vm)
-            } else {
-                self.execute_tx_in_vm(tx, vm)
-            };
+        let output = if self.optional_bytecode_compression {
+            self.execute_tx_in_vm_with_optional_compression(tx, vm)?
+        } else {
+            self.execute_tx_in_vm(tx, vm)?
+        };
         latency.observe();
         APP_METRICS.processed_txs[&TxStage::StateKeeper].inc();
         APP_METRICS.processed_l1_txs[&TxStage::StateKeeper].inc_by(tx.is_l1().into());
 
+        let TransactionOutput {
+            tx_result,
+            compressed_bytecodes,
+            calls,
+        } = output;
+
         if let ExecutionResult::Halt { reason } = tx_result.result {
-            return match reason {
+            return Ok(match reason {
                 Halt::BootloaderOutOfGas => TxExecutionResult::BootloaderOutOfGasForTx,
                 _ => TxExecutionResult::RejectedByVm { reason },
-            };
+            });
         }
 
         let tx_metrics = ExecutionMetricsForCriteria::new(Some(tx), &tx_result);
         let gas_remaining = vm.gas_remaining();
 
-        TxExecutionResult::Success {
+        Ok(TxExecutionResult::Success {
             tx_result: Box::new(tx_result),
             tx_metrics: Box::new(tx_metrics),
             compressed_bytecodes,
-            call_tracer_result,
+            call_tracer_result: calls,
             gas_remaining,
-        }
+        })
     }
 
     fn rollback_last_tx<S: ReadStorage>(&self, vm: &mut VmInstance<S, HistoryEnabled>) {
@@ -222,19 +234,18 @@ impl CommandReceiver {
     fn finish_batch<S: ReadStorage>(
         &self,
         vm: &mut VmInstance<S, HistoryEnabled>,
-    ) -> FinishedL1Batch {
+    ) -> anyhow::Result<FinishedL1Batch> {
         // The vm execution was paused right after the last transaction was executed.
         // There is some post-processing work that the VM needs to do before the block is fully processed.
         let result = vm.finish_batch();
-        if result.block_tip_execution_result.result.is_failed() {
-            panic!(
-                "VM must not fail when finalizing block: {:#?}",
-                result.block_tip_execution_result.result
-            );
-        }
+        anyhow::ensure!(
+            !result.block_tip_execution_result.result.is_failed(),
+            "VM must not fail when finalizing block: {:#?}",
+            result.block_tip_execution_result.result
+        );
 
         BATCH_TIP_METRICS.observe(&result.block_tip_execution_result);
-        result
+        Ok(result)
     }
 
     /// Attempts to execute transaction with or without bytecode compression.
@@ -243,11 +254,7 @@ impl CommandReceiver {
         &self,
         tx: &Transaction,
         vm: &mut VmInstance<S, HistoryEnabled>,
-    ) -> (
-        VmExecutionResultAndLogs,
-        Vec<CompressedBytecodeInfo>,
-        Vec<Call>,
-    ) {
+    ) -> anyhow::Result<TransactionOutput> {
         // Note, that the space where we can put the calldata for compressing transactions
         // is limited and the transactions do not pay for taking it.
         // In order to not let the accounts spam the space of compressed bytecodes with bytecodes
@@ -264,16 +271,20 @@ impl CommandReceiver {
             vec![]
         };
 
-        if let (Ok(()), result) =
+        if let (Ok(()), tx_result) =
             vm.inspect_transaction_with_bytecode_compression(tracer.into(), tx.clone(), true)
         {
             let compressed_bytecodes = vm.get_last_tx_compressed_bytecodes();
 
-            let trace = Arc::try_unwrap(call_tracer_result)
-                .unwrap()
+            let calls = Arc::try_unwrap(call_tracer_result)
+                .map_err(|_| anyhow::anyhow!("failed extracting call traces"))?
                 .take()
                 .unwrap_or_default();
-            return (result, compressed_bytecodes, trace);
+            return Ok(TransactionOutput {
+                tx_result,
+                compressed_bytecodes,
+                calls,
+            });
         }
 
         // Roll back to the snapshot just before the transaction execution taken in `Self::execute_tx()`
@@ -288,20 +299,22 @@ impl CommandReceiver {
             vec![]
         };
 
-        let result =
+        let (compression_result, tx_result) =
             vm.inspect_transaction_with_bytecode_compression(tracer.into(), tx.clone(), false);
-        result
-            .0
-            .expect("Compression can't fail if we don't apply it");
+        compression_result.context("compression failed when it wasn't applied")?;
         let compressed_bytecodes = vm.get_last_tx_compressed_bytecodes();
 
         // TODO implement tracer manager which will be responsible
-        // for collecting result from all tracers and save it to the database
-        let trace = Arc::try_unwrap(call_tracer_result)
-            .unwrap()
+        //   for collecting result from all tracers and save it to the database
+        let calls = Arc::try_unwrap(call_tracer_result)
+            .map_err(|_| anyhow::anyhow!("failed extracting call traces"))?
             .take()
             .unwrap_or_default();
-        (result.1, compressed_bytecodes, trace)
+        Ok(TransactionOutput {
+            tx_result,
+            compressed_bytecodes,
+            calls,
+        })
     }
 
     /// Attempts to execute transaction with mandatory bytecode compression.
@@ -310,11 +323,7 @@ impl CommandReceiver {
         &self,
         tx: &Transaction,
         vm: &mut VmInstance<S, HistoryEnabled>,
-    ) -> (
-        VmExecutionResultAndLogs,
-        Vec<CompressedBytecodeInfo>,
-        Vec<Call>,
-    ) {
+    ) -> anyhow::Result<TransactionOutput> {
         let call_tracer_result = Arc::new(OnceCell::default());
         let tracer = if self.save_call_traces {
             vec![CallTracer::new(call_tracer_result.clone()).into_tracer_pointer()]
@@ -322,22 +331,29 @@ impl CommandReceiver {
             vec![]
         };
 
-        let (published_bytecodes, mut result) =
+        let (published_bytecodes, mut tx_result) =
             vm.inspect_transaction_with_bytecode_compression(tracer.into(), tx.clone(), true);
         if published_bytecodes.is_ok() {
             let compressed_bytecodes = vm.get_last_tx_compressed_bytecodes();
-
-            let trace = Arc::try_unwrap(call_tracer_result)
-                .unwrap()
+            let calls = Arc::try_unwrap(call_tracer_result)
+                .map_err(|_| anyhow::anyhow!("failed extracting call traces"))?
                 .take()
                 .unwrap_or_default();
-            (result, compressed_bytecodes, trace)
+            Ok(TransactionOutput {
+                tx_result,
+                compressed_bytecodes,
+                calls,
+            })
         } else {
             // Transaction failed to publish bytecodes, we reject it so initiator doesn't pay fee.
-            result.result = ExecutionResult::Halt {
+            tx_result.result = ExecutionResult::Halt {
                 reason: Halt::FailedToPublishCompressedBytecodes,
             };
-            (result, Default::default(), Default::default())
+            Ok(TransactionOutput {
+                tx_result,
+                compressed_bytecodes: vec![],
+                calls: vec![],
+            })
         }
     }
 }

--- a/core/node/state_keeper/src/batch_executor/main_executor.rs
+++ b/core/node/state_keeper/src/batch_executor/main_executor.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
-use anyhow::Context as _;
 use once_cell::sync::OnceCell;
-use tokio::{runtime::Handle, sync::mpsc};
+use tokio::sync::mpsc;
 use zksync_multivm::{
     interface::{
         storage::{ReadStorage, StorageView},
@@ -76,12 +75,6 @@ impl BatchExecutor<OwnedStorage> for MainBatchExecutor {
         };
 
         let handle = tokio::task::spawn_blocking(move || {
-            let storage = match storage {
-                OwnedStorage::Static(storage) => storage,
-                OwnedStorage::Lending(ref storage) => Handle::current()
-                    .block_on(storage.borrow())
-                    .context("failed accessing state keeper storage")?,
-            };
             executor.run(storage, l1_batch_params, system_env);
             anyhow::Ok(())
         });

--- a/core/node/state_keeper/src/batch_executor/tests/read_storage_factory.rs
+++ b/core/node/state_keeper/src/batch_executor/tests/read_storage_factory.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use tokio::sync::watch;
 use zksync_dal::{ConnectionPool, Core};
-use zksync_state::{OwnedStorage, PgOrRocksdbStorage, ReadStorageFactory, RocksdbStorage};
+use zksync_state::{OwnedStorage, ReadStorageFactory, RocksdbStorage};
 use zksync_types::L1BatchNumber;
 
 #[derive(Debug, Clone)]
@@ -33,7 +33,7 @@ impl ReadStorageFactory for RocksdbStorageFactory {
         else {
             return Ok(None);
         };
-        Ok(Some(PgOrRocksdbStorage::Rocksdb(rocksdb_storage).into()))
+        Ok(Some(OwnedStorage::Rocksdb(rocksdb_storage)))
     }
 }
 

--- a/core/node/vm_runner/src/tests/mod.rs
+++ b/core/node/vm_runner/src/tests/mod.rs
@@ -9,7 +9,7 @@ use zksync_node_test_utils::{
     create_l1_batch_metadata, create_l2_block, execute_l2_transaction,
     l1_batch_metadata_to_commitment_artifacts,
 };
-use zksync_state::{OwnedPostgresStorage, OwnedStorage};
+use zksync_state::OwnedStorage;
 use zksync_state_keeper::{StateKeeperOutputHandler, UpdatesManager};
 use zksync_test_account::Account;
 use zksync_types::{
@@ -57,8 +57,8 @@ impl StorageLoader for PostgresLoader {
             return Ok(None);
         };
 
-        let storage = OwnedPostgresStorage::new(self.0.clone(), l1_batch_number - 1);
-        Ok(Some((data, storage.into())))
+        let storage = OwnedStorage::postgres(conn, l1_batch_number - 1).await?;
+        Ok(Some((data, storage)))
     }
 }
 

--- a/core/node/vm_runner/src/tests/storage.rs
+++ b/core/node/vm_runner/src/tests/storage.rs
@@ -301,12 +301,8 @@ async fn access_vm_runner_storage() -> anyhow::Result<()> {
                 .unwrap();
             let mut pg_storage =
                 PostgresStorage::new(rt_handle.clone(), conn, last_l2_block_number, true);
-            let (_, vm_storage) = rt_handle
+            let (_, mut vm_storage) = rt_handle
                 .block_on(vm_runner_storage.load_batch_eventually(L1BatchNumber(i + 1)))?;
-            let mut vm_storage = match vm_storage {
-                OwnedStorage::Lending(ref storage) => rt_handle.block_on(storage.borrow()).unwrap(),
-                OwnedStorage::Static(storage) => storage,
-            };
 
             // Check that both storages have identical key-value pairs written in them
             for storage_log in &storage_logs {


### PR DESCRIPTION
## What ❔

- Changes `Connection` so that it has `'static` lifetime if created from a pool (i.e., when it is non-transactional).
- Simplifies `ReadStorageFactory` and `MainBatchExecutor` accordingly.

## Why ❔

Reduces complexity. `'static` connections can be sent to a Tokio task etc., meaning improved DevEx.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.