### PR TITLE
chore: use Vec::with_capacity avoid reallocate

### DIFF
--- a/core/lib/crypto_primitives/src/eip712_signature/struct_builder.rs
+++ b/core/lib/crypto_primitives/src/eip712_signature/struct_builder.rs
@@ -133,8 +133,6 @@ impl EncodeBuilder {
     /// If the struct type references other struct types (and these in turn reference even more struct types),
     /// then the set of referenced struct types is collected, sorted by name and appended to the encoding.
     pub fn get_json_types(&self, type_name: &str) -> Vec<Value> {
-        let mut result = Vec::new();
-
         let mut outer_members_builder = OuterTypeBuilder::new();
         for (member, _) in self.members.iter() {
             outer_members_builder.add_member(member.clone());
@@ -158,7 +156,7 @@ impl EncodeBuilder {
                 inner_members,
             }
         };
-
+        let mut result = Vec::with_capacity(1 + outer_members.len());
         result.push(inner_member.get_json_types());
         for (_, outer_member) in outer_members {
             result.push(outer_member.get_json_types());

--- a/core/lib/crypto_primitives/src/eip712_signature/typed_structure.rs
+++ b/core/lib/crypto_primitives/src/eip712_signature/typed_structure.rs
@@ -127,7 +127,7 @@ pub trait EIP712TypedStructure {
         };
         let encode_data = self.encode_data();
 
-        let mut bytes = Vec::new();
+        let mut bytes = Vec::with_capacity(32 + 32 * encode_data.len());
         bytes.extend_from_slice(&type_hash);
         for data in encode_data {
             bytes.extend_from_slice(data.as_bytes());

--- a/core/lib/dal/src/storage_logs_dedup_dal.rs
+++ b/core/lib/dal/src/storage_logs_dedup_dal.rs
@@ -36,6 +36,7 @@ impl StorageLogsDedupDal<'_, '_> {
         .start(self.storage)
         .await?;
 
+        // XXX FIXME YSG
         let mut bytes: Vec<u8> = Vec::new();
         let now = Utc::now().naive_utc().to_string();
         for log in read_logs.iter() {

--- a/core/lib/dal/src/transactions_dal.rs
+++ b/core/lib/dal/src/transactions_dal.rs
@@ -1555,12 +1555,13 @@ impl TransactionsDal<'_, '_> {
                 .with_arg("l2_block_number", &l2_block_number)
                 .with_arg("upgrade_txs.len", &upgrade_txs_len);
 
-        let mut upgrade_hashes = Vec::new();
-        let mut upgrade_indices_in_block = Vec::new();
-        let mut upgrade_errors = Vec::new();
-        let mut upgrade_execution_infos = Vec::new();
-        let mut upgrade_refunded_gas = Vec::new();
-        let mut upgrade_effective_gas_prices = Vec::new();
+        let len = transactions.len();
+        let mut upgrade_hashes = Vec::with_capacity(len);
+        let mut upgrade_indices_in_block = Vec::with_capacity(len);
+        let mut upgrade_errors = Vec::with_capacity(len);
+        let mut upgrade_execution_infos = Vec::with_capacity(len);
+        let mut upgrade_refunded_gas = Vec::with_capacity(len);
+        let mut upgrade_effective_gas_prices = Vec::with_capacity(len);
 
         for (index_in_block, tx_res) in transactions.iter().enumerate() {
             let transaction = &tx_res.transaction;

--- a/core/lib/node_framework_derive/src/macro_impl.rs
+++ b/core/lib/node_framework_derive/src/macro_impl.rs
@@ -92,7 +92,7 @@ impl MacroImpl {
     fn render_from_context(self) -> Result<proc_macro2::TokenStream> {
         let crate_path = self.crate_path();
         let ident = self.ident;
-        let mut fields = Vec::new();
+        let mut fields = Vec::with_capacity(self.fields.len());
         for field in self.fields {
             let ty = field.ty;
             let ident = field.ident;
@@ -139,7 +139,7 @@ impl MacroImpl {
     fn render_into_context(self) -> Result<proc_macro2::TokenStream> {
         let crate_path = self.crate_path();
         let ident = self.ident;
-        let mut actions = Vec::new();
+        let mut actions = Vec::with_capacity(self.fields.len());
         for field in self.fields {
             let ty = field.ty;
             let ident = field.ident;

--- a/core/node/api_server/src/web3/tests/mod.rs
+++ b/core/node/api_server/src/web3/tests/mod.rs
@@ -916,7 +916,7 @@ impl HttpTest for TransactionReceiptsTest {
         ];
         store_l2_block(&mut storage, l2_block_number, &tx_results).await?;
 
-        let mut expected_receipts = Vec::new();
+        let mut expected_receipts = Vec::with_capacity(tx_results.len());
         for tx in &tx_results {
             expected_receipts.push(
                 client

--- a/core/node/eth_watch/src/event_processors/decentralized_upgrades.rs
+++ b/core/node/eth_watch/src/event_processors/decentralized_upgrades.rs
@@ -43,7 +43,7 @@ impl EventProcessor for DecentralizedUpgradesEventProcessor {
         sl_client: &dyn EthClient,
         events: Vec<Log>,
     ) -> Result<usize, EventProcessorError> {
-        let mut upgrades = Vec::new();
+        let mut upgrades = Vec::with_capacity(events.len());
         for event in &events {
             let version = event.topics.get(1).copied().context("missing topic 1")?;
             let timestamp: u64 = U256::from_big_endian(&event.data.0)

--- a/core/node/tee_verifier_input_producer/src/lib.rs
+++ b/core/node/tee_verifier_input_producer/src/lib.rs
@@ -105,7 +105,7 @@ impl TeeVerifierInputProducer {
         // `get_factory_deps()` returns the bytecode in chunks of `Vec<[u8; 32]>`,
         // but `fn store_factory_dep(&mut self, hash: H256, bytecode: Vec<u8>)` in `InMemoryStorage` wants flat byte vecs.
         pub fn into_flattened<T: Clone, const N: usize>(data: Vec<[T; N]>) -> Vec<T> {
-            let mut new = Vec::new();
+            let mut new = Vec::with_capacity(N * data.len());
             for slice in data.iter() {
                 new.extend_from_slice(slice);
             }

--- a/core/node/vm_runner/src/tests/mod.rs
+++ b/core/node/vm_runner/src/tests/mod.rs
@@ -244,8 +244,8 @@ async fn store_l1_batches(
         conn.transactions_dal()
             .insert_transaction_l2(&tx, TransactionExecutionMetrics::default())
             .await?;
-        let mut logs = Vec::new();
-        let mut written_keys = Vec::new();
+        let mut logs = Vec::with_capacity(10);
+        let mut written_keys = Vec::with_capacity(10);
         for _ in 0..10 {
             let key = StorageKey::new(AccountTreeId::new(H160::random()), H256::random());
             let value = StorageValue::random();
@@ -256,7 +256,7 @@ async fn store_l1_batches(
                 value,
             });
         }
-        let mut factory_deps = HashMap::new();
+        let mut factory_deps = HashMap::with_capacity(10);
         for _ in 0..10 {
             factory_deps.insert(H256::random(), rng.gen::<[u8; 32]>().into());
         }

--- a/prover/crates/bin/prover_cli/src/commands/status/batch.rs
+++ b/prover/crates/bin/prover_cli/src/commands/status/batch.rs
@@ -78,7 +78,7 @@ async fn get_batches_data(
         .await
         .context("failed to get a connection")?;
 
-    let mut batches_data = Vec::new();
+    let mut batches_data = Vec::with_capacity(batches.len());
     for batch in batches {
         let current_batch_data = BatchData {
             batch_number: batch,

--- a/prover/crates/bin/witness_generator/src/main.rs
+++ b/prover/crates/bin/witness_generator/src/main.rs
@@ -180,7 +180,7 @@ async fn main() -> anyhow::Result<()> {
     };
     let prometheus_task = prometheus_config.run(stop_receiver.clone());
 
-    let mut tasks = Vec::new();
+    let mut tasks = Vec::with_capacity(1 + rounds.len());
     tasks.push(tokio::spawn(prometheus_task));
 
     for round in rounds {


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔
use Vec::with_capacity avoid reallocate
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
