### PR TITLE
chore: increase max_nonce_ahead

### DIFF
--- a/etc/env/file_based/general.yaml
+++ b/etc/env/file_based/general.yaml
@@ -36,7 +36,7 @@ api:
     filters_limit: 10000
     subscriptions_limit: 10000
     pubsub_polling_interval: 200
-    max_nonce_ahead: 20
+    max_nonce_ahead: 40
     gas_price_scale_factor: 1.5
     estimate_gas_scale_factor: 1.3
     estimate_gas_acceptable_overestimation: 5000


### PR DESCRIPTION
## What ❔

increases max_nonce_ahead in default config

## Why ❔

fix flaky test

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
