### PR TITLE
feat: Add option to run prover images from tag

### DIFF
--- a/zkstack_cli/crates/zkstack/README.md
+++ b/zkstack_cli/crates/zkstack/README.md
@@ -102,10 +102,10 @@ Create a new ecosystem and chain, setting necessary configurations for later ini
 
   Possible values:
 
-  - `localhost`: Load wallets from localhost mnemonic, they are funded for localhost env
-  - `random`: Generate random wallets
-  - `empty`: Generate placeholder wallets
-  - `in-file`: Specify file with wallets
+    - `localhost`: Load wallets from localhost mnemonic, they are funded for localhost env
+    - `random`: Generate random wallets
+    - `empty`: Generate placeholder wallets
+    - `in-file`: Specify file with wallets
 
 - `--wallet-path <WALLET_PATH>` — Wallet path
 - `--l1-batch-commit-data-generator-mode <L1_BATCH_COMMIT_DATA_GENERATOR_MODE>` — Commit data generation mode
@@ -224,10 +224,10 @@ Create a new chain, setting the necessary configurations for later initializatio
 
   Possible values:
 
-  - `localhost`: Load wallets from localhost mnemonic, they are funded for localhost env
-  - `random`: Generate random wallets
-  - `empty`: Generate placeholder wallets
-  - `in-file`: Specify file with wallets
+    - `localhost`: Load wallets from localhost mnemonic, they are funded for localhost env
+    - `random`: Generate random wallets
+    - `empty`: Generate placeholder wallets
+    - `in-file`: Specify file with wallets
 
 - `--wallet-path <WALLET_PATH>` — Wallet path
 - `--l1-batch-commit-data-generator-mode <L1_BATCH_COMMIT_DATA_GENERATOR_MODE>` — Commit data generation mode
@@ -567,6 +567,10 @@ Run prover
 - `--docker` - Whether to run image of the component instead of binary.
 
   Possible values: `true`, `false`
