### PR TITLE
feat(prover): Use query macro instead string literals for queries

### DIFF
--- a/prover/crates/lib/prover_dal/.sqlx/query-0eac6f7b2d799059328584029b437891598dc79b5ed11258b2c90c3f282929ad.json
+++ b/prover/crates/lib/prover_dal/.sqlx/query-0eac6f7b2d799059328584029b437891598dc79b5ed11258b2c90c3f282929ad.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO\n                leaf_aggregation_witness_jobs_fri (\n                    l1_batch_number,\n                    circuit_id,\n                    status,\n                    number_of_basic_circuits,\n                    created_at,\n                    updated_at\n                )\n            VALUES\n                ($1, $2, 'waiting_for_proofs', 2, NOW(), NOW())\n            ON CONFLICT (l1_batch_number, circuit_id) DO\n            UPDATE\n            SET status = $3\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int2",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "0eac6f7b2d799059328584029b437891598dc79b5ed11258b2c90c3f282929ad"
+}

--- a/prover/crates/lib/prover_dal/.sqlx/query-1926cf432237684de2383179a6d0d001cdf5bc7ba988b742571ec90a938434e3.json
+++ b/prover/crates/lib/prover_dal/.sqlx/query-1926cf432237684de2383179a6d0d001cdf5bc7ba988b742571ec90a938434e3.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE leaf_aggregation_witness_jobs_fri \n                SET status = $1, attempts = $2\n                WHERE l1_batch_number = $3\n                AND circuit_id = $4",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int2",
+        "Int8",
+        "Int2"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1926cf432237684de2383179a6d0d001cdf5bc7ba988b742571ec90a938434e3"
+}

--- a/prover/crates/lib/prover_dal/.sqlx/query-39f60c638d445c5dbf23e01fd89a468057599be1e6c6c96a947c33df53a68224.json
+++ b/prover/crates/lib/prover_dal/.sqlx/query-39f60c638d445c5dbf23e01fd89a468057599be1e6c6c96a947c33df53a68224.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO\n                recursion_tip_witness_jobs_fri (\n                    l1_batch_number,\n                    status,\n                    number_of_final_node_jobs,\n                    created_at,\n                    updated_at\n                )\n            VALUES\n                ($1, 'waiting_for_proofs',1, NOW(), NOW())\n            ON CONFLICT (l1_batch_number) DO\n            UPDATE\n            SET status = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "39f60c638d445c5dbf23e01fd89a468057599be1e6c6c96a947c33df53a68224"
+}

--- a/prover/crates/lib/prover_dal/.sqlx/query-3a9ffd4d88f2cfac22835aac2512e61157bf58aec70903623afc9da24d46a336.json
+++ b/prover/crates/lib/prover_dal/.sqlx/query-3a9ffd4d88f2cfac22835aac2512e61157bf58aec70903623afc9da24d46a336.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO\n                node_aggregation_witness_jobs_fri (\n                    l1_batch_number,\n                    circuit_id,\n                    status,\n                    created_at,\n                    updated_at\n                )\n            VALUES\n                ($1, $2, 'waiting_for_proofs', NOW(), NOW())\n            ON CONFLICT (l1_batch_number, circuit_id, depth) DO\n            UPDATE\n            SET status = $3\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int2",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3a9ffd4d88f2cfac22835aac2512e61157bf58aec70903623afc9da24d46a336"
+}

--- a/prover/crates/lib/prover_dal/.sqlx/query-3bb8fbd9e83703887e0a3c196031b931c0d8dbc6835dfac20107ea7412ce9fbb.json
+++ b/prover/crates/lib/prover_dal/.sqlx/query-3bb8fbd9e83703887e0a3c196031b931c0d8dbc6835dfac20107ea7412ce9fbb.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO\n                proof_compression_jobs_fri (\n                    l1_batch_number,\n                    status,\n                    created_at,\n                    updated_at\n                )\n            VALUES\n                ($1, $2, NOW(), NOW())\n            ON CONFLICT (l1_batch_number) DO\n            UPDATE\n            SET status = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3bb8fbd9e83703887e0a3c196031b931c0d8dbc6835dfac20107ea7412ce9fbb"
+}

--- a/prover/crates/lib/prover_dal/.sqlx/query-434f7cb51a7d22948cd26e962679a67936d572f8046d3a1c7a4f100ff209d81d.json
+++ b/prover/crates/lib/prover_dal/.sqlx/query-434f7cb51a7d22948cd26e962679a67936d572f8046d3a1c7a4f100ff209d81d.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE prover_jobs_fri SET status = $1\n                WHERE l1_batch_number = $2\n                AND sequence_number = $3\n                AND aggregation_round = $4\n                AND circuit_id = $5",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8",
+        "Int4",
+        "Int2",
+        "Int2"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "434f7cb51a7d22948cd26e962679a67936d572f8046d3a1c7a4f100ff209d81d"
+}

