### PR TITLE
fix(ci): Remove deprecated artifacts dir in contracts

### DIFF
--- a/.github/workflows/build-core-template.yml
+++ b/.github/workflows/build-core-template.yml
@@ -71,15 +71,11 @@ jobs:
             if [ $(jq length <<<"$tags") -eq 0 ]; then
               echo "No tag found on all pages."
               echo "BUILD_CONTRACTS=true" >> "$GITHUB_ENV"
-              # TODO Remove it when we migrate to foundry inside contracts repository
-              mkdir -p contracts/l1-contracts/artifacts/ 
               exit 0
             fi
             filtered_tag=$(jq -r --arg commit_sha "$commit_sha" 'map(select(.commit.sha == $commit_sha)) | .[].name' <<<"$tags")
             if [[ ! -z "$filtered_tag" ]]; then
               echo "BUILD_CONTRACTS=false" >> "$GITHUB_ENV"
-              # TODO Remove it when we migrate to foundry inside contracts repository
-              mkdir -p contracts/l1-contracts/out
               break
             fi
             ((page++))

--- a/docker/external-node/Dockerfile
+++ b/docker/external-node/Dockerfile
@@ -28,8 +28,6 @@ COPY contracts/system-contracts/contracts-preprocessed/artifacts/ /contracts/sys
 COPY contracts/system-contracts/contracts-preprocessed/precompiles/artifacts/ /contracts/system-contracts/contracts-preprocessed/precompiles/artifacts/
 COPY contracts/system-contracts/artifacts-zk /contracts/system-contracts/artifacts-zk
 COPY contracts/l1-contracts/out/ /contracts/l1-contracts/out/
-# TODO Remove once we use foundry inside contracts repo
-COPY contracts/l1-contracts/artifacts/ /contracts/l1-contracts/artifacts/
 COPY contracts/l2-contracts/artifacts-zk/ /contracts/l2-contracts/artifacts-zk/
 COPY etc/tokens/ /etc/tokens/
 COPY etc/ERC20/ /etc/ERC20/

--- a/docker/server-v2/Dockerfile
+++ b/docker/server-v2/Dockerfile
@@ -36,8 +36,6 @@ COPY contracts/system-contracts/contracts-preprocessed/artifacts/ /contracts/sys
 COPY contracts/system-contracts/contracts-preprocessed/precompiles/artifacts/ /contracts/system-contracts/contracts-preprocessed/precompiles/artifacts/
 COPY contracts/system-contracts/artifacts-zk /contracts/system-contracts/artifacts-zk
 COPY contracts/l1-contracts/out/ /contracts/l1-contracts/out/
-# TODO Remove once we use foundry inside contracts repo
-COPY contracts/l1-contracts/artifacts/ /contracts/l1-contracts/artifacts/
 COPY contracts/l2-contracts/artifacts-zk/ /contracts/l2-contracts/artifacts-zk/
 COPY etc/tokens/ /etc/tokens/
 COPY etc/ERC20/ /etc/ERC20/


### PR DESCRIPTION
## What ❔

Removing deprecated `artifacts` dir from build process

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
