### PR TITLE
perf(vm): Fix VM performance regression on CI loadtest

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Loadtest configuration
         run: |
           echo EXPECTED_TX_COUNT=${{ matrix.vm_mode == 'new' && 22000 || 16000 }} >> .env
-          echo ACCOUNTS_AMOUNT="80" >> .env
+          echo ACCOUNTS_AMOUNT="100" >> .env
           echo MAX_INFLIGHT_TXS="10" >> .env
           echo FAIL_FAST=true >> .env
           echo IN_DOCKER=1 >> .env

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -91,7 +91,8 @@ jobs:
       - name: Loadtest configuration
         run: |
           echo EXPECTED_TX_COUNT=${{ matrix.vm_mode == 'new' && 22000 || 16000 }} >> .env
-          echo ACCOUNTS_AMOUNT="150" >> .env
+          echo ACCOUNTS_AMOUNT="80" >> .env
+          echo MAX_INFLIGHT_TXS="10" >> .env
           echo FAIL_FAST=true >> .env
           echo IN_DOCKER=1 >> .env
           echo DATABASE_MERKLE_TREE_MODE=lightweight >> .env

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -90,9 +90,10 @@ jobs:
 
       - name: Loadtest configuration
         run: |
-          echo EXPECTED_TX_COUNT=${{ matrix.vm_mode == 'new' && 21000 || 15000 }} >> .env
+          echo EXPECTED_TX_COUNT=${{ matrix.vm_mode == 'new' && 21000 || 16000 }} >> .env
           echo ACCOUNTS_AMOUNT="100" >> .env
           echo MAX_INFLIGHT_TXS="10" >> .env
+          echo SYNC_API_REQUESTS_LIMIT="15" >> .env
           echo FAIL_FAST=true >> .env
           echo IN_DOCKER=1 >> .env
           echo DATABASE_MERKLE_TREE_MODE=lightweight >> .env

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -116,7 +116,8 @@ jobs:
       - name: Run server
         run: |
           EXPERIMENTAL_VM_STATE_KEEPER_FAST_VM_MODE=${{ matrix.vm_mode }} \
-          PASSED_ENV_VARS="EXPERIMENTAL_VM_STATE_KEEPER_FAST_VM_MODE" \
+          CHAIN_MEMPOOL_DELAY_INTERVAL=50 \
+          PASSED_ENV_VARS="EXPERIMENTAL_VM_STATE_KEEPER_FAST_VM_MODE,CHAIN_MEMPOOL_DELAY_INTERVAL" \
             ci_run zk server --uring --components api,tree,eth,state_keeper,housekeeper,commitment_generator,vm_runner_protective_reads &>server.log &
           ci_run sleep 60
 

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Loadtest configuration
         run: |
-          echo EXPECTED_TX_COUNT=${{ matrix.vm_mode == 'new' && 22000 || 16000 }} >> .env
+          echo EXPECTED_TX_COUNT=${{ matrix.vm_mode == 'new' && 21000 || 15000 }} >> .env
           echo ACCOUNTS_AMOUNT="100" >> .env
           echo MAX_INFLIGHT_TXS="10" >> .env
           echo FAIL_FAST=true >> .env

--- a/core/lib/multivm/src/versions/shadow.rs
+++ b/core/lib/multivm/src/versions/shadow.rs
@@ -77,7 +77,7 @@ where
         tracer: Self::TracerDispatcher,
         tx: Transaction,
         with_compression: bool,
