### PR TITLE
fix: make set token multiplier optional

### DIFF
--- a/core/node/base_token_adjuster/src/base_token_ratio_persister.rs
+++ b/core/node/base_token_adjuster/src/base_token_ratio_persister.rs
@@ -95,15 +95,10 @@ impl BaseTokenRatioPersister {
 
         for attempt in 0..max_attempts {
             let (base_fee_per_gas, priority_fee_per_gas) =
-                self.get_eth_fees(&l1_params, prev_base_fee_per_gas, prev_priority_fee_per_gas);
+                self.get_eth_fees(l1_params, prev_base_fee_per_gas, prev_priority_fee_per_gas);
 
             result = self
-                .send_ratio_to_l1(
-                    &l1_params,
-                    new_ratio,
-                    base_fee_per_gas,
-                    priority_fee_per_gas,
-                )
+                .send_ratio_to_l1(l1_params, new_ratio, base_fee_per_gas, priority_fee_per_gas)
                 .await;
             if let Some(err) = result.as_ref().err() {
                 tracing::info!(

--- a/core/node/base_token_adjuster/src/base_token_ratio_persister.rs
+++ b/core/node/base_token_adjuster/src/base_token_ratio_persister.rs
@@ -126,7 +126,6 @@ impl BaseTokenRatioPersister {
             }
             result
         } else {
-            tracing::info!("Skipped setting base token multiplier on l1");
             Ok(())
         }
     }

--- a/core/node/base_token_adjuster/src/lib.rs
+++ b/core/node/base_token_adjuster/src/lib.rs
@@ -1,5 +1,5 @@
 pub use self::{
-    base_token_ratio_persister::BaseTokenRatioPersister,
+    base_token_ratio_persister::{BaseTokenRatioPersister, BaseTokenRatioPersisterL1Params},
     base_token_ratio_provider::{DBBaseTokenRatioProvider, NoOpRatioProvider},
 };
 

--- a/core/node/node_framework/src/implementations/layers/base_token/base_token_ratio_persister.rs
+++ b/core/node/node_framework/src/implementations/layers/base_token/base_token_ratio_persister.rs
@@ -1,8 +1,9 @@
-use zksync_base_token_adjuster::BaseTokenRatioPersister;
+use zksync_base_token_adjuster::{BaseTokenRatioPersister, BaseTokenRatioPersisterL1Params};
 use zksync_config::{
     configs::{base_token_adjuster::BaseTokenAdjusterConfig, wallets::Wallets},
     ContractsConfig,
 };
+use zksync_contracts::chain_admin_contract;
 use zksync_eth_client::clients::PKSigningClient;
 use zksync_types::L1ChainId;
 
@@ -81,37 +82,37 @@ impl WiringLayer for BaseTokenRatioPersisterLayer {
             .contracts_config
             .base_token_addr
             .expect("base token address is not set");
-        let diamond_proxy_contract_address = self.contracts_config.diamond_proxy_addr;
-        let chain_admin_contract_address = self.contracts_config.chain_admin_addr;
-        let token_multiplier_setter_wallet = self
-            .wallets_config
-            .token_multiplier_setter
-            .expect("base token adjuster wallet is not set")
-            .wallet;
 
-        let tms_private_key = token_multiplier_setter_wallet.private_key();
-        let tms_address = token_multiplier_setter_wallet.address();
-        let EthInterfaceResource(query_client) = input.eth_client;
+        let mut l1_params: Option<BaseTokenRatioPersisterL1Params> = None;
+        if let Some(token_multiplier_setter) = self.wallets_config.token_multiplier_setter {
+            let tms_private_key = token_multiplier_setter.wallet.private_key();
+            let tms_address = token_multiplier_setter.wallet.address();
+            let EthInterfaceResource(query_client) = input.eth_client;
 
-        let signing_client = PKSigningClient::new_raw(
-            tms_private_key.clone(),
-            self.contracts_config.diamond_proxy_addr,
-            self.config.default_priority_fee_per_gas,
-            #[allow(clippy::useless_conversion)]
-            self.l1_chain_id.into(),
-            query_client.clone().for_component("base_token_adjuster"),
-        );
+            let signing_client = PKSigningClient::new_raw(
+                tms_private_key.clone(),
+                self.contracts_config.diamond_proxy_addr,
+                self.config.default_priority_fee_per_gas,
+                #[allow(clippy::useless_conversion)]
+                self.l1_chain_id.into(),
+                query_client.clone().for_component("base_token_adjuster"),
+            );
+            l1_params = Some(BaseTokenRatioPersisterL1Params {
+                eth_client: Box::new(signing_client),
+                gas_adjuster: input.tx_params.0,
+                token_multiplier_setter_account_address: tms_address,
+                chain_admin_contract: chain_admin_contract(),
+                diamond_proxy_contract_address: self.contracts_config.diamond_proxy_addr,
+                chain_admin_contract_address: self.contracts_config.chain_admin_addr,
+            });
+        }
 
         let persister = BaseTokenRatioPersister::new(
             master_pool,
             self.config,
             base_token_addr,
             price_api_client.0,
-            Box::new(signing_client),
-            input.tx_params.0,
-            tms_address,
-            diamond_proxy_contract_address,
-            chain_admin_contract_address,
+            l1_params,
         );
 
         Ok(Output { persister })


### PR DESCRIPTION
For backwards compatibility make setting token multiplier on L1 optional. If private key for token multiplier setter is not provided, L1 quote update will be skipped. 
