### PR TITLE
chore(prover-gateway): Speed up polling

### DIFF
--- a/etc/env/base/fri_prover_gateway.toml
+++ b/etc/env/base/fri_prover_gateway.toml
@@ -1,6 +1,6 @@
 [fri_prover_gateway]
 api_url="http://127.0.0.1:3320"
-api_poll_duration_secs=1000
+api_poll_duration_secs=15
 prometheus_listener_port=3314
 prometheus_pushgateway_url="http://127.0.0.1:9091"
 prometheus_push_interval_ms=100

--- a/etc/env/file_based/general.yaml
+++ b/etc/env/file_based/general.yaml
@@ -172,7 +172,7 @@ data_handler:
   tee_support: true
 prover_gateway:
   api_url: http://127.0.0.1:3320
-  api_poll_duration_secs: 1000
+  api_poll_duration_secs: 15
   prometheus_listener_port: 3310
   prometheus_pushgateway_url: http://127.0.0.1:9091
   prometheus_push_interval_ms: 100


### PR DESCRIPTION
16 minutes is just ridiculous. This should've been done a long time ago, but has been avoided due to other priorities and always put on the back-burner/forgotten. Today we change it.
