### PR TITLE
chore: Reverts prover job metrics to HK metrics

### DIFF
--- a/prover/crates/bin/prover_job_monitor/src/archiver/gpu_prover_archiver.rs
+++ b/prover/crates/bin/prover_job_monitor/src/archiver/gpu_prover_archiver.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use zksync_prover_dal::{Connection, Prover, ProverDal};
 
-use crate::{metrics::PROVER_JOB_MONITOR_METRICS, task_wiring::Task};
+use crate::{metrics::HOUSE_KEEPER_METRICS, task_wiring::Task};
 
 /// `GpuProverArchiver` is a task that archives old fri GPU provers.
 /// The task will archive the `dead` prover records that have not been updated for a certain amount of time.
@@ -31,8 +31,8 @@ impl Task for GpuProverArchiver {
         if archived_provers > 0 {
             tracing::info!("Archived {:?} gpu provers", archived_provers);
         }
-        PROVER_JOB_MONITOR_METRICS
-            .archived_gpu_provers
+        HOUSE_KEEPER_METRICS
+            .gpu_prover_archived
             .inc_by(archived_provers as u64);
         Ok(())
     }

--- a/prover/crates/bin/prover_job_monitor/src/archiver/prover_jobs_archiver.rs
+++ b/prover/crates/bin/prover_job_monitor/src/archiver/prover_jobs_archiver.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use zksync_prover_dal::{Connection, Prover, ProverDal};
 
-use crate::{metrics::PROVER_JOB_MONITOR_METRICS, task_wiring::Task};
+use crate::{metrics::HOUSE_KEEPER_METRICS, task_wiring::Task};
 
 /// `ProverJobsArchiver` is a task that archives old finalized prover job.
 /// The task will archive the `successful` prover jobs that have been done for a certain amount of time.
@@ -29,8 +29,8 @@ impl Task for ProverJobsArchiver {
         if archived_jobs > 0 {
             tracing::info!("Archived {:?} prover jobs", archived_jobs);
         }
-        PROVER_JOB_MONITOR_METRICS
-            .archived_prover_jobs
+        HOUSE_KEEPER_METRICS
+            .prover_job_archived
             .inc_by(archived_jobs as u64);
         Ok(())
     }

--- a/prover/crates/bin/prover_job_monitor/src/job_requeuer/proof_compressor_job_requeuer.rs
+++ b/prover/crates/bin/prover_job_monitor/src/job_requeuer/proof_compressor_job_requeuer.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use zksync_prover_dal::{Connection, Prover, ProverDal};
 
-use crate::{metrics::PROVER_JOB_MONITOR_METRICS, task_wiring::Task};
+use crate::{metrics::PROVER_FRI_METRICS, task_wiring::Task};
 
 /// `ProofCompressorJobRequeuer` is a task that requeues compressor jobs that have not made progress in a given unit of time.
 #[derive(Debug)]
@@ -34,8 +34,8 @@ impl Task for ProofCompressorJobRequeuer {
         for stuck_job in stuck_jobs {
             tracing::info!("requeued proof compressor job {:?}", stuck_job);
         }
-        PROVER_JOB_MONITOR_METRICS
-            .requeued_proof_compressor_jobs
+        PROVER_FRI_METRICS
+            .proof_compressor_requeued_jobs
             .inc_by(job_len as u64);
         Ok(())
     }

--- a/prover/crates/bin/prover_job_monitor/src/job_requeuer/prover_job_requeuer.rs
+++ b/prover/crates/bin/prover_job_monitor/src/job_requeuer/prover_job_requeuer.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use zksync_prover_dal::{Connection, Prover, ProverDal};
 
-use crate::{metrics::PROVER_JOB_MONITOR_METRICS, task_wiring::Task};
+use crate::{metrics::SERVER_METRICS, task_wiring::Task};
 
 /// `ProverJobRequeuer` is a task that requeues prover jobs that have not made progress in a given unit of time.
 #[derive(Debug)]
@@ -34,8 +34,8 @@ impl Task for ProverJobRequeuer {
         for stuck_job in stuck_jobs {
             tracing::info!("requeued circuit prover job {:?}", stuck_job);
         }
-        PROVER_JOB_MONITOR_METRICS
-            .requeued_circuit_prover_jobs
+        SERVER_METRICS
+            .prover_fri_requeued_jobs
             .inc_by(job_len as u64);
         Ok(())
     }

