### PR TITLE
fix: add default ecosystem configs folder to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -26,8 +26,11 @@ binaryen
 system-contracts
 artifacts-zk
 cache-zk
-// Ignore directories with OZ and forge submodules.
+# Ignore directories with OZ and forge submodules.
 contracts/l1-contracts/lib
+
+# Ignore ecosystem configs
+/configs/
 
 **/.git
 **/node_modules


### PR DESCRIPTION
## What ❔

Added `configs` folder in the root directory to `.prettierignore`

## Why ❔

Ecosystem configs may include generated JS config files that may not pass `zk fmt --check`.
This change prevents errors during `zk fmt` execution.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
