### PR TITLE
fix(vm-runner): Fix statement timeouts in VM playground

### DIFF
--- a/core/node/node_framework/src/implementations/layers/vm_runner/playground.rs
+++ b/core/node/node_framework/src/implementations/layers/vm_runner/playground.rs
@@ -71,7 +71,13 @@ impl WiringLayer for VmPlaygroundLayer {
         //   to DB for querying last processed batch and last ready to be loaded batch.
         // - `window_size` connections for running VM instances.
         let connection_pool = replica_pool
-            .get_custom(2 + self.config.window_size.get())
+            .build(|builder| {
+                builder
+                    .set_max_size(2 + self.config.window_size.get())
+                    .set_statement_timeout(None);
+                // Unlike virtually all other replica pool uses, VM playground has some long-living operations,
+                // so the default statement timeout would only get in the way.
+            })
             .await?;
 
         let cursor = VmPlaygroundCursorOptions {


### PR DESCRIPTION
## What ❔

Fixes statement timeout errors in VM playground.

## Why ❔

VM playground uses the replica DB pool, which has statement timeout configured by default. This timeout is intended for the API server and doesn't make sense for VM playground. Hence, this PR removes the statement timeout and allows to configure it for each built DB pool (in case other components would require similar changes).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `zk fmt` and `zk lint`.