### PR TITLE
chore(ci): Fix cargo deny check and make output readable

### DIFF
--- a/.github/workflows/cargo-license.yaml
+++ b/.github/workflows/cargo-license.yaml
@@ -6,3 +6,6 @@ jobs:
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - uses: EmbarkStudios/cargo-deny-action@8371184bd11e21dcf8ac82ebf8c9c9f74ebf7268 # v2.0.1
+      with:
+        command: check
+        command-arguments: "--hide-inclusion-graph"

--- a/deny.toml
+++ b/deny.toml
@@ -12,10 +12,10 @@ ignore = [
     "RUSTSEC-2022-0041", # crossbeam-utils vulnerability, dependency coming from bellman_ce
     "RUSTSEC-2024-0320", # yaml_rust dependency being unmaintained, dependency in core, we should consider moving to yaml_rust2 fork
     "RUSTSEC-2020-0168", # mach dependency being unmaintained, dependency in consensus, we should consider moving to mach2 fork
+    "RUSTSEC-2024-0370", # `cs_derive` needs to be updated to not rely on `proc-macro-error`
     # all below caused by StructOpt which we still use and we should move to clap v3 instead
     "RUSTSEC-2021-0145",
     "RUSTSEC-2021-0139",
-
 ]
 
 [licenses]
@@ -51,7 +51,7 @@ ignore = false
 registries = []
 
 [bans]
-multiple-versions = "warn"
+multiple-versions = "allow"
 wildcards = "allow"
 highlight = "all"
 workspace-default-features = "allow"


### PR DESCRIPTION
## What ❔

- Allow new advisory (low impact; hard to fix).
- Omit printing the tree in output; because with it the output is not readable.

## Why ❔

- Unblock CI
- Make cargo deny CI usable.
