### PR TITLE
fix(ci): zksync-runtime-base proper platforms names

### DIFF
--- a/.github/workflows/build-runtime-base.yml
+++ b/.github/workflows/build-runtime-base.yml
@@ -57,8 +57,8 @@ jobs:
           push: true
           context: .
           platforms: |
-            - linux/arm64
-            - linux/amd64
+            - arm64
+            - amd64
           file: docker/${{ matrix.name }}/Dockerfile
           labels: |
             org.opencontainers.image.source=https://github.com/matter-labs/zksync-era


### PR DESCRIPTION
## What ❔

Proper platform names for docker build action

## Why ❔

Docker documentation (which is linked in docker-build-action docs) [points to non-working reference](https://docs.docker.com/reference/cli/docker/buildx/build/#platform)

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
