### PR TITLE
feat: Add 80 arch to cuda archs

### DIFF
--- a/.github/workflows/build-docker-from-tag.yml
+++ b/.github/workflows/build-docker-from-tag.yml
@@ -102,7 +102,7 @@ jobs:
     with:
       image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}-avx512
       ERA_BELLMAN_CUDA_RELEASE: ${{ vars.ERA_BELLMAN_CUDA_RELEASE }}
-      CUDA_ARCH: "60;70;75;89"
+      CUDA_ARCH: "60;70;75;80;89"
       WITNESS_GENERATOR_RUST_FLAGS: "-Ctarget_feature=+avx512bw,+avx512cd,+avx512dq,+avx512f,+avx512vl"
     secrets:
       DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/release-test-stage.yml
+++ b/.github/workflows/release-test-stage.yml
@@ -39,7 +39,7 @@ jobs:
               - '!prover/**'
   setup:
     name: Setup
-    runs-on: [matterlabs-deployer-stage]
+    runs-on: [ matterlabs-deployer-stage ]
     outputs:
       image_tag_suffix: ${{ steps.generate-tag-suffix.outputs.image_tag_suffix }}
       prover_fri_gpu_key_id: ${{ steps.extract-prover-fri-setup-key-ids.outputs.gpu_short_commit_sha }}
@@ -61,7 +61,7 @@ jobs:
 
   build-push-core-images:
     name: Build and push images
-    needs: [setup, changed_files]
+    needs: [ setup, changed_files ]
     uses: ./.github/workflows/build-core-template.yml
     if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.all == 'true'
     with:
@@ -72,7 +72,7 @@ jobs:
 
   build-push-tee-prover-images:
     name: Build and push images
-    needs: [setup, changed_files]
+    needs: [ setup, changed_files ]
     uses: ./.github/workflows/build-tee-prover-template.yml
     if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.all == 'true'
     with:
@@ -84,7 +84,7 @@ jobs:
 
   build-push-contract-verifier:
     name: Build and push images
-    needs: [setup, changed_files]
+    needs: [ setup, changed_files ]
     uses: ./.github/workflows/build-contract-verifier-template.yml
     if: needs.changed_files.outputs.core == 'true' || needs.changed_files.outputs.all == 'true'
     with:
@@ -95,26 +95,26 @@ jobs:
 
   build-push-prover-images:
     name: Build and push images
-    needs: [setup, changed_files]
+    needs: [ setup, changed_files ]
     uses: ./.github/workflows/build-prover-template.yml
     if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.all == 'true'
     with:
       image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}
       ERA_BELLMAN_CUDA_RELEASE: ${{ vars.ERA_BELLMAN_CUDA_RELEASE }}
-      CUDA_ARCH: "60;70;75;89"
+      CUDA_ARCH: "60;70;75;80;89"
     secrets:
       DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   build-push-witness-generator-image-avx512:
     name: Build and push prover images with avx512 instructions
-    needs: [setup, changed_files]
+    needs: [ setup, changed_files ]
     uses: ./.github/workflows/build-witness-generator-template.yml
     if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.all == 'true'
     with:
       image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}-avx512
       ERA_BELLMAN_CUDA_RELEASE: ${{ vars.ERA_BELLMAN_CUDA_RELEASE }}
-      CUDA_ARCH: "60;70;75;89"
+      CUDA_ARCH: "60;70;75;80;89"
       WITNESS_GENERATOR_RUST_FLAGS: "-Ctarget_feature=+avx512bw,+avx512cd,+avx512dq,+avx512f,+avx512vl"
     secrets:
       DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
@@ -122,7 +122,7 @@ jobs:
 
   build-gar-prover-fri-gpu:
     name: Build GAR prover FRI GPU
-    needs: [setup, build-push-prover-images]
+    needs: [ setup, build-push-prover-images ]
     uses: ./.github/workflows/build-prover-fri-gpu-gar.yml
     if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.all == 'true'
     with:


### PR DESCRIPTION
## What ❔

Add CUDA ARCH 80 to list of CUDA archs.

## Why ❔

To be able to run provers on A100.
## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