--- a/prover/crates/lib/prover_dal/.sqlx/query-548414f8148740c991c345e5fd46ea738d209eb07e7a6bcbdb33e25b3347a08c.json
+++ b/prover/crates/lib/prover_dal/.sqlx/query-548414f8148740c991c345e5fd46ea738d209eb07e7a6bcbdb33e25b3347a08c.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE witness_inputs_fri\n            SET\n                status = 'queued',\n                updated_at = NOW(),\n                processing_started_at = NOW()\n            WHERE\n                l1_batch_number = $1\n                AND attempts >= $2\n                AND (status = 'in_progress' OR status = 'failed')\n            RETURNING\n                l1_batch_number,\n                status,\n                attempts,\n                error,\n                picked_by\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "l1_batch_number",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "status",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "attempts",
+        "type_info": "Int2"
+      },
+      {
+        "ordinal": 3,
+        "name": "error",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "picked_by",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int2"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "548414f8148740c991c345e5fd46ea738d209eb07e7a6bcbdb33e25b3347a08c"
+}

--- a/prover/crates/lib/prover_dal/.sqlx/query-63cf7038e6c48af8ed9afc7d6ea07edd87cb16a79c13e7d4291d99736e51d3b9.json
+++ b/prover/crates/lib/prover_dal/.sqlx/query-63cf7038e6c48af8ed9afc7d6ea07edd87cb16a79c13e7d4291d99736e51d3b9.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO\n                scheduler_witness_jobs_fri (\n                    l1_batch_number,\n                    scheduler_partial_input_blob_url,\n                    status,\n                    created_at,\n                    updated_at\n                )\n            VALUES\n                ($1, '', 'waiting_for_proofs', NOW(), NOW())\n            ON CONFLICT (l1_batch_number) DO\n            UPDATE\n            SET status = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "63cf7038e6c48af8ed9afc7d6ea07edd87cb16a79c13e7d4291d99736e51d3b9"
+}

--- a/prover/crates/lib/prover_dal/.sqlx/query-75c1affbca0901edd5d0e2f12ef4d935674a5aff2f34421d753b4d1a9dea5b12.json
+++ b/prover/crates/lib/prover_dal/.sqlx/query-75c1affbca0901edd5d0e2f12ef4d935674a5aff2f34421d753b4d1a9dea5b12.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE scheduler_witness_jobs_fri\n            SET\n                status = 'queued',\n                updated_at = NOW(),\n                processing_started_at = NOW()\n            WHERE\n                l1_batch_number = $1\n                AND attempts >= $2\n                AND (status = 'in_progress' OR status = 'failed')\n            RETURNING\n                l1_batch_number,\n                status,\n                attempts,\n                error,\n                picked_by\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "l1_batch_number",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "status",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "attempts",
+        "type_info": "Int2"
+      },
+      {
+        "ordinal": 3,
+        "name": "error",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "picked_by",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int2"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "75c1affbca0901edd5d0e2f12ef4d935674a5aff2f34421d753b4d1a9dea5b12"
+}

--- a/prover/crates/lib/prover_dal/.sqlx/query-aabcfa9005b8e1d84cfa083a47a700302981be0afef31a8864613484f8521f9e.json
+++ b/prover/crates/lib/prover_dal/.sqlx/query-aabcfa9005b8e1d84cfa083a47a700302981be0afef31a8864613484f8521f9e.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE prover_jobs_fri \n                SET status = $1, attempts = $2\n                WHERE l1_batch_number = $3\n                AND sequence_number =$4\n                AND aggregation_round = $5\n                AND circuit_id = $6",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int2",
+        "Int8",
+        "Int4",
+        "Int2",
+        "Int2"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "aabcfa9005b8e1d84cfa083a47a700302981be0afef31a8864613484f8521f9e"
+}