--- a/prover/crates/bin/prover_job_monitor/src/job_requeuer/witness_generator_job_requeuer.rs
+++ b/prover/crates/bin/prover_job_monitor/src/job_requeuer/witness_generator_job_requeuer.rs
@@ -4,7 +4,7 @@ use zksync_prover_dal::{Connection, Prover, ProverDal};
 use zksync_types::prover_dal::StuckJobs;
 
 use crate::{
-    metrics::{WitnessType, PROVER_JOB_MONITOR_METRICS},
+    metrics::{WitnessType, SERVER_METRICS},
     task_wiring::Task,
 };
 
@@ -29,8 +29,7 @@ impl WitnessGeneratorJobRequeuer {
         for stuck_job in stuck_jobs {
             tracing::info!("requeued {:?} {:?}", witness_type, stuck_job);
         }
-        PROVER_JOB_MONITOR_METRICS.requeued_witness_generator_jobs[&witness_type]
-            .inc_by(stuck_jobs.len() as u64);
+        SERVER_METRICS.requeued_jobs[&witness_type].inc_by(stuck_jobs.len() as u64);
     }
 
     async fn requeue_stuck_basic_jobs(&self, connection: &mut Connection<'_, Prover>) {
@@ -38,7 +37,7 @@ impl WitnessGeneratorJobRequeuer {
             .fri_witness_generator_dal()
             .requeue_stuck_basic_jobs(self.processing_timeouts.basic(), self.max_attempts)
             .await;
-        self.emit_telemetry(WitnessType::BasicWitnessGenerator, &stuck_jobs);
+        self.emit_telemetry(WitnessType::WitnessInputsFri, &stuck_jobs);
     }
 
     async fn requeue_stuck_leaf_jobs(&self, connection: &mut Connection<'_, Prover>) {
@@ -46,7 +45,7 @@ impl WitnessGeneratorJobRequeuer {
             .fri_witness_generator_dal()
             .requeue_stuck_leaf_jobs(self.processing_timeouts.leaf(), self.max_attempts)
             .await;
-        self.emit_telemetry(WitnessType::LeafWitnessGenerator, &stuck_jobs);
+        self.emit_telemetry(WitnessType::LeafAggregationJobsFri, &stuck_jobs);
     }
 
     async fn requeue_stuck_node_jobs(&self, connection: &mut Connection<'_, Prover>) {
@@ -54,7 +53,7 @@ impl WitnessGeneratorJobRequeuer {
             .fri_witness_generator_dal()
             .requeue_stuck_node_jobs(self.processing_timeouts.node(), self.max_attempts)
             .await;
-        self.emit_telemetry(WitnessType::NodeWitnessGenerator, &stuck_jobs);
+        self.emit_telemetry(WitnessType::NodeAggregationJobsFri, &stuck_jobs);
     }
 
     async fn requeue_stuck_recursion_tip_jobs(&self, connection: &mut Connection<'_, Prover>) {
@@ -65,7 +64,7 @@ impl WitnessGeneratorJobRequeuer {
                 self.max_attempts,
             )
             .await;
-        self.emit_telemetry(WitnessType::RecursionTipWitnessGenerator, &stuck_jobs);
+        self.emit_telemetry(WitnessType::RecursionTipJobsFri, &stuck_jobs);
     }
 
     async fn requeue_stuck_scheduler_jobs(&self, connection: &mut Connection<'_, Prover>) {
@@ -73,7 +72,7 @@ impl WitnessGeneratorJobRequeuer {
             .fri_witness_generator_dal()
             .requeue_stuck_scheduler_jobs(self.processing_timeouts.scheduler(), self.max_attempts)
             .await;
-        self.emit_telemetry(WitnessType::SchedulerWitnessGenerator, &stuck_jobs);
+        self.emit_telemetry(WitnessType::SchedulerJobsFri, &stuck_jobs);
     }
 }
 

--- a/prover/crates/bin/prover_job_monitor/src/metrics.rs
+++ b/prover/crates/bin/prover_job_monitor/src/metrics.rs
@@ -2,97 +2,123 @@ use vise::{Counter, EncodeLabelSet, EncodeLabelValue, Family, Gauge, LabeledFami
 use zksync_types::protocol_version::ProtocolSemanticVersion;
 
 #[derive(Debug, Metrics)]
-#[metrics(prefix = "prover_job_monitor")]
-pub(crate) struct ProverJobMonitorMetrics {
-    // archivers
-    /// number of dead GPU provers archived
-    pub archived_gpu_provers: Counter,
-    /// number of finished prover job archived
-    pub archived_prover_jobs: Counter,
-
-    // job requeuers
-    /// number of proof compressor jobs that have been requeued for execution
-    pub requeued_proof_compressor_jobs: Counter<u64>,
-    /// number of circuit prover jobs that have been requeued for execution
-    pub requeued_circuit_prover_jobs: Counter<u64>,
-    /// number of witness generator jobs that have been requeued for execution
-    pub requeued_witness_generator_jobs: Family<WitnessType, Counter<u64>>,
-
-    // queues reporters
-    /// number of proof compressor jobs that are queued/in_progress per protocol version
-    #[metrics(labels = ["type", "protocol_version"])]
-    pub proof_compressor_jobs: LabeledFamily<(JobStatus, String), Gauge<u64>, 2>,
-    /// the oldest batch that has not been compressed yet
-    pub oldest_uncompressed_batch: Gauge<u64>,
-    /// number of prover jobs per circuit, per round, per protocol version, per status
-    /// Sets a specific value for a struct as follows:
-    /// {
-    ///     status: Queued,
-    ///     circuit_id: 1,
-    ///     round: 0,
-    ///     group_id:
-    ///     protocol_version: 0.24.2,
-    /// }
-    pub prover_jobs: Family<ProverJobsLabels, Gauge<u64>>,
-    /// the oldest batch that has not been proven yet, per circuit id and aggregation round
-    #[metrics(labels = ["circuit_id", "aggregation_round"])]
-    pub oldest_unprocessed_batch: LabeledFamily<(String, String), Gauge<u64>, 2>,
-    /// number of witness generator jobs per "round"
-    #[metrics(labels = ["type", "round", "protocol_version"])]
-    pub witness_generator_jobs_by_round: LabeledFamily<(JobStatus, String, String), Gauge<u64>, 3>,
-
-    // witness job queuer
-    /// number of jobs queued per type of witness generator
-    pub queued_witness_generator_jobs: Family<WitnessType, Counter<u64>>,
+#[metrics(prefix = "house_keeper")]
+pub(crate) struct HouseKeeperMetrics {
+    pub prover_job_archived: Counter,
+    pub gpu_prover_archived: Counter,
 }
 
-impl ProverJobMonitorMetrics {
+#[vise::register]
+pub(crate) static HOUSE_KEEPER_METRICS: vise::Global<HouseKeeperMetrics> = vise::Global::new();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue)]
+#[metrics(rename_all = "snake_case")]
+#[allow(dead_code)]
+pub enum JobStatus {
+    Queued,
+    InProgress,
+    Successful,
+    Failed,
+    SentToServer,
+    Skipped,
+}
+
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "prover_fri")]
+pub(crate) struct ProverFriMetrics {
+    pub proof_compressor_requeued_jobs: Counter<u64>,
+    #[metrics(labels = ["type", "protocol_version"])]
+    pub proof_compressor_jobs: LabeledFamily<(JobStatus, String), Gauge<u64>, 2>,
+    pub proof_compressor_oldest_uncompressed_batch: Gauge<u64>,
+}
+
+#[vise::register]
+pub(crate) static PROVER_FRI_METRICS: vise::Global<ProverFriMetrics> = vise::Global::new();
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, EncodeLabelSet)]
+pub(crate) struct ProverJobsLabels {
+    pub r#type: &'static str,
+    pub circuit_id: String,
+    pub aggregation_round: String,
+    pub prover_group_id: String,
+    pub protocol_version: String,
+}
+
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "fri_prover")]
+pub(crate) struct FriProverMetrics {
+    pub prover_jobs: Family<ProverJobsLabels, Gauge<u64>>,
+    #[metrics(labels = ["circuit_id", "aggregation_round"])]
+    pub block_number: LabeledFamily<(String, String), Gauge<u64>, 2>,
+    pub oldest_unpicked_batch: Gauge<u64>,
+    pub oldest_not_generated_batch: Gauge<u64>,
+    #[metrics(labels = ["round"])]
+    pub oldest_unprocessed_block_by_round: LabeledFamily<String, Gauge<u64>>,
+}
+
+impl FriProverMetrics {
     pub fn report_prover_jobs(
         &self,
-        status: JobStatus,
+        r#type: &'static str,
         circuit_id: u8,
-        round: u8,
-        group_id: u8,
+        aggregation_round: u8,
+        prover_group_id: u8,
         protocol_version: ProtocolSemanticVersion,
         amount: u64,
     ) {
         self.prover_jobs[&ProverJobsLabels {
-            status,
+            r#type,
             circuit_id: circuit_id.to_string(),
-            round: round.to_string(),
-            group_id: group_id.to_string(),
+            aggregation_round: aggregation_round.to_string(),
+            prover_group_id: prover_group_id.to_string(),
             protocol_version: protocol_version.to_string(),
         }]
             .set(amount);
     }
 }
