### PR TITLE
fix: cargo-deny advisory due to structopt

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,7 @@ ignore = [
     # all below caused by StructOpt which we still use and we should move to clap v3 instead
     "RUSTSEC-2021-0145",
     "RUSTSEC-2021-0139",
+    "RUSTSEC-2024-0375",
 ]
 
 [licenses]


### PR DESCRIPTION
## What ❔
Adds https://rustsec.org/advisories/RUSTSEC-2024-0375 to `deny.toml`, which is due to `StructOpt`. 

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔
* Currently it's impossible to migrate to clap as [zkevm_test_harness](https://github.com/matter-labs/era-zkevm_test_harness/blob/v1.5.0/Cargo.toml#L46) still depends on structopt.

* This [unblocks](https://github.com/matter-labs/zksync-era/actions/runs/11054218994/job/30710479095) the CI

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk fmt` and `zk lint`.
