### PR TITLE
chore: lower no base token ratio log level

### DIFF
--- a/core/node/base_token_adjuster/src/base_token_ratio_provider.rs
+++ b/core/node/base_token_adjuster/src/base_token_ratio_provider.rs
@@ -81,7 +81,7 @@ impl DBBaseTokenRatioProvider {
                 // Though the DB should be populated very soon after the server starts, it is possible
                 // to have no ratios in the DB right after genesis. Having initial ratios in the DB
                 // from the genesis stage will eliminate this possibility.
-                tracing::error!("No latest price found in the database. Using default ratio.");
+                tracing::warn!("No latest price found in the database. Using default ratio.");
                 BaseTokenConversionRatio::default()
             }
             Err(err) => anyhow::bail!("Failed to get latest base token ratio: {:?}", err),


### PR DESCRIPTION
## What ❔

Lowers no base token ratio log level to `WARN` instead of `ERROR`

## Why ❔

It gets printed >500 times during integration tests making it hard to find the actual errors.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
