### PR TITLE
feat(api): get rid of tx receipt root

### DIFF
--- a/core/lib/dal/src/models/storage_transaction.rs
+++ b/core/lib/dal/src/models/storage_transaction.rs
@@ -392,7 +392,6 @@ impl From<StorageTransactionReceipt> for TransactionReceipt {
             logs: vec![],
             l2_to_l1_logs: vec![],
             status,
-            root: block_hash,
             logs_bloom: Default::default(),
             // Even though the Rust SDK recommends us to supply "None" for legacy transactions
             // we always supply some number anyway to have the same behavior as most popular RPCs

--- a/core/lib/types/src/api/mod.rs
+++ b/core/lib/types/src/api/mod.rs
@@ -257,8 +257,6 @@ pub struct TransactionReceipt {
     pub l2_to_l1_logs: Vec<L2ToL1Log>,
     /// Status: either 1 (success) or 0 (failure).
     pub status: U64,
-    /// State root.
-    pub root: H256,
     /// Logs bloom
     #[serde(rename = "logsBloom")]
     pub logs_bloom: Bloom,


### PR DESCRIPTION
## What ❔

Transaction receipt `root` was replaced by `status` in [EIP658](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-658.md). Since we already return `status` there is no need in having `root` too.

Fixes #3188 

## Why ❔

It is actively harmful as it confuses some ETH tooling that considers having both `status` and `root` at the same time an invalid receipt.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
