### PR TITLE
docs(blocks_batches): fix expired links to referred code

### DIFF
--- a/docs/specs/blocks_batches.md
+++ b/docs/specs/blocks_batches.md
@@ -78,10 +78,10 @@ comprehensive understanding of their functionality and interactions.
   https://user-images.githubusercontent.com/128217157/236500717-165470ad-30b8-4ad6-97ed-fc29c8eb1fe0.png
   'explorer example'
 [conditional_sealer]:
-  https://github.com/matter-labs/zksync-era/blob/main/core/lib/zksync_core/src/state_keeper/seal_criteria/conditional_sealer.rs#20
+  https://github.com/matter-labs/zksync-era/blob/main/core/node/state_keeper/src/seal_criteria/conditional_sealer.rs
   'Conditional Sealer'
 [reasons_for_sealing]:
-  https://github.com/matter-labs/zksync-era/blob/main/core/lib/zksync_core/src/state_keeper/seal_criteria/mod.rs#L106
+  https://github.com/matter-labs/zksync-era/blob/main/core/node/state_keeper/src/seal_criteria/mod.rs
   'Reasons for Sealing'
 
 ## Deeper dive


### PR DESCRIPTION
## What ❔
Some referred links in the doc "blocks_batches.md" are expired, I found the correct links now and replaced them.  
## Why ❔
The readers might not be able to find the correct code parts that are mentioned in the documentation.
## Checklist
- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
