### PR TITLE
fix(zk_toolbox): various ways of writing zksync

### DIFF
--- a/zk_toolbox/README.md
+++ b/zk_toolbox/README.md
@@ -20,7 +20,7 @@ Install `zk_inception` from Git:
 cargo install --git https://github.com/matter-labs/zksync-era/ --locked zk_inception zk_supervisor --force
 ```
 
-Or manually build from a local copy of the [ZkSync](https://github.com/matter-labs/zksync-era/) repository:
+Or manually build from a local copy of the [ZKsync](https://github.com/matter-labs/zksync-era/) repository:
 
 ```bash
 ./bin/zkt
@@ -260,7 +260,7 @@ needed.
 
 ## ZK Supervisor
 
-Tools for developing zkSync.
+Tools for developing ZKsync.
 
 ### Database
 
@@ -296,7 +296,7 @@ Possible commands:
 
 ### Tests
 
-Run zkSync tests:
+Run ZKsync tests:
 
 ```bash
 zk_supervisor test

--- a/zk_toolbox/crates/zk_inception/README.md
+++ b/zk_toolbox/crates/zk_inception/README.md
@@ -52,7 +52,7 @@ ZK Toolbox is a set of tools for working with zk stack.
 - `containers` — Run containers for local development
 - `contract-verifier` — Run contract verifier
 - `portal` — Run dapp-portal
-- `update` — Update zkSync
+- `update` — Update ZKsync
 
 ###### **Options:**
 
@@ -622,7 +622,7 @@ Run dapp-portal
 
 ## `zk_inception update`
 
-Update zkSync
+Update ZKsync
 
 **Usage:** `zk_inception update [OPTIONS]`
 

--- a/zk_toolbox/crates/zk_inception/src/main.rs
+++ b/zk_toolbox/crates/zk_inception/src/main.rs
@@ -61,7 +61,7 @@ pub enum InceptionSubcommands {
     ContractVerifier(ContractVerifierCommands),
     /// Run dapp-portal
     Portal(PortalArgs),
-    /// Update zkSync
+    /// Update ZKsync
     #[command(alias = "u")]
     Update(UpdateArgs),
     #[command(hide = true)]

--- a/zk_toolbox/crates/zk_inception/src/messages.rs
+++ b/zk_toolbox/crates/zk_inception/src/messages.rs
@@ -38,11 +38,11 @@ pub(super) const MSG_ECOSYSTEM_CONFIG_INVALID_ERR: &str = "Invalid ecosystem con
 pub(super) const MSG_LINK_TO_CODE_SELECTION_CLONE: &str = "Clone for me (recommended)";
 pub(super) const MSG_LINK_TO_CODE_SELECTION_PATH: &str = "I have the code already";
 pub(super) const MSG_NOT_MAIN_REPO_OR_FORK_ERR: &str =
-    "It's not a zkSync Era main repository or fork";
+    "It's not a ZKsync Era main repository or fork";
 pub(super) const MSG_CONFIRM_STILL_USE_FOLDER: &str = "Do you still want to use this folder?";
 
 pub(super) fn msg_path_to_zksync_does_not_exist_err(path: &str) -> String {
-    format!("Path to zkSync Era repo does not exist: {path:?}")
+    format!("Path to ZKsync Era repo does not exist: {path:?}")
 }
 
 /// Ecosystem and chain init related messages
@@ -57,7 +57,7 @@ pub(super) const MSG_DEPLOY_ECOSYSTEM_PROMPT: &str =
 pub(super) const MSG_L1_RPC_URL_PROMPT: &str = "What is the RPC URL of the L1 network?";
 pub(super) const MSG_DEPLOY_PAYMASTER_PROMPT: &str = "Do you want to deploy Paymaster contract?";
 pub(super) const MSG_DEPLOY_ERC20_PROMPT: &str = "Do you want to deploy some test ERC20s?";
-pub(super) const MSG_ECOSYSTEM_CONTRACTS_PATH_PROMPT: &str = "Provide the path to the ecosystem contracts or keep it empty and you will use ZkSync ecosystem config. \
+pub(super) const MSG_ECOSYSTEM_CONTRACTS_PATH_PROMPT: &str = "Provide the path to the ecosystem contracts or keep it empty and you will use ZKsync ecosystem config. \
 For using this config, you need to have governance wallet";
 pub(super) const MSG_L1_RPC_URL_INVALID_ERR: &str = "Invalid RPC URL";
 pub(super) const MSG_ECOSYSTEM_CONTRACTS_PATH_INVALID_ERR: &str = "Invalid path";
@@ -360,8 +360,8 @@ pub(super) fn msg_downloading_binary_spinner(name: &str, version: &str) -> Strin
 /// Update related messages
 
 pub(super) const MSG_UPDATE_ONLY_CONFIG_HELP: &str = "Update only the config files";
-pub(super) const MSG_UPDATING_ZKSYNC: &str = "Updating ZkSync";
-pub(super) const MSG_ZKSYNC_UPDATED: &str = "ZkSync updated successfully";
+pub(super) const MSG_UPDATING_ZKSYNC: &str = "Updating ZKsync";
+pub(super) const MSG_ZKSYNC_UPDATED: &str = "ZKsync updated successfully";
 pub(super) const MSG_PULLING_ZKSYNC_CODE_SPINNER: &str = "Pulling zksync-era repo...";
 pub(super) const MSG_UPDATING_SUBMODULES_SPINNER: &str = "Updating submodules...";
 pub(super) const MSG_DIFF_GENERAL_CONFIG: &str =


### PR DESCRIPTION
## What ❔

- Fix casing of "ZKsync" in READMEs and console messages in `zksync-era/zk_toolbox`
  - ZKsync - correct
  - zkSync - incorrect
  - ZkSync (pascal case)
- PS: Some of those pascal cases may have been in purpose - let me know if I should revert any of those.


## Why ❔

- Matches newer branding

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
