### PR TITLE
fix(ci): Bring back hack for contracts build till full migration to foundry

### DIFF
--- a/.github/workflows/build-core-template.yml
+++ b/.github/workflows/build-core-template.yml
@@ -71,11 +71,15 @@ jobs:
             if [ $(jq length <<<"$tags") -eq 0 ]; then
               echo "No tag found on all pages."
               echo "BUILD_CONTRACTS=true" >> "$GITHUB_ENV"
+              # TODO Remove it when we migrate to foundry inside contracts repository
+              mkdir -p contracts/l1-contracts/artifacts/
               exit 0
             fi
             filtered_tag=$(jq -r --arg commit_sha "$commit_sha" 'map(select(.commit.sha == $commit_sha)) | .[].name' <<<"$tags")
             if [[ ! -z "$filtered_tag" ]]; then
               echo "BUILD_CONTRACTS=false" >> "$GITHUB_ENV"
+              # TODO Remove it when we migrate to foundry inside contracts repository
+              mkdir -p contracts/l1-contracts/out
               break
             fi
             ((page++))

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -61,12 +61,14 @@ check-contracts:
 	fi
 
 # Build and download needed contracts
+# TODO Remove mkdir once we use foundry inside contracts repo
 prepare-contracts: check-tools check-contracts
 	@cd ../ && \
 	export ZKSYNC_HOME=$$(pwd) && \
 	export PATH=$$PATH:$${ZKSYNC_HOME}/bin && \
 	zkt || true && \
-	zk_supervisor contracts
+	zk_supervisor contracts && \
+	mkdir -p contracts/l1-contracts/artifacts
 
 # Download setup-key
 prepare-keys:

--- a/docker/external-node/Dockerfile
+++ b/docker/external-node/Dockerfile
@@ -29,6 +29,8 @@ COPY contracts/system-contracts/contracts-preprocessed/precompiles/artifacts/ /c
 COPY contracts/system-contracts/artifacts-zk /contracts/system-contracts/artifacts-zk
 COPY contracts/l1-contracts/out/ /contracts/l1-contracts/out/
 COPY contracts/l2-contracts/artifacts-zk/ /contracts/l2-contracts/artifacts-zk/
+# TODO Remove once we use foundry inside contracts repo
+COPY contracts/l1-contracts/artifacts/ /contracts/l1-contracts/artifacts/
 COPY etc/tokens/ /etc/tokens/
 COPY etc/ERC20/ /etc/ERC20/
 COPY etc/multivm_bootloaders/ /etc/multivm_bootloaders/

--- a/docker/server-v2/Dockerfile
+++ b/docker/server-v2/Dockerfile
@@ -37,6 +37,8 @@ COPY contracts/system-contracts/contracts-preprocessed/precompiles/artifacts/ /c
 COPY contracts/system-contracts/artifacts-zk /contracts/system-contracts/artifacts-zk
 COPY contracts/l1-contracts/out/ /contracts/l1-contracts/out/
 COPY contracts/l2-contracts/artifacts-zk/ /contracts/l2-contracts/artifacts-zk/
+# TODO Remove once we use foundry inside contracts repo
+COPY contracts/l1-contracts/artifacts/ /contracts/l1-contracts/artifacts/
 COPY etc/tokens/ /etc/tokens/
 COPY etc/ERC20/ /etc/ERC20/
 COPY etc/multivm_bootloaders/ /etc/multivm_bootloaders/


### PR DESCRIPTION
## What ❔

Creation of empty dirs, to support building from both new (foundry-built) and old contracts

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk_supervisor fmt` and `zk_supervisor lint`.
