### PR TITLE
fix: token multiplier setter is taken from chain config

### DIFF
--- a/docs/guides/external-node/09_decentralization.md
+++ b/docs/guides/external-node/09_decentralization.md
@@ -9,5 +9,6 @@ On the gossipnet, the data integrity will be protected by the BFT (byzantine fau
 
 ### Add `--enable-consensus` flag to your entry point command
 
-For the consensus configuration to take effect you have to add `--enable-consensus` flag when
-running the node. You can do that by editing the docker compose files (mainnet-external-node-docker-compose.yml or testnet-external-node-docker-compose.yml) and uncommenting the line with `--enable-consensus`.
+For the consensus configuration to take effect you have to add `--enable-consensus` flag when running the node. You can
+do that by editing the docker compose files (mainnet-external-node-docker-compose.yml or
+testnet-external-node-docker-compose.yml) and uncommenting the line with `--enable-consensus`.

--- a/zk_toolbox/crates/zk_inception/src/commands/chain/set_token_multiplier_setter.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/chain/set_token_multiplier_setter.rs
@@ -43,8 +43,8 @@ pub async fn run(args: ForgeScriptArgs, shell: &Shell) -> anyhow::Result<()> {
         .l1_rpc_url
         .expose_str()
         .to_string();
-    let token_multiplier_setter_address = ecosystem_config
-        .get_wallets()
+    let token_multiplier_setter_address = chain_config
+        .get_wallets_config()
         .context(MSG_WALLETS_CONFIG_MUST_BE_PRESENT)?
         .token_multiplier_setter
         .context(MSG_WALLET_TOKEN_MULTIPLIER_SETTER_NOT_FOUND)?


### PR DESCRIPTION
Fix `zki chain update-toen-multiplier-setter` to take the address from the chain config instead of the ecosystem. 