### PR TITLE
feat(nix): use precompiled `rocksdb` and `snappy`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,6 @@
           };
 
           craneLib = (crane.mkLib pkgs).overrideToolchain rustVersion;
-          NIX_OUTPATH_USED_AS_RANDOM_SEED = "aaaaaaaaaa";
 
           commonArgs = {
             nativeBuildInputs = with pkgs;[
@@ -81,6 +80,8 @@
               snappy.dev
               lz4.dev
               bzip2.dev
+              rocksdb
+              snappy.dev
             ];
 
             src = with pkgs.lib.fileset; toSource {
@@ -97,7 +98,9 @@
 
             env = {
               OPENSSL_NO_VENDOR = "1";
-              inherit NIX_OUTPATH_USED_AS_RANDOM_SEED;
+              ROCKSDB_LIB_DIR = "${pkgs.rocksdb.out}/lib";
+              SNAPPY_LIB_DIR = "${pkgs.snappy.out}/lib";
+              NIX_OUTPATH_USED_AS_RANDOM_SEED = "aaaaaaaaaa";
             };
 
             doCheck = false;


### PR DESCRIPTION
## What ❔

Use precompiled `rocksdb` and `snappy` in the nix build.

## Why ❔

Speeds up compilation and is usually better maintained.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
