### PR TITLE
fix(nix): separate `tee_prover` and `zksync` deps

### DIFF
--- a/etc/nix/tee_prover.nix
+++ b/etc/nix/tee_prover.nix
@@ -1,12 +1,19 @@
-{ cargoArtifacts
-, craneLib
+{ craneLib
 , commonArgs
 }:
-craneLib.buildPackage (commonArgs // {
+let
   pname = "zksync_tee_prover";
+  cargoExtraArgs = "--locked -p zksync_tee_prover";
+in
+craneLib.buildPackage (commonArgs // {
+  inherit pname;
   version = (builtins.fromTOML (builtins.readFile ../../core/bin/zksync_tee_prover/Cargo.toml)).package.version;
-  cargoExtraArgs = "-p zksync_tee_prover --bin zksync_tee_prover";
-  inherit cargoArtifacts;
+  inherit cargoExtraArgs;
+
+  cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {
+    inherit pname;
+    inherit cargoExtraArgs;
+  });
 
   postInstall = ''
     strip $out/bin/zksync_tee_prover

--- a/etc/nix/zksync.nix
+++ b/etc/nix/zksync.nix
@@ -1,12 +1,14 @@
-{ cargoArtifacts
-, craneLib
+{ craneLib
 , commonArgs
 }:
 craneLib.buildPackage (commonArgs // {
   pname = "zksync";
   version = (builtins.fromTOML (builtins.readFile ../../core/bin/zksync_tee_prover/Cargo.toml)).package.version;
   cargoExtraArgs = "--all";
-  inherit cargoArtifacts;
+
+  cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {
+    pname = "zksync-era-workspace";
+  });
 
   outputs = [
     "out"

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
           packages = {
             # to ease potential cross-compilation, the overlay is used
             inherit (appliedOverlay.zksync-era) zksync tee_prover container-tee-prover-azure container-tee-prover-dcap;
-            default = appliedOverlay.zksync-era.zksync;
+            default = appliedOverlay.zksync-era.tee_prover;
           };
 
           devShells.default = appliedOverlay.zksync-era.devShell;
@@ -107,10 +107,6 @@
             strictDeps = true;
             inherit hardeningEnable;
           };
-
-          cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {
-            pname = "zksync-era-workspace";
-          });
         in
         {
           zksync-era = rec {
@@ -120,12 +116,11 @@
             };
 
             zksync = pkgs.callPackage ./etc/nix/zksync.nix {
-              inherit cargoArtifacts;
               inherit craneLib;
               inherit commonArgs;
             };
+
             tee_prover = pkgs.callPackage ./etc/nix/tee_prover.nix {
-              inherit cargoArtifacts;
               inherit craneLib;
               inherit commonArgs;
             };


### PR DESCRIPTION
## What ❔

While `zksync` deps might not compile with nix, `tee_prover` deps must.

To enable nix incompatible changes in the workspace, separate the build process completely.

## Why ❔

To enable nix incompatible changes in the workspace, which are unrelated to `tee_prover`.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk_supervisor fmt` and `zk_supervisor lint`.
