### PR TITLE
feat(metadata-calculator): Add debug endpoints for tree API

### DIFF
--- a/core/bin/external_node/src/tests/mod.rs
+++ b/core/bin/external_node/src/tests/mod.rs
@@ -17,7 +17,7 @@ mod utils;
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
-#[test_casing(3, ["all", "core", "api"])]
+#[test_casing(4, ["all", "core", "api", "core,tree_api"])]
 #[tokio::test]
 #[tracing::instrument] // Add args to the test logs
 async fn external_node_basics(components_str: &'static str) {
@@ -166,43 +166,6 @@ async fn running_tree_without_core_is_not_allowed() {
     assert!(
         err.to_string()
             .contains("Tree must run on the same machine as Core"),
-        "Unexpected errror: {}",
-        err
-    );
-}
-
-#[tokio::test]
-async fn running_tree_api_without_tree_is_not_allowed() {
-    let _guard = zksync_vlog::ObservabilityBuilder::new().try_build().ok(); // Enable logging to simplify debugging
-    let (env, _env_handles) = utils::TestEnvironment::with_genesis_block("core,tree_api").await;
-
-    let l2_client = utils::mock_l2_client(&env);
-    let eth_client = utils::mock_eth_client(env.config.diamond_proxy_address());
-
-    let node_handle = tokio::task::spawn_blocking(move || {
-        std::thread::spawn(move || {
-            let mut node = ExternalNodeBuilder::new(env.config)?;
-            inject_test_layers(
-                &mut node,
-                env.sigint_receiver,
-                env.app_health_sender,
-                eth_client,
-                l2_client,
-            );
-
-            // We're only interested in the error, so we drop the result.
-            node.build(env.components.0.into_iter().collect()).map(drop)
-        })
-        .join()
-        .unwrap()
-    });
-
-    // Check that we cannot build the node without the core component.
-    let result = node_handle.await.expect("Building the node panicked");
-    let err = result.expect_err("Building the node with tree api but without tree should fail");
-    assert!(
-        err.to_string()
-            .contains("Merkle tree API cannot be started without a tree component"),
         "Unexpected errror: {}",
         err
     );

--- a/core/lib/merkle_tree/src/domain.rs
+++ b/core/lib/merkle_tree/src/domain.rs
@@ -13,6 +13,7 @@ use crate::{
         ValueHash, TREE_DEPTH,
     },
     BlockOutput, HashTree, MerkleTree, MerkleTreePruner, MerkleTreePrunerHandle, NoVersionError,
+    PruneDatabase,
 };
 
 impl TreeInstruction<StorageKey> {
@@ -458,6 +459,12 @@ impl ZkSyncTreeReader {
                 })
             })
             .collect()
+    }
+
+    /// Returns raw stale keys obsoleted in the specified version of the tree.
+    pub fn raw_stale_keys(&self, l1_batch_number: L1BatchNumber) -> Vec<NodeKey> {
+        let version = u64::from(l1_batch_number.0);
+        self.0.db.stale_keys(version)
     }
 
     /// Verifies consistency of the tree at the specified L1 batch number.

--- a/core/lib/merkle_tree/src/domain.rs
+++ b/core/lib/merkle_tree/src/domain.rs
@@ -9,8 +9,8 @@ use crate::{
     consistency::ConsistencyError,
     storage::{PatchSet, Patched, RocksDBWrapper},
     types::{
-        Key, Root, TreeEntry, TreeEntryWithProof, TreeInstruction, TreeLogEntry, ValueHash,
-        TREE_DEPTH,
+        Key, NodeKey, RawNode, Root, TreeEntry, TreeEntryWithProof, TreeInstruction, TreeLogEntry,
+        ValueHash, TREE_DEPTH,
     },
     BlockOutput, HashTree, MerkleTree, MerkleTreePruner, MerkleTreePrunerHandle, NoVersionError,
 };
@@ -442,6 +442,22 @@ impl ZkSyncTreeReader {
     ) -> Result<Vec<TreeEntryWithProof>, NoVersionError> {
         let version = u64::from(l1_batch_number.0);
         self.0.entries_with_proofs(version, keys)
+    }
+
+    /// Returns raw nodes for the specified `keys`.
+    pub fn raw_nodes(&self, keys: &[NodeKey]) -> Vec<Option<RawNode>> {
+        let raw_nodes = self.0.db.raw_nodes(keys).into_iter();
+        raw_nodes
+            .zip(keys)
+            .map(|(slice, key)| {
+                let slice = slice?;
+                Some(if key.is_empty() {
+                    RawNode::deserialize_root(&slice)
+                } else {
+                    RawNode::deserialize(&slice)
+                })
+            })
+            .collect()
     }
 
     /// Verifies consistency of the tree at the specified L1 batch number.