--- a/prover/crates/lib/prover_dal/.sqlx/query-c19fc4c8e4b3a3ef4f9c0f4c22ed68c598eada8e60938a8e4b5cd32b53f5a574.json
+++ b/prover/crates/lib/prover_dal/.sqlx/query-c19fc4c8e4b3a3ef4f9c0f4c22ed68c598eada8e60938a8e4b5cd32b53f5a574.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE recursion_tip_witness_jobs_fri\n            SET\n                status = 'queued',\n                updated_at = NOW(),\n                processing_started_at = NOW()\n            WHERE\n                l1_batch_number = $1\n                AND attempts >= $2\n                AND (status = 'in_progress' OR status = 'failed')\n            RETURNING\n                l1_batch_number,\n                status,\n                attempts,\n                error,\n                picked_by\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "l1_batch_number",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "status",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "attempts",
+        "type_info": "Int2"
+      },
+      {
+        "ordinal": 3,
+        "name": "error",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "picked_by",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int2"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "c19fc4c8e4b3a3ef4f9c0f4c22ed68c598eada8e60938a8e4b5cd32b53f5a574"
+}

--- a/prover/crates/lib/prover_dal/src/cli_test_dal.rs
+++ b/prover/crates/lib/prover_dal/src/cli_test_dal.rs
@@ -20,14 +20,18 @@ impl CliTestDal<'_, '_> {
         batch_number: L1BatchNumber,
         sequence_number: usize,
     ) {
-        sqlx::query(&format!(
-            "UPDATE prover_jobs_fri SET status = '{}' 
-                WHERE l1_batch_number = {} 
-                AND sequence_number = {} 
-                AND aggregation_round = {}
-                AND circuit_id = {}",
-            status, batch_number.0, sequence_number, aggregation_round, circuit_id,
-        ))
+        sqlx::query!(
+            "UPDATE prover_jobs_fri SET status = $1
+                WHERE l1_batch_number = $2
+                AND sequence_number = $3
+                AND aggregation_round = $4
+                AND circuit_id = $5",
+            status.to_string(),
+            batch_number.0 as i64,
+            sequence_number as i64,
+            aggregation_round as i16,
+            circuit_id as i64,
+        )
         .execute(self.storage.conn())
         .await
         .unwrap();
@@ -39,7 +43,7 @@ impl CliTestDal<'_, '_> {
         batch_number: L1BatchNumber,
         circuit_id: u8,
     ) {
-        sqlx::query(&format!(
+        sqlx::query!(
             "
             INSERT INTO
                 leaf_aggregation_witness_jobs_fri (
@@ -51,13 +55,15 @@ impl CliTestDal<'_, '_> {
                     updated_at
                 )
             VALUES
-                ({}, {}, 'waiting_for_proofs', 2, NOW(), NOW())
+                ($1, $2, 'waiting_for_proofs', 2, NOW(), NOW())
             ON CONFLICT (l1_batch_number, circuit_id) DO
             UPDATE
-            SET status = '{}'
+            SET status = $3
             ",
-            batch_number.0, circuit_id, status
-        ))
+            batch_number.0 as i64,
+            circuit_id as i16,
+            status.to_string()
+        )
         .execute(self.storage.conn())
         .await
         .unwrap();
@@ -69,7 +75,7 @@ impl CliTestDal<'_, '_> {
         batch_number: L1BatchNumber,
         circuit_id: u8,
     ) {
-        sqlx::query(&format!(
+        sqlx::query!(
             "
             INSERT INTO
                 node_aggregation_witness_jobs_fri (
@@ -80,20 +86,22 @@ impl CliTestDal<'_, '_> {
                     updated_at
                 )
             VALUES
-                ({}, {}, 'waiting_for_proofs', NOW(), NOW())
+                ($1, $2, 'waiting_for_proofs', NOW(), NOW())
             ON CONFLICT (l1_batch_number, circuit_id, depth) DO
             UPDATE
-            SET status = '{}'
+            SET status = $3
             ",
-            batch_number.0, circuit_id, status,
-        ))
+            batch_number.0 as i64,
+            circuit_id as i16,
+            status.to_string(),
+        )
         .execute(self.storage.conn())
         .await
         .unwrap();
     }
 
     pub async fn insert_rt_job(&mut self, status: WitnessJobStatus, batch_number: L1BatchNumber) {
-        sqlx::query(&format!(
+        sqlx::query!(
             "
             INSERT INTO
                 recursion_tip_witness_jobs_fri (
@@ -104,13 +112,14 @@ impl CliTestDal<'_, '_> {
                     updated_at
                 )
             VALUES
-                ({}, 'waiting_for_proofs',1, NOW(), NOW())
+                ($1, 'waiting_for_proofs',1, NOW(), NOW())
             ON CONFLICT (l1_batch_number) DO
             UPDATE
-            SET status = '{}'
+            SET status = $2
             ",
-            batch_number.0, status,
-        ))
+            batch_number.0 as i64,
+            status.to_string(),
+        )
         .execute(self.storage.conn())
         .await
         .unwrap();
@@ -121,7 +130,7 @@ impl CliTestDal<'_, '_> {
         status: WitnessJobStatus,
         batch_number: L1BatchNumber,
     ) {
-        sqlx::query(&format!(
+        sqlx::query!(
             "
             INSERT INTO
                 scheduler_witness_jobs_fri (
@@ -132,13 +141,14 @@ impl CliTestDal<'_, '_> {
                     updated_at
                 )
             VALUES
-                ({}, '', 'waiting_for_proofs', NOW(), NOW())
+                ($1, '', 'waiting_for_proofs', NOW(), NOW())
             ON CONFLICT (l1_batch_number) DO
             UPDATE
-            SET status = '{}'
+            SET status = $2
             ",
-            batch_number.0, status,
-        ))
+            batch_number.0 as i64,
+            status.to_string(),
+        )
         .execute(self.storage.conn())
         .await
         .unwrap();
@@ -149,7 +159,7 @@ impl CliTestDal<'_, '_> {
         status: ProofCompressionJobStatus,
         batch_number: L1BatchNumber,
     ) {
-        sqlx::query(&format!(
+        sqlx::query!(
             "
             INSERT INTO
                 proof_compression_jobs_fri (
@@ -159,13 +169,14 @@ impl CliTestDal<'_, '_> {
                     updated_at
                 )
             VALUES
-                ({}, '{}', NOW(), NOW())
+                ($1, $2, NOW(), NOW())
             ON CONFLICT (l1_batch_number) DO
             UPDATE
-            SET status = '{}'
+            SET status = $2
             ",
-            batch_number.0, status, status,
-        ))
+            batch_number.0 as i64,
+            status.to_string(),
+        )
         .execute(self.storage.conn())
         .await
         .unwrap();
@@ -180,15 +191,20 @@ impl CliTestDal<'_, '_> {
         batch_number: L1BatchNumber,
         sequence_number: usize,
     ) {
-        sqlx::query(&format!(
+        sqlx::query!(
             "UPDATE prover_jobs_fri 
-                SET status = '{}', attempts = {} 
-                WHERE l1_batch_number = {} 
-                AND sequence_number = {} 
-                AND aggregation_round = {}
-                AND circuit_id = {}",
-            status, attempts, batch_number.0, sequence_number, aggregation_round, circuit_id,
-        ))
+                SET status = $1, attempts = $2
+                WHERE l1_batch_number = $3
+                AND sequence_number =$4
+                AND aggregation_round = $5
+                AND circuit_id = $6",
+            status.to_string(),
+            attempts as i64,
+            batch_number.0 as i64,
+            sequence_number as i64,
+            aggregation_round as i64,
+            circuit_id as i16,
+        )
         .execute(self.storage.conn())
         .await
         .unwrap();
@@ -201,13 +217,16 @@ impl CliTestDal<'_, '_> {
         circuit_id: u8,
         batch_number: L1BatchNumber,
     ) {
-        sqlx::query(&format!(
+        sqlx::query!(
             "UPDATE leaf_aggregation_witness_jobs_fri 
-                SET status = '{}', attempts = {} 
-                WHERE l1_batch_number = {}
-                AND circuit_id = {}",
-            status, attempts, batch_number.0, circuit_id,
-        ))
+                SET status = $1, attempts = $2
+                WHERE l1_batch_number = $3
+                AND circuit_id = $4",
+            status.to_string(),
+            attempts as i64,
+            batch_number.0 as i64,
+            circuit_id as i16,
+        )
         .execute(self.storage.conn())
         .await
         .unwrap();

--- a/prover/crates/lib/prover_dal/src/fri_witness_generator_dal.rs
+++ b/prover/crates/lib/prover_dal/src/fri_witness_generator_dal.rs
@@ -1709,7 +1709,7 @@ impl FriWitnessGeneratorDal<'_, '_> {
         block_number: L1BatchNumber,
         max_attempts: u32,
     ) -> Vec<StuckJobs> {
-        let query = format!(
+        sqlx::query!(
             r#"
             UPDATE witness_inputs_fri
             SET
@@ -1717,8 +1717,8 @@ impl FriWitnessGeneratorDal<'_, '_> {
                 updated_at = NOW(),
                 processing_started_at = NOW()
             WHERE
-                l1_batch_number = {}
-                AND attempts >= {}
+                l1_batch_number = $1
+                AND attempts >= $2
                 AND (status = 'in_progress' OR status = 'failed')
             RETURNING
                 l1_batch_number,
@@ -1728,22 +1728,21 @@ impl FriWitnessGeneratorDal<'_, '_> {
                 picked_by
             "#,
             i64::from(block_number.0),
-            max_attempts
-        );
-        sqlx::query(&query)
-            .fetch_all(self.storage.conn())
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|row| StuckJobs {
-                id: row.get::<i64, &str>("l1_batch_number") as u64,
-                status: row.get("status"),
-                attempts: row.get::<i16, &str>("attempts") as u64,
-                circuit_id: None,
-                error: row.get("error"),
-                picked_by: row.get("picked_by"),
-            })
-            .collect()
+            max_attempts as i64
+        )
+        .fetch_all(self.storage.conn())
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| StuckJobs {
+            id: row.l1_batch_number as u64,
+            status: row.status,
+            attempts: row.attempts as u64,
+            circuit_id: None,
+            error: row.error,
+            picked_by: row.picked_by,
+        })
+        .collect()
     }
 
     pub async fn requeue_stuck_leaf_aggregation_jobs_for_batch(
@@ -1777,7 +1776,7 @@ impl FriWitnessGeneratorDal<'_, '_> {
         block_number: L1BatchNumber,
         max_attempts: u32,
     ) -> Vec<StuckJobs> {
-        let query = format!(
+        sqlx::query!(
             r#"
             UPDATE recursion_tip_witness_jobs_fri
             SET
@@ -1785,8 +1784,8 @@ impl FriWitnessGeneratorDal<'_, '_> {
                 updated_at = NOW(),
                 processing_started_at = NOW()
             WHERE
-                l1_batch_number = {}
-                AND attempts >= {}
+                l1_batch_number = $1
+                AND attempts >= $2
                 AND (status = 'in_progress' OR status = 'failed')
             RETURNING
                 l1_batch_number,
@@ -1796,22 +1795,21 @@ impl FriWitnessGeneratorDal<'_, '_> {
                 picked_by
             "#,
             i64::from(block_number.0),
-            max_attempts
-        );
-        sqlx::query(&query)
-            .fetch_all(self.storage.conn())
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|row| StuckJobs {
-                id: row.get::<i64, &str>("l1_batch_number") as u64,
-                status: row.get("status"),
-                attempts: row.get::<i16, &str>("attempts") as u64,
-                circuit_id: None,
-                error: row.get("error"),
-                picked_by: row.get("picked_by"),
-            })
-            .collect()
+            max_attempts as i64
+        )
+        .fetch_all(self.storage.conn())
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| StuckJobs {
+            id: row.l1_batch_number as u64,
+            status: row.status,
+            attempts: row.attempts as u64,
+            circuit_id: None,
+            error: row.error,
+            picked_by: row.picked_by,
+        })
+        .collect()
     }
 
     pub async fn requeue_stuck_scheduler_jobs_for_batch(
@@ -1819,7 +1817,7 @@ impl FriWitnessGeneratorDal<'_, '_> {
         block_number: L1BatchNumber,
         max_attempts: u32,
     ) -> Vec<StuckJobs> {
-        let query = format!(
+        sqlx::query!(
             r#"
             UPDATE scheduler_witness_jobs_fri
             SET
@@ -1827,8 +1825,8 @@ impl FriWitnessGeneratorDal<'_, '_> {
                 updated_at = NOW(),
                 processing_started_at = NOW()
             WHERE
-                l1_batch_number = {}
-                AND attempts >= {}
+                l1_batch_number = $1
+                AND attempts >= $2
                 AND (status = 'in_progress' OR status = 'failed')
             RETURNING
                 l1_batch_number,
@@ -1838,22 +1836,21 @@ impl FriWitnessGeneratorDal<'_, '_> {
                 picked_by
             "#,
             i64::from(block_number.0),
-            max_attempts
-        );
-        sqlx::query(&query)
-            .fetch_all(self.storage.conn())
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|row| StuckJobs {
-                id: row.get::<i64, &str>("l1_batch_number") as u64,
-                status: row.get("status"),
-                attempts: row.get::<i16, &str>("attempts") as u64,
-                circuit_id: None,
-                error: row.get("error"),
-                picked_by: row.get("picked_by"),
-            })
-            .collect()
+            max_attempts as i64
+        )
+        .fetch_all(self.storage.conn())
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| StuckJobs {
+            id: row.l1_batch_number as u64,
+            status: row.status,
+            attempts: row.attempts as u64,
+            circuit_id: None,
+            error: row.error,
+            picked_by: row.picked_by,
+        })
+        .collect()
     }
 
     async fn requeue_stuck_jobs_for_batch_in_aggregation_round(


### PR DESCRIPTION
## What ❔

In some places our sqlx queries are using string literals instead of query macros. This PR changes this behaviour in places it is possible.

## Why ❔

To prevent possible SQL injections.
It also will cache the queries, which should make them faster.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
