### PR TITLE
fix(prover): fail when fri prover job is not found

### DIFF
--- a/prover/crates/bin/proof_fri_compressor/src/compressor.rs
+++ b/prover/crates/bin/proof_fri_compressor/src/compressor.rs
@@ -136,7 +136,7 @@ impl JobProcessor for ProofCompressor {
             .get_scheduler_proof_job_id(l1_batch_number)
             .await
         else {
-            return Ok(None);
+            anyhow::bail!("Failed to find fri prover job for {l1_batch_number}");
         };
         tracing::info!(
             "Started proof compression for L1 batch: {:?}",

--- a/prover/crates/bin/proof_fri_compressor/src/compressor.rs
+++ b/prover/crates/bin/proof_fri_compressor/src/compressor.rs
@@ -136,7 +136,7 @@ impl JobProcessor for ProofCompressor {
             .get_scheduler_proof_job_id(l1_batch_number)
             .await
         else {
-            anyhow::bail!("Failed to find fri prover job for {l1_batch_number}");
+            anyhow::bail!("Scheduler proof is missing from database for batch {l1_batch_number}");
         };
         tracing::info!(
             "Started proof compression for L1 batch: {:?}",


### PR DESCRIPTION
## What ❔

Compressor should fail when a corresponding fri prover job is not found. Unlikely to occur in real world but helps when manually populating DB for debugging.

## Why ❔

This behaviour makes more sense

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
