### PR TITLE
fix: bincode deserialization for VM run data

### DIFF
--- a/core/lib/prover_interface/src/inputs.rs
+++ b/core/lib/prover_interface/src/inputs.rs
@@ -198,7 +198,7 @@ impl StoredObject for VMRunWitnessInputData {
 
     fn deserialize(bytes: Vec<u8>) -> Result<Self, BoxedError> {
         zksync_object_store::bincode::deserialize::<VMRunWitnessInputData>(&bytes).or_else(|_| {
-            bincode::deserialize::<VMRunWitnessInputDataLegacy>(&bytes)
+            zksync_object_store::bincode::deserialize::<VMRunWitnessInputDataLegacy>(&bytes)
                 .map(Into::into)
                 .map_err(Into::into)
         })

--- a/core/lib/prover_interface/src/inputs.rs
+++ b/core/lib/prover_interface/src/inputs.rs
@@ -3,8 +3,7 @@ use std::{collections::HashMap, convert::TryInto, fmt::Debug};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, Bytes};
 use zksync_multivm::interface::{L1BatchEnv, SystemEnv};
-use zksync_object_store::_reexports::BoxedError;
-use zksync_object_store::{serialize_using_bincode, Bucket, StoredObject};
+use zksync_object_store::{_reexports::BoxedError, serialize_using_bincode, Bucket, StoredObject};
 use zksync_types::{
     basic_fri_types::Eip4844Blobs, block::L2BlockExecutionData,
     witness_block_state::WitnessStorageState, L1BatchNumber, ProtocolVersionId, H256, U256,

--- a/core/lib/prover_interface/src/inputs.rs
+++ b/core/lib/prover_interface/src/inputs.rs
@@ -193,11 +193,11 @@ impl StoredObject for VMRunWitnessInputData {
     }
 
     fn serialize(&self) -> Result<Vec<u8>, BoxedError> {
-        bincode::serialize(self).map_err(Into::into)
+        zksync_object_store::bincode::serialize(self).map_err(Into::into)
     }
 
     fn deserialize(bytes: Vec<u8>) -> Result<Self, BoxedError> {
-        bincode::deserialize::<VMRunWitnessInputData>(&bytes).or_else(|| {
+        zksync_object_store::bincode::deserialize::<VMRunWitnessInputData>(&bytes).or_else(|_| {
             bincode::deserialize::<VMRunWitnessInputDataLegacy>(&bytes)
                 .map(Into::into)
                 .map_err(Into::into)


### PR DESCRIPTION
## What ❔

Implement custom deserialize for VM run data

## Why ❔

serde(deserialize_if) is not working with bincode

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk_supervisor fmt` and `zk_supervisor lint`.
