### PR TITLE
fix(zk_toolbox): allow hyphens after `zks test rust --options`

### DIFF
--- a/zk_toolbox/crates/zk_supervisor/src/commands/test/args/integration.rs
+++ b/zk_toolbox/crates/zk_supervisor/src/commands/test/args/integration.rs
@@ -9,6 +9,6 @@ pub struct IntegrationArgs {
     pub external_node: bool,
     #[clap(short, long, help = MSG_NO_DEPS_HELP)]
     pub no_deps: bool,
-    #[clap(short, long, help = MSG_TEST_PATTERN_HELP)]
+    #[clap(short, long, help = MSG_TEST_PATTERN_HELP, allow_hyphen_values(true))]
     pub test_pattern: Option<String>,
 }

--- a/zk_toolbox/crates/zk_supervisor/src/commands/test/mod.rs
+++ b/zk_toolbox/crates/zk_supervisor/src/commands/test/mod.rs
@@ -40,7 +40,7 @@ pub enum TestCommands {
     Upgrade(UpgradeArgs),
     #[clap(about = MSG_BUILD_ABOUT)]
     Build,
-    #[clap(about = MSG_RUST_TEST_ABOUT, alias = "unit")]
+    #[clap(about = MSG_RUST_TEST_ABOUT, alias = "unit", allow_hyphen_values(true))]
     Rust(RustArgs),
     #[clap(about = MSG_L1_CONTRACTS_ABOUT, alias = "l1")]
     L1Contracts,


### PR DESCRIPTION
## What ❔

Forces clap to allow hyphens after `zks test rust --options`

## Why ❔

So that you can run sensible commands like `zks test rust --options "-E test(io::tests::continue_unsealed_batch_on_restart) --no-capture"`

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk_supervisor fmt` and `zk_supervisor lint`.
