### PR TITLE
fix(zksync_tee_prover): strip binary for nix package

### DIFF
--- a/etc/nix/tee_prover.nix
+++ b/etc/nix/tee_prover.nix
@@ -7,4 +7,8 @@ craneLib.buildPackage (commonArgs // {
   version = (builtins.fromTOML (builtins.readFile ../../core/bin/zksync_tee_prover/Cargo.toml)).package.version;
   cargoExtraArgs = "-p zksync_tee_prover --bin zksync_tee_prover";
   inherit cargoArtifacts;
+
+  postInstall = ''
+    strip $out/bin/zksync_tee_prover
+  '';
 })


### PR DESCRIPTION
## What ❔

Strip `zksync_tee_prover` binary for nix package.

## Why ❔

Somehow llvm decided to produce different symbol names each build

```diff
- 12916: 000000000194d628    48 OBJECT  LOCAL  HIDDEN    23 anon.c880a573512c356e53163839ee7cd669.742.llvm.17979232152659092167
+ 12916: 000000000194d628    48 OBJECT  LOCAL  HIDDEN    23 anon.c880a573512c356e53163839ee7cd669.742.llvm.14235143304249741099
[...]
```

Remove those to make the builds reproducible again.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
