### PR TITLE
fix: base token ratio startup as a separate component

### DIFF
--- a/core/bin/zksync_server/src/node_builder.rs
+++ b/core/bin/zksync_server/src/node_builder.rs
@@ -766,6 +766,7 @@ impl MainNodeBuilder {
                 }
                 Component::BaseTokenRatioPersister => {
                     self = self
+                        .add_l1_gas_layer()?
                         .add_external_api_client_layer()?
                         .add_base_token_ratio_persister_layer()?;
                 }


### PR DESCRIPTION
Base token ratio persister lacked L1 gas layer when started as a separate component. 