-    ) -> (BytecodeCompressionResult, VmExecutionResultAndLogs) {
+    ) -> (BytecodeCompressionResult<'_>, VmExecutionResultAndLogs) {
         let tx_hash = tx.hash();
         let main_result = self.main.inspect_transaction_with_bytecode_compression(
             tracer,

--- a/core/lib/multivm/src/versions/vm_1_3_2/vm.rs
+++ b/core/lib/multivm/src/versions/vm_1_3_2/vm.rs
@@ -83,7 +83,7 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
         tracer: Self::TracerDispatcher,
         tx: Transaction,
         with_compression: bool,
-    ) -> (BytecodeCompressionResult, VmExecutionResultAndLogs) {
+    ) -> (BytecodeCompressionResult<'_>, VmExecutionResultAndLogs) {
         if let Some(storage_invocations) = tracer.storage_invocations {
             self.vm
                 .execution_mode
@@ -156,7 +156,7 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
                 result,
             )
         } else {
-            (Ok(compressed_bytecodes), result)
+            (Ok(compressed_bytecodes.into()), result)
         }
     }
 

--- a/core/lib/multivm/src/versions/vm_1_4_1/bootloader_state/state.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_1/bootloader_state/state.rs
@@ -191,11 +191,11 @@ impl BootloaderState {
         l2_block.first_tx_index + l2_block.txs.len()
     }
 
-    pub(crate) fn get_last_tx_compressed_bytecodes(&self) -> Vec<CompressedBytecodeInfo> {
+    pub(crate) fn get_last_tx_compressed_bytecodes(&self) -> &[CompressedBytecodeInfo] {
         if let Some(tx) = self.last_l2_block().txs.last() {
-            tx.compressed_bytecodes.clone()
+            &tx.compressed_bytecodes
         } else {
-            vec![]
+            &[]
         }
     }
 

--- a/core/lib/multivm/src/versions/vm_1_4_1/vm.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_1/vm.rs
@@ -105,7 +105,7 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
         tracer: Self::TracerDispatcher,
         tx: Transaction,
         with_compression: bool,
-    ) -> (BytecodeCompressionResult, VmExecutionResultAndLogs) {
+    ) -> (BytecodeCompressionResult<'_>, VmExecutionResultAndLogs) {
         self.push_transaction_with_compression(tx, with_compression);
         let result = self.inspect_inner(tracer, VmExecutionMode::OneTx, None);
         if self.has_unpublished_bytecodes() {
@@ -115,7 +115,10 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
             )
         } else {
             (
-                Ok(self.bootloader_state.get_last_tx_compressed_bytecodes()),
+                Ok(self
+                    .bootloader_state
+                    .get_last_tx_compressed_bytecodes()
+                    .into()),
                 result,
             )
         }

--- a/core/lib/multivm/src/versions/vm_1_4_2/bootloader_state/state.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_2/bootloader_state/state.rs
@@ -191,11 +191,11 @@ impl BootloaderState {
         l2_block.first_tx_index + l2_block.txs.len()
     }
 
-    pub(crate) fn get_last_tx_compressed_bytecodes(&self) -> Vec<CompressedBytecodeInfo> {
+    pub(crate) fn get_last_tx_compressed_bytecodes(&self) -> &[CompressedBytecodeInfo] {
         if let Some(tx) = self.last_l2_block().txs.last() {
-            tx.compressed_bytecodes.clone()
+            &tx.compressed_bytecodes
         } else {
-            vec![]
+            &[]
         }
     }
 

--- a/core/lib/multivm/src/versions/vm_1_4_2/vm.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_2/vm.rs
@@ -105,7 +105,7 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
         tracer: Self::TracerDispatcher,
         tx: Transaction,
         with_compression: bool,
-    ) -> (BytecodeCompressionResult, VmExecutionResultAndLogs) {
+    ) -> (BytecodeCompressionResult<'_>, VmExecutionResultAndLogs) {
         self.push_transaction_with_compression(tx, with_compression);
         let result = self.inspect_inner(tracer, VmExecutionMode::OneTx, None);
         if self.has_unpublished_bytecodes() {
@@ -115,7 +115,10 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
             )
         } else {
             (
-                Ok(self.bootloader_state.get_last_tx_compressed_bytecodes()),
+                Ok(self
+                    .bootloader_state
+                    .get_last_tx_compressed_bytecodes()
+                    .into()),
                 result,
             )
         }

