### PR TITLE
fix(tee-prover): increase retries to reduce spurious alerts

### DIFF
--- a/core/lib/dal/src/tee_verifier_input_producer_dal.rs
+++ b/core/lib/dal/src/tee_verifier_input_producer_dal.rs
@@ -17,7 +17,7 @@ pub struct TeeVerifierInputProducerDal<'a, 'c> {
 }
 
 /// The amount of attempts to process a job before giving up.
-pub const JOB_MAX_ATTEMPT: i16 = 2;
+pub const JOB_MAX_ATTEMPT: i16 = 5;
 
 /// Time to wait for job to be processed
 const JOB_PROCESSING_TIMEOUT: PgInterval = pg_interval_from_duration(Duration::from_secs(10 * 60));


### PR DESCRIPTION
## What ❔

Increase retries.

## Why ❔

An alert fires when we hit maximum number of retries. Retries happen, for example, when a component restarts. Those restarts are transient and harmless. By increasing the number of retries, we reduce the number of false/spurious alerts.

## Checklist
