### PR TITLE
feat(zk_toolbox): added support for setting attester committee defined in a separate file

### DIFF
--- a/core/lib/protobuf_config/src/lib.rs
+++ b/core/lib/protobuf_config/src/lib.rs
@@ -71,17 +71,16 @@ pub fn read_optional_repr<P: ProtoRepr>(field: &Option<P>) -> Option<P::Type> {
         .flatten()
 }
 
-pub fn decode_yaml_repr<T: ProtoRepr>(
+/// Reads a yaml file.
+pub fn read_yaml_repr<T: ProtoRepr>(
     path: &PathBuf,
     deny_unknown_fields: bool,
 ) -> anyhow::Result<T::Type> {
     let yaml = std::fs::read_to_string(path).with_context(|| path.display().to_string())?;
-    let d = serde_yaml::Deserializer::from_str(&yaml);
-    let this: T = zksync_protobuf::serde::Deserialize {
+    zksync_protobuf::serde::Deserialize {
         deny_unknown_fields,
     }
-    .proto(d)?;
-    this.read()
+    .proto_repr_from_yaml::<T>(&yaml)
 }
 
 pub fn encode_yaml_repr<T: ProtoRepr>(value: &T::Type) -> anyhow::Result<Vec<u8>> {

--- a/zk_toolbox/Cargo.lock
+++ b/zk_toolbox/Cargo.lock
@@ -6366,6 +6366,8 @@ dependencies = [
  "eyre",
  "human-panic",
  "lazy_static",
+ "prost 0.12.6",
+ "rand",
  "secrecy",
  "serde",
  "serde_json",
@@ -6382,6 +6384,10 @@ dependencies = [
  "zksync_config",
  "zksync_consensus_crypto",
  "zksync_consensus_roles",
+ "zksync_consensus_utils",
+ "zksync_protobuf",
+ "zksync_protobuf_build",
+ "zksync_protobuf_config",
 ]
 
 [[package]]

--- a/zk_toolbox/Cargo.toml
+++ b/zk_toolbox/Cargo.toml
@@ -34,7 +34,9 @@ zksync_protobuf_config = { path = "../core/lib/protobuf_config" }
 zksync_basic_types = { path = "../core/lib/basic_types" }
 zksync_consensus_roles = "=0.3.0"
 zksync_consensus_crypto = "=0.3.0"
+zksync_consensus_utils = "=0.3.0"
 zksync_protobuf = "=0.3.0"
+zksync_protobuf_build = "=0.3.0"
 
 # External dependencies
 anyhow = "1.0.82"
@@ -49,6 +51,7 @@ futures = "0.3.30"
 human-panic = "2.0"
 lazy_static = "1.4.0"
 once_cell = "1.19.0"
+prost = "0.12.1"
 rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/zk_toolbox/crates/config/src/consensus_secrets.rs
+++ b/zk_toolbox/crates/config/src/consensus_secrets.rs
@@ -2,13 +2,13 @@ use std::path::Path;
 
 use xshell::Shell;
 use zksync_config::configs::consensus::ConsensusSecrets;
-use zksync_protobuf_config::decode_yaml_repr;
+use zksync_protobuf_config::read_yaml_repr;
 
 use crate::traits::ReadConfig;
 
 impl ReadConfig for ConsensusSecrets {
     fn read(shell: &Shell, path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let path = shell.current_dir().join(path);
-        decode_yaml_repr::<zksync_protobuf_config::proto::secrets::ConsensusSecrets>(&path, false)
+        read_yaml_repr::<zksync_protobuf_config::proto::secrets::ConsensusSecrets>(&path, false)
     }
 }

--- a/zk_toolbox/crates/config/src/ecosystem.rs
+++ b/zk_toolbox/crates/config/src/ecosystem.rs
@@ -146,16 +146,16 @@ impl EcosystemConfig {
             .unwrap_or(self.default_chain.as_ref())
     }
 
-    pub fn load_chain(&self, name: Option<String>) -> Option<ChainConfig> {
+    pub fn load_chain(&self, name: Option<String>) -> anyhow::Result<ChainConfig> {
         let name = name.unwrap_or(self.default_chain.clone());
         self.load_chain_inner(&name)
     }
 
-    fn load_chain_inner(&self, name: &str) -> Option<ChainConfig> {
+    fn load_chain_inner(&self, name: &str) -> anyhow::Result<ChainConfig> {
         let path = self.chains.join(name).join(CONFIG_NAME);
-        let config = ChainConfigInternal::read(self.get_shell(), path.clone()).ok()?;
+        let config = ChainConfigInternal::read(self.get_shell(), path.clone())?;
 
-        Some(ChainConfig {
+        Ok(ChainConfig {
             id: config.id,
             name: config.name,
             chain_id: config.chain_id,

--- a/zk_toolbox/crates/config/src/external_node.rs
+++ b/zk_toolbox/crates/config/src/external_node.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use xshell::Shell;
 pub use zksync_config::configs::en_config::ENConfig;
-use zksync_protobuf_config::{decode_yaml_repr, encode_yaml_repr};
+use zksync_protobuf_config::{encode_yaml_repr, read_yaml_repr};
 
 use crate::{
     consts::EN_CONFIG_FILE,
@@ -23,6 +23,6 @@ impl SaveConfig for ENConfig {
 impl ReadConfig for ENConfig {
     fn read(shell: &Shell, path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let path = shell.current_dir().join(path);
-        decode_yaml_repr::<zksync_protobuf_config::proto::en::ExternalNode>(&path, false)
+        read_yaml_repr::<zksync_protobuf_config::proto::en::ExternalNode>(&path, false)
     }
 }

--- a/zk_toolbox/crates/config/src/general.rs
+++ b/zk_toolbox/crates/config/src/general.rs
@@ -6,7 +6,7 @@ use url::Url;
 use xshell::Shell;
 pub use zksync_config::configs::GeneralConfig;
 use zksync_config::configs::{consensus::Host, object_store::ObjectStoreMode};
-use zksync_protobuf_config::{decode_yaml_repr, encode_yaml_repr};
+use zksync_protobuf_config::{encode_yaml_repr, read_yaml_repr};
 
 use crate::{
     consts::GENERAL_FILE,
@@ -249,7 +249,7 @@ impl SaveConfig for GeneralConfig {
 impl ReadConfig for GeneralConfig {
     fn read(shell: &Shell, path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let path = shell.current_dir().join(path);
-        decode_yaml_repr::<zksync_protobuf_config::proto::general::GeneralConfig>(&path, false)
+        read_yaml_repr::<zksync_protobuf_config::proto::general::GeneralConfig>(&path, false)
     }
 }
 

--- a/zk_toolbox/crates/config/src/genesis.rs
+++ b/zk_toolbox/crates/config/src/genesis.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use xshell::Shell;
 use zksync_basic_types::L1ChainId;
 pub use zksync_config::GenesisConfig;
-use zksync_protobuf_config::{decode_yaml_repr, encode_yaml_repr};
+use zksync_protobuf_config::{encode_yaml_repr, read_yaml_repr};
 
 use crate::{
     consts::GENESIS_FILE,
@@ -32,6 +32,6 @@ impl SaveConfig for GenesisConfig {
 impl ReadConfig for GenesisConfig {
     fn read(shell: &Shell, path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let path = shell.current_dir().join(path);
-        decode_yaml_repr::<zksync_protobuf_config::proto::genesis::Genesis>(&path, false)
+        read_yaml_repr::<zksync_protobuf_config::proto::genesis::Genesis>(&path, false)
     }
 }

--- a/zk_toolbox/crates/config/src/lib.rs
+++ b/zk_toolbox/crates/config/src/lib.rs
@@ -10,7 +10,7 @@ pub use manipulations::*;
 pub use secrets::*;
 pub use wallet_creation::*;
 pub use wallets::*;
-pub use zksync_protobuf_config::{decode_yaml_repr, encode_yaml_repr};
+pub use zksync_protobuf_config::{encode_yaml_repr, read_yaml_repr};
 
 mod apps;
 mod chain;

--- a/zk_toolbox/crates/config/src/secrets.rs
+++ b/zk_toolbox/crates/config/src/secrets.rs
@@ -5,7 +5,7 @@ use common::db::DatabaseConfig;
 use xshell::Shell;
 use zksync_basic_types::url::SensitiveUrl;
 pub use zksync_config::configs::Secrets as SecretsConfig;
-use zksync_protobuf_config::{decode_yaml_repr, encode_yaml_repr};
+use zksync_protobuf_config::{encode_yaml_repr, read_yaml_repr};
 
 use crate::{
     consts::SECRETS_FILE,
@@ -61,6 +61,6 @@ impl SaveConfig for SecretsConfig {
 impl ReadConfig for SecretsConfig {
     fn read(shell: &Shell, path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let path = shell.current_dir().join(path);
-        decode_yaml_repr::<zksync_protobuf_config::proto::secrets::Secrets>(&path, false)
+        read_yaml_repr::<zksync_protobuf_config::proto::secrets::Secrets>(&path, false)
     }
 }

--- a/zk_toolbox/crates/zk_inception/Cargo.toml
+++ b/zk_toolbox/crates/zk_inception/Cargo.toml
@@ -35,8 +35,16 @@ zksync_basic_types.workspace = true
 clap-markdown.workspace = true
 zksync_consensus_roles.workspace = true
 zksync_consensus_crypto.workspace = true
+zksync_protobuf.workspace = true
+zksync_protobuf_config.workspace = true
+prost.workspace = true
 secrecy.workspace = true
+
+[dev-dependencies]
+rand.workspace = true
+zksync_consensus_utils.workspace = true
 
 [build-dependencies]
 eyre.workspace = true
 ethers.workspace = true
+zksync_protobuf_build.workspace = true

--- a/zk_toolbox/crates/zk_inception/build.rs
+++ b/zk_toolbox/crates/zk_inception/build.rs
@@ -7,5 +7,15 @@ fn main() -> eyre::Result<()> {
     Abigen::new("ConsensusRegistry", "abi/ConsensusRegistry.json")?
         .generate()?
         .write_to_file(outdir.join("consensus_registry_abi.rs"))?;
+
+    zksync_protobuf_build::Config {
+        input_root: "src/commands/consensus/proto".into(),
+        proto_root: "zksync/toolbox/consensus".into(),
+        dependencies: vec!["::zksync_protobuf_config::proto".parse().unwrap()],
+        protobuf_crate: "::zksync_protobuf".parse().unwrap(),
+        is_public: false,
+    }
+    .generate()
+    .unwrap();
     Ok(())
 }

--- a/zk_toolbox/crates/zk_inception/src/commands/consensus.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/consensus.rs
@@ -173,10 +173,11 @@ impl Setup {
     }
 
     fn new(shell: &Shell) -> anyhow::Result<Self> {
-        let ecosystem_config = EcosystemConfig::from_file(shell)?;
+        let ecosystem_config = EcosystemConfig::from_file(shell).context("EcosystemConfig::from_file()")?;
         let chain_name = global_config().chain_name.clone();
         let chain = ecosystem_config
             .load_chain(chain_name)
+            .context("load_chain()")
             .context(messages::MSG_CHAIN_NOT_INITIALIZED)?;
         let contracts = chain
             .get_contracts_config()

--- a/zk_toolbox/crates/zk_inception/src/commands/consensus/conv.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/consensus/conv.rs
@@ -1,0 +1,47 @@
+use anyhow::Context as _;
+use zksync_config::configs::consensus as config;
+use zksync_consensus_crypto::TextFmt as _;
+use zksync_consensus_roles::attester;
+use zksync_protobuf::{ProtoFmt, ProtoRepr};
+
+use super::proto;
+use crate::utils::consensus::parse_attester_committee;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct SetAttesterCommitteeFile {
+    pub attesters: attester::Committee,
+}
+
+impl ProtoFmt for SetAttesterCommitteeFile {
+    type Proto = proto::SetAttesterCommitteeFile;
+
+    fn read(r: &Self::Proto) -> anyhow::Result<Self> {
+        // zksync_config was not allowed to depend on consensus crates,
+        // therefore to parse the config we need to go through the intermediate
+        // representation of consensus types defined in zksync_config.
+        let attesters: Vec<_> = r
+            .attesters
+            .iter()
+            .map(|x| x.read())
+            .collect::<Result<_, _>>()
+            .context("attesters")?;
+        Ok(Self {
+            attesters: parse_attester_committee(&attesters)?,
+        })
+    }
+
+    fn build(&self) -> Self::Proto {
+        Self::Proto {
+            attesters: self
+                .attesters
+                .iter()
+                .map(|a| {
+                    ProtoRepr::build(&config::WeightedAttester {
+                        key: config::AttesterPublicKey(a.key.encode()),
+                        weight: a.weight,
+                    })
+                })
+                .collect(),
+        }
+    }
+}

--- a/zk_toolbox/crates/zk_inception/src/commands/consensus/mod.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/consensus/mod.rs
@@ -1,10 +1,11 @@
-use std::{borrow::Borrow, collections::HashMap, sync::Arc};
+use std::{borrow::Borrow, collections::HashMap, path::PathBuf, sync::Arc};
 
 /// Consensus registry contract operations.
 /// Includes code duplicated from `zksync_node_consensus::registry::abi`.
 use anyhow::Context as _;
 use common::{config::global_config, logger};
 use config::EcosystemConfig;
+use conv::*;
 use ethers::{
     abi::Detokenize,
     contract::{FunctionCall, Multicall},
@@ -18,6 +19,11 @@ use zksync_consensus_crypto::ByteFmt;
 use zksync_consensus_roles::{attester, validator};
 
 use crate::{messages, utils::consensus::parse_attester_committee};
+
+mod conv;
+mod proto;
+#[cfg(test)]
+mod tests;
 
 #[allow(warnings)]
 mod abi {
@@ -65,11 +71,24 @@ fn encode_validator_pop(pop: &validator::ProofOfPossession) -> abi::Bls12381Sign
     }
 }
 
+#[derive(clap::Args, Debug)]
+#[group(required = true, multiple = false)]
+pub struct SetAttesterCommitteeCommand {
+    /// Sets the attester committee in the consensus registry contract to
+    /// `consensus.genesis_spec.attesters` in general.yaml.
+    #[clap(long)]
+    from_genesis: bool,
+    /// Sets the attester committee in the consensus registry contract to
+    /// the committee in the yaml file.
+    #[clap(long)]
+    from_file: Option<PathBuf>,
+}
+
 #[derive(clap::Subcommand, Debug)]
 pub enum Command {
     /// Sets the attester committee in the consensus registry contract to
     /// `consensus.genesis_spec.attesters` in general.yaml.
-    SetAttesterCommittee,
+    SetAttesterCommittee(SetAttesterCommitteeCommand),
     /// Fetches the attester committee from the consensus registry contract.
     GetAttesterCommittee,
 }
@@ -173,7 +192,8 @@ impl Setup {
     }
 
     fn new(shell: &Shell) -> anyhow::Result<Self> {
-        let ecosystem_config = EcosystemConfig::from_file(shell).context("EcosystemConfig::from_file()")?;
+        let ecosystem_config =
+            EcosystemConfig::from_file(shell).context("EcosystemConfig::from_file()")?;
         let chain_name = global_config().chain_name.clone();
         let chain = ecosystem_config
             .load_chain(chain_name)
@@ -229,9 +249,21 @@ impl Setup {
         attester::Committee::new(attesters.into_iter()).context("attester::Committee::new()")
     }
 
-    async fn set_attester_committee(&self) -> anyhow::Result<attester::Committee> {
+    fn read_attester_committee(
+        &self,
+        opts: &SetAttesterCommitteeCommand,
+    ) -> anyhow::Result<attester::Committee> {
         // Fetch the desired state.
-        let want = (|| {
+        if let Some(path) = &opts.from_file {
+            let yaml = std::fs::read_to_string(path).context("read_to_string()")?;
+            let file: SetAttesterCommitteeFile = zksync_protobuf::serde::Deserialize {
+                deny_unknown_fields: true,
+            }
+            .proto_fmt_from_yaml(&yaml)
+            .context("proto_fmt_from_yaml()")?;
+            return Ok(file.attesters);
+        }
+        let attesters = (|| {
             Some(
                 &self
                     .general
@@ -243,8 +275,10 @@ impl Setup {
             )
         })()
         .context(messages::MSG_CONSENSUS_GENESIS_SPEC_ATTESTERS_MISSING_IN_GENERAL_YAML)?;
-        let want = parse_attester_committee(want).context("parse_attester_committee()")?;
+        parse_attester_committee(attesters).context("parse_attester_committee()")
+    }
 
+    async fn set_attester_committee(&self, want: &attester::Committee) -> anyhow::Result<()> {
         let provider = self.provider().context("provider()")?;
         let block_id = self.last_block(&provider).await.context("last_block()")?;
         let governor = self.governor().context("governor()")?;
@@ -339,7 +373,7 @@ impl Setup {
         )
         .await?;
         txs.wait(&provider).await.context("wait()")?;
-        Ok(want)
+        Ok(())
     }
 }
 
@@ -347,8 +381,11 @@ impl Command {
     pub(crate) async fn run(self, shell: &Shell) -> anyhow::Result<()> {
         let setup = Setup::new(shell).context("Setup::new()")?;
         match self {
-            Self::SetAttesterCommittee => {
-                let want = setup.set_attester_committee().await?;
+            Self::SetAttesterCommittee(opts) => {
+                let want = setup
+                    .read_attester_committee(&opts)
+                    .context("read_attester_committee()")?;
+                setup.set_attester_committee(&want).await?;
                 let got = setup.get_attester_committee().await?;
                 anyhow::ensure!(
                     got == want,

--- a/zk_toolbox/crates/zk_inception/src/commands/consensus/proto/mod.proto
+++ b/zk_toolbox/crates/zk_inception/src/commands/consensus/proto/mod.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package zksync.toolbox.consensus;
+
+import "zksync/core/consensus.proto";
+
+message SetAttesterCommitteeFile {
+  repeated core.consensus.WeightedAttester attesters = 1;
+}

--- a/zk_toolbox/crates/zk_inception/src/commands/consensus/proto/mod.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/consensus/proto/mod.rs
@@ -1,0 +1,6 @@
+#![allow(warnings)]
+
+include!(concat!(
+    env!("OUT_DIR"),
+    "/src/commands/consensus/proto/gen.rs"
+));

--- a/zk_toolbox/crates/zk_inception/src/commands/consensus/tests.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/consensus/tests.rs
@@ -1,0 +1,19 @@
+use rand::{distributions::Distribution, Rng};
+use zksync_consensus_utils::EncodeDist;
+use zksync_protobuf::testonly::{test_encode_all_formats, FmtConv};
+
+use super::SetAttesterCommitteeFile;
+
+impl Distribution<SetAttesterCommitteeFile> for EncodeDist {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> SetAttesterCommitteeFile {
+        SetAttesterCommitteeFile {
+            attesters: rng.gen(),
+        }
+    }
+}
+
+#[test]
+fn test_encoding() {
+    let rng = &mut rand::thread_rng();
+    test_encode_all_formats::<FmtConv<SetAttesterCommitteeFile>>(rng);
+}

--- a/zk_toolbox/crates/zk_inception/src/commands/portal.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/portal.rs
@@ -107,7 +107,7 @@ async fn validate_portal_config(
             continue;
         }
         // Append missing chain, chain might not be initialized, so ignoring errors
-        if let Some(chain_config) = ecosystem_config.load_chain(Some(chain_name.clone())) {
+        if let Ok(chain_config) = ecosystem_config.load_chain(Some(chain_name.clone())) {
             if let Ok(portal_chain_config) = build_portal_chain_config(&chain_config).await {
                 portal_config.add_chain_config(&portal_chain_config);
             }

--- a/zk_toolbox/crates/zk_supervisor/src/dals.rs
+++ b/zk_toolbox/crates/zk_supervisor/src/dals.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context};
+use anyhow::Context as _;
 use common::config::global_config;
 use config::{EcosystemConfig, SecretsConfig};
 use url::Url;
@@ -92,7 +92,7 @@ fn get_secrets(shell: &Shell) -> anyhow::Result<SecretsConfig> {
     let ecosystem_config = EcosystemConfig::from_file(shell)?;
     let chain_config = ecosystem_config
         .load_chain(global_config().chain_name.clone())
-        .ok_or(anyhow!(MSG_CHAIN_NOT_FOUND_ERR))?;
+        .context(MSG_CHAIN_NOT_FOUND_ERR)?;
     let secrets = chain_config.get_secrets_config()?;
 
     Ok(secrets)


### PR DESCRIPTION
So far only setting committee to the value in genesis was supported which is too constraining for real world use. I've added support for specifying the attester committee in a separate yaml file and passing it to the set-attester-committee command.