### PR TITLE
feat(vm): Extract oneshot VM executor interface

### DIFF
--- a/core/lib/multivm/src/tracers/mod.rs
+++ b/core/lib/multivm/src/tracers/mod.rs
@@ -3,7 +3,9 @@ pub use self::{
     multivm_dispatcher::TracerDispatcher,
     prestate_tracer::PrestateTracer,
     storage_invocation::StorageInvocations,
-    validator::{ValidationError, ValidationTracer, ValidationTracerParams},
+    validator::{
+        ValidationError, ValidationTracer, ValidationTracerParams, ViolatedValidationRule,
+    },
 };
 
 mod call_tracer;

--- a/core/lib/multivm/src/tracers/validator/mod.rs
+++ b/core/lib/multivm/src/tracers/validator/mod.rs
@@ -10,13 +10,11 @@ use zksync_types::{
 };
 use zksync_utils::{be_bytes_to_safe_address, u256_to_account_address, u256_to_h256};
 
-pub use crate::tracers::validator::types::{ValidationError, ValidationTracerParams};
+use self::types::{NewTrustedValidationItems, ValidationTracerMode};
+pub use self::types::{ValidationError, ValidationTracerParams, ViolatedValidationRule};
 use crate::{
     glue::tracers::IntoOldVmTracer,
     interface::storage::{StoragePtr, WriteStorage},
-    tracers::validator::types::{
-        NewTrustedValidationItems, ValidationTracerMode, ViolatedValidationRule,
-    },
 };
 
 mod types;

--- a/core/lib/vm_interface/src/lib.rs
+++ b/core/lib/vm_interface/src/lib.rs
@@ -23,7 +23,10 @@ pub use crate::{
             BytecodeCompressionError, Halt, TxRevertReason, VmRevertReason,
             VmRevertReasonParsingError,
         },
-        inputs::{L1BatchEnv, L2BlockEnv, SystemEnv, TxExecutionMode, VmExecutionMode},
+        inputs::{
+            L1BatchEnv, L2BlockEnv, OneshotEnv, PendingL2BlockEnv, SystemEnv, TxExecutionMode,
+            VmExecutionMode,
+        },
         outputs::{
             BootloaderMemory, Call, CallType, CircuitStatistic, CompressedBytecodeInfo,
             CurrentExecutionState, DeduplicatedWritesMetrics, ExecutionResult, FinishedL1Batch,

--- a/core/lib/vm_interface/src/lib.rs
+++ b/core/lib/vm_interface/src/lib.rs
@@ -24,7 +24,7 @@ pub use crate::{
             VmRevertReasonParsingError,
         },
         inputs::{
-            L1BatchEnv, L2BlockEnv, OneshotEnv, PendingL2BlockEnv, SystemEnv, TxExecutionMode,
+            L1BatchEnv, L2BlockEnv, OneshotEnv, StoredL2BlockEnv, SystemEnv, TxExecutionMode,
             VmExecutionMode,
         },
         outputs::{

--- a/core/lib/vm_interface/src/types/inputs/l2_block.rs
+++ b/core/lib/vm_interface/src/types/inputs/l2_block.rs
@@ -19,3 +19,11 @@ impl L2BlockEnv {
         }
     }
 }
+
+/// Pending block information used in oneshot transaction / call execution.
+#[derive(Debug, Clone, Copy)]
+pub struct PendingL2BlockEnv {
+    pub number: u32,
+    pub timestamp: u64,
+    pub txs_rolling_hash: H256,
+}

