### PR TITLE
perf(logs-bloom): do not run heavy query if migration was completed

### DIFF
--- a/core/lib/dal/.sqlx/query-c988b8aa7708a4b76671a8454c3e9806a8cb4031f7c11c6890213d8693e7d385.json
+++ b/core/lib/dal/.sqlx/query-c988b8aa7708a4b76671a8454c3e9806a8cb4031f7c11c6890213d8693e7d385.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                (logs_bloom IS NOT NULL) AS \"logs_bloom_not_null!\"\n            FROM\n                miniblocks\n            WHERE\n                number = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "logs_bloom_not_null!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "c988b8aa7708a4b76671a8454c3e9806a8cb4031f7c11c6890213d8693e7d385"
+}

--- a/core/lib/dal/src/blocks_dal.rs
+++ b/core/lib/dal/src/blocks_dal.rs
@@ -2356,6 +2356,25 @@ impl BlocksDal<'_, '_> {
         Ok(results.into_iter().map(L::from).collect())
     }
 
+    pub async fn has_l2_block_bloom(&mut self, l2_block_number: L2BlockNumber) -> DalResult<bool> {
+        let row = sqlx::query!(
+            r#"
+            SELECT
+                (logs_bloom IS NOT NULL) AS "logs_bloom_not_null!"
+            FROM
+                miniblocks
+            WHERE
+                number = $1
+            "#,
+            i64::from(l2_block_number.0),
+        )
+        .instrument("has_l2_block_bloom")
+        .fetch_optional(self.storage)
+        .await?;
+
+        Ok(row.map(|row| row.logs_bloom_not_null).unwrap_or(false))
+    }
+
     pub async fn has_last_l2_block_bloom(&mut self) -> DalResult<bool> {
         let row = sqlx::query!(
             r#"

--- a/core/node/logs_bloom_backfill/src/lib.rs
+++ b/core/node/logs_bloom_backfill/src/lib.rs
@@ -57,6 +57,14 @@ impl LogsBloomBackfill {
             return Ok(()); // Stop signal received
         }
 
+        let genesis_block_has_bloom = connection
+            .blocks_dal()
+            .has_l2_block_bloom(L2BlockNumber(0))
+            .await?;
+        if genesis_block_has_bloom {
+            return Ok(()); // Migration has already been completed.
+        }
+
         let max_block_without_bloom = connection
             .blocks_dal()
             .get_max_l2_block_without_bloom()


### PR DESCRIPTION
## What ❔

Do not run heavy query if logs bloom migration was completed


## Why ❔

Do not put additional load on DB

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
