### PR TITLE
fix: return correct witness inputs

### DIFF
--- a/core/node/external_proof_integration_api/src/processor.rs
+++ b/core/node/external_proof_integration_api/src/processor.rs
@@ -25,7 +25,7 @@ pub(crate) struct ProofGenerationDataResponse(ProofGenerationData);
 impl IntoResponse for ProofGenerationDataResponse {
     fn into_response(self) -> Response {
         let l1_batch_number = self.0.l1_batch_number;
-        let data = match bincode::serialize(&self.0) {
+        let data = match bincode::serialize(&self.0.witness_input_data) {
             Ok(data) => data,
             Err(err) => {
                 return ProcessorError::Serialization(err).into_response();
@@ -171,7 +171,7 @@ impl Processor {
             return Err(ProcessorError::BatchNotReady(l1_batch_number));
         }
 
-        self.proof_generation_data_for_existing_batch_internal(latest_available_batch)
+        self.proof_generation_data_for_existing_batch_internal(l1_batch_number)
             .await
             .map(ProofGenerationDataResponse)
     }


### PR DESCRIPTION
## What ❔

* Return correct binary(was ProofGenerationData before, but WitnessInputData needed)
* Request for specific batch was always returning the latest one

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
