### PR TITLE
fix(tee_prover): add zstd compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd066d0b4ef8ecb03a55319dc13aa6910616d0f44008a045bb1835af830abff5"
+dependencies = [
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5886,6 +5900,7 @@ version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
@@ -8309,13 +8324,16 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
+ "async-compression",
  "bitflags 2.6.0",
  "bytes",
+ "futures-core",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
 ]
@@ -10866,6 +10884,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower 0.4.13",
+ "tower-http",
  "tracing",
  "vise",
  "zksync_basic_types",
@@ -11412,6 +11431,24 @@ dependencies = [
  "vise",
  "zksync_config",
  "zksync_types",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
 ]
 
 [[package]]

--- a/core/bin/zksync_tee_prover/Cargo.toml
+++ b/core/bin/zksync_tee_prover/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 anyhow.workspace = true
 async-trait.workspace = true
 envy.workspace = true
-reqwest.workspace = true
+reqwest = { workspace = true, features = ["zstd"] }
 secp256k1 = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true

--- a/core/node/proof_data_handler/Cargo.toml
+++ b/core/node/proof_data_handler/Cargo.toml
@@ -22,6 +22,7 @@ zksync_utils.workspace = true
 anyhow.workspace = true
 axum.workspace = true
 tokio.workspace = true
+tower-http = { workspace = true, features = ["compression-zstd", "decompression-zstd"] }
 tracing.workspace = true
 
 [dev-dependencies]

--- a/core/node/proof_data_handler/src/lib.rs
+++ b/core/node/proof_data_handler/src/lib.rs
@@ -139,4 +139,6 @@ fn create_proof_processing_router(
     }
 
     router
+        .layer(tower_http::compression::CompressionLayer::new())
+        .layer(tower_http::decompression::DecompressionLayer::new())
 }

--- a/core/node/proof_data_handler/src/lib.rs
+++ b/core/node/proof_data_handler/src/lib.rs
@@ -140,5 +140,5 @@ fn create_proof_processing_router(
 
     router
         .layer(tower_http::compression::CompressionLayer::new())
-        .layer(tower_http::decompression::DecompressionLayer::new())
+        .layer(tower_http::decompression::RequestDecompressionLayer::new().zstd(true))
 }


### PR DESCRIPTION
## What ❔

Add zstd compression for the HTTP connection between `proof_data_handler` and `zksync_tee_prover`.

## Why ❔

This enables faster intercloud communication.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