--- a/core/lib/vm_interface/src/types/inputs/l2_block.rs
+++ b/core/lib/vm_interface/src/types/inputs/l2_block.rs
@@ -10,20 +10,20 @@ pub struct L2BlockEnv {
 }
 
 impl L2BlockEnv {
-    pub fn from_l2_block_data(miniblock_execution_data: &L2BlockExecutionData) -> Self {
+    pub fn from_l2_block_data(execution_data: &L2BlockExecutionData) -> Self {
         Self {
-            number: miniblock_execution_data.number.0,
-            timestamp: miniblock_execution_data.timestamp,
-            prev_block_hash: miniblock_execution_data.prev_block_hash,
-            max_virtual_blocks_to_create: miniblock_execution_data.virtual_blocks,
+            number: execution_data.number.0,
+            timestamp: execution_data.timestamp,
+            prev_block_hash: execution_data.prev_block_hash,
+            max_virtual_blocks_to_create: execution_data.virtual_blocks,
         }
     }
 }
 
-/// Pending block information used in oneshot transaction / call execution.
-// FIXME: come up with a better name
+/// Current block information stored in the system context contract. Can be used to set up
+/// oneshot transaction / call execution.
 #[derive(Debug, Clone, Copy)]
-pub struct PendingL2BlockEnv {
+pub struct StoredL2BlockEnv {
     pub number: u32,
     pub timestamp: u64,
     pub txs_rolling_hash: H256,

--- a/core/lib/vm_interface/src/types/inputs/l2_block.rs
+++ b/core/lib/vm_interface/src/types/inputs/l2_block.rs
@@ -21,6 +21,7 @@ impl L2BlockEnv {
 }
 
 /// Pending block information used in oneshot transaction / call execution.
+// FIXME: come up with a better name
 #[derive(Debug, Clone, Copy)]
 pub struct PendingL2BlockEnv {
     pub number: u32,

--- a/core/lib/vm_interface/src/types/inputs/mod.rs
+++ b/core/lib/vm_interface/src/types/inputs/mod.rs
@@ -1,7 +1,7 @@
 pub use self::{
     execution_mode::VmExecutionMode,
     l1_batch_env::L1BatchEnv,
-    l2_block::L2BlockEnv,
+    l2_block::{L2BlockEnv, PendingL2BlockEnv},
     system_env::{SystemEnv, TxExecutionMode},
 };
 
@@ -9,3 +9,14 @@ mod execution_mode;
 mod l1_batch_env;
 mod l2_block;
 mod system_env;
+
+/// Full environment for oneshot transaction / call execution.
+#[derive(Debug)]
+pub struct OneshotEnv {
+    /// System environment.
+    pub system: SystemEnv,
+    /// Part of the environment specific to an L1 batch.
+    pub l1_batch: L1BatchEnv,
+    /// Part of the environment representing a pending L2 block.
+    pub pending_block: Option<PendingL2BlockEnv>,
+}

--- a/core/lib/vm_interface/src/types/inputs/mod.rs
+++ b/core/lib/vm_interface/src/types/inputs/mod.rs
@@ -1,7 +1,7 @@
 pub use self::{
     execution_mode::VmExecutionMode,
     l1_batch_env::L1BatchEnv,
-    l2_block::{L2BlockEnv, PendingL2BlockEnv},
+    l2_block::{L2BlockEnv, StoredL2BlockEnv},
     system_env::{SystemEnv, TxExecutionMode},
 };
 
@@ -17,6 +17,7 @@ pub struct OneshotEnv {
     pub system: SystemEnv,
     /// Part of the environment specific to an L1 batch.
     pub l1_batch: L1BatchEnv,
-    /// Part of the environment representing a pending L2 block.
-    pub pending_block: Option<PendingL2BlockEnv>,
+    /// Part of the environment representing the current L2 block. Can be used to override storage slots
+    /// in the system context contract, which are set from `L1BatchEnv.first_l2_block` by default.
+    pub current_block: Option<StoredL2BlockEnv>,
 }

--- a/core/node/api_server/src/execution_sandbox/execute.rs
+++ b/core/node/api_server/src/execution_sandbox/execute.rs
@@ -3,13 +3,12 @@
 use async_trait::async_trait;
 use zksync_dal::{Connection, Core};
 use zksync_multivm::interface::{
-    storage::ReadStorage, BytecodeCompressionError, OneshotEnv, TxExecutionMode,
-    VmExecutionResultAndLogs, TransactionExecutionMetrics,
+    storage::ReadStorage, BytecodeCompressionError, OneshotEnv, TransactionExecutionMetrics,
+    TxExecutionMode, VmExecutionResultAndLogs,
 };
 use zksync_types::{
-    api::state_override::StateOverride, l2::L2Tx,
-    transaction_request::CallOverrides, ExecuteTransactionCommon, Nonce, PackedEthSignature,
-    Transaction, U256,
+    api::state_override::StateOverride, l2::L2Tx, transaction_request::CallOverrides,
+    ExecuteTransactionCommon, Nonce, PackedEthSignature, Transaction, U256,
 };
 
 use super::{

--- a/core/node/api_server/src/execution_sandbox/mod.rs
+++ b/core/node/api_server/src/execution_sandbox/mod.rs
@@ -410,6 +410,7 @@ impl BlockArgs {
     }
 }
 
+/// VM executor capable of executing isolated transactions / calls (as opposed to batch execution).
 #[async_trait]
 trait OneshotExecutor<S: ReadStorage> {
     type Tracers: Default;

--- a/core/node/api_server/src/execution_sandbox/testonly.rs
+++ b/core/node/api_server/src/execution_sandbox/testonly.rs
@@ -13,12 +13,12 @@ use super::{execute::TransactionExecutor, OneshotExecutor, TxExecutionArgs};
 
 type TxResponseFn = dyn Fn(&Transaction, &OneshotEnv) -> VmExecutionResultAndLogs + Send + Sync;
 
-pub struct MockTransactionExecutor {
+pub struct MockOneshotExecutor {
     call_responses: Box<TxResponseFn>,
     tx_responses: Box<TxResponseFn>,
 }
 
-impl fmt::Debug for MockTransactionExecutor {
+impl fmt::Debug for MockOneshotExecutor {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("MockTransactionExecutor")
@@ -26,7 +26,7 @@ impl fmt::Debug for MockTransactionExecutor {
     }
 }
 
-impl Default for MockTransactionExecutor {
+impl Default for MockOneshotExecutor {
     fn default() -> Self {
         Self {
             call_responses: Box::new(|tx, _| {
@@ -42,7 +42,7 @@ impl Default for MockTransactionExecutor {
     }
 }
 
-impl MockTransactionExecutor {
+impl MockOneshotExecutor {
     #[cfg(test)]
     pub(crate) fn set_call_responses<F>(&mut self, responses: F)
     where
@@ -95,7 +95,7 @@ impl MockTransactionExecutor {
 }
 
 #[async_trait]
-impl<S> OneshotExecutor<S> for MockTransactionExecutor
+impl<S> OneshotExecutor<S> for MockOneshotExecutor
 where
     S: ReadStorage + Send + 'static,
 {
@@ -125,8 +125,8 @@ where
     }
 }
 
-impl From<MockTransactionExecutor> for TransactionExecutor {
-    fn from(executor: MockTransactionExecutor) -> Self {
+impl From<MockOneshotExecutor> for TransactionExecutor {
+    fn from(executor: MockOneshotExecutor) -> Self {
         Self::Mock(executor)
     }
 }

--- a/core/node/api_server/src/execution_sandbox/testonly.rs
+++ b/core/node/api_server/src/execution_sandbox/testonly.rs
@@ -85,7 +85,7 @@ impl MockOneshotExecutor {
     }
 
     fn mock_inspect(&self, env: OneshotEnv, args: TxExecutionArgs) -> VmExecutionResultAndLogs {
-        match args.execution_mode {
+        match env.system.execution_mode {
             TxExecutionMode::EthCall => (self.call_responses)(&args.transaction, &env),
             TxExecutionMode::VerifyExecute | TxExecutionMode::EstimateFee => {
                 (self.tx_responses)(&args.transaction, &env)

--- a/core/node/api_server/src/execution_sandbox/testonly.rs
+++ b/core/node/api_server/src/execution_sandbox/testonly.rs
@@ -1,17 +1,17 @@
 use std::fmt;
 
+use async_trait::async_trait;
+#[cfg(test)]
+use zksync_multivm::interface::ExecutionResult;
 use zksync_multivm::interface::{
-    ExecutionResult, TransactionExecutionMetrics, VmExecutionResultAndLogs,
+    storage::ReadStorage, BytecodeCompressionError, OneshotEnv, TxExecutionMode,
+    VmExecutionResultAndLogs,
 };
-use zksync_types::{l2::L2Tx, ExecuteTransactionCommon, Transaction};
+use zksync_types::Transaction;
 
-use super::{
-    execute::{TransactionExecutionOutput, TransactionExecutor},
-    validate::ValidationError,
-    BlockArgs,
-};
+use super::{execute::TransactionExecutor, OneshotExecutor, TxExecutionArgs};
 
-type TxResponseFn = dyn Fn(&Transaction, &BlockArgs) -> VmExecutionResultAndLogs + Send + Sync;
+type TxResponseFn = dyn Fn(&Transaction, &OneshotEnv) -> VmExecutionResultAndLogs + Send + Sync;
 
 pub struct MockTransactionExecutor {
     call_responses: Box<TxResponseFn>,
@@ -46,7 +46,7 @@ impl MockTransactionExecutor {
     #[cfg(test)]
     pub(crate) fn set_call_responses<F>(&mut self, responses: F)
     where
-        F: Fn(&Transaction, &BlockArgs) -> ExecutionResult + 'static + Send + Sync,
+        F: Fn(&Transaction, &OneshotEnv) -> ExecutionResult + 'static + Send + Sync,
     {
         self.call_responses = self.wrap_responses(responses);
     }
@@ -54,7 +54,7 @@ impl MockTransactionExecutor {
     #[cfg(test)]
     pub(crate) fn set_tx_responses<F>(&mut self, responses: F)
     where
-        F: Fn(&Transaction, &BlockArgs) -> ExecutionResult + 'static + Send + Sync,
+        F: Fn(&Transaction, &OneshotEnv) -> ExecutionResult + 'static + Send + Sync,
     {
         self.tx_responses = self.wrap_responses(responses);
     }
@@ -62,12 +62,12 @@ impl MockTransactionExecutor {
     #[cfg(test)]
     fn wrap_responses<F>(&mut self, responses: F) -> Box<TxResponseFn>
     where
-        F: Fn(&Transaction, &BlockArgs) -> ExecutionResult + 'static + Send + Sync,
+        F: Fn(&Transaction, &OneshotEnv) -> ExecutionResult + 'static + Send + Sync,
     {
         Box::new(
-            move |tx: &Transaction, ba: &BlockArgs| -> VmExecutionResultAndLogs {
+            move |tx: &Transaction, env: &OneshotEnv| -> VmExecutionResultAndLogs {
                 VmExecutionResultAndLogs {
-                    result: responses(tx, ba),
+                    result: responses(tx, env),
                     logs: Default::default(),
                     statistics: Default::default(),
                     refunds: Default::default(),
@@ -79,51 +79,49 @@ impl MockTransactionExecutor {
     #[cfg(test)]
     pub(crate) fn set_tx_responses_with_logs<F>(&mut self, responses: F)
     where
-        F: Fn(&Transaction, &BlockArgs) -> VmExecutionResultAndLogs + 'static + Send + Sync,
+        F: Fn(&Transaction, &OneshotEnv) -> VmExecutionResultAndLogs + 'static + Send + Sync,
     {
         self.tx_responses = Box::new(responses);
     }
 
-    pub(crate) fn validate_tx(
-        &self,
-        tx: L2Tx,
-        block_args: &BlockArgs,
-    ) -> Result<(), ValidationError> {
-        let result = (self.tx_responses)(&tx.into(), block_args);
-        match result.result {
-            ExecutionResult::Success { .. } => Ok(()),
-            other => Err(ValidationError::Internal(anyhow::anyhow!(
-                "transaction validation failed: {other:?}"
-            ))),
-        }
-    }
-
-    pub(crate) fn execute_tx(
-        &self,
-        tx: &Transaction,
-        block_args: &BlockArgs,
-    ) -> anyhow::Result<TransactionExecutionOutput> {
-        let result = self.get_execution_result(tx, block_args);
-        let output = TransactionExecutionOutput {
-            vm: result,
-            metrics: TransactionExecutionMetrics::default(),
-            are_published_bytecodes_ok: true,
-        };
-
-        Ok(output)
-    }
-
-    fn get_execution_result(
-        &self,
-        tx: &Transaction,
-        block_args: &BlockArgs,
-    ) -> VmExecutionResultAndLogs {
-        if let ExecuteTransactionCommon::L2(data) = &tx.common_data {
-            if data.input.is_none() {
-                return (self.call_responses)(tx, block_args);
+    fn mock_inspect(&self, env: OneshotEnv, args: TxExecutionArgs) -> VmExecutionResultAndLogs {
+        match args.execution_mode {
+            TxExecutionMode::EthCall => (self.call_responses)(&args.transaction, &env),
+            TxExecutionMode::VerifyExecute | TxExecutionMode::EstimateFee => {
+                (self.tx_responses)(&args.transaction, &env)
             }
         }
-        (self.tx_responses)(tx, block_args)
+    }
+}
+
+#[async_trait]
+impl<S> OneshotExecutor<S> for MockTransactionExecutor
+where
+    S: ReadStorage + Send + 'static,
+{
+    type Tracers = ();
+
+    async fn inspect_transaction(
+        &self,
+        _storage: S,
+        env: OneshotEnv,
+        args: TxExecutionArgs,
+        (): Self::Tracers,
+    ) -> anyhow::Result<VmExecutionResultAndLogs> {
+        Ok(self.mock_inspect(env, args))
+    }
+
+    async fn inspect_transaction_with_bytecode_compression(
+        &self,
+        _storage: S,
+        env: OneshotEnv,
+        args: TxExecutionArgs,
+        (): Self::Tracers,
+    ) -> anyhow::Result<(
+        Result<(), BytecodeCompressionError>,
+        VmExecutionResultAndLogs,
+    )> {
+        Ok((Ok(()), self.mock_inspect(env, args)))
     }
 }
 

--- a/core/node/api_server/src/execution_sandbox/tests.rs
+++ b/core/node/api_server/src/execution_sandbox/tests.rs
@@ -191,7 +191,7 @@ async fn test_instantiating_vm(connection: Connection<'static, Core>, block_args
     let transaction = Transaction::from(create_l2_transaction(10, 100));
     let estimate_gas_contracts = ApiContracts::load_from_disk().await.unwrap().estimate_gas;
 
-    let execution_args = TxExecutionArgs::for_gas_estimate(None, transaction.clone(), 123);
+    let execution_args = TxExecutionArgs::for_gas_estimate(transaction.clone(), 123);
     let (env, storage) = apply::prepare_env_and_storage(
         connection,
         TxSharedArgs::mock(estimate_gas_contracts),

--- a/core/node/api_server/src/execution_sandbox/tests.rs
+++ b/core/node/api_server/src/execution_sandbox/tests.rs
@@ -191,11 +191,10 @@ async fn test_instantiating_vm(connection: Connection<'static, Core>, block_args
     let transaction = Transaction::from(create_l2_transaction(10, 100));
     let estimate_gas_contracts = ApiContracts::load_from_disk().await.unwrap().estimate_gas;
 
-    let execution_args = TxExecutionArgs::for_gas_estimate(transaction.clone(), 123);
+    let execution_args = TxExecutionArgs::for_gas_estimate(transaction.clone());
     let (env, storage) = apply::prepare_env_and_storage(
         connection,
-        TxSharedArgs::mock(estimate_gas_contracts),
-        &execution_args,
+        TxSetupArgs::mock(TxExecutionMode::EstimateFee, estimate_gas_contracts),
         &block_args,
     )
     .await

--- a/core/node/api_server/src/execution_sandbox/tracers.rs
+++ b/core/node/api_server/src/execution_sandbox/tracers.rs
@@ -3,26 +3,48 @@ use std::sync::Arc;
 use once_cell::sync::OnceCell;
 use zksync_multivm::{
     interface::{storage::WriteStorage, Call},
-    tracers::CallTracer,
+    tracers::{CallTracer, ValidationTracer, ValidationTracerParams, ViolatedValidationRule},
     vm_latest::HistoryMode,
     MultiVMTracer, MultiVmTracerPointer,
 };
 
-/// Custom tracers supported by our API
+use super::apply::InitializedVm;
+
+/// Custom tracers supported by the API sandbox.
 #[derive(Debug)]
 pub(crate) enum ApiTracer {
     CallTracer(Arc<OnceCell<Vec<Call>>>),
+    Validation {
+        params: ValidationTracerParams,
+        result: Arc<OnceCell<ViolatedValidationRule>>,
+    },
 }
 
 impl ApiTracer {
-    pub fn into_boxed<
+    pub fn validation(
+        params: ValidationTracerParams,
+    ) -> (Self, Arc<OnceCell<ViolatedValidationRule>>) {
+        let result = Arc::<OnceCell<_>>::default();
+        let this = Self::Validation {
+            params,
+            result: result.clone(),
+        };
+        (this, result)
+    }
+
+    pub(super) fn into_boxed<S, H>(self, vm: &InitializedVm) -> MultiVmTracerPointer<S, H>
+    where
         S: WriteStorage,
         H: HistoryMode + zksync_multivm::HistoryMode<Vm1_5_0 = H> + 'static,
-    >(
-        self,
-    ) -> MultiVmTracerPointer<S, H> {
+    {
         match self {
-            ApiTracer::CallTracer(tracer) => CallTracer::new(tracer.clone()).into_tracer_pointer(),
+            Self::CallTracer(traces) => CallTracer::new(traces).into_tracer_pointer(),
+            Self::Validation { params, result } => {
+                let (mut tracer, _) =
+                    ValidationTracer::<H>::new(params, vm.protocol_version().into());
+                tracer.result = result;
+                tracer.into_tracer_pointer()
+            }
         }
     }
 }

--- a/core/node/api_server/src/execution_sandbox/tracers.rs
+++ b/core/node/api_server/src/execution_sandbox/tracers.rs
@@ -8,7 +8,7 @@ use zksync_multivm::{
     MultiVMTracer, MultiVmTracerPointer,
 };
 
-use super::apply::InitializedVm;
+use super::apply::OneshotExecutor;
 
 /// Custom tracers supported by the API sandbox.
 #[derive(Debug)]
@@ -32,7 +32,7 @@ impl ApiTracer {
         (this, result)
     }
 
-    pub(super) fn into_boxed<S, H>(self, vm: &InitializedVm) -> MultiVmTracerPointer<S, H>
+    pub(super) fn into_boxed<S, H>(self, vm: &OneshotExecutor) -> MultiVmTracerPointer<S, H>
     where
         S: WriteStorage,
         H: HistoryMode + zksync_multivm::HistoryMode<Vm1_5_0 = H> + 'static,

--- a/core/node/api_server/src/execution_sandbox/tracers.rs
+++ b/core/node/api_server/src/execution_sandbox/tracers.rs
@@ -7,8 +7,7 @@ use zksync_multivm::{
     vm_latest::HistoryDisabled,
     MultiVMTracer, MultiVmTracerPointer,
 };
-
-use super::apply::OneshotExecutor;
+use zksync_types::ProtocolVersionId;
 
 /// Custom tracers supported by the API sandbox.
 #[derive(Debug)]

--- a/core/node/api_server/src/tx_sender/mod.rs
+++ b/core/node/api_server/src/tx_sender/mod.rs
@@ -380,10 +380,8 @@ impl TxSender {
             .execute_tx_in_sandbox(
                 vm_permit.clone(),
                 shared_args.clone(),
-                true,
-                TxExecutionArgs::for_validation(&tx),
+                TxExecutionArgs::for_validation(tx.clone()),
                 connection,
-                tx.clone().into(),
                 block_args,
                 None,
                 vec![],
@@ -694,7 +692,7 @@ impl TxSender {
         let shared_args = self.shared_args_for_gas_estimate(fee_model_params).await;
         let vm_execution_cache_misses_limit = self.0.sender_config.vm_execution_cache_misses_limit;
         let execution_args =
-            TxExecutionArgs::for_gas_estimate(vm_execution_cache_misses_limit, &tx, base_fee);
+            TxExecutionArgs::for_gas_estimate(vm_execution_cache_misses_limit, tx, base_fee);
         let connection = self.acquire_replica_connection().await?;
         let execution_output = self
             .0
@@ -702,10 +700,8 @@ impl TxSender {
             .execute_tx_in_sandbox(
                 vm_permit,
                 shared_args,
-                true,
                 execution_args,
                 connection,
-                tx.clone(),
                 block_args,
                 state_override,
                 vec![],

--- a/core/node/api_server/src/tx_sender/mod.rs
+++ b/core/node/api_server/src/tx_sender/mod.rs
@@ -372,7 +372,7 @@ impl TxSender {
         stage_latency.observe();
 
         let stage_latency = SANDBOX_METRICS.start_tx_submit_stage(tx_hash, SubmitTxStage::DryRun);
-        let shared_args = self.call_args(&tx, None).await?;
+        let setup_args = self.call_args(&tx, None).await?;
         let vm_permit = self.0.vm_concurrency_limiter.acquire().await;
         let vm_permit = vm_permit.ok_or(SubmitTxError::ServerShuttingDown)?;
         let mut connection = self.acquire_replica_connection().await?;
@@ -383,7 +383,7 @@ impl TxSender {
             .executor
             .execute_tx_in_sandbox(
                 vm_permit.clone(),
-                shared_args.clone(),
+                setup_args.clone(),
                 TxExecutionArgs::for_validation(tx.clone()),
                 connection,
                 block_args,
@@ -408,7 +408,7 @@ impl TxSender {
                 connection,
                 vm_permit,
                 tx.clone(),
-                shared_args,
+                setup_args,
                 block_args,
                 computational_gas_limit,
             )
@@ -707,7 +707,7 @@ impl TxSender {
             }
         }
 
-        let shared_args = self.args_for_gas_estimate(fee_model_params, base_fee).await;
+        let setup_args = self.args_for_gas_estimate(fee_model_params, base_fee).await;
         let execution_args = TxExecutionArgs::for_gas_estimate(tx);
         let connection = self.acquire_replica_connection().await?;
         let execution_output = self
@@ -715,7 +715,7 @@ impl TxSender {
             .executor
             .execute_tx_in_sandbox(
                 vm_permit,
-                shared_args,
+                setup_args,
                 execution_args,
                 connection,
                 block_args,

--- a/core/node/api_server/src/tx_sender/mod.rs
+++ b/core/node/api_server/src/tx_sender/mod.rs
@@ -263,7 +263,7 @@ impl TxSenderBuilder {
             storage_caches,
             whitelisted_tokens_for_aa_cache,
             sealer,
-            executor: TransactionExecutor::Real,
+            executor: TransactionExecutor::real(),
         }))
     }
 }
@@ -320,7 +320,7 @@ pub struct TxSenderInner {
     // Cache for white-listed tokens.
     pub(super) whitelisted_tokens_for_aa_cache: Arc<RwLock<Vec<Address>>>,
     /// Batch sealer used to check whether transaction can be executed by the sequencer.
-    sealer: Arc<dyn ConditionalSealer>,
+    pub(super) sealer: Arc<dyn ConditionalSealer>,
     pub(super) executor: TransactionExecutor,
 }
 

--- a/core/node/api_server/src/tx_sender/mod.rs
+++ b/core/node/api_server/src/tx_sender/mod.rs
@@ -13,7 +13,7 @@ use zksync_multivm::{
     interface::{TransactionExecutionMetrics, TxExecutionMode, VmExecutionResultAndLogs},
     utils::{
         adjust_pubdata_price_for_tx, derive_base_fee_and_gas_per_pubdata, derive_overhead,
-        get_eth_call_gas_limit, get_max_batch_gas_limit,
+        get_max_batch_gas_limit,
     },
     vm_latest::constants::BATCH_COMPUTATIONAL_GAS_LIMIT,
 };
@@ -1074,21 +1074,5 @@ impl TxSender {
             return Err(SubmitTxError::Unexecutable(message));
         }
         Ok(())
-    }
-
-    // FIXME: rework as `BlockArgs` method with supplied connection
-    pub(crate) async fn get_default_eth_call_gas(
-        &self,
-        block_args: BlockArgs,
-    ) -> anyhow::Result<u64> {
-        let mut connection = self.acquire_replica_connection().await?;
-
-        let protocol_version = block_args
-            .resolve_block_info(&mut connection)
-            .await
-            .context("failed to resolve block info")?
-            .protocol_version;
-
-        Ok(get_eth_call_gas_limit(protocol_version.into()))
     }
 }

--- a/core/node/api_server/src/tx_sender/tests.rs
+++ b/core/node/api_server/src/tx_sender/tests.rs
@@ -10,7 +10,7 @@ use zksync_utils::u256_to_h256;
 
 use super::*;
 use crate::{
-    execution_sandbox::testonly::MockTransactionExecutor, web3::testonly::create_test_tx_sender,
+    execution_sandbox::testonly::MockOneshotExecutor, web3::testonly::create_test_tx_sender,
 };
 
 #[tokio::test]
@@ -31,7 +31,7 @@ async fn getting_nonce_for_account() {
         .await
         .unwrap();
 
-    let tx_executor = MockTransactionExecutor::default().into();
+    let tx_executor = MockOneshotExecutor::default().into();
     let (tx_sender, _) = create_test_tx_sender(pool.clone(), l2_chain_id, tx_executor).await;
 
     let nonce = tx_sender.get_expected_nonce(test_address).await.unwrap();
@@ -81,7 +81,7 @@ async fn getting_nonce_for_account_after_snapshot_recovery() {
     .await;
 
     let l2_chain_id = L2ChainId::default();
-    let tx_executor = MockTransactionExecutor::default().into();
+    let tx_executor = MockOneshotExecutor::default().into();
     let (tx_sender, _) = create_test_tx_sender(pool.clone(), l2_chain_id, tx_executor).await;
 
     storage
@@ -136,7 +136,7 @@ async fn submitting_tx_requires_one_connection() {
         .unwrap();
     drop(storage);
 
-    let mut tx_executor = MockTransactionExecutor::default();
+    let mut tx_executor = MockOneshotExecutor::default();
     tx_executor.set_tx_responses(move |received_tx, _| {
         assert_eq!(received_tx.hash(), tx_hash);
         ExecutionResult::Success { output: vec![] }

--- a/core/node/api_server/src/web3/namespaces/debug.rs
+++ b/core/node/api_server/src/web3/namespaces/debug.rs
@@ -4,7 +4,7 @@ use anyhow::Context as _;
 use once_cell::sync::OnceCell;
 use zksync_dal::{CoreDal, DalError};
 use zksync_multivm::{
-    interface::{Call, CallType, ExecutionResult},
+    interface::{Call, CallType, ExecutionResult, TxExecutionMode},
     vm_latest::constants::BATCH_COMPUTATIONAL_GAS_LIMIT,
 };
 use zksync_system_constants::MAX_ENCODED_TX_SIZE;
@@ -19,7 +19,7 @@ use zksync_types::{
 use zksync_web3_decl::error::Web3Error;
 
 use crate::{
-    execution_sandbox::{ApiTracer, TxSharedArgs},
+    execution_sandbox::{ApiTracer, TxExecutionArgs, TxSetupArgs},
     tx_sender::{ApiContracts, TxSenderConfig},
     web3::{backend_jsonrpsee::MethodTracer, state::RpcState},
 };
@@ -189,7 +189,7 @@ impl DebugNamespace {
         let call_overrides = request.get_call_overrides()?;
         let tx = L2Tx::from_request(request.into(), MAX_ENCODED_TX_SIZE)?;
 
-        let shared_args = self.shared_args().await;
+        let shared_args = self.call_args(call_overrides.enforced_base_fee).await;
         let vm_permit = self
             .state
             .tx_sender
@@ -209,17 +209,17 @@ impl DebugNamespace {
         let connection = self.state.acquire_connection().await?;
         let executor = &self.state.tx_sender.0.executor;
         let result = executor
-            .execute_tx_eth_call(
+            .execute_tx_in_sandbox(
                 vm_permit,
                 shared_args,
+                TxExecutionArgs::for_eth_call(tx.clone()),
                 connection,
-                call_overrides,
-                tx.clone(),
                 block_args,
-                custom_tracers,
                 None,
+                custom_tracers,
             )
-            .await?;
+            .await?
+            .vm;
 
         let (output, revert_reason) = match result.result {
             ExecutionResult::Success { output, .. } => (output, None),
@@ -249,9 +249,10 @@ impl DebugNamespace {
         Ok(Self::map_call(call, false))
     }
 
-    async fn shared_args(&self) -> TxSharedArgs {
+    async fn call_args(&self, enforced_base_fee: Option<u64>) -> TxSetupArgs {
         let sender_config = self.sender_config();
-        TxSharedArgs {
+        TxSetupArgs {
+            execution_mode: TxExecutionMode::EthCall,
             operator_account: AccountTreeId::default(),
             fee_input: self.batch_fee_input,
             base_system_contracts: self.api_contracts.eth_call.clone(),
@@ -263,6 +264,7 @@ impl DebugNamespace {
                 .tx_sender
                 .read_whitelisted_tokens_for_aa_cache()
                 .await,
+            enforced_base_fee,
         }
     }
 }

--- a/core/node/api_server/src/web3/namespaces/debug.rs
+++ b/core/node/api_server/src/web3/namespaces/debug.rs
@@ -216,7 +216,6 @@ impl DebugNamespace {
                 call_overrides,
                 tx.clone(),
                 block_args,
-                self.sender_config().vm_execution_cache_misses_limit,
                 custom_tracers,
                 None,
             )

--- a/core/node/api_server/src/web3/namespaces/debug.rs
+++ b/core/node/api_server/src/web3/namespaces/debug.rs
@@ -180,7 +180,7 @@ impl DebugNamespace {
         let call_overrides = request.get_call_overrides()?;
         let tx = L2Tx::from_request(request.into(), MAX_ENCODED_TX_SIZE)?;
 
-        let shared_args = self.call_args(call_overrides.enforced_base_fee).await;
+        let setup_args = self.call_args(call_overrides.enforced_base_fee).await;
         let vm_permit = self
             .state
             .tx_sender
@@ -202,7 +202,7 @@ impl DebugNamespace {
         let result = executor
             .execute_tx_in_sandbox(
                 vm_permit,
-                shared_args,
+                setup_args,
                 TxExecutionArgs::for_eth_call(tx.clone()),
                 connection,
                 block_args,

--- a/core/node/api_server/src/web3/namespaces/debug.rs
+++ b/core/node/api_server/src/web3/namespaces/debug.rs
@@ -206,12 +206,13 @@ impl DebugNamespace {
             vec![ApiTracer::CallTracer(call_tracer_result.clone())]
         };
 
+        let connection = self.state.acquire_connection().await?;
         let executor = &self.state.tx_sender.0.executor;
         let result = executor
             .execute_tx_eth_call(
                 vm_permit,
                 shared_args,
-                self.state.connection_pool.clone(),
+                connection,
                 call_overrides,
                 tx.clone(),
                 block_args,

--- a/core/node/api_server/src/web3/namespaces/eth.rs
+++ b/core/node/api_server/src/web3/namespaces/eth.rs
@@ -70,18 +70,11 @@ impl EthNamespace {
                 .last_sealed_l2_block
                 .diff_with_block_args(&block_args),
         );
+        if request.gas.is_none() {
+            request.gas = Some(block_args.default_eth_call_gas(&mut connection).await?);
+        }
         drop(connection);
 
-        if request.gas.is_none() {
-            request.gas = Some(
-                self.state
-                    .tx_sender
-                    .get_default_eth_call_gas(block_args)
-                    .await
-                    .map_err(Web3Error::InternalError)?
-                    .into(),
-            )
-        }
         let call_overrides = request.get_call_overrides()?;
         let tx = L2Tx::from_request(request.into(), self.state.api_config.max_tx_size)?;
 

--- a/core/node/api_server/src/web3/testonly.rs
+++ b/core/node/api_server/src/web3/testonly.rs
@@ -8,6 +8,7 @@ use zksync_dal::ConnectionPool;
 use zksync_health_check::CheckHealth;
 use zksync_node_fee_model::MockBatchFeeParamsProvider;
 use zksync_state::PostgresStorageCaches;
+use zksync_state_keeper::seal_criteria::NoopSealer;
 use zksync_types::L2ChainId;
 
 use super::{metrics::ApiTransportLabel, *};
@@ -48,7 +49,9 @@ pub(crate) async fn create_test_tx_sender(
     .await
     .expect("failed building transaction sender");
 
-    Arc::get_mut(&mut tx_sender.0).unwrap().executor = tx_executor;
+    let tx_sender_inner = Arc::get_mut(&mut tx_sender.0).unwrap();
+    tx_sender_inner.executor = tx_executor;
+    tx_sender_inner.sealer = Arc::new(NoopSealer); // prevents "unexecutable transaction" errors
     (tx_sender, vm_barrier)
 }
 

--- a/core/node/api_server/src/web3/testonly.rs
+++ b/core/node/api_server/src/web3/testonly.rs
@@ -13,7 +13,7 @@ use zksync_types::L2ChainId;
 
 use super::{metrics::ApiTransportLabel, *};
 use crate::{
-    execution_sandbox::{testonly::MockTransactionExecutor, TransactionExecutor},
+    execution_sandbox::{testonly::MockOneshotExecutor, TransactionExecutor},
     tx_sender::TxSenderConfig,
 };
 
@@ -102,7 +102,7 @@ impl ApiServerHandles {
 pub async fn spawn_http_server(
     api_config: InternalApiConfig,
     pool: ConnectionPool<Core>,
-    tx_executor: MockTransactionExecutor,
+    tx_executor: MockOneshotExecutor,
     method_tracer: Arc<MethodTracer>,
     stop_receiver: watch::Receiver<bool>,
 ) -> ApiServerHandles {
@@ -130,7 +130,7 @@ pub async fn spawn_ws_server(
         api_config,
         pool,
         websocket_requests_per_minute_limit,
-        MockTransactionExecutor::default(),
+        MockOneshotExecutor::default(),
         Arc::default(),
         stop_receiver,
     )
@@ -142,7 +142,7 @@ async fn spawn_server(
     api_config: InternalApiConfig,
     pool: ConnectionPool<Core>,
     websocket_requests_per_minute_limit: Option<NonZeroU32>,
-    tx_executor: MockTransactionExecutor,
+    tx_executor: MockOneshotExecutor,
     method_tracer: Arc<MethodTracer>,
     stop_receiver: watch::Receiver<bool>,
 ) -> (ApiServerHandles, mpsc::UnboundedReceiver<PubSubEvent>) {

--- a/core/node/api_server/src/web3/tests/mod.rs
+++ b/core/node/api_server/src/web3/tests/mod.rs
@@ -25,9 +25,12 @@ use zksync_node_test_utils::{
     create_l1_batch, create_l1_batch_metadata, create_l2_block, create_l2_transaction,
     l1_batch_metadata_to_commitment_artifacts, prepare_recovery_snapshot,
 };
+use zksync_system_constants::{
+    SYSTEM_CONTEXT_ADDRESS, SYSTEM_CONTEXT_CURRENT_L2_BLOCK_INFO_POSITION,
+};
 use zksync_types::{
     api,
-    block::L2BlockHeader,
+    block::{pack_block_info, L2BlockHeader},
     get_nonce_key,
     l2::L2Tx,
     storage::get_code_key,
@@ -173,7 +176,7 @@ impl StorageInitialization {
     }
 
     async fn prepare_storage(
-        &self,
+        self,
         network_config: &NetworkConfig,
         storage: &mut Connection<'_, Core>,
     ) -> anyhow::Result<()> {
@@ -188,17 +191,33 @@ impl StorageInitialization {
                     insert_genesis_batch(storage, &params).await?;
                 }
             }
-            Self::Recovery { logs, factory_deps } => {
+            Self::Recovery {
+                mut logs,
+                factory_deps,
+            } => {
+                let l2_block_info_key = StorageKey::new(
+                    AccountTreeId::new(SYSTEM_CONTEXT_ADDRESS),
+                    SYSTEM_CONTEXT_CURRENT_L2_BLOCK_INFO_POSITION,
+                );
+                let block_info = pack_block_info(
+                    Self::SNAPSHOT_RECOVERY_BLOCK.0.into(),
+                    Self::SNAPSHOT_RECOVERY_BLOCK.0.into(),
+                );
+                logs.push(StorageLog::new_write_log(
+                    l2_block_info_key,
+                    u256_to_h256(block_info),
+                ));
+
                 prepare_recovery_snapshot(
                     storage,
                     Self::SNAPSHOT_RECOVERY_BATCH,
                     Self::SNAPSHOT_RECOVERY_BLOCK,
-                    logs,
+                    &logs,
                 )
                 .await;
                 storage
                     .factory_deps_dal()
-                    .insert_factory_deps(Self::SNAPSHOT_RECOVERY_BLOCK, factory_deps)
+                    .insert_factory_deps(Self::SNAPSHOT_RECOVERY_BLOCK, &factory_deps)
                     .await?;
 
                 // Insert the next L1 batch in the storage so that the API server doesn't hang up.
@@ -281,7 +300,7 @@ fn execute_l2_transaction(transaction: L2Tx) -> TransactionExecutionResult {
     }
 }
 
-/// Stores L2 block with a single transaction and returns the L2 block header + transaction hash.
+/// Stores L2 block and returns the L2 block header.
 async fn store_l2_block(
     storage: &mut Connection<'_, Core>,
     number: L2BlockNumber,
@@ -296,6 +315,18 @@ async fn store_l2_block(
             .unwrap();
         assert_matches!(tx_submission_result, L2TxSubmissionResult::Added);
     }
+
+    // Record L2 block info which is read by the VM sandbox logic
+    let l2_block_info_key = StorageKey::new(
+        AccountTreeId::new(SYSTEM_CONTEXT_ADDRESS),
+        SYSTEM_CONTEXT_CURRENT_L2_BLOCK_INFO_POSITION,
+    );
+    let block_info = pack_block_info(number.0.into(), number.0.into());
+    let l2_block_log = StorageLog::new_write_log(l2_block_info_key, u256_to_h256(block_info));
+    storage
+        .storage_logs_dal()
+        .append_storage_logs(number, &[l2_block_log])
+        .await?;
 
     let new_l2_block = create_l2_block(number.0);
     storage.blocks_dal().insert_l2_block(&new_l2_block).await?;

--- a/core/node/api_server/src/web3/tests/mod.rs
+++ b/core/node/api_server/src/web3/tests/mod.rs
@@ -57,7 +57,7 @@ use zksync_web3_decl::{
 
 use super::*;
 use crate::{
-    execution_sandbox::testonly::MockTransactionExecutor,
+    execution_sandbox::testonly::MockOneshotExecutor,
     web3::testonly::{spawn_http_server, spawn_ws_server},
 };
 
@@ -137,8 +137,8 @@ trait HttpTest: Send + Sync {
         StorageInitialization::Genesis
     }
 
-    fn transaction_executor(&self) -> MockTransactionExecutor {
-        MockTransactionExecutor::default()
+    fn transaction_executor(&self) -> MockOneshotExecutor {
+        MockOneshotExecutor::default()
     }
 
     fn method_tracer(&self) -> Arc<MethodTracer> {

--- a/core/node/api_server/src/web3/tests/vm.rs
+++ b/core/node/api_server/src/web3/tests/vm.rs
@@ -34,15 +34,15 @@ impl CallTest {
         }
     }
 
-    fn create_executor(only_block: L2BlockNumber) -> MockTransactionExecutor {
+    fn create_executor(latest_block: L2BlockNumber) -> MockTransactionExecutor {
         let mut tx_executor = MockTransactionExecutor::default();
-        tx_executor.set_call_responses(move |tx, block_args| {
+        tx_executor.set_call_responses(move |tx, env| {
             let expected_block_number = match tx.execute.calldata() {
-                b"pending" => only_block + 1,
-                b"first" => only_block,
+                b"pending" => latest_block + 1,
+                b"latest" => latest_block,
                 data => panic!("Unexpected calldata: {data:?}"),
             };
-            assert_eq!(block_args.resolved_block_number(), expected_block_number);
+            assert_eq!(env.l1_batch.first_l2_block.number, expected_block_number.0);
 
             ExecutionResult::Success {
                 output: b"output".to_vec(),
@@ -55,14 +55,19 @@ impl CallTest {
 #[async_trait]
 impl HttpTest for CallTest {
     fn transaction_executor(&self) -> MockTransactionExecutor {
-        Self::create_executor(L2BlockNumber(0))
+        Self::create_executor(L2BlockNumber(1))
     }
 
     async fn test(
         &self,
         client: &DynClient<L2>,
-        _pool: &ConnectionPool<Core>,
+        pool: &ConnectionPool<Core>,
     ) -> anyhow::Result<()> {
+        // Store an additional L2 block because L2 block #0 has some special processing making it work incorrectly.
+        let mut connection = pool.connection().await?;
+        store_l2_block(&mut connection, L2BlockNumber(1), &[]).await?;
+        drop(connection);
+
         let call_result = client
             .call(Self::call_request(b"pending"), None, None)
             .await?;
@@ -70,8 +75,8 @@ impl HttpTest for CallTest {
 
         let valid_block_numbers_and_calldata = [
             (api::BlockNumber::Pending, b"pending" as &[_]),
-            (api::BlockNumber::Latest, b"first"),
-            (0.into(), b"first"),
+            (api::BlockNumber::Latest, b"latest"),
+            (0.into(), b"latest"),
         ];
         for (number, calldata) in valid_block_numbers_and_calldata {
             let number = api::BlockIdVariant::BlockNumber(number);
@@ -150,7 +155,7 @@ impl HttpTest for CallTestAfterSnapshotRecovery {
         for number in first_l2_block_numbers {
             let number = api::BlockIdVariant::BlockNumber(number);
             let call_result = client
-                .call(CallTest::call_request(b"first"), Some(number), None)
+                .call(CallTest::call_request(b"latest"), Some(number), None)
                 .await?;
             assert_eq!(call_result.0, b"output");
         }
@@ -224,9 +229,9 @@ impl HttpTest for SendRawTransactionTest {
         } else {
             L2BlockNumber(1)
         };
-        tx_executor.set_tx_responses(move |tx, block_args| {
+        tx_executor.set_tx_responses(move |tx, env| {
             assert_eq!(tx.hash(), Self::transaction_bytes_and_hash().1);
-            assert_eq!(block_args.resolved_block_number(), pending_block);
+            assert_eq!(env.l1_batch.first_l2_block.number, pending_block.0);
             ExecutionResult::Success { output: vec![] }
         });
         tx_executor
@@ -326,9 +331,9 @@ impl HttpTest for SendTransactionWithDetailedOutputTest {
             total_log_queries_count: 0,
         };
 
-        tx_executor.set_tx_responses_with_logs(move |tx, block_args| {
+        tx_executor.set_tx_responses_with_logs(move |tx, env| {
             assert_eq!(tx.hash(), tx_bytes_and_hash.1);
-            assert_eq!(block_args.resolved_block_number(), L2BlockNumber(1));
+            assert_eq!(env.l1_batch.first_l2_block.number, 1);
 
             VmExecutionResultAndLogs {
                 result: ExecutionResult::Success { output: vec![] },
@@ -411,14 +416,19 @@ impl TraceCallTest {
 #[async_trait]
 impl HttpTest for TraceCallTest {
     fn transaction_executor(&self) -> MockTransactionExecutor {
-        CallTest::create_executor(L2BlockNumber(0))
+        CallTest::create_executor(L2BlockNumber(1))
     }
 
     async fn test(
         &self,
         client: &DynClient<L2>,
-        _pool: &ConnectionPool<Core>,
+        pool: &ConnectionPool<Core>,
     ) -> anyhow::Result<()> {
+        // Store an additional L2 block because L2 block #0 has some special processing making it work incorrectly.
+        let mut connection = pool.connection().await?;
+        store_l2_block(&mut connection, L2BlockNumber(1), &[]).await?;
+        drop(connection);
+
         let call_request = CallTest::call_request(b"pending");
         let call_result = client.trace_call(call_request.clone(), None, None).await?;
         Self::assert_debug_call(&call_request, &call_result);
@@ -428,13 +438,9 @@ impl HttpTest for TraceCallTest {
             .await?;
         Self::assert_debug_call(&call_request, &call_result);
 
-        let genesis_block_numbers = [
-            api::BlockNumber::Earliest,
-            api::BlockNumber::Latest,
-            0.into(),
-        ];
-        let call_request = CallTest::call_request(b"first");
-        for number in genesis_block_numbers {
+        let latest_block_numbers = [api::BlockNumber::Latest, 1.into()];
+        let call_request = CallTest::call_request(b"latest");
+        for number in latest_block_numbers {
             let call_result = client
                 .trace_call(
                     call_request.clone(),
@@ -508,7 +514,7 @@ impl HttpTest for TraceCallTestAfterSnapshotRecovery {
             assert_pruned_block_error(&error, first_local_l2_block);
         }
 
-        let call_request = CallTest::call_request(b"first");
+        let call_request = CallTest::call_request(b"latest");
         let first_l2_block_numbers = [api::BlockNumber::Latest, first_local_l2_block.0.into()];
         for number in first_l2_block_numbers {
             let number = api::BlockId::Number(number);
@@ -556,10 +562,10 @@ impl HttpTest for EstimateGasTest {
             L2BlockNumber(1)
         };
         let gas_limit_threshold = self.gas_limit_threshold.clone();
-        tx_executor.set_call_responses(move |tx, block_args| {
+        tx_executor.set_tx_responses(move |tx, env| {
             assert_eq!(tx.execute.calldata(), [] as [u8; 0]);
             assert_eq!(tx.nonce(), Some(Nonce(0)));
-            assert_eq!(block_args.resolved_block_number(), pending_block_number);
+            assert_eq!(env.l1_batch.first_l2_block.number, pending_block_number.0);
 
             let gas_limit_threshold = gas_limit_threshold.load(Ordering::SeqCst);
             if tx.gas_limit() >= U256::from(gas_limit_threshold) {
@@ -641,49 +647,17 @@ async fn estimate_gas_after_snapshot_recovery() {
 
 #[derive(Debug)]
 struct EstimateGasWithStateOverrideTest {
-    gas_limit_threshold: Arc<AtomicU32>,
-    snapshot_recovery: bool,
-}
-
-impl EstimateGasWithStateOverrideTest {
-    fn new(snapshot_recovery: bool) -> Self {
-        Self {
-            gas_limit_threshold: Arc::default(),
-            snapshot_recovery,
-        }
-    }
+    inner: EstimateGasTest,
 }
 
 #[async_trait]
 impl HttpTest for EstimateGasWithStateOverrideTest {
     fn storage_initialization(&self) -> StorageInitialization {
-        let snapshot_recovery = self.snapshot_recovery;
-        SendRawTransactionTest { snapshot_recovery }.storage_initialization()
+        self.inner.storage_initialization()
     }
 
     fn transaction_executor(&self) -> MockTransactionExecutor {
-        let mut tx_executor = MockTransactionExecutor::default();
-        let pending_block_number = if self.snapshot_recovery {
-            StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 2
-        } else {
-            L2BlockNumber(1)
-        };
-        let gas_limit_threshold = self.gas_limit_threshold.clone();
-        tx_executor.set_call_responses(move |tx, block_args| {
-            assert_eq!(tx.execute.calldata(), [] as [u8; 0]);
-            assert_eq!(tx.nonce(), Some(Nonce(0)));
-            assert_eq!(block_args.resolved_block_number(), pending_block_number);
-
-            let gas_limit_threshold = gas_limit_threshold.load(Ordering::SeqCst);
-            if tx.gas_limit() >= U256::from(gas_limit_threshold) {
-                ExecutionResult::Success { output: vec![] }
-            } else {
-                ExecutionResult::Revert {
-                    output: VmRevertReason::VmError,
-                }
-            }
-        });
-        tx_executor
+        self.inner.transaction_executor()
     }
 
     async fn test(
@@ -739,5 +713,6 @@ impl HttpTest for EstimateGasWithStateOverrideTest {
 
 #[tokio::test]
 async fn estimate_gas_with_state_override() {
-    test_http_server(EstimateGasWithStateOverrideTest::new(false)).await;
+    let inner = EstimateGasTest::new(false);
+    test_http_server(EstimateGasWithStateOverrideTest { inner }).await;
 }

--- a/core/node/api_server/src/web3/tests/vm.rs
+++ b/core/node/api_server/src/web3/tests/vm.rs
@@ -34,8 +34,8 @@ impl CallTest {
         }
     }
 
-    fn create_executor(latest_block: L2BlockNumber) -> MockTransactionExecutor {
-        let mut tx_executor = MockTransactionExecutor::default();
+    fn create_executor(latest_block: L2BlockNumber) -> MockOneshotExecutor {
+        let mut tx_executor = MockOneshotExecutor::default();
         tx_executor.set_call_responses(move |tx, env| {
             let expected_block_number = match tx.execute.calldata() {
                 b"pending" => latest_block + 1,
@@ -54,7 +54,7 @@ impl CallTest {
 
 #[async_trait]
 impl HttpTest for CallTest {
-    fn transaction_executor(&self) -> MockTransactionExecutor {
+    fn transaction_executor(&self) -> MockOneshotExecutor {
         Self::create_executor(L2BlockNumber(1))
     }
 
@@ -116,7 +116,7 @@ impl HttpTest for CallTestAfterSnapshotRecovery {
         StorageInitialization::empty_recovery()
     }
 
-    fn transaction_executor(&self) -> MockTransactionExecutor {
+    fn transaction_executor(&self) -> MockOneshotExecutor {
         let first_local_l2_block = StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 1;
         CallTest::create_executor(first_local_l2_block)
     }
@@ -222,8 +222,8 @@ impl HttpTest for SendRawTransactionTest {
         }
     }
 
-    fn transaction_executor(&self) -> MockTransactionExecutor {
-        let mut tx_executor = MockTransactionExecutor::default();
+    fn transaction_executor(&self) -> MockOneshotExecutor {
+        let mut tx_executor = MockOneshotExecutor::default();
         let pending_block = if self.snapshot_recovery {
             StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 2
         } else {
@@ -320,8 +320,8 @@ impl SendTransactionWithDetailedOutputTest {
 }
 #[async_trait]
 impl HttpTest for SendTransactionWithDetailedOutputTest {
-    fn transaction_executor(&self) -> MockTransactionExecutor {
-        let mut tx_executor = MockTransactionExecutor::default();
+    fn transaction_executor(&self) -> MockOneshotExecutor {
+        let mut tx_executor = MockOneshotExecutor::default();
         let tx_bytes_and_hash = SendRawTransactionTest::transaction_bytes_and_hash();
         let vm_execution_logs = VmExecutionLogs {
             storage_logs: self.storage_logs(),
@@ -415,7 +415,7 @@ impl TraceCallTest {
 
 #[async_trait]
 impl HttpTest for TraceCallTest {
-    fn transaction_executor(&self) -> MockTransactionExecutor {
+    fn transaction_executor(&self) -> MockOneshotExecutor {
         CallTest::create_executor(L2BlockNumber(1))
     }
 
@@ -484,7 +484,7 @@ impl HttpTest for TraceCallTestAfterSnapshotRecovery {
         StorageInitialization::empty_recovery()
     }
 
-    fn transaction_executor(&self) -> MockTransactionExecutor {
+    fn transaction_executor(&self) -> MockOneshotExecutor {
         let number = StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 1;
         CallTest::create_executor(number)
     }
@@ -554,8 +554,8 @@ impl HttpTest for EstimateGasTest {
         SendRawTransactionTest { snapshot_recovery }.storage_initialization()
     }
 
-    fn transaction_executor(&self) -> MockTransactionExecutor {
-        let mut tx_executor = MockTransactionExecutor::default();
+    fn transaction_executor(&self) -> MockOneshotExecutor {
+        let mut tx_executor = MockOneshotExecutor::default();
         let pending_block_number = if self.snapshot_recovery {
             StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 2
         } else {
@@ -656,7 +656,7 @@ impl HttpTest for EstimateGasWithStateOverrideTest {
         self.inner.storage_initialization()
     }
 
-    fn transaction_executor(&self) -> MockTransactionExecutor {
+    fn transaction_executor(&self) -> MockOneshotExecutor {
         self.inner.transaction_executor()
     }
 


### PR DESCRIPTION
## What ❔

Extracts oneshot VM executor from the API server crate.

## Why ❔

Simplifies reasoning about oneshot VM execution and its maintenance. Allows for alternative implementations.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.