### PR TITLE
chore: Make PJM metrics match HK

### DIFF
--- a/prover/crates/bin/prover_job_monitor/src/queue_reporter/witness_generator_queue_reporter.rs
+++ b/prover/crates/bin/prover_job_monitor/src/queue_reporter/witness_generator_queue_reporter.rs
@@ -35,12 +35,15 @@ impl WitnessGeneratorQueueReporter {
             );
         }
 
-        SERVER_METRICS.witness_generator_jobs_by_round
-            [&("queued", round.to_string(), protocol_version.to_string())]
+        SERVER_METRICS.witness_generator_jobs_by_round[&(
+            "queued",
+            format!("{:?}", round),
+            protocol_version.to_string(),
+        )]
             .set(stats.queued as u64);
         SERVER_METRICS.witness_generator_jobs_by_round[&(
             "in_progress",
-            round.to_string(),
+            format!("{:?}", round),
             protocol_version.to_string(),
         )]
             .set(stats.in_progress as u64);


### PR DESCRIPTION
As agreed, PJM metrics must match HK 100%. This means we need to backport everything. `.to_string()` results in `basic_circuits`, whilst `format!` results in `BasicCircuits`.
