### PR TITLE
docs: Update system requirements

### DIFF
--- a/docs/guides/external-node/00_quick_start.md
+++ b/docs/guides/external-node/00_quick_start.md
@@ -65,12 +65,12 @@ The HTTP JSON-RPC API can be accessed on port `3060` and WebSocket API can be ac
 
 > [!NOTE]
 >
-> To stop state growth, you can enable state pruning by uncommenting `EN_PRUNING_ENABLED: true` in docker compose file,
+> To stop historical DB growth, you can enable DB pruning by uncommenting `EN_PRUNING_ENABLED: true` in docker compose file,
 > you can read more about pruning in
 > [08_pruning.md](https://github.com/matter-labs/zksync-era/blob/main/docs/guides/external-node/08_pruning.md)
 
 - 32 GB of RAM and a relatively modern CPU
-- 30 GB of storage for testnet nodes
+- 50 GB of storage for testnet nodes
 - 300 GB of storage for mainnet nodes
 - 100 Mbps connection (1 Gbps+ recommended)
 


### PR DESCRIPTION
## What ❔
- 30 GB of free disk space are no longer sufficient to run a testnet EN. Upped the system requirements to 50 GB.
- State growth is normally used to refer to the growth of the state tree, not of the historical state. What we have is historical state pruning, not state pruning.