### PR TITLE
fix(base_token_adjuster): bug with a wrong metrics namespace

### DIFF
--- a/core/node/base_token_adjuster/src/metrics.rs
+++ b/core/node/base_token_adjuster/src/metrics.rs
@@ -15,7 +15,7 @@ pub(crate) struct OperationResultLabels {
 }
 
 #[derive(Debug, Metrics)]
-#[metrics(prefix = "snapshots_creator")]
+#[metrics(prefix = "base_token_adjuster")]
 pub(crate) struct BaseTokenAdjusterMetrics {
     pub l1_gas_used: Gauge<u64>,
     #[metrics(buckets = Buckets::LATENCIES)]


### PR DESCRIPTION
Fix a bug with base_token_adjuster metrics reported under a wrong namespace. 