### PR TITLE
fix(eth-client): fix l2_fee_history

### DIFF
--- a/core/lib/eth_client/src/clients/http/query.rs
+++ b/core/lib/eth_client/src/clients/http/query.rs
@@ -15,7 +15,7 @@ use crate::{
     BaseFees, EthFeeInterface, EthInterface, RawTransactionBytes,
 };
 
-const FEE_HISTORY_MAX_REQUEST_CHUNK: usize = 1024;
+const FEE_HISTORY_MAX_REQUEST_CHUNK: usize = 1023;
 
 #[async_trait]
 impl<T> EthInterface for T
@@ -311,7 +311,7 @@ where
     // starting from the oldest block.
     for chunk_start in (from_block..=upto_block).step_by(FEE_HISTORY_MAX_REQUEST_CHUNK) {
         let chunk_end = (chunk_start + FEE_HISTORY_MAX_REQUEST_CHUNK).min(upto_block);
-        let chunk_size = chunk_end - chunk_start;
+        let chunk_size = chunk_end - chunk_start + 1;
 
         let fee_history = client
             .fee_history(
@@ -324,21 +324,47 @@ where
             .with_arg("block", &chunk_end)
             .await?;
 
-        // Check that the lengths are the same.
+        if fee_history.oldest_block != web3::BlockNumber::Number(chunk_start.into()) {
+            let oldest_block = match fee_history.oldest_block {
+                web3::BlockNumber::Number(oldest_block) => oldest_block.to_string(),
+                _ => format!("{:?}", fee_history.oldest_block),
+            };
+            let message =
+                format!("unexpected `oldest_block`, expected: {chunk_start}, got {oldest_block}");
+            return Err(EnrichedClientError::custom(message, "l1_fee_history")
+                .with_arg("chunk_size", &chunk_size)
+                .with_arg("chunk_end", &chunk_end));
+        }
+
+        if fee_history.base_fee_per_gas.len() != chunk_size + 1 {
+            let message = format!(
+                "unexpected `base_fee_per_gas.len()`, expected: {}, got {}",
+                chunk_size + 1,
+                fee_history.base_fee_per_gas.len()
+            );
+            return Err(EnrichedClientError::custom(message, "l1_fee_history")
+                .with_arg("chunk_size", &chunk_size)
+                .with_arg("chunk_end", &chunk_end));
+        }
+
         // Per specification, the values should always be provided, and must be 0 for blocks
         // prior to EIP-4844.
         // https://ethereum.github.io/execution-apis/api-documentation/
-        if fee_history.base_fee_per_gas.len() != fee_history.base_fee_per_blob_gas.len() {
-            tracing::error!(
-                "base_fee_per_gas and base_fee_per_blob_gas have different lengths: {} and {}",
-                fee_history.base_fee_per_gas.len(),
+        if fee_history.base_fee_per_blob_gas.len() != chunk_size + 1 {
+            let message = format!(
+                "unexpected `base_fee_per_blob_gas.len()`, expected: {}, got {}",
+                chunk_size + 1,
                 fee_history.base_fee_per_blob_gas.len()
             );
+            return Err(EnrichedClientError::custom(message, "l1_fee_history")
+                .with_arg("chunk_size", &chunk_size)
+                .with_arg("chunk_end", &chunk_end));
         }
 
         for (base, blob) in fee_history
             .base_fee_per_gas
             .into_iter()
+            .take(chunk_size)
             .zip(fee_history.base_fee_per_blob_gas)
         {
             let fees = BaseFees {
@@ -394,7 +420,7 @@ where
     // starting from the oldest block.
     for chunk_start in (from_block..=upto_block).step_by(FEE_HISTORY_MAX_REQUEST_CHUNK) {
         let chunk_end = (chunk_start + FEE_HISTORY_MAX_REQUEST_CHUNK).min(upto_block);
-        let chunk_size = chunk_end - chunk_start;
+        let chunk_size = chunk_end - chunk_start + 1;
 
         let fee_history = EthNamespaceClient::fee_history(
             client,
@@ -407,19 +433,45 @@ where
         .with_arg("block", &chunk_end)
         .await?;
 
-        // Check that the lengths are the same.
-        if fee_history.inner.base_fee_per_gas.len() != fee_history.l2_pubdata_price.len() {
-            tracing::error!(
-                "base_fee_per_gas and pubdata_price have different lengths: {} and {}",
-                fee_history.inner.base_fee_per_gas.len(),
+        if fee_history.inner.oldest_block != web3::BlockNumber::Number(chunk_start.into()) {
+            let oldest_block = match fee_history.inner.oldest_block {
+                web3::BlockNumber::Number(oldest_block) => oldest_block.to_string(),
+                _ => format!("{:?}", fee_history.inner.oldest_block),
+            };
+            let message =
+                format!("unexpected `oldest_block`, expected: {chunk_start}, got {oldest_block}");
+            return Err(EnrichedClientError::custom(message, "l2_fee_history")
+                .with_arg("chunk_size", &chunk_size)
+                .with_arg("chunk_end", &chunk_end));
+        }
+
+        if fee_history.inner.base_fee_per_gas.len() != chunk_size + 1 {
+            let message = format!(
+                "unexpected `base_fee_per_gas.len()`, expected: {}, got {}",
+                chunk_size + 1,
+                fee_history.inner.base_fee_per_gas.len()
+            );
+            return Err(EnrichedClientError::custom(message, "l2_fee_history")
+                .with_arg("chunk_size", &chunk_size)
+                .with_arg("chunk_end", &chunk_end));
+        }
+
+        if fee_history.l2_pubdata_price.len() != chunk_size {
+            let message = format!(
+                "unexpected `l2_pubdata_price.len()`, expected: {}, got {}",
+                chunk_size + 1,
                 fee_history.l2_pubdata_price.len()
             );
+            return Err(EnrichedClientError::custom(message, "l2_fee_history")
+                .with_arg("chunk_size", &chunk_size)
+                .with_arg("chunk_end", &chunk_end));
         }
 
         for (base, l2_pubdata_price) in fee_history
             .inner
             .base_fee_per_gas
             .into_iter()
+            .take(chunk_size)
             .zip(fee_history.l2_pubdata_price)
         {
             let fees = BaseFees {

--- a/core/lib/eth_client/src/clients/http/query.rs
+++ b/core/lib/eth_client/src/clients/http/query.rs
@@ -361,6 +361,8 @@ where
                 .with_arg("chunk_end", &chunk_end));
         }
 
+        // We take `chunk_size` entries for consistency with `l2_base_fee_history` which doesn't
+        // have correct data for block with number `upto_block + 1`.
         for (base, blob) in fee_history
             .base_fee_per_gas
             .into_iter()
@@ -467,6 +469,7 @@ where
                 .with_arg("chunk_end", &chunk_end));
         }
 
+        // We take `chunk_size` entries because base fee for block `upto_block + 1` may change.
         for (base, l2_pubdata_price) in fee_history
             .inner
             .base_fee_per_gas

--- a/core/lib/eth_client/src/clients/http/query.rs
+++ b/core/lib/eth_client/src/clients/http/query.rs
@@ -304,7 +304,7 @@ where
     COUNTERS.call[&(Method::BaseFeeHistory, client.component())].inc();
     let latency = LATENCIES.direct[&Method::BaseFeeHistory].start();
     let mut history = Vec::with_capacity(block_count);
-    let from_block = upto_block.saturating_sub(block_count);
+    let from_block = upto_block.saturating_sub(block_count - 1);
 
     // Here we are requesting `fee_history` from blocks
     // `(from_block; upto_block)` in chunks of size `MAX_REQUEST_CHUNK`
@@ -413,7 +413,7 @@ where
     COUNTERS.call[&(Method::L2FeeHistory, client.component())].inc();
     let latency = LATENCIES.direct[&Method::BaseFeeHistory].start();
     let mut history = Vec::with_capacity(block_count);
-    let from_block = upto_block.saturating_sub(block_count);
+    let from_block = upto_block.saturating_sub(block_count - 1);
 
     // Here we are requesting `fee_history` from blocks
     // `(from_block; upto_block)` in chunks of size `FEE_HISTORY_MAX_REQUEST_CHUNK`

--- a/core/lib/eth_client/src/clients/mock.rs
+++ b/core/lib/eth_client/src/clients/mock.rs
@@ -415,12 +415,14 @@ fn l2_eth_fee_history(
     let from_block = from_block.as_usize();
     let start_block = from_block.saturating_sub(block_count.as_usize() - 1);
 
+    // duplicates last value to follow `feeHistory` response format, it should return `block_count + 1` values
     let base_fee_per_gas = base_fee_history[start_block..=from_block]
+        .chain([&base_fee_history[from_block]])
         .iter()
-        .chain([&base_fee_history[from_block]]) // duplicate last value
         .map(|fee| U256::from(fee.base_fee_per_gas))
         .collect();
 
+    // duplicates last value to follow `feeHistory` response format, it should return `block_count + 1` values
     let base_fee_per_blob_gas = base_fee_history[start_block..=from_block]
         .iter()
         .chain([&base_fee_history[from_block]]) // duplicate last value

--- a/core/lib/eth_client/src/clients/mock.rs
+++ b/core/lib/eth_client/src/clients/mock.rs
@@ -415,25 +415,33 @@ fn l2_eth_fee_history(
     let from_block = from_block.as_usize();
     let start_block = from_block.saturating_sub(block_count.as_usize() - 1);
 
+    let base_fee_per_gas = base_fee_history[start_block..=from_block]
+        .iter()
+        .chain([&base_fee_history[from_block]]) // duplicate last value
+        .map(|fee| U256::from(fee.base_fee_per_gas))
+        .collect();
+
+    let base_fee_per_blob_gas = base_fee_history[start_block..=from_block]
+        .iter()
+        .chain([&base_fee_history[from_block]]) // duplicate last value
+        .map(|fee| fee.base_fee_per_blob_gas)
+        .collect();
+
+    let l2_pubdata_price = base_fee_history[start_block..=from_block]
+        .iter()
+        .map(|fee| fee.l2_pubdata_price)
+        .collect();
+
     FeeHistory {
         inner: web3::FeeHistory {
             oldest_block: start_block.into(),
-            base_fee_per_gas: base_fee_history[start_block..=from_block]
-                .iter()
-                .map(|fee| U256::from(fee.base_fee_per_gas))
-                .collect(),
-            base_fee_per_blob_gas: base_fee_history[start_block..=from_block]
-                .iter()
-                .map(|fee| fee.base_fee_per_blob_gas)
-                .collect(),
+            base_fee_per_gas,
+            base_fee_per_blob_gas,
             gas_used_ratio: vec![],      // not used
             blob_gas_used_ratio: vec![], // not used
             reward: None,
         },
-        l2_pubdata_price: base_fee_history[start_block..=from_block]
-            .iter()
-            .map(|fee| fee.l2_pubdata_price)
-            .collect(),
+        l2_pubdata_price,
     }
 }
 


### PR DESCRIPTION
## What ❔

There was a wrong assertion: `if fee_history.inner.base_fee_per_gas.len() != fee_history.l2_pubdata_price.len()`. Instead `base_fee_per_gas.len()` should equal `l2_pubdata_price.len() + 1`.

Refactors code of l*_fee_history methods: 
- adds exhaustive assertions
- returns errors instead of only logging

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
