### PR TITLE
feat: enable CORS for local reth

### DIFF
--- a/docker-compose-cpu-runner.yml
+++ b/docker-compose-cpu-runner.yml
@@ -11,7 +11,7 @@ services:
         source: ./etc/reth/chaindata
         target: /chaindata
 
-    command: node --dev --datadir /rethdata --http --http.addr 0.0.0.0 --http.port 8545  --dev.block-time 300ms --chain /chaindata/reth_config
+    command: node --dev --datadir /rethdata --http --http.addr 0.0.0.0 --http.port 8545 --http.corsdomain "*" --dev.block-time 300ms --chain /chaindata/reth_config
     ports:
       - 127.0.0.1:8545:8545
 

--- a/docker-compose-gpu-runner-cuda-12-0.yml
+++ b/docker-compose-gpu-runner-cuda-12-0.yml
@@ -11,7 +11,7 @@ services:
         source: ./etc/reth/chaindata
         target: /chaindata
 
-    command: node --dev --datadir /rethdata --http --http.addr 0.0.0.0 --http.port 8545  --dev.block-time 300ms --chain /chaindata/reth_config
+    command: node --dev --datadir /rethdata --http --http.addr 0.0.0.0 --http.port 8545 --http.corsdomain "*" --dev.block-time 300ms --chain /chaindata/reth_config
     ports:
       - 127.0.0.1:8545:8545
 

--- a/docker-compose-gpu-runner.yml
+++ b/docker-compose-gpu-runner.yml
@@ -11,7 +11,7 @@ services:
         source: ./etc/reth/chaindata
         target: /chaindata
 
-    command: node --dev --datadir /rethdata --http --http.addr 0.0.0.0 --http.port 8545  --dev.block-time 300ms --chain /chaindata/reth_config
+    command: node --dev --datadir /rethdata --http --http.addr 0.0.0.0 --http.port 8545 --http.corsdomain "*" --dev.block-time 300ms --chain /chaindata/reth_config
     ports:
       - 127.0.0.1:8545:8545
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
         source: ./etc/reth/chaindata
         target: /chaindata
 
-    command: node --dev --datadir /rethdata --http --http.addr 0.0.0.0 --http.port 8545  --dev.block-time 300ms --chain /chaindata/reth_config
+    command: node --dev --datadir /rethdata --http --http.addr 0.0.0.0 --http.port 8545 --http.corsdomain "*" --dev.block-time 300ms --chain /chaindata/reth_config
     ports:
       - 127.0.0.1:8545:8545
 


### PR DESCRIPTION
## What ❔
This PR adds the `--http.corsdomain "*"` option to Docker Compose files to enable CORS (Cross-Origin Resource Sharing) on locally running Reth nodes.

## Why ❔
Enables web applications like dapp-portal and block-explorer to make requests to the local RPC endpoint. Without CORS enabled, browser policies block these requests, causing the applications to fail.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`