+
+- `--tag' - Tag of the docker image to run.
+
+  Default value is `latest2.0` but you can specify your prefered one.
 
 - `--round <ROUND>`
 

--- a/zkstack_cli/crates/zkstack/README.md
+++ b/zkstack_cli/crates/zkstack/README.md
@@ -102,10 +102,10 @@ Create a new ecosystem and chain, setting necessary configurations for later ini
 
   Possible values:
 
-    - `localhost`: Load wallets from localhost mnemonic, they are funded for localhost env
-    - `random`: Generate random wallets
-    - `empty`: Generate placeholder wallets
-    - `in-file`: Specify file with wallets
+  - `localhost`: Load wallets from localhost mnemonic, they are funded for localhost env
+  - `random`: Generate random wallets
+  - `empty`: Generate placeholder wallets
+  - `in-file`: Specify file with wallets
 
 - `--wallet-path <WALLET_PATH>` — Wallet path
 - `--l1-batch-commit-data-generator-mode <L1_BATCH_COMMIT_DATA_GENERATOR_MODE>` — Commit data generation mode
@@ -224,10 +224,10 @@ Create a new chain, setting the necessary configurations for later initializatio
 
   Possible values:
 
-    - `localhost`: Load wallets from localhost mnemonic, they are funded for localhost env
-    - `random`: Generate random wallets
-    - `empty`: Generate placeholder wallets
-    - `in-file`: Specify file with wallets
+  - `localhost`: Load wallets from localhost mnemonic, they are funded for localhost env
+  - `random`: Generate random wallets
+  - `empty`: Generate placeholder wallets
+  - `in-file`: Specify file with wallets
 
 - `--wallet-path <WALLET_PATH>` — Wallet path
 - `--l1-batch-commit-data-generator-mode <L1_BATCH_COMMIT_DATA_GENERATOR_MODE>` — Commit data generation mode

--- a/zkstack_cli/crates/zkstack/README.md
+++ b/zkstack_cli/crates/zkstack/README.md
@@ -508,7 +508,11 @@ Initialize prover
 - `--public-location <PUBLIC_LOCATION>`
 - `--public-project-id <PUBLIC_PROJECT_ID>`
 - `--bellman-cuda-dir <BELLMAN_CUDA_DIR>`
-- `--download-key <DOWNLOAD_KEY>`
+- `--bellman-cuda`
+
+  Possible values: `true`, `false`
+
+- `--setup-compressor-key <SETUP_COMPRESSOR_KEY>`
 
   Possible values: `true`, `false`
 

--- a/zkstack_cli/crates/zkstack/src/commands/prover/args/init.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/args/init.rs
@@ -61,7 +61,7 @@ pub struct ProverInitArgs {
     pub bellman_cuda: Option<bool>,
 
     #[clap(long, default_missing_value = "true", num_args = 0..=1)]
-    pub setup_compressor_keys: Option<bool>,
+    pub setup_compressor_key: Option<bool>,
     #[clap(flatten)]
     pub compressor_keys_args: CompressorKeysArgs,
 
@@ -363,7 +363,7 @@ impl ProverInitArgs {
             });
         }
 
-        let download_key = self.clone().setup_compressor_keys.unwrap_or_else(|| {
+        let download_key = self.clone().setup_compressor_key.unwrap_or_else(|| {
             PromptConfirm::new(MSG_DOWNLOAD_SETUP_COMPRESSOR_KEY_PROMPT)
                 .default(false)
                 .ask()

--- a/zkstack_cli/crates/zkstack/src/commands/prover/args/run.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/args/run.rs
@@ -35,6 +35,8 @@ pub struct ProverRunArgs {
     pub circuit_prover_args: CircuitProverArgs,
     #[clap(long)]
     pub docker: Option<bool>,
+    #[clap(long)]
+    pub tag: Option<String>,
 }
 
 #[derive(
@@ -300,6 +302,8 @@ impl ProverRunArgs {
                 .ask()
         });
 
+        let tag = self.tag.unwrap_or("latest2.0".to_string());
+
         Ok(ProverRunArgs {
             component: Some(component),
             witness_generator_args,
@@ -307,6 +311,7 @@ impl ProverRunArgs {
             fri_prover_args: self.fri_prover_args,
             circuit_prover_args,
             docker: Some(docker),
+            tag: Some(tag),
         })
     }
 }

--- a/zkstack_cli/crates/zkstack/src/commands/prover/run.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/run.rs
@@ -83,6 +83,7 @@ pub(crate) async fn run(args: ProverRunArgs, shell: &Shell) -> anyhow::Result<()
         run_dockerized_component(
             shell,
             component.image_name(),
+            args.tag.unwrap(),
             &application_args,
             &additional_args,
             message,
@@ -110,6 +111,7 @@ pub(crate) async fn run(args: ProverRunArgs, shell: &Shell) -> anyhow::Result<()
 fn run_dockerized_component(
     shell: &Shell,
     image_name: &str,
+    tag: &str,
     application_args: &[String],
     args: &[String],
     message: &'static str,
@@ -124,7 +126,7 @@ fn run_dockerized_component(
 
     let mut cmd = Cmd::new(cmd!(
         shell,
-        "docker run --net=host -v {path_to_prover}/data/keys:/prover/data/keys -v {path_to_prover}/artifacts:/artifacts -v {path_to_configs}:/configs {application_args...} {image_name} {args...}"
+        "docker run --net=host -v {path_to_prover}/data/keys:/prover/data/keys -v {path_to_prover}/artifacts:/artifacts -v {path_to_configs}:/configs {application_args...} {image_name}:{tag} {args...}"
     ));
 
     cmd = cmd.with_force_run();

--- a/zkstack_cli/crates/zkstack/src/commands/prover/run.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/run.rs
@@ -83,7 +83,7 @@ pub(crate) async fn run(args: ProverRunArgs, shell: &Shell) -> anyhow::Result<()
         run_dockerized_component(
             shell,
             component.image_name(),
-            args.tag.unwrap(),
+            &args.tag.unwrap(),
             &application_args,
             &additional_args,
             message,

--- a/zkstack_cli/crates/zkstack/src/commands/prover/run.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/run.rs
@@ -33,7 +33,7 @@ pub(crate) async fn run(args: ProverRunArgs, shell: &Shell) -> anyhow::Result<()
 
     let application_args = component.get_application_args(in_docker)?;
     let additional_args =
-        component.get_additional_args(in_docker, args, &chain, &path_to_ecosystem)?;
+        component.get_additional_args(in_docker, args.clone(), &chain, &path_to_ecosystem)?;
 
     let (message, error) = match component {
         ProverComponent::WitnessGenerator => (

--- a/zkstack_cli/crates/zkstack/src/consts.rs
+++ b/zkstack_cli/crates/zkstack/src/consts.rs
@@ -17,14 +17,13 @@ pub const EXPLORER_APP_DOCKER_IMAGE: &str = "matterlabs/block-explorer-app";
 pub const PORTAL_DOCKER_CONFIG_PATH: &str = "/usr/src/app/dist/config.js";
 pub const PORTAL_DOCKER_IMAGE: &str = "matterlabs/dapp-portal";
 
-pub const PROVER_GATEWAY_DOCKER_IMAGE: &str = "matterlabs/prover-fri-gateway:latest2.0";
-pub const WITNESS_GENERATOR_DOCKER_IMAGE: &str = "matterlabs/witness-generator:latest2.0";
-pub const WITNESS_VECTOR_GENERATOR_DOCKER_IMAGE: &str =
-    "matterlabs/witness-vector-generator:latest2.0";
-pub const PROVER_DOCKER_IMAGE: &str = "matterlabs/prover-gpu-fri:latest2.0";
-pub const CIRCUIT_PROVER_DOCKER_IMAGE: &str = "matterlabs/circuit-prover-gpu:latest2.0";
-pub const COMPRESSOR_DOCKER_IMAGE: &str = "matterlabs/proof-fri-gpu-compressor:latest2.0";
-pub const PROVER_JOB_MONITOR_DOCKER_IMAGE: &str = "matterlabs/prover-job-monitor:latest2.0";
+pub const PROVER_GATEWAY_DOCKER_IMAGE: &str = "matterlabs/prover-fri-gateway";
+pub const WITNESS_GENERATOR_DOCKER_IMAGE: &str = "matterlabs/witness-generator";
+pub const WITNESS_VECTOR_GENERATOR_DOCKER_IMAGE: &str = "matterlabs/witness-vector-generator";
+pub const PROVER_DOCKER_IMAGE: &str = "matterlabs/prover-gpu-fri";
+pub const CIRCUIT_PROVER_DOCKER_IMAGE: &str = "matterlabs/circuit-prover-gpu";
+pub const COMPRESSOR_DOCKER_IMAGE: &str = "matterlabs/proof-fri-gpu-compressor";
+pub const PROVER_JOB_MONITOR_DOCKER_IMAGE: &str = "matterlabs/prover-job-monitor";
 
 pub const PROVER_GATEWAY_BINARY_NAME: &str = "zksync_prover_fri_gateway";
 pub const WITNESS_GENERATOR_BINARY_NAME: &str = "zksync_witness_generator";


### PR DESCRIPTION
## What ❔

Add option to run prover images from tag, but not only latest.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
