### PR TITLE
fix(ci): Fix pseudo-check for contacts submodule in Makefile

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -55,7 +55,7 @@ check-tools: check-nodejs check-yarn check-rust check-sqlx-cli check-docker chec
 
 # Check that contracts are checkout properly
 check-contracts:
-	@if [ ! -d ../contracts/l1-contracts/lib/forge-std/foundry.toml ] || [ -z "$$(ls -A ../contracts/l1-contracts/lib/forge-std/foundry.toml)" ]; then \
+	@if [ -z "$$(ls -A ../contracts/l1-contracts/lib/forge-std/foundry.toml)" ]; then \
 		echo "l1-contracts git submodule is missing. Please re-download repo with 'git clone --recurse-submodules https://github.com/matter-labs/zksync-era.git'"; \
 		exit 1; \
 	fi


### PR DESCRIPTION
## What ❔

Fix pseudo-check for contacts submodule in Makefile

## Why ❔


## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk_supervisor fmt` and `zk_supervisor lint`.
