### PR TITLE
fix(zk_toolbox): Remove prover db from server init

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -216,8 +216,6 @@ jobs:
           --deploy-ecosystem --l1-rpc-url=http://localhost:8545 \
           --server-db-url=postgres://postgres:notsecurepassword@localhost:5432 \
           --server-db-name=zksync_server_localhost_era \
-          --prover-db-url=postgres://postgres:notsecurepassword@localhost:5432 \
-          --prover-db-name=zksync_prover_localhost_era \
           --ignore-prerequisites --verbose \
           --observability=false
 
@@ -246,8 +244,6 @@ jobs:
           --l1-rpc-url=http://localhost:8545 \
           --server-db-url=postgres://postgres:notsecurepassword@localhost:5432 \
           --server-db-name=zksync_server_localhost_validium \
-          --prover-db-url=postgres://postgres:notsecurepassword@localhost:5432 \
-          --prover-db-name=zksync_prover_localhost_validium \
           --chain validium
 
       - name: Create and initialize chain with Custom Token
@@ -269,8 +265,6 @@ jobs:
           --l1-rpc-url=http://localhost:8545 \
           --server-db-url=postgres://postgres:notsecurepassword@localhost:5432 \
           --server-db-name=zksync_server_localhost_custom_token \
-          --prover-db-url=postgres://postgres:notsecurepassword@localhost:5432 \
-          --prover-db-name=zksync_prover_localhost_custom_token \
           --chain custom_token
 
       - name: Create and register chain with transactions signed "offline"
@@ -327,8 +321,6 @@ jobs:
           --l1-rpc-url=http://localhost:8545 \
           --server-db-url=postgres://postgres:notsecurepassword@localhost:5432 \
           --server-db-name=zksync_server_localhost_consensus \
-          --prover-db-url=postgres://postgres:notsecurepassword@localhost:5432 \
-          --prover-db-name=zksync_prover_localhost_consensus \
           --chain consensus
 
       - name: Build test dependencies

--- a/zk_toolbox/crates/config/src/secrets.rs
+++ b/zk_toolbox/crates/config/src/secrets.rs
@@ -12,17 +12,15 @@ use crate::{
     traits::{FileConfigWithDefaultName, ReadConfig, SaveConfig},
 };
 
