### PR TITLE
fix(zk_toolbox): fix port offset for new chains

### DIFF
--- a/zk_toolbox/crates/config/src/general.rs
+++ b/zk_toolbox/crates/config/src/general.rs
@@ -127,7 +127,7 @@ pub fn update_ports(config: &mut GeneralConfig, ports_config: &PortsConfig) -> a
     let prometheus = config
         .prometheus_config
         .as_mut()
-        .context("Contract Verifier config is not presented")?;
+        .context("Prometheus config is not presented")?;
 
     api.web3_json_rpc.http_port = ports_config.web3_json_rpc_http_port;
     update_port_in_url(

--- a/zk_toolbox/crates/zk_inception/src/commands/chain/args/init.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/chain/args/init.rs
@@ -22,7 +22,7 @@ pub struct PortOffset(u16);
 
 impl PortOffset {
     pub fn from_chain_id(chain_id: u16) -> Self {
-        Self(chain_id * 100)
+        Self((chain_id - 1) * 100)
     }
 }
 
@@ -88,7 +88,7 @@ impl InitArgs {
             l1_rpc_url,
             port_offset: self
                 .port_offset
-                .unwrap_or(PortOffset::from_chain_id(config.chain_id.as_u64() as u16))
+                .unwrap_or(PortOffset::from_chain_id(config.id as u16))
                 .into(),
         }
     }


### PR DESCRIPTION
## What ❔
Fixed port offset for newly created chains via `zk_inception`:
- Use `chain.id` instead of `chain.chain_id`
- Use `(chain.id - 1) * 100` as an offset to keep the port for the first chain as 3050

## Why ❔
Using `chain.chain_id` was not intended as the resulting port number could potentially overflow.

## Checklist
- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
