### PR TITLE
fix(da-clients): add padding to the data within EigenDA blob

### DIFF
--- a/core/node/da_clients/Cargo.toml
+++ b/core/node/da_clients/Cargo.toml
@@ -50,7 +50,7 @@ sha2.workspace = true
 prost.workspace = true
 bech32.workspace = true
 ripemd.workspace = true
-tonic = { workspace = true, features = ["tls", "tls-roots", "prost", "codegen"] }
+tonic = { workspace = true, features = ["tls-roots", "prost", "codegen"] }
 pbjson-types.workspace = true
 
 # Eigen dependencies


### PR DESCRIPTION
## What ❔

Add the padding to the blob data in EigenDA client

## Why ❔

The unpadded larger blobs can't be decoded by the EigenDA disperser.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
