### PR TITLE
fix: Changed debug page address on config file

### DIFF
--- a/docs/guides/external-node/docker-compose-examples/configs/mainnet_consensus_config.yaml
+++ b/docs/guides/external-node/docker-compose-examples/configs/mainnet_consensus_config.yaml
@@ -1,6 +1,6 @@
 server_addr: '0.0.0.0:3054'
 public_addr: '127.0.0.1:3054'
-debug_page_addr: '127.0.0.1:5000'
+debug_page_addr: '0.0.0.0:5000'
 max_payload_size: 5000000
 gossip_dynamic_inbound_limit: 100
 gossip_static_outbound:

--- a/docs/guides/external-node/docker-compose-examples/configs/testnet_consensus_config.yaml
+++ b/docs/guides/external-node/docker-compose-examples/configs/testnet_consensus_config.yaml
@@ -1,6 +1,6 @@
 server_addr: '0.0.0.0:3054'
 public_addr: '127.0.0.1:3054'
-debug_page_addr: '127.0.0.1:5000'
+debug_page_addr: '0.0.0.0:5000'
 max_payload_size: 5000000
 gossip_dynamic_inbound_limit: 100
 gossip_static_outbound:


### PR DESCRIPTION
Debug page address was set to 127.0.0.1:5000 on the consensus config file for the docker node. That didn't let users access the page from outside the container. It was set to 0.0.0.0:5000 and it now works.