### PR TITLE
fix(vm): Check protocol version for fast VM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11331,6 +11331,7 @@ name = "zksync_vm_executor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-trait",
  "once_cell",
  "tokio",

--- a/core/lib/multivm/src/lib.rs
+++ b/core/lib/multivm/src/lib.rs
@@ -16,7 +16,7 @@ pub use crate::{
         vm_1_3_2, vm_1_4_1, vm_1_4_2, vm_boojum_integration, vm_fast, vm_latest, vm_m5, vm_m6,
         vm_refunds_enhancement, vm_virtual_blocks,
     },
-    vm_instance::{FastVmInstance, LegacyVmInstance},
+    vm_instance::{is_supported_by_fast_vm, FastVmInstance, LegacyVmInstance},
 };
 
 mod glue;

--- a/core/lib/multivm/src/versions/vm_fast/vm.rs
+++ b/core/lib/multivm/src/versions/vm_fast/vm.rs
@@ -40,6 +40,7 @@ use crate::{
         VmExecutionStatistics, VmFactory, VmInterface, VmInterfaceHistoryEnabled, VmRevertReason,
         VmTrackingContracts,
     },
+    is_supported_by_fast_vm,
     utils::events::extract_l2tol1logs_from_l1_messenger,
     vm_fast::{
         bootloader_state::utils::{apply_l2_block, apply_pubdata_to_memory},
@@ -104,6 +105,12 @@ pub struct Vm<S, Tr = ()> {
 
 impl<S: ReadStorage, Tr: Tracer> Vm<S, Tr> {
     pub fn custom(batch_env: L1BatchEnv, system_env: SystemEnv, storage: S) -> Self {
+        assert!(
+            is_supported_by_fast_vm(system_env.version),
+            "Protocol version {:?} is not supported by fast VM",
+            system_env.version
+        );
+
         let default_aa_code_hash = system_env
             .base_system_smart_contracts
             .default_aa

--- a/core/lib/multivm/src/vm_instance.rs
+++ b/core/lib/multivm/src/vm_instance.rs
@@ -1,6 +1,6 @@
 use std::mem;
 
-use zksync_types::{vm::VmVersion, Transaction};
+use zksync_types::{vm::VmVersion, ProtocolVersionId, Transaction};
 use zksync_vm2::interface::Tracer;
 
 use crate::{
@@ -327,4 +327,12 @@ impl<S: ReadStorage, Tr: Tracer + Default + 'static> FastVmInstance<S, Tr> {
     ) -> Self {
         Self::Shadowed(ShadowedFastVm::new(l1_batch_env, system_env, storage_view))
     }
+}
+
+/// Checks whether the protocol version is supported by the fast VM.
+pub fn is_supported_by_fast_vm(protocol_version: ProtocolVersionId) -> bool {
+    matches!(
+        protocol_version.into(),
+        VmVersion::Vm1_5_0IncreasedBootloaderMemory
+    )
 }

--- a/core/lib/vm_executor/Cargo.toml
+++ b/core/lib/vm_executor/Cargo.toml
@@ -23,3 +23,6 @@ tokio.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
 vise.workspace = true
+
+[dev-dependencies]
+assert_matches.workspace = true

--- a/core/lib/vm_executor/src/lib.rs
+++ b/core/lib/vm_executor/src/lib.rs
@@ -9,3 +9,5 @@ pub mod batch;
 pub mod oneshot;
 mod shared;
 pub mod storage;
+#[cfg(test)]
+mod testonly;

--- a/core/lib/vm_executor/src/testonly.rs
+++ b/core/lib/vm_executor/src/testonly.rs
@@ -1,0 +1,45 @@
+use once_cell::sync::Lazy;
+use zksync_contracts::BaseSystemContracts;
+use zksync_multivm::{
+    interface::{L1BatchEnv, L2BlockEnv, SystemEnv, TxExecutionMode},
+    vm_latest::constants::BATCH_COMPUTATIONAL_GAS_LIMIT,
+};
+use zksync_types::{
+    block::L2BlockHasher, fee_model::BatchFeeInput, vm::FastVmMode, Address, L1BatchNumber,
+    L2BlockNumber, L2ChainId, ProtocolVersionId, H256, ZKPORTER_IS_AVAILABLE,
+};
+
+static BASE_SYSTEM_CONTRACTS: Lazy<BaseSystemContracts> =
+    Lazy::new(BaseSystemContracts::load_from_disk);
+
+pub(crate) const FAST_VM_MODES: [FastVmMode; 3] =
+    [FastVmMode::Old, FastVmMode::New, FastVmMode::Shadow];
+
+pub(crate) fn default_system_env(execution_mode: TxExecutionMode) -> SystemEnv {
+    SystemEnv {
+        zk_porter_available: ZKPORTER_IS_AVAILABLE,
+        version: ProtocolVersionId::latest(),
+        base_system_smart_contracts: BASE_SYSTEM_CONTRACTS.clone(),
+        bootloader_gas_limit: BATCH_COMPUTATIONAL_GAS_LIMIT,
+        execution_mode,
+        default_validation_computational_gas_limit: BATCH_COMPUTATIONAL_GAS_LIMIT,
+        chain_id: L2ChainId::default(),
+    }
+}
+
+pub(crate) fn default_l1_batch_env(number: u32) -> L1BatchEnv {
+    L1BatchEnv {
+        previous_batch_hash: Some(H256::zero()),
+        number: L1BatchNumber(number),
+        timestamp: number.into(),
+        fee_account: Address::repeat_byte(0x22),
+        enforced_base_fee: None,
+        first_l2_block: L2BlockEnv {
+            number,
+            timestamp: number.into(),
+            prev_block_hash: L2BlockHasher::legacy_hash(L2BlockNumber(number - 1)),
+            max_virtual_blocks_to_create: 1,
+        },
+        fee_input: BatchFeeInput::sensible_l1_pegged_default(),
+    }
+}


### PR DESCRIPTION
## What ❔

Fixes a regression introduced by https://github.com/matter-labs/zksync-era/pull/2915: The protocol version is now not checked before instantiating a fast VM.

## Why ❔

Without this check, fast VM can be used with old protocol versions, which most likely will cause divergencies.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk_supervisor fmt` and `zk_supervisor lint`.