-#[vise::register]
-pub(crate) static PROVER_JOB_MONITOR_METRICS: vise::Global<ProverJobMonitorMetrics> =
-    vise::Global::new();
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, EncodeLabelSet)]
-pub(crate) struct ProverJobsLabels {
-    pub status: JobStatus,
-    pub circuit_id: String,
-    pub round: String,
-    pub group_id: String,
-    pub protocol_version: String,
-}
+#[vise::register]
+pub(crate) static FRI_PROVER_METRICS: vise::Global<FriProverMetrics> = vise::Global::new();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, EncodeLabelSet)]
 #[metrics(label = "type", rename_all = "snake_case")]
 #[allow(clippy::enum_variant_names)]
 pub(crate) enum WitnessType {
-    BasicWitnessGenerator,
-    LeafWitnessGenerator,
-    NodeWitnessGenerator,
-    RecursionTipWitnessGenerator,
-    SchedulerWitnessGenerator,
+    WitnessInputsFri,
+    LeafAggregationJobsFri,
+    NodeAggregationJobsFri,
+    RecursionTipJobsFri,
+    SchedulerJobsFri,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue)]
-#[metrics(rename_all = "snake_case")]
-pub enum JobStatus {
-    Queued,
-    InProgress,
+impl From<&str> for WitnessType {
+    fn from(s: &str) -> Self {
+        match s {
+            "witness_inputs_fri" => Self::WitnessInputsFri,
+            "leaf_aggregations_jobs_fri" => Self::LeafAggregationJobsFri,
+            "node_aggregations_jobs_fri" => Self::NodeAggregationJobsFri,
+            "recursion_tip_jobs_fri" => Self::RecursionTipJobsFri,
+            "scheduler_jobs_fri" => Self::SchedulerJobsFri,
+            _ => panic!("Invalid witness type"),
+        }
+    }
 }
+
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "server")]
+pub(crate) struct ServerMetrics {
+    pub prover_fri_requeued_jobs: Counter<u64>,
+    pub requeued_jobs: Family<WitnessType, Counter<u64>>,
+    #[metrics(labels = ["type", "round", "protocol_version"])]
+    pub witness_generator_jobs_by_round:
+        LabeledFamily<(&'static str, String, String), Gauge<u64>, 3>,
+    #[metrics(labels = ["type", "protocol_version"])]
+    pub witness_generator_jobs: LabeledFamily<(&'static str, String), Gauge<u64>, 2>,
+    pub leaf_fri_witness_generator_waiting_to_queued_jobs_transitions: Counter<u64>,
+    pub node_fri_witness_generator_waiting_to_queued_jobs_transitions: Counter<u64>,
+    pub recursion_tip_witness_generator_waiting_to_queued_jobs_transitions: Counter<u64>,
+    pub scheduler_witness_generator_waiting_to_queued_jobs_transitions: Counter<u64>,
+}
+
+#[vise::register]
+pub(crate) static SERVER_METRICS: vise::Global<ServerMetrics> = vise::Global::new();

--- a/prover/crates/bin/prover_job_monitor/src/queue_reporter/proof_compressor_queue_reporter.rs
+++ b/prover/crates/bin/prover_job_monitor/src/queue_reporter/proof_compressor_queue_reporter.rs
@@ -5,7 +5,7 @@ use zksync_prover_dal::{Connection, Prover, ProverDal};
 use zksync_types::{protocol_version::ProtocolSemanticVersion, prover_dal::JobCountStatistics};
 
 use crate::{
-    metrics::{JobStatus, PROVER_JOB_MONITOR_METRICS},
+    metrics::{JobStatus, PROVER_FRI_METRICS},
     task_wiring::Task,
 };
 
@@ -43,11 +43,11 @@ impl Task for ProofCompressorQueueReporter {
                 );
             }
 
-            PROVER_JOB_MONITOR_METRICS.proof_compressor_jobs
+            PROVER_FRI_METRICS.proof_compressor_jobs
                 [&(JobStatus::Queued, protocol_version.to_string())]
                 .set(stats.queued as u64);
 
-            PROVER_JOB_MONITOR_METRICS.proof_compressor_jobs
+            PROVER_FRI_METRICS.proof_compressor_jobs
                 [&(JobStatus::InProgress, protocol_version.to_string())]
                 .set(stats.in_progress as u64);
         }
