### PR TITLE
fix(tee-prover): simplify TeeProofGenerationDataResponse

### DIFF
--- a/core/bin/zksync_tee_prover/src/api_client.rs
+++ b/core/bin/zksync_tee_prover/src/api_client.rs
@@ -77,7 +77,7 @@ impl TeeApiClient {
     pub async fn get_job(
         &self,
         tee_type: TeeType,
-    ) -> Result<Option<Box<TeeVerifierInput>>, TeeProverError> {
+    ) -> Result<Box<TeeVerifierInput>, TeeProverError> {
         let request = TeeProofGenerationDataRequest { tee_type };
         let response = self
             .post::<_, TeeProofGenerationDataResponse, _>("/tee/proof_inputs", request)

--- a/core/lib/dal/src/tee_proof_generation_dal.rs
+++ b/core/lib/dal/src/tee_proof_generation_dal.rs
@@ -33,7 +33,7 @@ impl TeeProofGenerationDal<'_, '_> {
         tee_type: TeeType,
         processing_timeout: Duration,
         min_batch_number: Option<L1BatchNumber>,
-    ) -> DalResult<Option<L1BatchNumber>> {
+    ) -> DalResult<L1BatchNumber> {
         let processing_timeout = pg_interval_from_duration(processing_timeout);
         let min_batch_number = min_batch_number.map_or(0, |num| i64::from(num.0));
         let batch_number = sqlx::query!(
@@ -105,11 +105,10 @@ impl TeeProofGenerationDal<'_, '_> {
         .with_arg("tee_type", &tee_type)
         .with_arg("processing_timeout", &processing_timeout)
         .with_arg("l1_batch_number", &min_batch_number)
-        .fetch_optional(self.storage)
-        .await?
-        .map(|row| L1BatchNumber(row.l1_batch_number as u32));
+        .fetch_one(self.storage)
+        .await?;
 
-        Ok(batch_number)
+        Ok(L1BatchNumber(batch_number.l1_batch_number as u32))
     }
 
     pub async fn unlock_batch(

--- a/core/lib/prover_interface/src/api.rs
+++ b/core/lib/prover_interface/src/api.rs
@@ -31,7 +31,7 @@ pub enum ProofGenerationDataResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct TeeProofGenerationDataResponse(pub Option<Box<TeeVerifierInput>>);
+pub struct TeeProofGenerationDataResponse(pub Box<TeeVerifierInput>);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum SubmitProofResponse {

--- a/core/node/proof_data_handler/src/lib.rs
+++ b/core/node/proof_data_handler/src/lib.rs
@@ -10,7 +10,7 @@ use zksync_dal::{ConnectionPool, Core};
 use zksync_object_store::ObjectStore;
 use zksync_prover_interface::api::{
     ProofGenerationDataRequest, RegisterTeeAttestationRequest, SubmitProofRequest,
-    SubmitTeeProofRequest, TeeProofGenerationDataRequest, TeeProofGenerationDataResponse,
+    SubmitTeeProofRequest, TeeProofGenerationDataRequest,
 };
 use zksync_types::{commitment::L1BatchCommitmentMode, L2ChainId};
 
@@ -109,7 +109,6 @@ fn create_proof_processing_router(
                         .await;
 
                     match result {
-                        Ok(Json(TeeProofGenerationDataResponse(None))) => (StatusCode::NO_CONTENT, Json("No new TeeVerifierInputs are available yet")).into_response(),
                         Ok(data) => (StatusCode::OK, data).into_response(),
                         Err(e) => e.into_response(),
                     }

--- a/core/node/proof_data_handler/src/tests.rs
+++ b/core/node/proof_data_handler/src/tests.rs
@@ -31,7 +31,7 @@ async fn request_tee_proof_inputs() {
         L2ChainId::default(),
     );
     let test_cases = vec![
-        (json!({ "tee_type": "sgx" }), StatusCode::NO_CONTENT),
+        (json!({ "tee_type": "sgx" }), StatusCode::NOT_FOUND),
         (
             json!({ "tee_type": "Sgx" }),
             StatusCode::UNPROCESSABLE_ENTITY,


### PR DESCRIPTION
This PR addresses Alex's code review comment:
https://github.com/matter-labs/zksync-era/pull/3017#discussion_r1795237929
and partially addresses this one too:
https://github.com/matter-labs/zksync-era/pull/3017#discussion_r1795240750

## What ❔

Simplify `TeeProofGenerationDataResponse`.

## Why ❔

Because it's ugly.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk_supervisor fmt` and `zk_supervisor lint`.
