### PR TITLE
ci: Change schedule to monthly and add grouping to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,13 @@
 {
-  "extends": ["config:base", "schedule:earlyMondays","helpers:pinGitHubActionDigests"],
+  "extends": ["config:base", "helpers:pinGitHubActionDigests"],
   "enabledManagers": ["github-actions"],
-  "prCreation": "immediate"
+  "prCreation": "not-pending",
+  "groupName": "github actions monthly updates",
+  "schedule": ["monthly"],
+  "packageRules": [
+    {
+      "managers": ["github-actions"],
+      "groupName": "all-github-actions-updates"
+    }
+  ]
 }


### PR DESCRIPTION
## What ❔
Change renovatebot pr schedule to monthly and grouping changes in one PR.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔
Do not have a lot of PR's and save time to merge them and test.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