@@ -58,8 +58,8 @@ impl Task for ProofCompressorQueueReporter {
             .await;
 
         if let Some(l1_batch_number) = oldest_not_compressed_batch {
-            PROVER_JOB_MONITOR_METRICS
-                .oldest_uncompressed_batch
+            PROVER_FRI_METRICS
+                .proof_compressor_oldest_uncompressed_batch
                 .set(l1_batch_number.0 as u64);
         }
 

--- a/prover/crates/bin/prover_job_monitor/src/queue_reporter/prover_queue_reporter.rs
+++ b/prover/crates/bin/prover_job_monitor/src/queue_reporter/prover_queue_reporter.rs
@@ -3,10 +3,7 @@ use zksync_config::configs::fri_prover_group::FriProverGroupConfig;
 use zksync_prover_dal::{Connection, Prover, ProverDal};
 use zksync_types::{basic_fri_types::CircuitIdRoundTuple, prover_dal::JobCountStatistics};
 
-use crate::{
-    metrics::{JobStatus, PROVER_JOB_MONITOR_METRICS},
-    task_wiring::Task,
-};
+use crate::{metrics::FRI_PROVER_METRICS, task_wiring::Task};
 
 /// `ProverQueueReporter` is a task that reports prover jobs status.
 /// Note: these values will be used for auto-scaling provers and Witness Vector Generators.
@@ -47,8 +44,8 @@ impl Task for ProverQueueReporter {
                     )
                     .unwrap_or(u8::MAX);
 
-                PROVER_JOB_MONITOR_METRICS.report_prover_jobs(
-                    JobStatus::Queued,
+                FRI_PROVER_METRICS.report_prover_jobs(
+                    "queued",
                     circuit_id,
                     aggregation_round,
                     group_id,
@@ -56,8 +53,8 @@ impl Task for ProverQueueReporter {
                     queued as u64,
                 );
 
-                PROVER_JOB_MONITOR_METRICS.report_prover_jobs(
-                    JobStatus::InProgress,
+                FRI_PROVER_METRICS.report_prover_jobs(
+                    "in_progress",
                     circuit_id,
                     aggregation_round,
                     group_id,
@@ -73,7 +70,7 @@ impl Task for ProverQueueReporter {
             .await;
 
         for ((circuit_id, aggregation_round), l1_batch_number) in lag_by_circuit_type {
-            PROVER_JOB_MONITOR_METRICS.oldest_unprocessed_batch
+            FRI_PROVER_METRICS.block_number
                 [&(circuit_id.to_string(), aggregation_round.to_string())]
                 .set(l1_batch_number.0 as u64);
         }

--- a/prover/crates/bin/prover_job_monitor/src/queue_reporter/witness_generator_queue_reporter.rs
+++ b/prover/crates/bin/prover_job_monitor/src/queue_reporter/witness_generator_queue_reporter.rs
@@ -5,10 +5,7 @@ use zksync_types::{
     prover_dal::JobCountStatistics,
 };
 
-use crate::{
-    metrics::{JobStatus, PROVER_JOB_MONITOR_METRICS},
-    task_wiring::Task,
-};
+use crate::{metrics::SERVER_METRICS, task_wiring::Task};
 
 /// `WitnessGeneratorQueueReporter` is a task that reports witness generator jobs status.
 /// Note: these values will be used for auto-scaling witness generators (Basic, Leaf, Node, Recursion Tip and Scheduler).
@@ -38,14 +35,11 @@ impl WitnessGeneratorQueueReporter {
             );
         }
 
-        PROVER_JOB_MONITOR_METRICS.witness_generator_jobs_by_round[&(
-            JobStatus::Queued,
-            round.to_string(),
-            protocol_version.to_string(),
-        )]
+        SERVER_METRICS.witness_generator_jobs_by_round
+            [&("queued", round.to_string(), protocol_version.to_string())]
             .set(stats.queued as u64);
-        PROVER_JOB_MONITOR_METRICS.witness_generator_jobs_by_round[&(
-            JobStatus::InProgress,
+        SERVER_METRICS.witness_generator_jobs_by_round[&(
+            "in_progress",
             round.to_string(),
             protocol_version.to_string(),
         )]

--- a/prover/crates/bin/prover_job_monitor/src/witness_job_queuer.rs
+++ b/prover/crates/bin/prover_job_monitor/src/witness_job_queuer.rs
@@ -1,10 +1,7 @@
 use async_trait::async_trait;
 use zksync_prover_dal::{Connection, Prover, ProverDal};
 
-use crate::{
-    metrics::{WitnessType, PROVER_JOB_MONITOR_METRICS},
-    task_wiring::Task,
-};
+use crate::{metrics::SERVER_METRICS, task_wiring::Task};
 
 /// `WitnessJobQueuer` is a task that moves witness generator jobs from 'waiting_for_proofs' to 'queued'.
 /// Note: this task is the backbone of scheduling/getting ready witness jobs to execute.
@@ -28,8 +25,8 @@ impl WitnessJobQueuer {
             );
         }
 
-        PROVER_JOB_MONITOR_METRICS.queued_witness_generator_jobs
-            [&WitnessType::LeafWitnessGenerator]
+        SERVER_METRICS
+            .leaf_fri_witness_generator_waiting_to_queued_jobs_transitions
             .inc_by(len as u64);
     }
 
@@ -65,8 +62,8 @@ impl WitnessJobQueuer {
                 depth
             );
         }
-        PROVER_JOB_MONITOR_METRICS.queued_witness_generator_jobs
-            [&WitnessType::NodeWitnessGenerator]
+        SERVER_METRICS
+            .node_fri_witness_generator_waiting_to_queued_jobs_transitions
             .inc_by(len as u64);
     }
 
@@ -83,8 +80,8 @@ impl WitnessJobQueuer {
                 l1_batch_number,
             );
         }
-        PROVER_JOB_MONITOR_METRICS.queued_witness_generator_jobs
-            [&WitnessType::RecursionTipWitnessGenerator]
+        SERVER_METRICS
+            .recursion_tip_witness_generator_waiting_to_queued_jobs_transitions
             .inc_by(l1_batch_numbers.len() as u64);
     }
 
@@ -101,8 +98,8 @@ impl WitnessJobQueuer {
                 l1_batch_number,
             );
         }
-        PROVER_JOB_MONITOR_METRICS.queued_witness_generator_jobs
-            [&WitnessType::SchedulerWitnessGenerator]
+        SERVER_METRICS
+            .scheduler_witness_generator_waiting_to_queued_jobs_transitions
             .inc_by(l1_batch_numbers.len() as u64);
     }
 }


### PR DESCRIPTION
The point of this PR is to keep metrics history the same  as house keeper such that analytics can be ran retroactively on top of it.

Whilst I find it both confusing (house keeper metrics in prover job monitor) and of overall worst quality, I disagreed and committed with the decision.

