### PR TITLE
fix(zk chains): Increase Batch Seal Default Deadline

### DIFF
--- a/etc/env/file_based/overrides/mainnet.yaml
+++ b/etc/env/file_based/overrides/mainnet.yaml
@@ -1,5 +1,6 @@
 state_keeper:
-  block_commit_deadline_ms: 3600000
+  # Default batch seal time deadline: 8 hours
+  block_commit_deadline_ms: 28000000
   minimal_l2_gas_price: 45250000
 eth:
   sender:

--- a/etc/env/file_based/overrides/testnet.yaml
+++ b/etc/env/file_based/overrides/testnet.yaml
@@ -1,5 +1,6 @@
 state_keeper:
-  block_commit_deadline_ms: 3600000
+  # Default batch seal time deadline: 8 hours
+  block_commit_deadline_ms: 28000000
   minimal_l2_gas_price: 25000000
 eth:
   sender:


### PR DESCRIPTION
## What ❔

This PR increases the L1 Batch seadl default deadline from 1 hour to 8 hours.

## Why ❔

- For lower TPS chains, this configuration matches reality better and is less wasteful in terms of Ethereum interactions.
- For higher TPS chains, the batches will be sealed by other seal criteria anyways

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
