### PR TITLE
feat(genesis): Validate genesis config against L1

### DIFF
--- a/core/node/genesis/src/lib.rs
+++ b/core/node/genesis/src/lib.rs
@@ -6,9 +6,12 @@ use std::fmt::Formatter;
 
 use anyhow::Context as _;
 use zksync_config::GenesisConfig;
-use zksync_contracts::{BaseSystemContracts, BaseSystemContractsHashes, SET_CHAIN_ID_EVENT};
+use zksync_contracts::{
+    hyperchain_contract, verifier_contract, BaseSystemContracts, BaseSystemContractsHashes,
+    SET_CHAIN_ID_EVENT,
+};
 use zksync_dal::{Connection, Core, CoreDal, DalError};
-use zksync_eth_client::EthInterface;
+use zksync_eth_client::{CallFunctionArgs, EthInterface};
 use zksync_merkle_tree::{domain::ZkSyncTree, TreeInstruction};
 use zksync_multivm::utils::get_max_gas_per_pubdata_byte;
 use zksync_system_constants::PRIORITY_EXPIRATION;
@@ -21,7 +24,7 @@ use zksync_types::{
     system_contracts::get_system_smart_contracts,
     web3::{BlockNumber, FilterBuilder},
     AccountTreeId, Address, Bloom, L1BatchNumber, L1ChainId, L2BlockNumber, L2ChainId,
-    ProtocolVersion, ProtocolVersionId, StorageKey, H256,
+    ProtocolVersion, ProtocolVersionId, StorageKey, H256, U256,
 };
 use zksync_utils::{bytecode::hash_bytecode, u256_to_h256};
 
@@ -110,11 +113,8 @@ impl GenesisParams {
                 },
             )));
         }
-        // Try to convert value from config to the real protocol version and return error
-        // if the version doesn't exist
-        let _: ProtocolVersionId = config
+        let _ = config
             .protocol_version
-            .map(|p| p.minor)
             .ok_or(GenesisError::MalformedConfig("protocol_version"))?;
         Ok(GenesisParams {
             base_system_contracts,
@@ -262,6 +262,55 @@ pub async fn insert_genesis_batch(
 
 pub async fn is_genesis_needed(storage: &mut Connection<'_, Core>) -> Result<bool, GenesisError> {
     Ok(storage.blocks_dal().is_genesis_needed().await?)
+}
+
+pub async fn validate_genesis_params(
+    genesis_params: &GenesisParams,
+    query_client: &dyn EthInterface,
+    diamond_proxy_address: Address,
+) -> anyhow::Result<()> {
+    let hyperchain_abi = hyperchain_contract();
+    let verifier_abi = verifier_contract();
+
+    let packed_protocol_version: U256 = CallFunctionArgs::new("getProtocolVersion", ())
+        .for_contract(diamond_proxy_address, &hyperchain_abi)
+        .call(query_client)
+        .await?;
+
+    let (minor_version, patch_version) = packed_protocol_version.div_mod((1u64 << 32).into());
+
+    if minor_version != U256::from(genesis_params.minor_protocol_version() as u16) {
+        return Err(anyhow::anyhow!(
+            "Minor protocol version mismatch: {minor_version} on contract, {} in config",
+            genesis_params.minor_protocol_version() as u16
+        ));
+    }
+
+    if patch_version != U256::from(genesis_params.protocol_version().patch.0) {
+        return Err(anyhow::anyhow!(
+            "Patch protocol version mismatch: {patch_version} on contract, {} in config",
+            genesis_params.protocol_version().patch.0
+        ));
+    }
+
+    let verifier_address: Address = CallFunctionArgs::new("getVerifier", ())
+        .for_contract(diamond_proxy_address, &hyperchain_abi)
+        .call(query_client)
+        .await?;
+
+    let verification_key_hash: H256 = CallFunctionArgs::new("verificationKeyHash", ())
+        .for_contract(verifier_address, &verifier_abi)
+        .call(query_client)
+        .await?;
+
+    if verification_key_hash != genesis_params.config().recursion_scheduler_level_vk_hash {
+        return Err(anyhow::anyhow!(
+            "Verification key hash mismatch: {verification_key_hash:?} on contract, {:?} in config",
+            genesis_params.config().recursion_scheduler_level_vk_hash
+        ));
+    }
+
+    Ok(())
 }
 
 pub async fn ensure_genesis_state(

--- a/core/node/node_storage_init/src/main_node/genesis.rs
+++ b/core/node/node_storage_init/src/main_node/genesis.rs
@@ -30,6 +30,12 @@ impl InitializeStorage for MainNodeGenesis {
         }
 
         let params = GenesisParams::load_genesis_params(self.genesis.clone())?;
+        zksync_node_genesis::validate_genesis_params(
+            &params,
+            &self.l1_client,
+            self.contracts.diamond_proxy_addr,
+        )
+        .await?;
         zksync_node_genesis::ensure_genesis_state(&mut storage, &params).await?;
 
         if let Some(ecosystem_contracts) = &self.contracts.ecosystem_contracts {


### PR DESCRIPTION
## What ❔

Validate protocol version and vk hash from genesis config against L1

## Why ❔

Right now nothing prevents from initializing contracts and node with different protocol versions or vk hashs, and it already happened 🥲 

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
