### PR TITLE
docs(dal): update ProofGenerationDal docs chart

### DIFF
--- a/core/lib/dal/doc/ProofGenerationDal.md
+++ b/core/lib/dal/doc/ProofGenerationDal.md
@@ -11,9 +11,10 @@ proof_generation_details
 title: Status Diagram
 ---
 stateDiagram-v2
-[*] --> ready_to_be_proven : insert_proof_generation_details
-ready_to_be_proven --> picked_by_prover : get_next_block_to_be_proven
+[*] --> unpicked : insert_proof_generation_details
+unpicked --> picked_by_prover : lock_batch_for_proving
 picked_by_prover --> generated : save_proof_artifacts_metadata
+picked_by_prover --> unpicked : unlock_batch
 generated --> [*]
 
 [*] --> skipped : mark_proof_generation_job_as_skipped


### PR DESCRIPTION
It should have been updated as part of these 2 PRs:
- https://github.com/matter-labs/zksync-era/pull/2258
- https://github.com/matter-labs/zksync-era/pull/2486

## What ❔

Update ProofGenerationDal docs chart.

## Why ❔

We like up-to-date docs.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
