### PR TITLE
fix(ci): Switch build-base to ghcr.io

### DIFF
--- a/docker/contract-verifier/Dockerfile
+++ b/docker/contract-verifier/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM matterlabs/zksync-build-base:latest AS builder
+FROM ghcr.io/matter-labs/zksync-build-base:latest AS builder
 
 ARG CUDA_ARCH=89
 ENV CUDAARCHS=${CUDA_ARCH}

--- a/docker/external-node/Dockerfile
+++ b/docker/external-node/Dockerfile
@@ -1,6 +1,6 @@
 # Will work locally only after prior contracts build
 
-FROM matterlabs/zksync-build-base:latest AS builder
+FROM ghcr.io/matter-labs/zksync-build-base:latest AS builder
 
 # set of args for use of sccache
 ARG SCCACHE_GCS_BUCKET=""

--- a/docker/prover-fri-gateway/Dockerfile
+++ b/docker/prover-fri-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM matterlabs/zksync-build-base:latest AS builder
+FROM ghcr.io/matter-labs/zksync-build-base:latest AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docker/prover-job-monitor/Dockerfile
+++ b/docker/prover-job-monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM matterlabs/zksync-build-base:latest AS builder
+FROM ghcr.io/matter-labs/zksync-build-base:latest AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docker/server-v2/Dockerfile
+++ b/docker/server-v2/Dockerfile
@@ -1,6 +1,6 @@
 # Will work locally only after prior contracts build
 # syntax=docker/dockerfile:experimental
-FROM matterlabs/zksync-build-base:latest AS builder
+FROM ghcr.io/matter-labs/zksync-build-base:latest AS builder
 
 # set of args for use of sccache
 ARG SCCACHE_GCS_BUCKET=""

--- a/docker/snapshots-creator/Dockerfile
+++ b/docker/snapshots-creator/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM matterlabs/zksync-build-base:latest AS builder
+FROM ghcr.io/matter-labs/zksync-build-base:latest AS builder
 
 # set of args for use of sccache
 ARG SCCACHE_GCS_BUCKET=""

--- a/docker/verified-sources-fetcher/Dockerfile
+++ b/docker/verified-sources-fetcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM matterlabs/zksync-build-base:latest AS builder
+FROM ghcr.io/matter-labs/zksync-build-base:latest AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docker/witness-generator/Dockerfile
+++ b/docker/witness-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM matterlabs/zksync-build-base:latest AS builder
+FROM ghcr.io/matter-labs/zksync-build-base:latest AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG RUST_FLAGS=""

--- a/docker/witness-vector-generator/Dockerfile
+++ b/docker/witness-vector-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM matterlabs/zksync-build-base:latest AS builder
+FROM ghcr.io/matter-labs/zksync-build-base:latest AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## What ❔

Change build-base image location from dockerhub to ghcr.io

## Why ❔

Workaround for dockerhub rate-limiting 

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