--- a/core/lib/multivm/src/versions/vm_boojum_integration/bootloader_state/state.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/bootloader_state/state.rs
@@ -191,11 +191,11 @@ impl BootloaderState {
         l2_block.first_tx_index + l2_block.txs.len()
     }
 
-    pub(crate) fn get_last_tx_compressed_bytecodes(&self) -> Vec<CompressedBytecodeInfo> {
+    pub(crate) fn get_last_tx_compressed_bytecodes(&self) -> &[CompressedBytecodeInfo] {
         if let Some(tx) = self.last_l2_block().txs.last() {
-            tx.compressed_bytecodes.clone()
+            &tx.compressed_bytecodes
         } else {
-            vec![]
+            &[]
         }
     }
 

--- a/core/lib/multivm/src/versions/vm_boojum_integration/vm.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/vm.rs
@@ -106,7 +106,7 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
         tracer: Self::TracerDispatcher,
         tx: Transaction,
         with_compression: bool,
-    ) -> (BytecodeCompressionResult, VmExecutionResultAndLogs) {
+    ) -> (BytecodeCompressionResult<'_>, VmExecutionResultAndLogs) {
         self.push_transaction_with_compression(tx, with_compression);
         let result = self.inspect_inner(tracer, VmExecutionMode::OneTx);
         if self.has_unpublished_bytecodes() {
@@ -116,7 +116,10 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
             )
         } else {
             (
-                Ok(self.bootloader_state.get_last_tx_compressed_bytecodes()),
+                Ok(self
+                    .bootloader_state
+                    .get_last_tx_compressed_bytecodes()
+                    .into()),
                 result,
             )
         }

--- a/core/lib/multivm/src/versions/vm_fast/bootloader_state/state.rs
+++ b/core/lib/multivm/src/versions/vm_fast/bootloader_state/state.rs
@@ -189,11 +189,11 @@ impl BootloaderState {
         l2_block.first_tx_index + l2_block.txs.len()
     }
 
