### PR TITLE
chore: make artificially shortened executions count as successes

### DIFF
--- a/core/lib/multivm/src/versions/vm_latest/tracers/default_tracers.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tracers/default_tracers.rs
@@ -230,7 +230,7 @@ impl<S: WriteStorage, H: HistoryMode> Tracer for DefaultExecutionTracer<S, H> {
         match hook {
             VmHook::TxHasEnded if matches!(self.execution_mode, VmExecutionMode::OneTx) => {
                 self.result_tracer.tx_finished_in_one_tx_mode = true;
-                self.tx_has_been_processed = true
+                self.tx_has_been_processed = true;
             }
             VmHook::NoValidationEntered => self.in_account_validation = false,
             VmHook::AccountValidationEntered => self.in_account_validation = true,

--- a/core/lib/multivm/src/versions/vm_latest/tracers/default_tracers.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tracers/default_tracers.rs
@@ -228,7 +228,10 @@ impl<S: WriteStorage, H: HistoryMode> Tracer for DefaultExecutionTracer<S, H> {
         );
 
         match hook {
-            VmHook::TxHasEnded => self.tx_has_been_processed = true,
+            VmHook::TxHasEnded if matches!(self.execution_mode, VmExecutionMode::OneTx) => {
+                self.result_tracer.tx_finished_in_one_tx_mode = true;
+                self.tx_has_been_processed = true
+            }
             VmHook::NoValidationEntered => self.in_account_validation = false,
             VmHook::AccountValidationEntered => self.in_account_validation = true,
             VmHook::FinalBatchInfo => self.final_batch_info_requested = true,

--- a/core/lib/multivm/src/versions/vm_latest/tracers/result_tracer.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tracers/result_tracer.rs
@@ -306,9 +306,9 @@ impl<S: WriteStorage> ResultTracer<S> {
                     },
                 });
             } else {
-                self.result = Some(self.result.clone().unwrap_or(Result::Success {
+                self.result = Some(Result::Success {
                     return_data: vec![],
-                }));
+                });
             }
         }
     }

--- a/core/lib/multivm/src/versions/vm_latest/tracers/result_tracer.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tracers/result_tracer.rs
@@ -104,6 +104,8 @@ pub(crate) struct ResultTracer<S> {
     far_call_tracker: FarCallTracker,
     subversion: MultiVMSubversion,
 
+    pub(crate) tx_finished_in_one_tx_mode: bool,
+
     _phantom: PhantomData<S>,
 }
 
@@ -115,6 +117,7 @@ impl<S> ResultTracer<S> {
             execution_mode,
             far_call_tracker: Default::default(),
             subversion,
+            tx_finished_in_one_tx_mode: false,
             _phantom: PhantomData,
         }
     }
@@ -297,7 +300,7 @@ impl<S: WriteStorage> ResultTracer<S> {
 
             let has_failed =
                 tx_has_failed(state, bootloader_state.current_tx() as u32, self.subversion);
-            if has_failed {
+            if self.tx_finished_in_one_tx_mode && has_failed {
                 self.result = Some(Result::Error {
                     error_reason: VmRevertReason::General {
                         msg: "Transaction reverted with empty reason. Possibly out of gas"


### PR DESCRIPTION
Currently, successful validations are reported as reverts, which is super confusing.

Why this is safe:
- `TracerExecutionStopReason::Finished` is only emitted on success, Errors always emit Abort instead
- Some of the removed code was just dead code. `self.result` was checked twice.

I'd rather fix the strange behaviour than emulate it to make ShadowVm line up.