--- a/core/lib/merkle_tree/src/errors.rs
+++ b/core/lib/merkle_tree/src/errors.rs
@@ -22,6 +22,8 @@ pub enum DeserializeErrorKind {
     /// Bit mask specifying a child kind in an internal tree node is invalid.
     #[error("invalid bit mask specifying a child kind in an internal tree node")]
     InvalidChildKind,
+    #[error("data left after deserialization")]
+    Leftovers,
 
     /// Missing required tag in the tree manifest.
     #[error("missing required tag `{0}` in tree manifest")]

--- a/core/lib/merkle_tree/src/lib.rs
+++ b/core/lib/merkle_tree/src/lib.rs
@@ -82,7 +82,7 @@ mod utils;
 pub mod unstable {
     pub use crate::{
         errors::DeserializeError,
-        types::{Manifest, Node, NodeKey, ProfiledTreeOperation, Root},
+        types::{Manifest, Node, NodeKey, ProfiledTreeOperation, RawNode, Root},
     };
 }
 

--- a/core/lib/merkle_tree/src/types/mod.rs
+++ b/core/lib/merkle_tree/src/types/mod.rs
@@ -6,7 +6,7 @@ pub(crate) use self::internal::{
     ChildRef, Nibbles, NibblesBytes, StaleNodeKey, TreeTags, HASH_SIZE, KEY_SIZE, TREE_DEPTH,
 };
 pub use self::internal::{
-    InternalNode, LeafNode, Manifest, Node, NodeKey, ProfiledTreeOperation, Root,
+    InternalNode, LeafNode, Manifest, Node, NodeKey, ProfiledTreeOperation, RawNode, Root,
 };
 
 mod internal;

--- a/core/node/metadata_calculator/src/api_server/metrics.rs
+++ b/core/node/metadata_calculator/src/api_server/metrics.rs
@@ -10,6 +10,7 @@ pub(super) enum MerkleTreeApiMethod {
     Info,
     GetProofs,
     GetNodes,
+    GetStaleKeys,
 }
 
 /// Metrics for Merkle tree API.

--- a/core/node/metadata_calculator/src/api_server/metrics.rs
+++ b/core/node/metadata_calculator/src/api_server/metrics.rs
@@ -9,6 +9,7 @@ use vise::{Buckets, EncodeLabelSet, EncodeLabelValue, Family, Histogram, Metrics
 pub(super) enum MerkleTreeApiMethod {
     Info,
     GetProofs,
+    GetNodes,
 }
 
 /// Metrics for Merkle tree API.

--- a/core/node/metadata_calculator/src/api_server/mod.rs
+++ b/core/node/metadata_calculator/src/api_server/mod.rs
@@ -1,6 +1,6 @@
 //! Primitive Merkle tree API used internally to fetch proofs.
 
-use std::{fmt, future::Future, net::SocketAddr, pin::Pin};
+use std::{collections::HashMap, fmt, future::Future, net::SocketAddr, pin::Pin};
 
 use anyhow::Context as _;
 use async_trait::async_trait;
@@ -10,12 +10,16 @@ use axum::{
     response::{IntoResponse, Response},
     routing, Json, Router,
 };
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use tokio::sync::watch;
 use zksync_crypto_primitives::hasher::blake2::Blake2Hasher;
 use zksync_health_check::{CheckHealth, Health, HealthStatus};
-use zksync_merkle_tree::NoVersionError;
-use zksync_types::{L1BatchNumber, H256, U256};
+use zksync_merkle_tree::{
+    unstable::{NodeKey, RawNode},
+    NoVersionError, ValueHash,
+};
+use zksync_types::{web3, L1BatchNumber, H256, U256};
+use zksync_utils::u256_to_h256;
 
 use self::metrics::{MerkleTreeApiMethod, API_METRICS};
 use crate::{AsyncTreeReader, LazyAsyncTreeReader, MerkleTreeInfo};
@@ -75,6 +79,107 @@ impl TreeEntryWithProof {
         }
         .verify(&Blake2Hasher, trusted_root_hash)
     }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct HexNodeKey(NodeKey);
+
+impl Serialize for HexNodeKey {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.0.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for HexNodeKey {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct HexNodeKeyVisitor;
+
+        impl de::Visitor<'_> for HexNodeKeyVisitor {
+            type Value = HexNodeKey;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("hex-encoded versioned key like `123:c0ffee`")
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                v.parse().map(HexNodeKey).map_err(de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_str(HexNodeKeyVisitor)
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ApiLeafNode {
+    full_key: H256,
+    value_hash: H256,
+    leaf_index: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct ApiChildRef {
+    hash: ValueHash,
+    version: u64,
+    is_leaf: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(transparent)]
+struct ApiInternalNode(HashMap<char, ApiChildRef>);
+
+#[derive(Debug, Serialize)]
+struct ApiRawNode {
+    raw: web3::Bytes,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    leaf: Option<ApiLeafNode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    internal: Option<ApiInternalNode>,
+}
+
+impl From<RawNode> for ApiRawNode {
+    fn from(node: RawNode) -> Self {
+        Self {
+            raw: web3::Bytes(node.raw),
+            leaf: node.leaf.map(|leaf| ApiLeafNode {
+                full_key: u256_to_h256(leaf.full_key),
+                value_hash: leaf.value_hash,
+                leaf_index: leaf.leaf_index,
+            }),
+            internal: node.internal.map(|internal| {
+                ApiInternalNode(
+                    internal
+                        .children()
+                        .map(|(nibble, child_ref)| {
+                            let nibble = if nibble < 10 {
+                                b'0' + nibble
+                            } else {
+                                b'a' + nibble - 10
+                            };
+                            (
+                                char::from(nibble),
+                                ApiChildRef {
+                                    hash: child_ref.hash,
+                                    version: child_ref.version,
+                                    is_leaf: child_ref.is_leaf,
+                                },
+                            )
+                        })
+                        .collect(),
+                )
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct TreeNodesRequest {
+    keys: Vec<HexNodeKey>,
+}
+
+#[derive(Debug, Serialize)]
+struct TreeNodesResponse {
+    nodes: HashMap<HexNodeKey, ApiRawNode>,
 }
 
 /// Server-side tree API error.
@@ -343,6 +448,24 @@ impl AsyncTreeReader {
         Ok(Json(response))
     }
 
+    async fn get_nodes_handler(
+        State(this): State<Self>,
+        Json(request): Json<TreeNodesRequest>,
+    ) -> Json<TreeNodesResponse> {
+        let latency = API_METRICS.latency[&MerkleTreeApiMethod::GetNodes].start();
+        let keys: Vec<_> = request.keys.iter().map(|key| key.0).collect();
+        let nodes = this.clone().raw_nodes(keys).await;
+        let nodes = request
+            .keys
+            .into_iter()
+            .zip(nodes)
+            .filter_map(|(key, node)| Some((key, node?.into())))
+            .collect();
+        let response = TreeNodesResponse { nodes };
+        latency.observe();
+        Json(response)
+    }
+
     async fn create_api_server(
         self,
         bind_address: &SocketAddr,
@@ -353,6 +476,7 @@ impl AsyncTreeReader {
         let app = Router::new()
             .route("/", routing::get(Self::info_handler))
             .route("/proofs", routing::post(Self::get_proofs_handler))
+            .route("/debug/nodes", routing::post(Self::get_nodes_handler))
             .with_state(self);
 
         let listener = tokio::net::TcpListener::bind(bind_address)
@@ -369,8 +493,8 @@ impl AsyncTreeReader {
                 }
                 tracing::info!("Stop signal received, Merkle tree API server is shutting down");
             })
-                .await
-                .context("Merkle tree API server failed")?;
+            .await
+            .context("Merkle tree API server failed")?;
 
             tracing::info!("Merkle tree API server shut down");
             Ok(())

--- a/core/node/metadata_calculator/src/api_server/tests.rs
+++ b/core/node/metadata_calculator/src/api_server/tests.rs
@@ -72,9 +72,43 @@ async fn merkle_tree_api() {
     assert_eq!(err.version_count, 6);
     assert_eq!(err.missing_version, 10);
 
+    let raw_nodes_response = api_client
+        .inner
+        .post(format!("http://{local_addr}/debug/nodes"))
+        .json(&serde_json::json!({ "keys": ["0:", "0:0"] }))
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+    let raw_nodes_response: serde_json::Value = raw_nodes_response.json().await.unwrap();
+    assert_raw_nodes_response(&raw_nodes_response);
+
     // Stop the calculator and the tree API server.
     stop_sender.send_replace(true);
     api_server_task.await.unwrap().unwrap();
+}
+
+fn assert_raw_nodes_response(response: &serde_json::Value) {
+    let response = response.as_object().expect("not an object");
+    let response = response["nodes"].as_object().expect("not an object");
+    let root = response["0:"].as_object().expect("not an object");
+    assert!(
+        root.len() == 2 && root.contains_key("internal") && root.contains_key("raw"),
+        "{root:#?}"
+    );
+    let root = root["internal"].as_object().expect("not an object");
+    for key in root.keys() {
+        assert_eq!(key.len(), 1, "{key}");
+        let key = key.as_bytes()[0];
+        assert_matches!(key, b'0'..=b'9' | b'a'..=b'f');
+    }
+
+    let node = response["0:0"].as_object().expect("not an object");
+    assert!(
+        node.len() == 2 && node.contains_key("internal") && node.contains_key("raw"),
+        "{node:#?}"
+    );
 }
 
 #[tokio::test]

--- a/core/node/metadata_calculator/src/helpers.rs
+++ b/core/node/metadata_calculator/src/helpers.rs
@@ -22,6 +22,7 @@ use zksync_health_check::{CheckHealth, Health, HealthStatus, ReactiveHealthCheck
 use zksync_merkle_tree::{
     domain::{TreeMetadata, ZkSyncTree, ZkSyncTreeReader},
     recovery::{MerkleTreeRecovery, PersistenceThreadHandle},
+    unstable::{NodeKey, RawNode},
     Database, Key, MerkleTreeColumnFamily, NoVersionError, RocksDBWrapper, TreeEntry,
     TreeEntryWithProof, TreeInstruction,
 };
@@ -363,6 +364,12 @@ impl AsyncTreeReader {
         keys: Vec<Key>,
     ) -> Result<Vec<TreeEntryWithProof>, NoVersionError> {
         tokio::task::spawn_blocking(move || self.inner.entries_with_proofs(l1_batch_number, &keys))
+            .await
+            .unwrap()
+    }
+
+    pub(crate) async fn raw_nodes(self, keys: Vec<NodeKey>) -> Vec<Option<RawNode>> {
+        tokio::task::spawn_blocking(move || self.inner.raw_nodes(&keys))
             .await
             .unwrap()
     }

--- a/core/node/metadata_calculator/src/helpers.rs
+++ b/core/node/metadata_calculator/src/helpers.rs
@@ -414,6 +414,12 @@ impl AsyncTreeReader {
             .await
             .unwrap()
     }
+
+    pub(crate) async fn raw_stale_keys(self, l1_batch_number: L1BatchNumber) -> Vec<NodeKey> {
+        tokio::task::spawn_blocking(move || self.inner.raw_stale_keys(l1_batch_number))
+            .await
+            .unwrap()
+    }
 }
 
 /// Version of async tree reader that holds a weak reference to RocksDB. Used in [`MerkleTreeHealthCheck`].

--- a/core/node/metadata_calculator/src/helpers.rs
+++ b/core/node/metadata_calculator/src/helpers.rs
@@ -36,7 +36,7 @@ use zksync_types::{
 use super::{
     metrics::{LoadChangesStage, TreeUpdateStage, METRICS},
     pruning::PruningHandles,
-    MetadataCalculatorConfig, MetadataCalculatorRecoveryConfig,
+    MerkleTreeReaderConfig, MetadataCalculatorConfig, MetadataCalculatorRecoveryConfig,
 };
 
 /// General information about the Merkle tree.
@@ -177,6 +177,40 @@ fn create_db_sync(config: &MetadataCalculatorConfig) -> anyhow::Result<RocksDBWr
     Ok(db)
 }
 
+pub(super) async fn create_readonly_db(
+    config: MerkleTreeReaderConfig,
+) -> anyhow::Result<RocksDBWrapper> {
+    tokio::task::spawn_blocking(move || {
+        let MerkleTreeReaderConfig {
+            db_path,
+            max_open_files,
+            multi_get_chunk_size,
+            block_cache_capacity,
+            include_indices_and_filters_in_block_cache,
+        } = config;
+
+        tracing::info!(
+            "Initializing Merkle tree database at `{db_path}` (max open files: {max_open_files:?}) with {multi_get_chunk_size} multi-get chunk size, \
+             {block_cache_capacity}B block cache (indices & filters included: {include_indices_and_filters_in_block_cache:?})"
+        );
+        let mut db = RocksDB::with_options(
+            db_path.as_ref(),
+            RocksDBOptions {
+                block_cache_capacity: Some(block_cache_capacity),
+                include_indices_and_filters_in_block_cache,
+                max_open_files,
+                ..RocksDBOptions::default()
+            }
+        )?;
+        if cfg!(test) {
+            db = db.with_sync_writes();
+        }
+        Ok(RocksDBWrapper::from(db))
+    })
+    .await
+    .context("panicked creating Merkle tree RocksDB")?
+}
+
 /// Wrapper around the "main" tree implementation used by [`MetadataCalculator`].
 ///
 /// Async methods provided by this wrapper are not cancel-safe! This is probably not an issue;
@@ -308,6 +342,13 @@ pub struct AsyncTreeReader {
 }
 
 impl AsyncTreeReader {
+    pub(super) fn new(db: RocksDBWrapper, mode: MerkleTreeMode) -> anyhow::Result<Self> {
+        Ok(Self {
+            inner: ZkSyncTreeReader::new(db)?,
+            mode,
+        })
+    }
+
     fn downgrade(&self) -> WeakAsyncTreeReader {
         WeakAsyncTreeReader {
             db: self.inner.db().clone().into_inner().downgrade(),

--- a/core/node/node_framework/src/implementations/layers/metadata_calculator.rs
+++ b/core/node/node_framework/src/implementations/layers/metadata_calculator.rs
@@ -7,7 +7,8 @@ use std::{
 use anyhow::Context as _;
 use zksync_config::configs::{api::MerkleTreeApiConfig, database::MerkleTreeMode};
 use zksync_metadata_calculator::{
-    LazyAsyncTreeReader, MerkleTreePruningTask, MetadataCalculator, MetadataCalculatorConfig,
+    LazyAsyncTreeReader, MerkleTreePruningTask, MerkleTreeReaderConfig, MetadataCalculator,
+    MetadataCalculatorConfig, TreeReaderTask,
 };
 use zksync_storage::RocksDB;
 
@@ -19,7 +20,7 @@ use crate::{
         web3_api::TreeApiClientResource,
     },
     service::{ShutdownHook, StopReceiver},
-    task::{Task, TaskId},
+    task::{Task, TaskId, TaskKind},
     wiring_layer::{WiringError, WiringLayer},
     FromContext, IntoContext,
 };
@@ -199,6 +200,68 @@ impl Task for TreeApiTask {
 impl Task for MerkleTreePruningTask {
     fn id(&self) -> TaskId {
         "merkle_tree_pruning_task".into()
+    }
+
+    async fn run(self: Box<Self>, stop_receiver: StopReceiver) -> anyhow::Result<()> {
+        (*self).run(stop_receiver.0).await
+    }
+}
+
+/// Mutually exclusive with [`MetadataCalculatorLayer`].
+#[derive(Debug)]
+pub struct TreeApiServerLayer {
+    config: MerkleTreeReaderConfig,
+    api_config: MerkleTreeApiConfig,
+}
+
+impl TreeApiServerLayer {
+    pub fn new(config: MerkleTreeReaderConfig, api_config: MerkleTreeApiConfig) -> Self {
+        Self { config, api_config }
+    }
+}
+
+#[derive(Debug, IntoContext)]
+#[context(crate = crate)]
+pub struct TreeApiServerOutput {
+    tree_api_client: TreeApiClientResource,
+    #[context(task)]
+    tree_reader_task: TreeReaderTask,
+    #[context(task)]
+    tree_api_task: TreeApiTask,
+}
+
+#[async_trait::async_trait]
+impl WiringLayer for TreeApiServerLayer {
+    type Input = ();
+    type Output = TreeApiServerOutput;
+
+    fn layer_name(&self) -> &'static str {
+        "tree_api_server"
+    }
+
+    async fn wire(self, (): Self::Input) -> Result<Self::Output, WiringError> {
+        let tree_reader_task = TreeReaderTask::new(self.config);
+        let bind_addr = (Ipv4Addr::UNSPECIFIED, self.api_config.port).into();
+        let tree_api_task = TreeApiTask {
+            bind_addr,
+            tree_reader: tree_reader_task.tree_reader(),
+        };
+        Ok(TreeApiServerOutput {
+            tree_api_client: TreeApiClientResource(Arc::new(tree_reader_task.tree_reader())),
+            tree_api_task,
+            tree_reader_task,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Task for TreeReaderTask {
+    fn kind(&self) -> TaskKind {
+        TaskKind::OneshotTask
+    }
+
+    fn id(&self) -> TaskId {
+        "merkle_tree_reader_task".into()
     }
 
     async fn run(self: Box<Self>, stop_receiver: StopReceiver) -> anyhow::Result<()> {


### PR DESCRIPTION
## What ❔

- Adds `/debug/nodes` and `/debug/stale-keys` endpoints for tree API to debug tree-related incidents.
- Allows to run tree API on EN without a tree.

## Why ❔

Allows investigating tree-related incidents easier. Allowing to run tree API without a tree potentially improves UX / DevEx.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.