### PR TITLE
chore(ci): Limit tokio/rayon pools for zk_toolbox CI

### DIFF
--- a/.github/workflows/ci-zk-toolbox-reusable.yml
+++ b/.github/workflows/ci-zk-toolbox-reusable.yml
@@ -4,6 +4,11 @@ on:
 
 env:
   CLICOLOR: 1
+  # We run multiple binaries in parallel, and by default they will try to utilize all the
+  # available CPUs. In tests, there is not much CPU-intensive work (rayon), but a lot of
+  # async work (tokio), so we prioritize tokio.
+  TOKIO_WORKER_THREADS: 4
+  RAYON_NUM_THREADS: 2
 
 jobs:
   lint:

--- a/.github/workflows/ci-zk-toolbox-reusable.yml
+++ b/.github/workflows/ci-zk-toolbox-reusable.yml
@@ -16,7 +16,7 @@ jobs:
     uses: ./.github/workflows/ci-core-lint-reusable.yml
 
   tests:
-    runs-on: [ matterlabs-ci-runner ]
+    runs-on: [ matterlabs-ci-runner-ultra-performance ]
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
         with:


### PR DESCRIPTION
## What ❔

Limits rayon threadpool size to 2 and tokio threadpool size to 4 in zk_toolbox CI.
I have checked locally, and with this configuration time to run integration tests is pretty close to the default configuration.

## Why ❔

By default, both tokio and rayon will try to use all the CPUs. When we run multiple Rust binaries at the same time (3 servers and 3 ENs in our case), it causes a lot of conflict for resources, regardless of the number of CPUs.