-    pub(crate) fn get_last_tx_compressed_bytecodes(&self) -> Vec<CompressedBytecodeInfo> {
+    pub(crate) fn get_last_tx_compressed_bytecodes(&self) -> &[CompressedBytecodeInfo] {
         if let Some(tx) = self.last_l2_block().txs.last() {
-            tx.compressed_bytecodes.clone()
+            &tx.compressed_bytecodes
         } else {
-            vec![]
+            &[]
         }
     }
 

--- a/core/lib/multivm/src/versions/vm_fast/vm.rs
+++ b/core/lib/multivm/src/versions/vm_fast/vm.rs
@@ -30,7 +30,7 @@ use super::{
 use crate::{
     glue::GlueInto,
     interface::{
-        storage::ReadStorage, BytecodeCompressionError, CompressedBytecodeInfo,
+        storage::ReadStorage, BytecodeCompressionError, BytecodeCompressionResult,
         CurrentExecutionState, ExecutionResult, FinishedL1Batch, Halt, L1BatchEnv, L2BlockEnv,
         Refunds, SystemEnv, TxRevertReason, VmEvent, VmExecutionLogs, VmExecutionMode,
         VmExecutionResultAndLogs, VmExecutionStatistics, VmInterface, VmInterfaceHistoryEnabled,
@@ -548,17 +548,17 @@ impl<S: ReadStorage> VmInterface for Vm<S> {
         (): Self::TracerDispatcher,
         tx: zksync_types::Transaction,
         with_compression: bool,
-    ) -> (
-        Result<Vec<CompressedBytecodeInfo>, BytecodeCompressionError>,
-        VmExecutionResultAndLogs,
-    ) {
+    ) -> (BytecodeCompressionResult<'_>, VmExecutionResultAndLogs) {
         self.push_transaction_inner(tx, 0, with_compression);
         let result = self.inspect((), VmExecutionMode::OneTx);
 
         let compression_result = if self.has_unpublished_bytecodes() {
             Err(BytecodeCompressionError::BytecodeCompressionFailed)
         } else {
-            Ok(self.bootloader_state.get_last_tx_compressed_bytecodes())
+            Ok(self
+                .bootloader_state
+                .get_last_tx_compressed_bytecodes()
+                .into())
         };
         (compression_result, result)
     }

--- a/core/lib/multivm/src/versions/vm_latest/bootloader_state/state.rs
+++ b/core/lib/multivm/src/versions/vm_latest/bootloader_state/state.rs
@@ -191,11 +191,11 @@ impl BootloaderState {
         l2_block.first_tx_index + l2_block.txs.len()
     }
 
-    pub(crate) fn get_last_tx_compressed_bytecodes(&self) -> Vec<CompressedBytecodeInfo> {
+    pub(crate) fn get_last_tx_compressed_bytecodes(&self) -> &[CompressedBytecodeInfo] {
         if let Some(tx) = self.last_l2_block().txs.last() {
-            tx.compressed_bytecodes.clone()
+            &tx.compressed_bytecodes
         } else {
-            vec![]
+            &[]
         }
     }
 

--- a/core/lib/multivm/src/versions/vm_latest/vm.rs
+++ b/core/lib/multivm/src/versions/vm_latest/vm.rs
@@ -141,7 +141,7 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
         tracer: Self::TracerDispatcher,
         tx: Transaction,
         with_compression: bool,
-    ) -> (BytecodeCompressionResult, VmExecutionResultAndLogs) {
+    ) -> (BytecodeCompressionResult<'_>, VmExecutionResultAndLogs) {
         self.push_transaction_with_compression(tx, with_compression);
         let result = self.inspect_inner(tracer, VmExecutionMode::OneTx, None);
         if self.has_unpublished_bytecodes() {
@@ -151,7 +151,10 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
             )
         } else {
             (
-                Ok(self.bootloader_state.get_last_tx_compressed_bytecodes()),
+                Ok(self
+                    .bootloader_state
+                    .get_last_tx_compressed_bytecodes()
+                    .into()),
                 result,
             )
         }

--- a/core/lib/multivm/src/versions/vm_m5/vm.rs
+++ b/core/lib/multivm/src/versions/vm_m5/vm.rs
@@ -93,14 +93,14 @@ impl<S: Storage, H: HistoryMode> VmInterface for Vm<S, H> {
         _tracer: Self::TracerDispatcher,
         tx: Transaction,
         _with_compression: bool,
-    ) -> (BytecodeCompressionResult, VmExecutionResultAndLogs) {
+    ) -> (BytecodeCompressionResult<'_>, VmExecutionResultAndLogs) {
         crate::vm_m5::vm_with_bootloader::push_transaction_to_bootloader_memory(
             &mut self.vm,
             &tx,
             self.system_env.execution_mode.glue_into(),
         );
         // Bytecode compression isn't supported
-        (Ok(vec![]), self.inspect((), VmExecutionMode::OneTx))
+        (Ok(vec![].into()), self.inspect((), VmExecutionMode::OneTx))
     }
 
     fn record_vm_memory_metrics(&self) -> VmMemoryMetrics {

--- a/core/lib/multivm/src/versions/vm_m6/vm.rs
+++ b/core/lib/multivm/src/versions/vm_m6/vm.rs
@@ -109,7 +109,7 @@ impl<S: Storage, H: HistoryMode> VmInterface for Vm<S, H> {
         tracer: Self::TracerDispatcher,
         tx: Transaction,
         with_compression: bool,
-    ) -> (BytecodeCompressionResult, VmExecutionResultAndLogs) {
+    ) -> (BytecodeCompressionResult<'_>, VmExecutionResultAndLogs) {
         if let Some(storage_invocations) = tracer.storage_invocations {
             self.vm
                 .execution_mode
@@ -182,7 +182,7 @@ impl<S: Storage, H: HistoryMode> VmInterface for Vm<S, H> {
                 result,
             )
         } else {
-            (Ok(compressed_bytecodes), result)
+            (Ok(compressed_bytecodes.into()), result)
         }
     }
 

--- a/core/lib/multivm/src/versions/vm_refunds_enhancement/bootloader_state/state.rs
+++ b/core/lib/multivm/src/versions/vm_refunds_enhancement/bootloader_state/state.rs
@@ -167,11 +167,11 @@ impl BootloaderState {
         l2_block.first_tx_index + l2_block.txs.len()
     }
 
-    pub(crate) fn get_last_tx_compressed_bytecodes(&self) -> Vec<CompressedBytecodeInfo> {
+    pub(crate) fn get_last_tx_compressed_bytecodes(&self) -> &[CompressedBytecodeInfo] {
         if let Some(tx) = self.last_l2_block().txs.last() {
-            tx.compressed_bytecodes.clone()
+            &tx.compressed_bytecodes
         } else {
-            vec![]
+            &[]
         }
     }
 

--- a/core/lib/multivm/src/versions/vm_refunds_enhancement/vm.rs
+++ b/core/lib/multivm/src/versions/vm_refunds_enhancement/vm.rs
@@ -99,7 +99,7 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
         dispatcher: Self::TracerDispatcher,
         tx: Transaction,
         with_compression: bool,
-    ) -> (BytecodeCompressionResult, VmExecutionResultAndLogs) {
+    ) -> (BytecodeCompressionResult<'_>, VmExecutionResultAndLogs) {
         self.push_transaction_with_compression(tx, with_compression);
         let result = self.inspect(dispatcher, VmExecutionMode::OneTx);
         if self.has_unpublished_bytecodes() {
@@ -109,7 +109,10 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
             )
         } else {
             (
-                Ok(self.bootloader_state.get_last_tx_compressed_bytecodes()),
+                Ok(self
+                    .bootloader_state
+                    .get_last_tx_compressed_bytecodes()
+                    .into()),
                 result,
             )
         }

--- a/core/lib/multivm/src/versions/vm_virtual_blocks/bootloader_state/state.rs
+++ b/core/lib/multivm/src/versions/vm_virtual_blocks/bootloader_state/state.rs
@@ -167,11 +167,11 @@ impl BootloaderState {
         l2_block.first_tx_index + l2_block.txs.len()
     }
 
-    pub(crate) fn get_last_tx_compressed_bytecodes(&self) -> Vec<CompressedBytecodeInfo> {
+    pub(crate) fn get_last_tx_compressed_bytecodes(&self) -> &[CompressedBytecodeInfo] {
         if let Some(tx) = self.last_l2_block().txs.last() {
-            tx.compressed_bytecodes.clone()
+            &tx.compressed_bytecodes
         } else {
-            vec![]
+            &[]
         }
     }
 

--- a/core/lib/multivm/src/versions/vm_virtual_blocks/vm.rs
+++ b/core/lib/multivm/src/versions/vm_virtual_blocks/vm.rs
@@ -99,7 +99,7 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
         tracer: TracerDispatcher<S, H::VmVirtualBlocksMode>,
         tx: Transaction,
         with_compression: bool,
-    ) -> (BytecodeCompressionResult, VmExecutionResultAndLogs) {
+    ) -> (BytecodeCompressionResult<'_>, VmExecutionResultAndLogs) {
         self.push_transaction_with_compression(tx, with_compression);
         let result = self.inspect_inner(tracer, VmExecutionMode::OneTx);
         if self.has_unpublished_bytecodes() {
@@ -109,7 +109,10 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
             )
         } else {
             (
-                Ok(self.bootloader_state.get_last_tx_compressed_bytecodes()),
+                Ok(self
+                    .bootloader_state
+                    .get_last_tx_compressed_bytecodes()
+                    .into()),
                 result,
             )
         }

--- a/core/lib/multivm/src/vm_instance.rs
+++ b/core/lib/multivm/src/vm_instance.rs
@@ -74,7 +74,7 @@ impl<S: ReadStorage, H: HistoryMode> VmInterface for VmInstance<S, H> {
         dispatcher: Self::TracerDispatcher,
         tx: zksync_types::Transaction,
         with_compression: bool,
-    ) -> (BytecodeCompressionResult, VmExecutionResultAndLogs) {
+    ) -> (BytecodeCompressionResult<'_>, VmExecutionResultAndLogs) {
         dispatch_vm!(self.inspect_transaction_with_bytecode_compression(
             dispatcher.into(),
             tx,

--- a/core/lib/vm_executor/src/batch/factory.rs
+++ b/core/lib/vm_executor/src/batch/factory.rs
@@ -250,7 +250,7 @@ impl<S: ReadStorage + 'static> CommandReceiver<S> {
                 .unwrap_or_default();
             return Ok(BatchTransactionExecutionResult {
                 tx_result: Box::new(tx_result),
-                compressed_bytecodes,
+                compressed_bytecodes: compressed_bytecodes.into_owned(),
                 call_traces,
             });
         }
@@ -269,8 +269,9 @@ impl<S: ReadStorage + 'static> CommandReceiver<S> {
 
         let (compression_result, tx_result) =
             vm.inspect_transaction_with_bytecode_compression(tracer.into(), tx.clone(), false);
-        let compressed_bytecodes =
-            compression_result.context("compression failed when it wasn't applied")?;
+        let compressed_bytecodes = compression_result
+            .context("compression failed when it wasn't applied")?
+            .into_owned();
 
         // TODO implement tracer manager which will be responsible
         //   for collecting result from all tracers and save it to the database
@@ -308,7 +309,7 @@ impl<S: ReadStorage + 'static> CommandReceiver<S> {
                 .unwrap_or_default();
             Ok(BatchTransactionExecutionResult {
                 tx_result: Box::new(tx_result),
-                compressed_bytecodes,
+                compressed_bytecodes: compressed_bytecodes.into_owned(),
                 call_traces,
             })
         } else {

--- a/core/lib/vm_interface/src/types/errors/bytecode_compression.rs
+++ b/core/lib/vm_interface/src/types/errors/bytecode_compression.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::CompressedBytecodeInfo;
 
 /// Errors related to bytecode compression.
@@ -9,4 +11,5 @@ pub enum BytecodeCompressionError {
 }
 
 /// Result of compressing bytecodes used by a transaction.
-pub type BytecodeCompressionResult = Result<Vec<CompressedBytecodeInfo>, BytecodeCompressionError>;
+pub type BytecodeCompressionResult<'a> =
+    Result<Cow<'a, [CompressedBytecodeInfo]>, BytecodeCompressionError>;

--- a/core/lib/vm_interface/src/vm.rs
+++ b/core/lib/vm_interface/src/vm.rs
@@ -41,7 +41,7 @@ pub trait VmInterface {
         tracer: Self::TracerDispatcher,
         tx: Transaction,
         with_compression: bool,
-    ) -> (BytecodeCompressionResult, VmExecutionResultAndLogs);
+    ) -> (BytecodeCompressionResult<'_>, VmExecutionResultAndLogs);
 
     /// Record VM memory metrics.
     fn record_vm_memory_metrics(&self) -> VmMemoryMetrics;
@@ -63,7 +63,7 @@ pub trait VmInterfaceExt: VmInterface {
         &mut self,
         tx: Transaction,
         with_compression: bool,
-    ) -> (BytecodeCompressionResult, VmExecutionResultAndLogs) {
+    ) -> (BytecodeCompressionResult<'_>, VmExecutionResultAndLogs) {
         self.inspect_transaction_with_bytecode_compression(
             Self::TracerDispatcher::default(),
             tx,

--- a/core/lib/web3_decl/src/client/mod.rs
+++ b/core/lib/web3_decl/src/client/mod.rs
@@ -318,6 +318,7 @@ pub struct ClientBuilder<Net, C = HttpClient> {
     client: C,
     url: SensitiveUrl,
     rate_limit: (usize, Duration),
+    report_config: bool,
     network: Net,
 }
 
@@ -328,6 +329,7 @@ impl<Net: fmt::Debug, C: 'static> fmt::Debug for ClientBuilder<Net, C> {
             .field("client", &any::type_name::<C>())
             .field("url", &self.url)
             .field("rate_limit", &self.rate_limit)
+            .field("report_config", &self.report_config)
             .field("network", &self.network)
             .finish_non_exhaustive()
     }
@@ -340,6 +342,7 @@ impl<Net: Network, C: ClientBase> ClientBuilder<Net, C> {
             client,
             url,
             rate_limit: (1, Duration::ZERO),
+            report_config: true,
             network: Net::default(),
         }
     }
@@ -366,16 +369,25 @@ impl<Net: Network, C: ClientBase> ClientBuilder<Net, C> {
         self
     }
 
+    /// Allows switching off config reporting for this client in logs and metrics. This is useful if a client is a short-living one
+    /// and is not injected as a dependency.
+    pub fn report_config(mut self, report: bool) -> Self {
+        self.report_config = report;
+        self
+    }
+
     /// Builds the client.
     pub fn build(self) -> Client<Net, C> {
-        tracing::info!(
-            "Creating JSON-RPC client for network {:?} with inner client: {:?} and rate limit: {:?}",
-            self.network,
-            self.client,
-            self.rate_limit
-        );
         let rate_limit = SharedRateLimit::new(self.rate_limit.0, self.rate_limit.1);
-        METRICS.observe_config(self.network.metric_label(), &rate_limit);
+        if self.report_config {
+            tracing::info!(
+                "Creating JSON-RPC client for network {:?} with inner client: {:?} and rate limit: {:?}",
+                self.network,
+                self.client,
+                self.rate_limit
+            );
+            METRICS.observe_config(self.network.metric_label(), &rate_limit);
+        }
 
         Client {
             inner: self.client,

--- a/core/tests/loadnext/src/account_pool.rs
+++ b/core/tests/loadnext/src/account_pool.rs
@@ -101,7 +101,9 @@ impl AccountPool {
                 .context("invalid L2 RPC URL")?,
         )?
         .for_network(l2_chain_id.into())
+        .report_config(false)
         .build();
+
         // Perform a health check: check whether ZKsync server is alive.
         let mut server_alive = false;
         for _ in 0usize..3 {

--- a/core/tests/loadnext/src/constants.rs
+++ b/core/tests/loadnext/src/constants.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{ops, time::Duration};
 
 /// Normally, block is committed on Ethereum every 15 seconds; however there are no guarantees that our transaction
 /// will be included in the next block right after sending.
@@ -14,7 +14,7 @@ pub const ETH_POLLING_INTERVAL: Duration = Duration::from_secs(10);
 pub const COMMIT_TIMEOUT: Duration = Duration::from_secs(600);
 /// We don't want to overload the server with too many requests; given the fact that blocks are expected to be created
 /// every couple of seconds, chosen value seems to be adequate to provide the result in one or two calls at average.
-pub const POLLING_INTERVAL: Duration = Duration::from_secs(3);
+pub const POLLING_INTERVAL: ops::Range<Duration> = Duration::from_secs(2)..Duration::from_secs(3);
 
 pub const MAX_OUTSTANDING_NONCE: usize = 20;
 

--- a/core/tests/loadnext/src/executor.rs
+++ b/core/tests/loadnext/src/executor.rs
@@ -244,7 +244,7 @@ impl Executor {
             });
 
         priority_op_handle
-            .polling_interval(POLLING_INTERVAL)
+            .polling_interval(POLLING_INTERVAL.end)
             .unwrap();
         priority_op_handle
             .commit_timeout(COMMIT_TIMEOUT)
@@ -313,7 +313,7 @@ impl Executor {
             });
 
         priority_op_handle
-            .polling_interval(POLLING_INTERVAL)
+            .polling_interval(POLLING_INTERVAL.end)
             .unwrap();
         priority_op_handle
             .commit_timeout(COMMIT_TIMEOUT)
@@ -463,7 +463,7 @@ impl Executor {
         // Wait for transactions to be committed, if at least one of them fails,
         // return error.
         for mut handle in handles {
-            handle.polling_interval(POLLING_INTERVAL).unwrap();
+            handle.polling_interval(POLLING_INTERVAL.end).unwrap();
 
             let result = handle
                 .commit_timeout(COMMIT_TIMEOUT)

--- a/core/tests/loadnext/src/sdk/ethereum/mod.rs
+++ b/core/tests/loadnext/src/sdk/ethereum/mod.rs
@@ -102,6 +102,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
         let query_client = Client::http(eth_web3_url)
             .map_err(|err| ClientError::NetworkError(err.to_string()))?
             .for_network(sl_chain_id.into())
+            .report_config(false)
             .build();
         let query_client: Box<DynClient<L1>> = Box::new(query_client);
         let eth_client = SigningClient::new(

--- a/core/tests/loadnext/src/sdk/wallet.rs
+++ b/core/tests/loadnext/src/sdk/wallet.rs
@@ -45,6 +45,7 @@ where
         let client = Client::http(rpc_address)
             .map_err(|err| ClientError::NetworkError(err.to_string()))?
             .for_network(signer.chain_id.into())
+            .report_config(false)
             .build();
 
         Ok(Wallet {

--- a/infrastructure/zk/src/prover_setup.ts
+++ b/infrastructure/zk/src/prover_setup.ts
@@ -30,7 +30,8 @@ export async function setupProver(proverType: ProverType) {
         } else {
             env.modify(
                 'FRI_PROVER_SETUP_DATA_PATH',
-                `${process.env.ZKSYNC_HOME}/etc/hyperchains/prover-keys/${process.env.ZKSYNC_ENV}/${proverType === ProverType.GPU ? 'gpu' : 'cpu'
+                `${process.env.ZKSYNC_HOME}/etc/hyperchains/prover-keys/${process.env.ZKSYNC_ENV}/${
+                    proverType === ProverType.GPU ? 'gpu' : 'cpu'
                 }/`,
                 process.env.ENV_FILE!
             );
@@ -97,7 +98,8 @@ async function setupProverKeys(proverType: ProverType) {
 
     env.modify(
         'FRI_PROVER_SETUP_DATA_PATH',
-        `${process.env.ZKSYNC_HOME}/etc/hyperchains/prover-keys/${process.env.ZKSYNC_ENV}/${proverType === ProverType.GPU ? 'gpu' : 'cpu'
+        `${process.env.ZKSYNC_HOME}/etc/hyperchains/prover-keys/${process.env.ZKSYNC_ENV}/${
+            proverType === ProverType.GPU ? 'gpu' : 'cpu'
         }/`,
         process.env.ENV_FILE!
     );


### PR DESCRIPTION
## What ❔

Fixes VM performance regression on CI loadtest introduced in https://github.com/matter-labs/zksync-era/pull/2760.

## Why ❔

Changes in the VM interface made the VM eagerly clone compressed bytecodes if compression hasn't failed. Compressed bytecodes aren't used during sandboxed VM execution in the API server (the sandbox only checks that compression is successful).For new VMs, bytecodes can be borrowed from the VM state, which is what this PR does using `Cow`.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.