### PR TITLE
feat(prover): Make compressor build with 80 CUDA arch.

### DIFF
--- a/docker/proof-fri-gpu-compressor/Dockerfile
+++ b/docker/proof-fri-gpu-compressor/Dockerfile
@@ -4,7 +4,8 @@ FROM nvidia/cuda:12.2.0-devel-ubuntu22.04 as builder
 ARG DEBIAN_FRONTEND=noninteractive
 
 ARG CUDA_ARCH=89
-ENV CUDAARCHS=${CUDA_ARCH}
+ARG A100_CUDA_ARCH=80
+ENV CUDAARCHS=${CUDA_ARCH};${A100_CUDA_ARCH}
 
 RUN apt-get update && apt-get install -y curl clang openssl libssl-dev gcc g++ git \
     pkg-config build-essential libclang-dev && \


### PR DESCRIPTION
## What ❔

Add arch 80 to docker image of compressor

## Why ❔

To be able to run it on NVIDIA A100

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
