### PR TITLE
fix(tee-prover): passthrough env vars to the SGX enclave

### DIFF
--- a/etc/nix/container-tee_prover.nix
+++ b/etc/nix/container-tee_prover.nix
@@ -33,9 +33,9 @@ nixsgxLib.mkSGXContainer {
       env = {
         TEE_PROVER_API_URL.passthrough = true;
         TEE_PROVER_MAX_RETRIES.passthrough = true;
-        TEE_PROVER_INITIAL_RETRY_BACKOFF_SECONDS.passthrough = true;
+        TEE_PROVER_INITIAL_RETRY_BACKOFF_SEC.passthrough = true;
         TEE_PROVER_RETRY_BACKOFF_MULTIPLIER.passthrough = true;
-        TEE_PROVER_MAX_BACKOFF_SECONDS.passthrough = true;
+        TEE_PROVER_MAX_BACKOFF_SEC.passthrough = true;
         API_PROMETHEUS_LISTENER_PORT.passthrough = true;
         API_PROMETHEUS_PUSHGATEWAY_URL.passthrough = true;
         API_PROMETHEUS_PUSH_INTERVAL_MS.passthrough = true;


### PR DESCRIPTION
## What ❔

Passthrough env vars to the SGX enclave.

Relevant logs showcasing the issue:
https://grafana.matterlabs.dev/goto/1iFHMIeIg?orgId=1

## Why ❔

To fix the bug.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
