### PR TITLE
fix(contract-verifier): Check for 0x in zkvyper output

### DIFF
--- a/core/lib/contract_verifier/src/lib.rs
+++ b/core/lib/contract_verifier/src/lib.rs
@@ -271,7 +271,9 @@ impl ContractVerifier {
                 let bytecode_str = artifact["bytecode"]
                     .as_str()
                     .ok_or(ContractVerifierError::InternalError)?;
-                let bytecode = hex::decode(bytecode_str).unwrap();
+                let bytecode_without_prefix =
+                    bytecode_str.strip_prefix("0x").unwrap_or(bytecode_str);
+                let bytecode = hex::decode(bytecode_without_prefix).unwrap();
                 return Ok(CompilationArtifacts {
                     abi: artifact["abi"].clone(),
                     bytecode,


### PR DESCRIPTION
## What ❔

Check for 0x in zkvyper output

## Why ❔

Don't panic when bytecode is 0x prefixed

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
