### PR TITLE
feat(en): Resume incomplete snapshot in snapshot creator in more cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6840,6 +6840,7 @@ dependencies = [
  "futures 0.3.30",
  "rand 0.8.5",
  "structopt",
+ "test-casing",
  "tokio",
  "tracing",
  "vise",

--- a/core/bin/snapshots_creator/Cargo.toml
+++ b/core/bin/snapshots_creator/Cargo.toml
@@ -29,3 +29,4 @@ futures.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
+test-casing.workspace = true

--- a/infrastructure/zk/src/docker.ts
+++ b/infrastructure/zk/src/docker.ts
@@ -1,4 +1,4 @@
-import {Command} from 'commander';
+import { Command } from 'commander';
 import * as utils from 'utils';
 
 const IMAGES = [
@@ -31,7 +31,7 @@ async function dockerCommand(
     dockerOrg: string = 'matterlabs'
 ) {
     // Generating all tags for containers. We need 2 tags here: SHA and SHA+TS
-    const {stdout: COMMIT_SHORT_SHA}: { stdout: string } = await utils.exec('git rev-parse --short HEAD');
+    const { stdout: COMMIT_SHORT_SHA }: { stdout: string } = await utils.exec('git rev-parse --short HEAD');
     // COMMIT_SHORT_SHA returns with newline, so we need to trim it
     const imageTagShaTS: string = process.env.IMAGE_TAG_SUFFIX
         ? process.env.IMAGE_TAG_SUFFIX
@@ -126,7 +126,7 @@ async function _build(image: string, tagList: string[], dockerOrg: string, platf
     }
     buildArgs += extraArgs;
 
-    console.log("Build args: ", buildArgs);
+    console.log('Build args: ', buildArgs);
 
     const buildCommand =
         `DOCKER_BUILDKIT=1 docker buildx build ${tagsToBuild}` +


### PR DESCRIPTION
## What ❔

Resumes an incomplete snapshot in the snapshot creator if the creator config doesn't specify an L1 batch.

## Why ❔

This effectively reverts the relevant changes from https://github.com/matter-labs/zksync-era/pull/2256. It makes the snapshot creator resilient by default without additional setup, at the cost of parallel creator jobs working incorrectly (unless they all specify L1 batches).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.