### PR TITLE
fix(en): Return `SyncState` health check

### DIFF
--- a/core/bin/external_node/src/tests/mod.rs
+++ b/core/bin/external_node/src/tests/mod.rs
@@ -22,10 +22,18 @@ const POLL_INTERVAL: Duration = Duration::from_millis(100);
 #[tracing::instrument] // Add args to the test logs
 async fn external_node_basics(components_str: &'static str) {
     let _guard = zksync_vlog::ObservabilityBuilder::new().try_build().ok(); // Enable logging to simplify debugging
-
     let (env, env_handles) = utils::TestEnvironment::with_genesis_block(components_str).await;
 
-    let expected_health_components = utils::expected_health_components(&env.components);
+    let mut expected_health_components = utils::expected_health_components(&env.components);
+    let expected_shutdown_components = expected_health_components.clone();
+    let has_core_or_api = env.components.0.iter().any(|component| {
+        [Component::Core, Component::HttpApi, Component::WsApi].contains(component)
+    });
+    if has_core_or_api {
+        // The `sync_state` component doesn't signal its shutdown, but should be present in the list of components
+        expected_health_components.push("sync_state");
+    }
+
     let l2_client = utils::mock_l2_client(&env);
     let eth_client = utils::mock_eth_client(env.config.diamond_proxy_address());
 
@@ -84,7 +92,7 @@ async fn external_node_basics(components_str: &'static str) {
     let health_data = app_health.check_health().await;
     tracing::info!(?health_data, "final health data");
     assert_matches!(health_data.inner().status(), HealthStatus::ShutDown);
-    for name in expected_health_components {
+    for name in expected_shutdown_components {
         let component_health = &health_data.components()[name];
         assert_matches!(component_health.status(), HealthStatus::ShutDown);
     }

--- a/core/node/node_sync/src/sync_state.rs
+++ b/core/node/node_sync/src/sync_state.rs
@@ -173,6 +173,7 @@ impl CheckHealth for SyncState {
         Health::from(&*self.0.borrow())
     }
 }
+
 impl SyncStateInner {
     fn is_synced(&self) -> (bool, Option<u32>) {
         if let (Some(main_node_block), Some(local_block)) = (self.main_node_block, self.local_block)


### PR DESCRIPTION
## What ❔

Returns `SyncState`-based health check, which was removed when transitioning to the node framework.

## Why ❔

This health check looks useful and is used at least in some internal automations.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.