### PR TITLE
feat(ci): Migrate to vendored image as a zksync-runtime-base

### DIFF
--- a/docker/contract-verifier/Dockerfile
+++ b/docker/contract-verifier/Dockerfile
@@ -19,9 +19,9 @@ COPY . .
 
 RUN cargo build --release
 
-FROM debian:bookworm-slim
+FROM ghcr.io/matter-labs/zksync-runtime-base:latest
 
-RUN apt-get update && apt-get install -y curl libpq5 ca-certificates wget python3 jq && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y wget python3 jq && rm -rf /var/lib/apt/lists/*
 
 # install zksolc 1.3.x
 RUN skip_versions="v1.3.12 v1.3.15 v1.3.20" && \

--- a/docker/external-node/Dockerfile
+++ b/docker/external-node/Dockerfile
@@ -17,9 +17,7 @@ WORKDIR /usr/src/zksync
 COPY . .
 RUN cargo build --release
 
-FROM debian:bookworm-slim
-
-RUN apt-get update && apt-get install -y curl libpq5 ca-certificates && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/matter-labs/zksync-runtime-base:latest
 
 COPY --from=builder /usr/src/zksync/target/release/zksync_external_node /usr/bin
 COPY --from=builder /usr/src/zksync/target/release/block_reverter /usr/bin

--- a/docker/prover-fri-gateway/Dockerfile
+++ b/docker/prover-fri-gateway/Dockerfile
@@ -18,8 +18,7 @@ COPY . .
 
 RUN cd prover && cargo build --release --bin zksync_prover_fri_gateway
 
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y curl libpq5 ca-certificates && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/matter-labs/zksync-runtime-base:latest
 
 # copy VK required for proof wrapping
 COPY prover/data/keys/ /prover/data/keys/

--- a/docker/prover-job-monitor/Dockerfile
+++ b/docker/prover-job-monitor/Dockerfile
@@ -18,8 +18,7 @@ COPY . .
 
 RUN cd prover && cargo build --release --bin zksync_prover_job_monitor
 
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y curl libpq5 ca-certificates && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/matter-labs/zksync-runtime-base:latest
 
 COPY --from=builder /usr/src/zksync/prover/target/release/zksync_prover_job_monitor /usr/bin/
 

--- a/docker/server-v2/Dockerfile
+++ b/docker/server-v2/Dockerfile
@@ -19,9 +19,9 @@ COPY . .
 
 RUN cargo build --release --features=rocksdb/io-uring
 
-FROM debian:bookworm-slim
+FROM ghcr.io/matter-labs/zksync-runtime-base:latest
 
-RUN apt-get update && apt-get install -y curl libpq5 liburing-dev ca-certificates && \
+RUN apt-get update && apt-get install -y liburing-dev && \
     rm -rf /var/lib/apt/lists/*
 
 EXPOSE 3000

--- a/docker/snapshots-creator/Dockerfile
+++ b/docker/snapshots-creator/Dockerfile
@@ -17,9 +17,9 @@ COPY . .
 
 RUN cargo build --release --bin snapshots_creator
 
-FROM debian:bookworm-slim
+FROM ghcr.io/matter-labs/zksync-runtime-base:latest
 
-RUN apt-get update && apt-get install -y curl libpq5 liburing-dev ca-certificates && \
+RUN apt-get update && apt-get install -y liburing-dev && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/src/zksync/target/release/snapshots_creator /usr/bin

--- a/docker/verified-sources-fetcher/Dockerfile
+++ b/docker/verified-sources-fetcher/Dockerfile
@@ -18,8 +18,9 @@ COPY . .
 
 RUN cargo build --release --bin verified_sources_fetcher
 
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl git && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/matter-labs/zksync-runtime-base:latest
+
+RUN apt-get update && apt-get install -y apt-transport-https gnupg git && rm -rf /var/lib/apt/lists/*
 
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list

--- a/docker/witness-generator/Dockerfile
+++ b/docker/witness-generator/Dockerfile
@@ -20,9 +20,7 @@ COPY . .
 
 RUN cd prover && cargo build --release --bin zksync_witness_generator
 
-FROM debian:bookworm-slim
-
-RUN apt-get update && apt-get install -y curl libpq5 ca-certificates && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/matter-labs/zksync-runtime-base:latest
 
 COPY prover/data/keys/ /prover/data/keys/
 

--- a/docker/witness-vector-generator/Dockerfile
+++ b/docker/witness-vector-generator/Dockerfile
@@ -18,9 +18,7 @@ COPY . .
 
 RUN cd prover && cargo build --release --bin zksync_witness_vector_generator
 
-FROM debian:bookworm-slim
-
-RUN apt-get update && apt-get install -y curl libpq5 ca-certificates && rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/matter-labs/zksync-runtime-base:latest
 
 # copy finalization hints required for witness vector generation
 COPY prover/data/keys/ /prover/data/keys/


### PR DESCRIPTION
## What ❔

Move building images to zksync-runtime-base

## Why ❔

Workaround for dockerhub rate limits

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
