### PR TITLE
fix(consensus): preventing config update reverts

### DIFF
--- a/core/node/consensus/src/en.rs
+++ b/core/node/consensus/src/en.rs
@@ -100,7 +100,12 @@ impl EN {
                     let old = old;
                     loop {
                         if let Ok(new) = self.fetch_global_config(ctx).await {
-                            if new != old {
+                            // We verify the transition here to work around the situation
+                            // where `consenus_global_config()` RPC fails randomly and fallback
+                            // to `consensus_genesis()` RPC activates.
+                            if new != old
+                                && consensus_dal::verify_config_transition(&old, &new).is_ok()
+                            {
                                 return Err(anyhow::format_err!(
                                     "global config changed: old {old:?}, new {new:?}"
                                 )


### PR DESCRIPTION
Random failures of consensus_global_config RPC may cause config reverts, until the consensus_genesis() RPC is fully deprecated. Although the problems of this sort are transient, this pr adds extra protection from this kind of situations to prevent unnecessary binary restarts.