### PR TITLE
fix(tee-prover): simplify TeeProofGenerationDataResponse

### DIFF
--- a/core/bin/zksync_tee_prover/src/api_client.rs
+++ b/core/bin/zksync_tee_prover/src/api_client.rs
@@ -8,7 +8,6 @@ use zksync_prover_interface::{
         RegisterTeeAttestationRequest, RegisterTeeAttestationResponse, SubmitTeeProofRequest,
         SubmitTeeProofResponse, TeeProofGenerationDataRequest, TeeProofGenerationDataResponse,
     },
-    inputs::TeeVerifierInput,
     outputs::L1BatchTeeProofForL1,
 };
 use zksync_types::{tee_types::TeeType, L1BatchNumber};
@@ -77,12 +76,12 @@ impl TeeApiClient {
     pub async fn get_job(
         &self,
         tee_type: TeeType,
-    ) -> Result<Option<Box<TeeVerifierInput>>, TeeProverError> {
+    ) -> Result<TeeProofGenerationDataResponse, TeeProverError> {
         let request = TeeProofGenerationDataRequest { tee_type };
         let response = self
             .post::<_, TeeProofGenerationDataResponse, _>("/tee/proof_inputs", request)
             .await?;
-        Ok(response.0)
+        Ok(response)
     }
 
     /// Submits the successfully verified proof to the TEE prover interface API.

--- a/core/bin/zksync_tee_prover/src/config.rs
+++ b/core/bin/zksync_tee_prover/src/config.rs
@@ -47,7 +47,7 @@ impl FromEnv for TeeProverConfig {
     /// export TEE_PROVER_SIGNING_KEY="b50b38c8d396c88728fc032ece558ebda96907a0b1a9340289715eef7bf29deb"
     /// export TEE_PROVER_ATTESTATION_QUOTE_FILE_PATH="/tmp/test"  # run `echo test > /tmp/test` beforehand
     /// export TEE_PROVER_TEE_TYPE="sgx"
-    /// export TEE_PROVER_API_URL="http://127.0.0.1:3320"
+    /// export TEE_PROVER_API_URL="http://127.0.0.1:3421"
     /// export TEE_PROVER_MAX_RETRIES=10
     /// export TEE_PROVER_INITIAL_RETRY_BACKOFF_SEC=1
     /// export TEE_PROVER_RETRY_BACKOFF_MULTIPLIER=2.0

--- a/core/lib/prover_interface/src/api.rs
+++ b/core/lib/prover_interface/src/api.rs
@@ -31,7 +31,10 @@ pub enum ProofGenerationDataResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct TeeProofGenerationDataResponse(pub Option<Box<TeeVerifierInput>>);
+pub enum TeeProofGenerationDataResponse {
+    VerifierInputReady(Box<TeeVerifierInput>),
+    VerifierInputNotReady,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum SubmitProofResponse {

--- a/core/node/proof_data_handler/src/lib.rs
+++ b/core/node/proof_data_handler/src/lib.rs
@@ -109,8 +109,14 @@ fn create_proof_processing_router(
                         .await;
 
                     match result {
-                        Ok(Json(TeeProofGenerationDataResponse(None))) => (StatusCode::NO_CONTENT, Json("No new TeeVerifierInputs are available yet")).into_response(),
-                        Ok(data) => (StatusCode::OK, data).into_response(),
+                        Ok(data) => match data {
+                            Json(TeeProofGenerationDataResponse::VerifierInputReady(input)) => {
+                                (StatusCode::OK, Json(TeeProofGenerationDataResponse::VerifierInputReady(input))).into_response()
+                            }
+                            Json(TeeProofGenerationDataResponse::VerifierInputNotReady) => {
+                                (StatusCode::NO_CONTENT, Json(TeeProofGenerationDataResponse::VerifierInputNotReady)).into_response()
+                            }
+                        }
                         Err(e) => e.into_response(),
                     }
                 },

--- a/core/node/proof_data_handler/src/tee_request_processor.rs
+++ b/core/node/proof_data_handler/src/tee_request_processor.rs
@@ -56,7 +56,7 @@ impl TeeRequestProcessor {
                 .await?
             {
                 Some(number) => number,
-                None => break Ok(Json(TeeProofGenerationDataResponse(None))),
+                None => break Ok(Json(TeeProofGenerationDataResponse::VerifierInputNotReady)),
             };
 
             match self
@@ -64,7 +64,9 @@ impl TeeRequestProcessor {
                 .await
             {
                 Ok(input) => {
-                    break Ok(Json(TeeProofGenerationDataResponse(Some(Box::new(input)))));
+                    break Ok(Json(TeeProofGenerationDataResponse::VerifierInputReady(
+                        Box::new(input),
+                    )));
                 }
                 Err(RequestProcessorError::ObjectStore(ObjectStoreError::KeyNotFound(_))) => {
                     missing_range = match missing_range {


### PR DESCRIPTION
This PR addresses Alex's code review comment:
https://github.com/matter-labs/zksync-era/pull/3017#discussion_r1795237929
and partially addresses this one too:
https://github.com/matter-labs/zksync-era/pull/3017#discussion_r1795240750

## What ❔

Simplify `TeeProofGenerationDataResponse`.

## Why ❔

Because it's ugly.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk_supervisor fmt` and `zk_supervisor lint`.
