### PR TITLE
docs(zk_toolbox): remove generate-sk subcommand references

### DIFF
--- a/zk_toolbox/README.md
+++ b/zk_toolbox/README.md
@@ -183,12 +183,6 @@ Initialize the prover:
 zk_inception prover init
 ```
 
-Generate setup keys:
-
-```bash
-zk_inception prover generate-sk
-```
-
 Run the prover:
 
 ```bash

--- a/zk_toolbox/crates/zk_inception/README.md
+++ b/zk_toolbox/crates/zk_inception/README.md
@@ -423,7 +423,6 @@ Prover related commands
 ###### **Subcommands:**
 
 - `init` — Initialize prover
-- `generate-sk` — Generate setup keys
 - `run` — Run prover
 - `init-bellman-cuda` — Initialize bellman-cuda
 


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->
Remove `generate-sk` subcommand which doesn’t exist anymore.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk_supervisor fmt` and `zk_supervisor lint`.
