### PR TITLE
chore: ignore derivative advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,7 @@ ignore = [
     "RUSTSEC-2021-0145",
     "RUSTSEC-2021-0139",
     "RUSTSEC-2024-0375",
+    "RUSTSEC-2024-0388", # `derivative` is unmaintained, crypto dependenicies (boojum, circuit_encodings and others) rely on it
 ]
 
 [licenses]


### PR DESCRIPTION
## What ❔

Ignores RUSTSEC advisory for `derivative` crate being unmaintained

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
