### PR TITLE
feat: allow specifying what tests to run with zks

### DIFF
--- a/zk_toolbox/crates/zk_supervisor/src/commands/test/args/integration.rs
+++ b/zk_toolbox/crates/zk_supervisor/src/commands/test/args/integration.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 
-use crate::messages::{MSG_NO_DEPS_HELP, MSG_TESTS_EXTERNAL_NODE_HELP};
+use crate::messages::{MSG_NO_DEPS_HELP, MSG_TESTS_EXTERNAL_NODE_HELP, MSG_TEST_PATTERN_HELP};
 
 #[derive(Debug, Serialize, Deserialize, Parser)]
 pub struct IntegrationArgs {
@@ -9,4 +9,6 @@ pub struct IntegrationArgs {
     pub external_node: bool,
     #[clap(short, long, help = MSG_NO_DEPS_HELP)]
     pub no_deps: bool,
+    #[clap(short, long, help = MSG_TEST_PATTERN_HELP)]
+    pub test_pattern: Option<String>,
 }

--- a/zk_toolbox/crates/zk_supervisor/src/commands/test/integration.rs
+++ b/zk_toolbox/crates/zk_supervisor/src/commands/test/integration.rs
@@ -39,9 +39,13 @@ pub async fn run(shell: &Shell, args: IntegrationArgs) -> anyhow::Result<()> {
         .init_test_wallet(&ecosystem_config, &chain_config)
         .await?;
 
-    let mut command = cmd!(shell, "yarn jest --forceExit --testTimeout 120000")
-        .env("CHAIN_NAME", ecosystem_config.current_chain())
-        .env("MASTER_WALLET_PK", wallets.get_test_pk(&chain_config)?);
+    let test_pattern: Option<&str> = args.test_pattern.as_ref().map(|x| x.as_str());
+    let mut command = cmd!(
+        shell,
+        "yarn jest --forceExit --testTimeout 120000 -t {test_pattern...}"
+    )
+    .env("CHAIN_NAME", ecosystem_config.current_chain())
+    .env("MASTER_WALLET_PK", wallets.get_test_pk(&chain_config)?);
 
     if args.external_node {
         command = command.env("EXTERNAL_NODE", format!("{:?}", args.external_node))

--- a/zk_toolbox/crates/zk_supervisor/src/commands/test/integration.rs
+++ b/zk_toolbox/crates/zk_supervisor/src/commands/test/integration.rs
@@ -39,7 +39,7 @@ pub async fn run(shell: &Shell, args: IntegrationArgs) -> anyhow::Result<()> {
         .init_test_wallet(&ecosystem_config, &chain_config)
         .await?;
 
-    let test_pattern: Option<&str> = args.test_pattern.as_ref().map(|x| x.as_str());
+    let test_pattern = args.test_pattern;
     let mut command = cmd!(
         shell,
         "yarn jest --forceExit --testTimeout 120000 -t {test_pattern...}"

--- a/zk_toolbox/crates/zk_supervisor/src/messages.rs
+++ b/zk_toolbox/crates/zk_supervisor/src/messages.rs
@@ -92,6 +92,8 @@ pub(super) const MSG_TEST_RUST_OPTIONS_HELP: &str = "Cargo test flags";
 pub(super) const MSG_BUILD_ABOUT: &str = "Build all test dependencies";
 pub(super) const MSG_TESTS_EXTERNAL_NODE_HELP: &str = "Run tests for external node";
 pub(super) const MSG_NO_DEPS_HELP: &str = "Do not install or build dependencies";
+pub(super) const MSG_TEST_PATTERN_HELP: &str =
+    "Run just the tests matching a pattern. Same as the -t flag on jest.";
 pub(super) const MSG_NO_KILL_HELP: &str = "The test will not kill all the nodes during execution";
 pub(super) const MSG_TESTS_RECOVERY_SNAPSHOT_HELP: &str =
     "Run recovery from a snapshot instead of genesis";


### PR DESCRIPTION
`zks t i` now accepts a `-t` flag that can can be used to specify a pattern. Only matching tests are run.