### PR TITLE
chore(docs): run fmt on docs

### DIFF
--- a/.github/workflows/ci-docs-reusable.yml
+++ b/.github/workflows/ci-docs-reusable.yml
@@ -35,4 +35,5 @@ jobs:
 
       - name: Lints
         run: |
+          ci_run zk_supervisor fmt --check
           ci_run zk_supervisor lint -t md --check

--- a/docs/guides/external-node/00_quick_start.md
+++ b/docs/guides/external-node/00_quick_start.md
@@ -38,8 +38,8 @@ sudo docker compose --file testnet-external-node-docker-compose.yml down --volum
 
 ### Observability
 
-You can see the status of the node (after recovery) in [local grafana dashboard](http://localhost:3000/dashboards).
-You can also access a debug page with more information about the node [here](http://localhost:5000).
+You can see the status of the node (after recovery) in [local grafana dashboard](http://localhost:3000/dashboards). You
+can also access a debug page with more information about the node [here](http://localhost:5000).
 
 The HTTP JSON-RPC API can be accessed on port `3060` and WebSocket API can be accessed on port `3061`.
 


### PR DESCRIPTION
## What ❔

Stuff was left misformatted after https://github.com/matter-labs/zksync-era/pull/3060.

Seems like we don't run `zks fmt` on PRs that only touch MD files

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk_supervisor fmt` and `zk_supervisor lint`.
