### PR TITLE
fix(api): `tx.gas_price` field

### DIFF
--- a/core/lib/dal/src/models/storage_transaction.rs
+++ b/core/lib/dal/src/models/storage_transaction.rs
@@ -508,6 +508,19 @@ impl StorageApiTransaction {
             .signature
             .and_then(|signature| PackedEthSignature::deserialize_packed(&signature).ok());
 
+        // For legacy and EIP-2930 transactions it is gas price willing to be paid by the sender in wei.
+        // For other transactions it should be the effective gas price if transaction is included in block,
+        // otherwise this value should be set equal to the max fee per gas.
+        let gas_price = match self.tx_format {
+            None | Some(0) | Some(1) => self
+                .max_fee_per_gas
+                .clone()
+                .unwrap_or_else(BigDecimal::zero),
+            _ => self
+                .effective_gas_price
+                .or_else(|| self.max_fee_per_gas.clone())
+                .unwrap_or_else(BigDecimal::zero),
+        };
         let mut tx = api::Transaction {
             hash: H256::from_slice(&self.tx_hash),
             nonce: U256::from(self.nonce.unwrap_or(0) as u64),
@@ -517,11 +530,7 @@ impl StorageApiTransaction {
             from: Some(Address::from_slice(&self.initiator_address)),
             to: Some(serde_json::from_value(self.execute_contract_address).unwrap()),
             value: bigdecimal_to_u256(self.value),
-            gas_price: Some(bigdecimal_to_u256(
-                self.effective_gas_price
-                    .or_else(|| self.max_fee_per_gas.clone())
-                    .unwrap_or_else(BigDecimal::zero),
-            )),
+            gas_price: Some(bigdecimal_to_u256(gas_price)),
             gas: bigdecimal_to_u256(self.gas_limit.unwrap_or_else(BigDecimal::zero)),
             input: serde_json::from_value(self.calldata).expect("incorrect calldata in Postgres"),
             v: signature.as_ref().map(|s| U64::from(s.v())),

--- a/core/tests/ts-integration/tests/api/web3.test.ts
+++ b/core/tests/ts-integration/tests/api/web3.test.ts
@@ -249,14 +249,16 @@ describe('web3 API compatibility tests', () => {
 
     test('Should check transactions from API / Legacy tx', async () => {
         const LEGACY_TX_TYPE = 0;
+        const gasPrice = (await alice._providerL2().getGasPrice()) * 2n;
         const legacyTx = await alice.sendTransaction({
             type: LEGACY_TX_TYPE,
-            to: alice.address
+            to: alice.address,
+            gasPrice
         });
         await legacyTx.wait();
 
         const legacyApiReceipt = await alice.provider.getTransaction(legacyTx.hash);
-        expect(legacyApiReceipt.gasPrice).toBeLessThanOrEqual(legacyTx.gasPrice!);
+        expect(legacyApiReceipt.gasPrice).toEqual(gasPrice);
     });
 
     test('Should check transactions from API / EIP1559 tx', async () => {

--- a/zk_toolbox/crates/zk_supervisor/src/commands/database/reset.rs
+++ b/zk_toolbox/crates/zk_supervisor/src/commands/database/reset.rs
@@ -26,7 +26,7 @@ pub async fn run(shell: &Shell, args: DatabaseCommonArgs) -> anyhow::Result<()> 
 
     let dals = get_dals(shell, &args.selected_dals)?;
     for dal in dals {
-        logger::info(&msg_database_loading(MSG_DATABASE_RESET_GERUND, &dal.path));
+        logger::info(msg_database_loading(MSG_DATABASE_RESET_GERUND, &dal.path));
         reset_database(shell, ecoseystem_config.link_to_code.clone(), dal).await?;
     }
 

--- a/zk_toolbox/crates/zk_supervisor/src/commands/test/prover.rs
+++ b/zk_toolbox/crates/zk_supervisor/src/commands/test/prover.rs
@@ -6,7 +6,7 @@ use crate::messages::MSG_PROVER_TEST_SUCCESS;
 
 pub fn run(shell: &Shell) -> anyhow::Result<()> {
     let ecosystem = EcosystemConfig::from_file(shell)?;
-    let _dir_guard = shell.push_dir(&ecosystem.link_to_code.join("prover"));
+    let _dir_guard = shell.push_dir(ecosystem.link_to_code.join("prover"));
 
     Cmd::new(cmd!(shell, "cargo test --release --workspace --locked"))
         .with_force_run()


### PR DESCRIPTION
## What ❔

Fixes `tx.gas_price` field for legacy and EIP-2930 transactions.

## Why ❔

Follow the [spec](https://ethereum.github.io/execution-apis/api-documentation/)

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