-pub fn set_databases(
+pub fn set_server_database(
     secrets: &mut SecretsConfig,
     server_db_config: &DatabaseConfig,
-    prover_db_config: &DatabaseConfig,
 ) -> anyhow::Result<()> {
     let database = secrets
         .database
         .as_mut()
-        .context("Databases must be presented")?;
+        .context("Server database must be presented")?;
     database.server_url = Some(SensitiveUrl::from(server_db_config.full_url()));
-    database.prover_url = Some(SensitiveUrl::from(prover_db_config.full_url()));
     Ok(())
 }
 
@@ -33,7 +31,7 @@ pub fn set_prover_database(
     let database = secrets
         .database
         .as_mut()
-        .context("Databases must be presented")?;
+        .context("Prover database must be presented")?;
     database.prover_url = Some(SensitiveUrl::from(prover_db_config.full_url()));
     Ok(())
 }

--- a/zk_toolbox/crates/zk_inception/src/commands/chain/args/genesis.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/chain/args/genesis.rs
@@ -28,10 +28,7 @@ pub struct GenesisArgs {
 
 impl GenesisArgs {
     pub fn fill_values_with_prompt(self, config: &ChainConfig) -> GenesisArgsFinal {
-        let DBNames {
-            server_name,
-            prover_name: _,
-        } = generate_db_names(config);
+        let DBNames { server_name, .. } = generate_db_names(config);
         let chain_name = config.name.clone();
         if self.use_default {
             GenesisArgsFinal {

--- a/zk_toolbox/crates/zk_inception/src/commands/chain/args/genesis.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/chain/args/genesis.rs
@@ -7,11 +7,10 @@ use slugify_rs::slugify;
 use url::Url;
 
 use crate::{
-    defaults::{generate_db_names, DBNames, DATABASE_PROVER_URL, DATABASE_SERVER_URL},
+    defaults::{generate_db_names, DBNames, DATABASE_SERVER_URL},
     messages::{
-        msg_prover_db_name_prompt, msg_prover_db_url_prompt, msg_server_db_name_prompt,
-        msg_server_db_url_prompt, MSG_PROVER_DB_NAME_HELP, MSG_PROVER_DB_URL_HELP,
-        MSG_SERVER_DB_NAME_HELP, MSG_SERVER_DB_URL_HELP, MSG_USE_DEFAULT_DATABASES_HELP,
+        msg_server_db_name_prompt, msg_server_db_url_prompt, MSG_SERVER_DB_NAME_HELP,
+        MSG_SERVER_DB_URL_HELP, MSG_USE_DEFAULT_DATABASES_HELP,
     },
 };
 
@@ -21,10 +20,6 @@ pub struct GenesisArgs {
     pub server_db_url: Option<Url>,
     #[clap(long, help = MSG_SERVER_DB_NAME_HELP)]
     pub server_db_name: Option<String>,
-    #[clap(long, help = MSG_PROVER_DB_URL_HELP)]
-    pub prover_db_url: Option<Url>,
-    #[clap(long, help = MSG_PROVER_DB_NAME_HELP)]
-    pub prover_db_name: Option<String>,
     #[clap(long, short, help = MSG_USE_DEFAULT_DATABASES_HELP)]
     pub use_default: bool,
     #[clap(long, short, action)]
@@ -35,13 +30,12 @@ impl GenesisArgs {
     pub fn fill_values_with_prompt(self, config: &ChainConfig) -> GenesisArgsFinal {
         let DBNames {
             server_name,
-            prover_name,
+            prover_name: _,
         } = generate_db_names(config);
         let chain_name = config.name.clone();
         if self.use_default {
             GenesisArgsFinal {
                 server_db: DatabaseConfig::new(DATABASE_SERVER_URL.clone(), server_name),
-                prover_db: DatabaseConfig::new(DATABASE_PROVER_URL.clone(), prover_name),
                 dont_drop: self.dont_drop,
             }
         } else {
@@ -58,22 +52,8 @@ impl GenesisArgs {
                 }),
                 separator = "_"
             );
-            let prover_db_url = self.prover_db_url.unwrap_or_else(|| {
-                Prompt::new(&msg_prover_db_url_prompt(&chain_name))
-                    .default(DATABASE_PROVER_URL.as_str())
-                    .ask()
-            });
-            let prover_db_name = slugify!(
-                &self.prover_db_name.unwrap_or_else(|| {
-                    Prompt::new(&msg_prover_db_name_prompt(&chain_name))
-                        .default(&prover_name)
-                        .ask()
-                }),
-                separator = "_"
-            );
             GenesisArgsFinal {
                 server_db: DatabaseConfig::new(server_db_url, server_db_name),
-                prover_db: DatabaseConfig::new(prover_db_url, prover_db_name),
                 dont_drop: self.dont_drop,
             }
         }
@@ -96,25 +76,13 @@ impl GenesisArgs {
             (None, None)
         };
 
-        let (prover_db_url, prover_db_name) = if let Some(db_full_url) = database.prover_url {
-            let db_config = DatabaseConfig::from_url(db_full_url.expose_url())
-                .context("Invalid prover database URL")?;
-            (Some(db_config.url), Some(db_config.name))
-        } else {
-            (None, None)
-        };
-
         self.server_db_url = self.server_db_url.or(server_db_url);
         self.server_db_name = self.server_db_name.or(server_db_name);
-        self.prover_db_url = self.prover_db_url.or(prover_db_url);
-        self.prover_db_name = self.prover_db_name.or(prover_db_name);
 
         Ok(self.fill_values_with_prompt(chain_config))
     }
 
     pub fn reset_db_names(&mut self) {
-        self.prover_db_name = None;
-        self.prover_db_url = None;
         self.server_db_name = None;
         self.server_db_url = None;
     }
@@ -123,6 +91,5 @@ impl GenesisArgs {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GenesisArgsFinal {
     pub server_db: DatabaseConfig,
-    pub prover_db: DatabaseConfig,
     pub dont_drop: bool,
 }

--- a/zk_toolbox/crates/zk_inception/src/commands/chain/genesis/mod.rs
+++ b/zk_toolbox/crates/zk_inception/src/commands/chain/genesis/mod.rs
@@ -7,7 +7,7 @@ use xshell::Shell;
 use crate::{
     commands::chain::{
         args::genesis::{GenesisArgs, GenesisArgsFinal},
-        genesis::{self, database::initialize_databases, server::run_server_genesis},
+        genesis::{self, database::initialize_server_database, server::run_server_genesis},
     },
     messages::{
         MSG_CHAIN_NOT_INITIALIZED, MSG_GENESIS_COMPLETED, MSG_INITIALIZING_DATABASES_SPINNER,
@@ -70,16 +70,14 @@ pub async fn genesis(
         logger::object_to_string(serde_json::json!({
             "chain_config": config,
             "server_db_config": args.server_db,
-            "prover_db_config": args.prover_db,
         })),
     );
     logger::info(MSG_STARTING_GENESIS);
 
     let spinner = Spinner::new(MSG_INITIALIZING_DATABASES_SPINNER);
-    initialize_databases(
+    initialize_server_database(
         shell,
         &args.server_db,
-        &args.prover_db,
         config.link_to_code.clone(),
         args.dont_drop,
     )


### PR DESCRIPTION
## What ❔
Remove prover db from server init

## Why ❔

prover db is not needed in server init since prover  db is initialized with prover init