### PR TITLE
chore(ci): Remove spammy logs from ts-integration

### DIFF
--- a/.github/workflows/ci-zk-toolbox-reusable.yml
+++ b/.github/workflows/ci-zk-toolbox-reusable.yml
@@ -146,13 +146,13 @@ jobs:
 
       - name: Run integration tests
         run: |
-          ci_run zk_supervisor test integration --no-deps --ignore-prerequisites --chain era &> ${{ env.INTEGRATION_TESTS_LOGS_DIR }}/rollup.log &
+          ci_run zk_supervisor test integration --verbose --no-deps --ignore-prerequisites --chain era &> ${{ env.INTEGRATION_TESTS_LOGS_DIR }}/rollup.log &
           PID1=$!
 
-          ci_run zk_supervisor test integration --no-deps --ignore-prerequisites --chain validium &> ${{ env.INTEGRATION_TESTS_LOGS_DIR }}/validium.log &
+          ci_run zk_supervisor test integration --verbose --no-deps --ignore-prerequisites --chain validium &> ${{ env.INTEGRATION_TESTS_LOGS_DIR }}/validium.log &
           PID2=$!
 
-          ci_run zk_supervisor test integration --no-deps --ignore-prerequisites --chain custom_token &> ${{ env.INTEGRATION_TESTS_LOGS_DIR }}/custom_token.log &
+          ci_run zk_supervisor test integration --verbose --no-deps --ignore-prerequisites --chain custom_token &> ${{ env.INTEGRATION_TESTS_LOGS_DIR }}/custom_token.log &
           PID3=$!
 
           wait $PID1

--- a/core/tests/ts-integration/src/retry-provider.ts
+++ b/core/tests/ts-integration/src/retry-provider.ts
@@ -57,9 +57,6 @@ export class RetryProvider extends zksync.Provider {
 
     override _wrapTransactionReceipt(receipt: any): zksync.types.TransactionReceipt {
         const wrapped = super._wrapTransactionReceipt(receipt);
-        this.reporter.debug(
-            `Obtained receipt for transaction ${receipt.transactionHash}: blockNumber=${receipt.blockNumber}, status=${receipt.status}`
-        );
         return wrapped;
     }
 }

--- a/zk_toolbox/Cargo.lock
+++ b/zk_toolbox/Cargo.lock
@@ -6539,7 +6539,6 @@ dependencies = [
  "bigdecimal",
  "futures",
  "hex",
- "itertools 0.10.5",
  "num",
  "once_cell",
  "reqwest 0.12.5",

--- a/zk_toolbox/crates/zk_supervisor/src/commands/test/integration.rs
+++ b/zk_toolbox/crates/zk_supervisor/src/commands/test/integration.rs
@@ -45,7 +45,8 @@ pub async fn run(shell: &Shell, args: IntegrationArgs) -> anyhow::Result<()> {
         "yarn jest --forceExit --testTimeout 120000 -t {test_pattern...}"
     )
     .env("CHAIN_NAME", ecosystem_config.current_chain())
-    .env("MASTER_WALLET_PK", wallets.get_test_pk(&chain_config)?);
+    .env("MASTER_WALLET_PK", wallets.get_test_pk(&chain_config)?)
+    .env("ZKSYNC_DEBUG_LOGS", "true");
 
     if args.external_node {
         command = command.env("EXTERNAL_NODE", format!("{:?}", args.external_node))

--- a/zk_toolbox/crates/zk_supervisor/src/commands/test/integration.rs
+++ b/zk_toolbox/crates/zk_supervisor/src/commands/test/integration.rs
@@ -45,8 +45,7 @@ pub async fn run(shell: &Shell, args: IntegrationArgs) -> anyhow::Result<()> {
         "yarn jest --forceExit --testTimeout 120000 -t {test_pattern...}"
     )
     .env("CHAIN_NAME", ecosystem_config.current_chain())
-    .env("MASTER_WALLET_PK", wallets.get_test_pk(&chain_config)?)
-    .env("ZKSYNC_DEBUG_LOGS", "true");
+    .env("MASTER_WALLET_PK", wallets.get_test_pk(&chain_config)?);
 
     if args.external_node {
         command = command.env("EXTERNAL_NODE", format!("{:?}", args.external_node))


### PR DESCRIPTION
## What ❔

- Removes spammy logs that make ts-integration output unreadable in CI.
- Enables debug reported in tests ran via zk_toolbox.

## Why ❔

- These logs were useful, but something was poorly ported during migration to ethers v6 and it became a spam machine.
- Other debug logs are very useful however.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
