### PR TITLE
fix(zk_toolbox): wrong configs path for prover binaries

### DIFF
--- a/zk_toolbox/crates/zk_inception/src/commands/prover/args/run.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/prover/args/run.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use anyhow::anyhow;
 use clap::{Parser, ValueEnum};
 use common::{Prompt, PromptSelect};
@@ -92,6 +94,7 @@ impl ProverComponent {
         in_docker: bool,
         args: ProverRunArgs,
         chain: &ChainConfig,
+        path_to_ecosystem: &PathBuf,
     ) -> anyhow::Result<Vec<String>> {
         let mut additional_args = vec![];
         if in_docker {
@@ -108,6 +111,24 @@ impl ProverComponent {
                 .into_os_string()
                 .into_string()
                 .map_err(|_| anyhow!("Failed to convert path to string"))?;
+
+            let general_config = if general_config.starts_with("./") {
+                path_to_ecosystem.join(general_config)
+            } else {
+                PathBuf::from(general_config)
+            }
+            .into_os_string()
+            .into_string()
+            .unwrap();
+
+            let secrets_config = if secrets_config.starts_with("./") {
+                path_to_ecosystem.join(secrets_config)
+            } else {
+                PathBuf::from(secrets_config)
+            }
+            .into_os_string()
+            .into_string()
+            .unwrap();
 
             additional_args.push(format!("--config-path={}", general_config));
             additional_args.push(format!("--secrets-path={}", secrets_config));

--- a/zk_toolbox/crates/zk_inception/src/commands/prover/args/run.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/prover/args/run.rs
@@ -112,23 +112,17 @@ impl ProverComponent {
                 .into_string()
                 .map_err(|_| anyhow!("Failed to convert path to string"))?;
 
-            let general_config = if general_config.starts_with("./") {
-                path_to_ecosystem.join(general_config)
-            } else {
-                PathBuf::from(general_config)
-            }
-            .into_os_string()
-            .into_string()
-            .unwrap();
+            let general_config = path_to_ecosystem
+                .join(general_config)
+                .into_os_string()
+                .into_string()
+                .unwrap();
 
-            let secrets_config = if secrets_config.starts_with("./") {
-                path_to_ecosystem.join(secrets_config)
-            } else {
-                PathBuf::from(secrets_config)
-            }
-            .into_os_string()
-            .into_string()
-            .unwrap();
+            let secrets_config = path_to_ecosystem
+                .join(secrets_config)
+                .into_os_string()
+                .into_string()
+                .unwrap();
 
             additional_args.push(format!("--config-path={}", general_config));
             additional_args.push(format!("--secrets-path={}", secrets_config));

--- a/zk_toolbox/crates/zk_inception/src/commands/prover/args/run.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/prover/args/run.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::anyhow;
 use clap::{Parser, ValueEnum};

--- a/zk_toolbox/crates/zk_inception/src/commands/prover/args/run.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/prover/args/run.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::anyhow;
 use clap::{Parser, ValueEnum};
@@ -94,7 +94,7 @@ impl ProverComponent {
         in_docker: bool,
         args: ProverRunArgs,
         chain: &ChainConfig,
-        path_to_ecosystem: &PathBuf,
+        path_to_ecosystem: &Path,
     ) -> anyhow::Result<Vec<String>> {
         let mut additional_args = vec![];
         if in_docker {

--- a/zk_toolbox/crates/zk_inception/src/commands/prover/run.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/prover/run.rs
@@ -22,6 +22,8 @@ pub(crate) async fn run(args: ProverRunArgs, shell: &Shell) -> anyhow::Result<()
         .load_chain(global_config().chain_name.clone())
         .expect(MSG_CHAIN_NOT_FOUND_ERR);
 
+    let path_to_ecosystem = shell.current_dir();
+
     let link_to_prover = get_link_to_prover(&ecosystem_config);
     shell.change_dir(link_to_prover.clone());
 
@@ -29,7 +31,8 @@ pub(crate) async fn run(args: ProverRunArgs, shell: &Shell) -> anyhow::Result<()
     let in_docker = args.docker.unwrap_or(false);
 
     let application_args = component.get_application_args(in_docker)?;
-    let additional_args = component.get_additional_args(in_docker, args, &chain)?;
+    let additional_args =
+        component.get_additional_args(in_docker, args, &chain, &path_to_ecosystem)?;
 
     let (message, error) = match component {
         ProverComponent::WitnessGenerator => (
@@ -79,6 +82,7 @@ pub(crate) async fn run(args: ProverRunArgs, shell: &Shell) -> anyhow::Result<()
             error,
             &path_to_configs,
             &path_to_prover,
+            &path_to_ecosystem,
         )?
     } else {
         update_setup_data_path(&chain, "data/keys".to_string())?;
@@ -105,8 +109,15 @@ fn run_dockerized_component(
     error: &'static str,
     path_to_configs: &PathBuf,
     path_to_prover: &PathBuf,
+    path_to_ecosystem: &PathBuf,
 ) -> anyhow::Result<()> {
     logger::info(message);
+
+    let path_to_configs = if path_to_configs.starts_with("./") {
+        path_to_ecosystem.join(path_to_configs)
+    } else {
+        path_to_configs.clone()
+    };
 
     let mut cmd = Cmd::new(cmd!(
         shell,

--- a/zk_toolbox/crates/zk_inception/src/commands/prover/run.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/prover/run.rs
@@ -113,11 +113,7 @@ fn run_dockerized_component(
 ) -> anyhow::Result<()> {
     logger::info(message);
 
-    let path_to_configs = if path_to_configs.starts_with("./") {
-        path_to_ecosystem.join(path_to_configs)
-    } else {
-        path_to_configs.clone()
-    };
+    let path_to_configs = path_to_ecosystem.join(path_to_configs);
 
     let mut cmd = Cmd::new(cmd!(
         shell,

--- a/zk_toolbox/crates/zk_inception/src/commands/prover/run.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/prover/run.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context};
 use common::{check_prerequisites, cmd::Cmd, config::global_config, logger, GPU_PREREQUISITES};
@@ -109,7 +109,7 @@ fn run_dockerized_component(
     error: &'static str,
     path_to_configs: &PathBuf,
     path_to_prover: &PathBuf,
-    path_to_ecosystem: &PathBuf,
+    path_to_ecosystem: &Path,
 ) -> anyhow::Result<()> {
     logger::info(message);
 


### PR DESCRIPTION
## What ❔

Right now, while running prover binaries inside of zksync-era, config paths are specified as path to config from chain config(which is `./chain/configs` - relative path, but not absolute). This breaks, because to run prover binaries, shell enters prover directory of era.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
