### PR TITLE
fix: update logging in cbt l1 behaviour

### DIFF
--- a/core/node/base_token_adjuster/src/base_token_l1_behaviour.rs
+++ b/core/node/base_token_adjuster/src/base_token_l1_behaviour.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use anyhow::Context;
-use bigdecimal::{num_bigint::ToBigInt, BigDecimal, ToPrimitive, Zero};
+use bigdecimal::{BigDecimal, Zero};
 use zksync_config::BaseTokenAdjusterConfig;
 use zksync_eth_client::{BoundEthInterface, CallFunctionArgs, Options};
 use zksync_node_fee_model::l1_gas_price::TxParamsProvider;
@@ -57,7 +57,7 @@ impl BaseTokenL1Behaviour {
             self.update_last_persisted_l1_ratio(prev_ratio.clone());
             tracing::info!(
                 "Fetched current base token ratio from the L1: {}",
-                prev_ratio
+                prev_ratio.to_bigint()
             );
             prev_ratio
         };

--- a/core/node/base_token_adjuster/src/base_token_l1_behaviour.rs
+++ b/core/node/base_token_adjuster/src/base_token_l1_behaviour.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use anyhow::Context;
-use bigdecimal::{num_bigint::ToBigInt, BigDecimal, Zero};
+use bigdecimal::{num_bigint::ToBigInt, BigDecimal, ToPrimitive, Zero};
 use zksync_config::BaseTokenAdjusterConfig;
 use zksync_eth_client::{BoundEthInterface, CallFunctionArgs, Options};
 use zksync_node_fee_model::l1_gas_price::TxParamsProvider;
@@ -57,7 +57,7 @@ impl BaseTokenL1Behaviour {
             self.update_last_persisted_l1_ratio(prev_ratio.clone());
             tracing::info!(
                 "Fetched current base token ratio from the L1: {}",
-                prev_ratio.to_bigint().unwrap()
+                prev_ratio
             );
             prev_ratio
         };
@@ -71,7 +71,7 @@ impl BaseTokenL1Behaviour {
                 "Skipping L1 update. current_ratio {}, previous_ratio {}, deviation {}",
                 current_ratio,
                 prev_ratio,
-                deviation.to_bigint().unwrap()
+                deviation
             );
             return Ok(());
         }
@@ -98,7 +98,7 @@ impl BaseTokenL1Behaviour {
                         new_ratio.denominator.get(),
                         base_fee_per_gas,
                         priority_fee_per_gas,
-                        deviation.to_bigint().unwrap()
+                        deviation
                     );
                     METRICS
                         .l1_gas_used

--- a/core/node/base_token_adjuster/src/base_token_l1_behaviour.rs
+++ b/core/node/base_token_adjuster/src/base_token_l1_behaviour.rs
@@ -57,7 +57,7 @@ impl BaseTokenL1Behaviour {
             self.update_last_persisted_l1_ratio(prev_ratio.clone());
             tracing::info!(
                 "Fetched current base token ratio from the L1: {}",
-                prev_ratio.to_bigint()
+                prev_ratio
             );
             prev_ratio
         };


### PR DESCRIPTION
Stop converting `BigDecimal` to `BigInt` when logging to avoid loosing precision. 