### PR TITLE
refactor(prover_keystore): Reduce number of Keystore constructors

### DIFF
--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -8236,8 +8236,6 @@ dependencies = [
  "tracing",
  "zkevm_test_harness",
  "zksync_basic_types",
- "zksync_config",
- "zksync_env_config",
  "zksync_prover_fri_types",
  "zksync_utils",
 ]

--- a/prover/crates/bin/proof_fri_compressor/src/compressor.rs
+++ b/prover/crates/bin/proof_fri_compressor/src/compressor.rs
@@ -35,7 +35,7 @@ pub struct ProofCompressor {
     compression_mode: u8,
     max_attempts: u32,
     protocol_version: ProtocolSemanticVersion,
-    setup_data_path: String,
+    keystore: Keystore,
 }
 
 impl ProofCompressor {
@@ -45,7 +45,7 @@ impl ProofCompressor {
         compression_mode: u8,
         max_attempts: u32,
         protocol_version: ProtocolSemanticVersion,
-        setup_data_path: String,
+        keystore: Keystore,
     ) -> Self {
         Self {
             blob_store,
@@ -53,7 +53,7 @@ impl ProofCompressor {
             compression_mode,
             max_attempts,
             protocol_version,
-            setup_data_path,
+            keystore,
         }
     }
 
@@ -62,9 +62,8 @@ impl ProofCompressor {
         l1_batch: L1BatchNumber,
         proof: ZkSyncRecursionLayerProof,
         _compression_mode: u8,
-        setup_data_path: String,
+        keystore: Keystore,
     ) -> anyhow::Result<FinalProof> {
-        let keystore = Keystore::new_with_setup_data_path(setup_data_path);
         let scheduler_vk = keystore
             .load_recursive_layer_verification_key(
                 ZkSyncRecursionLayerStorageType::SchedulerCircuit as u8,
@@ -178,9 +177,9 @@ impl JobProcessor for ProofCompressor {
     ) -> JoinHandle<anyhow::Result<Self::JobArtifacts>> {
         let compression_mode = self.compression_mode;
         let block_number = *job_id;
-        let setup_data_path = self.setup_data_path.clone();
+        let keystore = self.keystore.clone();
         tokio::task::spawn_blocking(move || {
-            Self::compress_proof(block_number, job, compression_mode, setup_data_path)
+            Self::compress_proof(block_number, job, compression_mode, keystore)
         })
     }
 

--- a/prover/crates/bin/proof_fri_compressor/src/main.rs
+++ b/prover/crates/bin/proof_fri_compressor/src/main.rs
@@ -11,6 +11,7 @@ use zksync_env_config::object_store::ProverObjectStoreConfig;
 use zksync_object_store::ObjectStoreFactory;
 use zksync_prover_dal::{ConnectionPool, Prover};
 use zksync_prover_fri_types::PROVER_PROTOCOL_SEMANTIC_VERSION;
+use zksync_prover_keystore::keystore::Keystore;
 use zksync_queued_job_processor::JobProcessor;
 use zksync_utils::wait_for_tasks::ManagedTasks;
 use zksync_vlog::prometheus::PrometheusExporterConfig;
@@ -70,16 +71,18 @@ async fn main() -> anyhow::Result<()> {
 
     let protocol_version = PROVER_PROTOCOL_SEMANTIC_VERSION;
 
+    let prover_config = general_config
+        .prover_config
+        .expect("ProverConfig doesn't exist");
+    let keystore =
+        Keystore::locate().with_setup_path(Some(prover_config.setup_data_path.clone().into()));
     let proof_compressor = ProofCompressor::new(
         blob_store,
         pool,
         config.compression_mode,
         config.max_attempts,
         protocol_version,
-        general_config
-            .prover_config
-            .expect("ProverConfig doesn't exist")
-            .setup_data_path,
+        keystore,
     );
 
     let (stop_sender, stop_receiver) = watch::channel(false);

--- a/prover/crates/bin/prover_fri/tests/basic_test.rs
+++ b/prover/crates/bin/prover_fri/tests/basic_test.rs
@@ -57,7 +57,7 @@ async fn prover_and_assert_base_layer(
         CircuitWrapper::Base(base) => base.clone(),
         _ => anyhow::bail!("Expected base layer circuit"),
     };
-    let keystore = Keystore::default();
+    let keystore = Keystore::locate();
     let circuit_setup_data = generate_setup_data_common(
         &keystore,
         ProverServiceDataKey::new_basic(circuit.numeric_circuit_type()),

--- a/prover/crates/bin/vk_setup_data_generator_server_fri/src/commitment_generator.rs
+++ b/prover/crates/bin/vk_setup_data_generator_server_fri/src/commitment_generator.rs
@@ -34,6 +34,6 @@ mod test {
 
     #[test]
     fn test_read_and_update_contract_toml() {
-        read_and_update_contract_toml(&Keystore::default(), true).unwrap();
+        read_and_update_contract_toml(&Keystore::locate(), true).unwrap();
     }
 }

--- a/prover/crates/bin/vk_setup_data_generator_server_fri/src/main.rs
+++ b/prover/crates/bin/vk_setup_data_generator_server_fri/src/main.rs
@@ -1,7 +1,7 @@
 //! Tool to generate different types of keys used by the proving system.
 //!
 //! It can generate verification keys, setup keys, and also commitments.
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 use anyhow::Context as _;
 use clap::{Parser, Subcommand};
@@ -196,14 +196,14 @@ fn print_stats(digests: HashMap<String, String>) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn keystore_from_optional_path(path: Option<String>, setup_path: Option<String>) -> Keystore {
+fn keystore_from_optional_path(path: Option<String>, setup_data_path: Option<String>) -> Keystore {
     if let Some(path) = path {
-        return Keystore::new_with_optional_setup_path(path.into(), setup_path);
+        return Keystore::new(path.into()).with_setup_path(setup_data_path.map(PathBuf::from));
     }
-    if setup_path.is_some() {
+    if setup_data_path.is_some() {
         panic!("--setup_path must not be set when --path is not set");
     }
-    Keystore::default()
+    Keystore::locate()
 }
 
 fn generate_setup_keys(

--- a/prover/crates/bin/vk_setup_data_generator_server_fri/src/tests.rs
+++ b/prover/crates/bin/vk_setup_data_generator_server_fri/src/tests.rs
@@ -36,21 +36,21 @@ fn all_possible_prover_service_data_key() -> impl Strategy<Value = ProverService
 proptest! {
     #[test]
     fn test_get_base_layer_vk_for_circuit_type(circuit_id in 1u8..13) {
-        let keystore = Keystore::default();
+        let keystore = Keystore::locate();
         let vk = keystore.load_base_layer_verification_key(circuit_id).unwrap();
         assert_eq!(circuit_id, vk.numeric_circuit_type());
     }
 
     #[test]
     fn test_get_recursive_layer_vk_for_circuit_type(circuit_id in 1u8..15) {
-        let keystore = Keystore::default();
+        let keystore = Keystore::locate();
         let vk = keystore.load_recursive_layer_verification_key(circuit_id).unwrap();
         assert_eq!(circuit_id, vk.numeric_circuit_type());
     }
 
     #[test]
     fn test_get_finalization_hints(key in all_possible_prover_service_data_key()) {
-        let keystore = Keystore::default();
+        let keystore = Keystore::locate();
 
         let result = keystore.load_finalization_hints(key).unwrap();
 

--- a/prover/crates/bin/witness_generator/src/main.rs
+++ b/prover/crates/bin/witness_generator/src/main.rs
@@ -61,7 +61,7 @@ struct Opt {
 async fn ensure_protocol_alignment(
     prover_pool: &ConnectionPool<Prover>,
     protocol_version: ProtocolSemanticVersion,
-    setup_data_path: String,
+    keystore: &Keystore,
 ) -> anyhow::Result<()> {
     tracing::info!("Verifying protocol alignment for {:?}", protocol_version);
     let vk_commitments_in_db = match prover_pool
@@ -80,7 +80,6 @@ async fn ensure_protocol_alignment(
             );
         }
     };
-    let keystore = Keystore::new_with_setup_data_path(setup_data_path);
     let scheduler_vk_hash = vk_commitments_in_db.snark_wrapper_vk_hash;
     keystore
         .verify_scheduler_vk_hash(scheduler_vk_hash)
@@ -118,6 +117,8 @@ async fn main() -> anyhow::Result<()> {
         .witness_generator_config
         .context("witness generator config")?
         .clone();
+    let keystore =
+        Keystore::locate().with_setup_path(Some(prover_config.setup_data_path.clone().into()));
 
     let prometheus_config = general_config.prometheus_config.clone();
 
@@ -139,13 +140,9 @@ async fn main() -> anyhow::Result<()> {
     let (stop_sender, stop_receiver) = watch::channel(false);
 
     let protocol_version = PROVER_PROTOCOL_SEMANTIC_VERSION;
-    ensure_protocol_alignment(
-        &prover_connection_pool,
-        protocol_version,
-        prover_config.setup_data_path.clone(),
-    )
-    .await
-    .unwrap_or_else(|err| panic!("Protocol alignment check failed: {:?}", err));
+    ensure_protocol_alignment(&prover_connection_pool, protocol_version, &keystore)
+        .await
+        .unwrap_or_else(|err| panic!("Protocol alignment check failed: {:?}", err));
 
     let rounds = match (opt.round, opt.all_rounds) {
         (Some(round), false) => vec![round],
@@ -186,8 +183,6 @@ async fn main() -> anyhow::Result<()> {
     let mut tasks = Vec::new();
     tasks.push(tokio::spawn(prometheus_task));
 
-    let setup_data_path = prover_config.setup_data_path.clone();
-
     for round in rounds {
         tracing::info!(
             "initializing the {:?} witness generator, batch size: {:?} with protocol_version: {:?}",
@@ -226,7 +221,7 @@ async fn main() -> anyhow::Result<()> {
                     store_factory.create_store().await?,
                     prover_connection_pool.clone(),
                     protocol_version,
-                    setup_data_path.clone(),
+                    keystore.clone(),
                 );
                 generator.run(stop_receiver.clone(), opt.batch_size)
             }
@@ -236,7 +231,7 @@ async fn main() -> anyhow::Result<()> {
                     store_factory.create_store().await?,
                     prover_connection_pool.clone(),
                     protocol_version,
-                    setup_data_path.clone(),
+                    keystore.clone(),
                 );
                 generator.run(stop_receiver.clone(), opt.batch_size)
             }
@@ -246,7 +241,7 @@ async fn main() -> anyhow::Result<()> {
                     store_factory.create_store().await?,
                     prover_connection_pool.clone(),
                     protocol_version,
-                    setup_data_path.clone(),
+                    keystore.clone(),
                 );
                 generator.run(stop_receiver.clone(), opt.batch_size)
             }
@@ -256,7 +251,7 @@ async fn main() -> anyhow::Result<()> {
                     store_factory.create_store().await?,
                     prover_connection_pool.clone(),
                     protocol_version,
-                    setup_data_path.clone(),
+                    keystore.clone(),
                 );
                 generator.run(stop_receiver.clone(), opt.batch_size)
             }

--- a/prover/crates/bin/witness_generator/src/recursion_tip.rs
+++ b/prover/crates/bin/witness_generator/src/recursion_tip.rs
@@ -75,7 +75,7 @@ pub struct RecursionTipWitnessGenerator {
     object_store: Arc<dyn ObjectStore>,
     prover_connection_pool: ConnectionPool<Prover>,
     protocol_version: ProtocolSemanticVersion,
-    setup_data_path: String,
+    keystore: Keystore,
 }
 
 impl RecursionTipWitnessGenerator {
@@ -84,14 +84,14 @@ impl RecursionTipWitnessGenerator {
         object_store: Arc<dyn ObjectStore>,
         prover_connection_pool: ConnectionPool<Prover>,
         protocol_version: ProtocolSemanticVersion,
-        setup_data_path: String,
+        keystore: Keystore,
     ) -> Self {
         Self {
             config,
             object_store,
             prover_connection_pool,
             protocol_version,
-            setup_data_path,
+            keystore,
         }
     }
 
@@ -175,7 +175,7 @@ impl JobProcessor for RecursionTipWitnessGenerator {
                 l1_batch_number,
                 final_node_proof_job_ids,
                 &*self.object_store,
-                self.setup_data_path.clone(),
+                self.keystore.clone(),
             )
             .await
             .context("prepare_job()")?,
@@ -288,7 +288,7 @@ pub async fn prepare_job(
     l1_batch_number: L1BatchNumber,
     final_node_proof_job_ids: Vec<(u8, u32)>,
     object_store: &dyn ObjectStore,
-    setup_data_path: String,
+    keystore: Keystore,
 ) -> anyhow::Result<RecursionTipWitnessGeneratorJob> {
     let started_at = Instant::now();
     let recursion_tip_proofs =
@@ -296,7 +296,6 @@ pub async fn prepare_job(
     WITNESS_GENERATOR_METRICS.blob_fetch_time[&AggregationRound::RecursionTip.into()]
         .observe(started_at.elapsed());
 
-    let keystore = Keystore::new_with_setup_data_path(setup_data_path);
     let node_vk = keystore
         .load_recursive_layer_verification_key(
             ZkSyncRecursionLayerStorageType::NodeLayerCircuit as u8,

--- a/prover/crates/bin/witness_generator/src/scheduler.rs
+++ b/prover/crates/bin/witness_generator/src/scheduler.rs
@@ -57,7 +57,7 @@ pub struct SchedulerWitnessGenerator {
     object_store: Arc<dyn ObjectStore>,
     prover_connection_pool: ConnectionPool<Prover>,
     protocol_version: ProtocolSemanticVersion,
-    setup_data_path: String,
+    keystore: Keystore,
 }
 
 impl SchedulerWitnessGenerator {
@@ -66,14 +66,14 @@ impl SchedulerWitnessGenerator {
         object_store: Arc<dyn ObjectStore>,
         prover_connection_pool: ConnectionPool<Prover>,
         protocol_version: ProtocolSemanticVersion,
-        setup_data_path: String,
+        keystore: Keystore,
     ) -> Self {
         Self {
             config,
             object_store,
             prover_connection_pool,
             protocol_version,
-            setup_data_path,
+            keystore,
         }
     }
 
@@ -154,7 +154,7 @@ impl JobProcessor for SchedulerWitnessGenerator {
                 l1_batch_number,
                 recursion_tip_job_id,
                 &*self.object_store,
-                self.setup_data_path.clone(),
+                self.keystore.clone(),
             )
             .await
             .context("prepare_job()")?,
@@ -266,7 +266,7 @@ pub async fn prepare_job(
     l1_batch_number: L1BatchNumber,
     recursion_tip_job_id: u32,
     object_store: &dyn ObjectStore,
-    setup_data_path: String,
+    keystore: Keystore,
 ) -> anyhow::Result<SchedulerWitnessGeneratorJob> {
     let started_at = Instant::now();
     let wrapper = object_store.get(recursion_tip_job_id).await?;
@@ -280,7 +280,6 @@ pub async fn prepare_job(
         .observe(started_at.elapsed());
 
     let started_at = Instant::now();
-    let keystore = Keystore::new_with_setup_data_path(setup_data_path);
     let node_vk = keystore
         .load_recursive_layer_verification_key(
             ZkSyncRecursionLayerStorageType::NodeLayerCircuit as u8,

--- a/prover/crates/bin/witness_generator/tests/basic_test.rs
+++ b/prover/crates/bin/witness_generator/tests/basic_test.rs
@@ -8,6 +8,7 @@ use zksync_prover_fri_types::{
     CircuitWrapper,
 };
 use zksync_prover_fri_utils::get_recursive_layer_circuit_id_for_base_layer;
+use zksync_prover_keystore::keystore::Keystore;
 use zksync_types::{
     basic_fri_types::AggregationRound,
     prover_dal::{LeafAggregationJobMetadata, NodeAggregationJobMetadata},
@@ -50,13 +51,10 @@ async fn test_leaf_witness_gen() {
         .await
         .unwrap();
 
-    let job = prepare_leaf_aggregation_job(
-        leaf_aggregation_job_metadata,
-        &*object_store,
-        "crates/bin/vk_setup_data_generator/data".to_string(),
-    )
-    .await
-    .unwrap();
+    let keystore = Keystore::locate();
+    let job = prepare_leaf_aggregation_job(leaf_aggregation_job_metadata, &*object_store, keystore)
+        .await
+        .unwrap();
 
     let artifacts = LeafAggregationWitnessGenerator::process_job_impl(
         job,
@@ -143,13 +141,11 @@ async fn test_node_witness_gen() {
         prover_job_ids_for_proofs: vec![5211320],
     };
 
-    let job = node_aggregation::prepare_job(
-        node_aggregation_job_metadata,
-        &*object_store,
-        "crates/bin/vk_setup_data_generator/data".to_string(),
-    )
-    .await
-    .unwrap();
+    let keystore = Keystore::locate();
+    let job =
+        node_aggregation::prepare_job(node_aggregation_job_metadata, &*object_store, keystore)
+            .await
+            .unwrap();
 
     let artifacts = NodeAggregationWitnessGenerator::process_job_impl(
         job,

--- a/prover/crates/bin/witness_vector_generator/src/generator.rs
+++ b/prover/crates/bin/witness_vector_generator/src/generator.rs
@@ -34,7 +34,7 @@ pub struct WitnessVectorGenerator {
     config: FriWitnessVectorGeneratorConfig,
     protocol_version: ProtocolSemanticVersion,
     max_attempts: u32,
-    setup_data_path: Option<String>,
+    keystore: Keystore,
 }
 
 impl WitnessVectorGenerator {
@@ -47,7 +47,7 @@ impl WitnessVectorGenerator {
         config: FriWitnessVectorGeneratorConfig,
         protocol_version: ProtocolSemanticVersion,
         max_attempts: u32,
-        setup_data_path: Option<String>,
+        keystore: Keystore,
     ) -> Self {
         Self {
             object_store,
@@ -57,7 +57,7 @@ impl WitnessVectorGenerator {
             config,
             protocol_version,
             max_attempts,
-            setup_data_path,
+            keystore,
         }
     }
 
@@ -127,16 +127,10 @@ impl JobProcessor for WitnessVectorGenerator {
         job: ProverJob,
         _started_at: Instant,
     ) -> JoinHandle<anyhow::Result<Self::JobArtifacts>> {
-        let setup_data_path = self.setup_data_path.clone();
-
+        let keystore = self.keystore.clone();
         tokio::task::spawn_blocking(move || {
             let block_number = job.block_number;
             let _span = tracing::info_span!("witness_vector_generator", %block_number).entered();
-            let keystore = if let Some(setup_data_path) = setup_data_path {
-                Keystore::new_with_setup_data_path(setup_data_path)
-            } else {
-                Keystore::default()
-            };
             Self::generate_witness_vector(job, &keystore)
         })
     }

--- a/prover/crates/bin/witness_vector_generator/tests/basic_test.rs
+++ b/prover/crates/bin/witness_vector_generator/tests/basic_test.rs
@@ -22,8 +22,7 @@ fn test_generate_witness_vector() {
         circuit_wrapper,
         setup_data_key: key,
     };
-    let vector =
-        WitnessVectorGenerator::generate_witness_vector(job, &Keystore::default()).unwrap();
+    let vector = WitnessVectorGenerator::generate_witness_vector(job, &Keystore::locate()).unwrap();
     assert!(!vector.witness_vector.all_values.is_empty());
     assert!(!vector.witness_vector.multiplicities.is_empty());
     assert!(!vector.witness_vector.public_inputs_locations.is_empty());

--- a/prover/crates/lib/keystore/Cargo.toml
+++ b/prover/crates/lib/keystore/Cargo.toml
@@ -17,8 +17,6 @@ zksync_prover_fri_types.workspace = true
 zkevm_test_harness.workspace = true
 circuit_definitions = { workspace = true, features = ["log_tracing"] }
 shivini = { workspace = true, optional = true }
-zksync_config.workspace = true
-zksync_env_config.workspace = true
 
 anyhow.workspace = true
 tracing.workspace = true

--- a/prover/crates/lib/keystore/src/utils.rs
+++ b/prover/crates/lib/keystore/src/utils.rs
@@ -137,7 +137,7 @@ mod tests {
         for entry in std::fs::read_dir(path_to_input.clone()).unwrap().flatten() {
             if entry.metadata().unwrap().is_dir() {
                 let basepath = path_to_input.join(entry.file_name());
-                let keystore = Keystore::new_with_optional_setup_path(basepath.clone(), None);
+                let keystore = Keystore::new(basepath.clone());
 
                 let expected =
                     H256::from_str(&keystore.load_commitments().unwrap().snark_wrapper).unwrap();


### PR DESCRIPTION
- Remove `Keystore::default`, which implicitly used env config to find the setup path.
- Remove dependency on `zksync_config` and `zksync_env_config` from keystore crate.
- Reduce the number of constructors for `Keystore`
- Pass `Keystore` instead of `setup_data_path` to the components to make access more explicit.

*What next?*

The following will be done separately to not overly expand the PR:

- Remove implicit lookups from `Keystore` completely. Config-less lookup should be done by the caller, not the keystore.
- Remove boilerplate code from `Keystore` (e.g. family of `load_x` and `load_y` methods -- this should be reworked as traits)
- Cover code with tests.