### PR TITLE
fix(zk_toolbox): secrets path, artifacts path

### DIFF
--- a/zk_toolbox/crates/zk_inception/src/commands/prover/init.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/prover/init.rs
@@ -163,7 +163,7 @@ fn init_file_backed_proof_storage(
     ecosystem_config: &EcosystemConfig,
     config: ProofStorageFileBacked,
 ) -> anyhow::Result<ObjectStoreConfig> {
-    let proof_store_dir = config.proof_store_dir;
+    let proof_store_dir = config.proof_store_dir.clone();
     let prover_path = get_link_to_prover(ecosystem_config);
 
     let proof_store_dir = prover_path.join(proof_store_dir).join("witness_inputs");
@@ -173,7 +173,7 @@ fn init_file_backed_proof_storage(
 
     let object_store_config = ObjectStoreConfig {
         mode: ObjectStoreMode::FileBacked {
-            file_backed_base_path: proof_store_dir.into_os_string().into_string().unwrap(),
+            file_backed_base_path: config.proof_store_dir,
         },
         max_retries: PROVER_STORE_MAX_RETRIES,
         local_mirror_path: None,

--- a/zk_toolbox/crates/zk_supervisor/src/commands/prover/insert_batch.rs
+++ b/zk_toolbox/crates/zk_supervisor/src/commands/prover/insert_batch.rs
@@ -1,19 +1,27 @@
-use common::{check_prerequisites, cmd::Cmd, logger, PROVER_CLI_PREREQUISITE};
+use common::{
+    check_prerequisites, cmd::Cmd, config::global_config, logger, PROVER_CLI_PREREQUISITE,
+};
 use config::{get_link_to_prover, EcosystemConfig};
 use xshell::{cmd, Shell};
 
-use crate::commands::prover::{
-    args::insert_batch::{InsertBatchArgs, InsertBatchArgsFinal},
-    info,
+use crate::{
+    commands::prover::{
+        args::insert_batch::{InsertBatchArgs, InsertBatchArgsFinal},
+        info,
+    },
+    messages::MSG_CHAIN_NOT_FOUND_ERR,
 };
 
 pub async fn run(shell: &Shell, args: InsertBatchArgs) -> anyhow::Result<()> {
     check_prerequisites(shell, &PROVER_CLI_PREREQUISITE, false);
 
     let ecosystem_config = EcosystemConfig::from_file(shell)?;
+    let chain_config = ecosystem_config
+        .load_chain(global_config().chain_name.clone())
+        .expect(MSG_CHAIN_NOT_FOUND_ERR);
 
     let version = info::get_protocol_version(shell, &get_link_to_prover(&ecosystem_config)).await?;
-    let prover_url = info::get_database_url(shell).await?;
+    let prover_url = info::get_database_url(&chain_config).await?;
 
     let InsertBatchArgsFinal { number, version } = args.fill_values_with_prompts(version);
 

--- a/zk_toolbox/crates/zk_supervisor/src/commands/prover/insert_version.rs
+++ b/zk_toolbox/crates/zk_supervisor/src/commands/prover/insert_version.rs
@@ -1,21 +1,29 @@
-use common::{check_prerequisites, cmd::Cmd, logger, PROVER_CLI_PREREQUISITE};
+use common::{
+    check_prerequisites, cmd::Cmd, config::global_config, logger, PROVER_CLI_PREREQUISITE,
+};
 use config::{get_link_to_prover, EcosystemConfig};
 use xshell::{cmd, Shell};
 
-use crate::commands::prover::{
-    args::insert_version::{InsertVersionArgs, InsertVersionArgsFinal},
-    info,
+use crate::{
+    commands::prover::{
+        args::insert_version::{InsertVersionArgs, InsertVersionArgsFinal},
+        info,
+    },
+    messages::MSG_CHAIN_NOT_FOUND_ERR,
 };
 
 pub async fn run(shell: &Shell, args: InsertVersionArgs) -> anyhow::Result<()> {
     check_prerequisites(shell, &PROVER_CLI_PREREQUISITE, false);
 
     let ecosystem_config = EcosystemConfig::from_file(shell)?;
+    let chain_config = ecosystem_config
+        .load_chain(global_config().chain_name.clone())
+        .expect(MSG_CHAIN_NOT_FOUND_ERR);
 
     let version = info::get_protocol_version(shell, &get_link_to_prover(&ecosystem_config)).await?;
     let snark_wrapper = info::get_snark_wrapper(&get_link_to_prover(&ecosystem_config)).await?;
 
-    let prover_url = info::get_database_url(shell).await?;
+    let prover_url = info::get_database_url(&chain_config).await?;
 
     let InsertVersionArgsFinal {
         version,


### PR DESCRIPTION
## What ❔

Fix getting chain config in zk_supervisor prover
Fix artifacts path when initializing.
Setup data path for provers

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
