### PR TITLE
fix: use_dummy_inclusion_data condition

### DIFF
--- a/core/node/da_dispatcher/src/da_dispatcher.rs
+++ b/core/node/da_dispatcher/src/da_dispatcher.rs
@@ -137,6 +137,8 @@ impl DataAvailabilityDispatcher {
         };
 
         let inclusion_data = if self.config.use_dummy_inclusion_data() {
+            Some(InclusionData { data: vec![] })
+        } else {
             self.client
                 .get_inclusion_data(blob_info.blob_id.as_str())
                 .await
@@ -146,10 +148,6 @@ impl DataAvailabilityDispatcher {
                         blob_info.blob_id, blob_info.l1_batch_number
                     )
                 })?
-        } else {
-            // if the inclusion verification is disabled, we don't need to wait for the inclusion
-            // data before committing the batch, so simply return an empty vector
-            Some(InclusionData { data: vec![] })
         };
 
         let Some(inclusion_data) = inclusion_data else {


### PR DESCRIPTION
## What ❔

Fix invalid `if` usage for `use_dummy_inclusion_data` flag.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
