### PR TITLE
feat(contract-verifier): Support Vyper toolchain for EVM bytecodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10820,6 +10820,7 @@ name = "zksync_contract_verifier_lib"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "chrono",
  "ethabi",
  "hex",

--- a/core/lib/contract_verifier/Cargo.toml
+++ b/core/lib/contract_verifier/Cargo.toml
@@ -34,4 +34,6 @@ semver.workspace = true
 [dev-dependencies]
 zksync_node_test_utils.workspace = true
 zksync_vm_interface.workspace = true
+
+assert_matches.workspace = true
 test-casing.workspace = true

--- a/core/lib/contract_verifier/src/compilers/mod.rs
+++ b/core/lib/contract_verifier/src/compilers/mod.rs
@@ -117,8 +117,12 @@ fn parse_standard_json_output(
         None
     };
 
-    let abi = contract["abi"].clone();
-    if !abi.is_array() {
+    let mut abi = contract["abi"].clone();
+    if abi.is_null() {
+        // ABI is undefined for Yul contracts when compiled with standalone `solc`. For uniformity with `zksolc`,
+        // replace it with an empty array.
+        abi = serde_json::json!([]);
+    } else if !abi.is_array() {
         let err = anyhow::anyhow!(
             "unexpected value for ABI: {}",
             serde_json::to_string_pretty(&abi).unwrap()

--- a/core/lib/contract_verifier/src/compilers/mod.rs
+++ b/core/lib/contract_verifier/src/compilers/mod.rs
@@ -1,17 +1,39 @@
+use std::collections::HashMap;
+
 use anyhow::Context as _;
 use serde::{Deserialize, Serialize};
 use zksync_types::contract_verification_api::CompilationArtifacts;
 
 pub(crate) use self::{
     solc::{Solc, SolcInput},
+    vyper::{Vyper, VyperInput},
     zksolc::{ZkSolc, ZkSolcInput},
-    zkvyper::{ZkVyper, ZkVyperInput},
+    zkvyper::ZkVyper,
 };
 use crate::error::ContractVerifierError;
 
 mod solc;
+mod vyper;
 mod zksolc;
 mod zkvyper;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct StandardJson {
+    pub language: String,
+    pub sources: HashMap<String, Source>,
+    settings: Settings,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Settings {
+    /// The output selection filters.
+    output_selection: Option<serde_json::Value>,
+    /// Other settings (only filled when parsing `StandardJson` input from the request).
+    #[serde(flatten)]
+    other: serde_json::Value,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/core/lib/contract_verifier/src/compilers/mod.rs
+++ b/core/lib/contract_verifier/src/compilers/mod.rs
@@ -77,7 +77,6 @@ fn parse_standard_json_output(
             .iter()
             .any(|err| err["severity"].as_str() == Some("error"))
         {
-            // FIXME: collected messages contain warnings as well; is this intentional?
             let error_messages = errors
                 .into_iter()
                 .filter_map(|err| {

--- a/core/lib/contract_verifier/src/compilers/mod.rs
+++ b/core/lib/contract_verifier/src/compilers/mod.rs
@@ -22,6 +22,7 @@ mod zkvyper;
 pub(crate) struct StandardJson {
     pub language: String,
     pub sources: HashMap<String, Source>,
+    #[serde(default)]
     settings: Settings,
 }
 
@@ -33,6 +34,15 @@ struct Settings {
     /// Other settings (only filled when parsing `StandardJson` input from the request).
     #[serde(flatten)]
     other: serde_json::Value,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            output_selection: None,
+            other: serde_json::json!({}),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/core/lib/contract_verifier/src/compilers/solc.rs
+++ b/core/lib/contract_verifier/src/compilers/solc.rs
@@ -7,7 +7,7 @@ use zksync_types::contract_verification_api::{
     CompilationArtifacts, SourceCodeData, VerificationIncomingRequest,
 };
 
-use super::{parse_standard_json_output, Settings, Source, StandardJson};
+use super::{parse_standard_json_output, process_contract_name, Settings, Source, StandardJson};
 use crate::{error::ContractVerifierError, resolver::Compiler};
 
 // Here and below, fields are public for testing purposes.
@@ -31,17 +31,7 @@ impl Solc {
     pub fn build_input(
         req: VerificationIncomingRequest,
     ) -> Result<SolcInput, ContractVerifierError> {
-        // Users may provide either just contract name or
-        // source file name and contract name joined with ":".
-        let (file_name, contract_name) =
-            if let Some((file_name, contract_name)) = req.contract_name.rsplit_once(':') {
-                (file_name.to_string(), contract_name.to_string())
-            } else {
-                (
-                    format!("{}.sol", req.contract_name),
-                    req.contract_name.clone(),
-                )
-            };
+        let (file_name, contract_name) = process_contract_name(&req.contract_name, "sol");
         let default_output_selection = serde_json::json!({
             "*": {
                 "*": [ "abi", "evm.bytecode", "evm.deployedBytecode" ],

--- a/core/lib/contract_verifier/src/compilers/solc.rs
+++ b/core/lib/contract_verifier/src/compilers/solc.rs
@@ -1,14 +1,13 @@
 use std::{collections::HashMap, path::PathBuf, process::Stdio};
 
 use anyhow::Context;
-use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
 use zksync_queued_job_processor::async_trait;
 use zksync_types::contract_verification_api::{
     CompilationArtifacts, SourceCodeData, VerificationIncomingRequest,
 };
 
-use super::{parse_standard_json_output, Source};
+use super::{parse_standard_json_output, Settings, Source, StandardJson};
 use crate::{error::ContractVerifierError, resolver::Compiler};
 
 // Here and below, fields are public for testing purposes.
@@ -17,24 +16,6 @@ pub(crate) struct SolcInput {
     pub standard_json: StandardJson,
     pub contract_name: String,
     pub file_name: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct StandardJson {
-    pub language: String,
-    pub sources: HashMap<String, Source>,
-    settings: Settings,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct Settings {
-    /// The output selection filters.
-    output_selection: Option<serde_json::Value>,
-    /// Other settings (only filled when parsing `StandardJson` input from the request).
-    #[serde(flatten)]
-    other: serde_json::Value,
 }
 
 #[derive(Debug)]

--- a/core/lib/contract_verifier/src/compilers/vyper.rs
+++ b/core/lib/contract_verifier/src/compilers/vyper.rs
@@ -31,7 +31,6 @@ impl VyperInput {
             file_name,
             sources,
             optimizer_mode: if req.optimization_used {
-                // FIXME: values have differing semantics compared to other compilers; is this OK?
                 req.optimizer_mode
             } else {
                 // `none` mode is not the default mode (which is `gas`), so we must specify it explicitly here

--- a/core/lib/contract_verifier/src/compilers/vyper.rs
+++ b/core/lib/contract_verifier/src/compilers/vyper.rs
@@ -1,0 +1,114 @@
+use std::{collections::HashMap, path::PathBuf, process::Stdio};
+
+use anyhow::Context;
+use tokio::io::AsyncWriteExt;
+use zksync_queued_job_processor::async_trait;
+use zksync_types::contract_verification_api::{
+    CompilationArtifacts, SourceCodeData, VerificationIncomingRequest,
+};
+
+use super::{Settings, Source, StandardJson};
+use crate::{error::ContractVerifierError, resolver::Compiler};
+
+#[derive(Debug)]
+pub(crate) struct VyperInput {
+    pub contract_name: String,
+    pub sources: HashMap<String, String>,
+    pub optimizer_mode: Option<String>,
+}
+
+impl VyperInput {
+    pub fn new(req: VerificationIncomingRequest) -> Result<Self, ContractVerifierError> {
+        // Users may provide either just contract name or
+        // source file name and contract name joined with ":".
+        let contract_name = if let Some((_, contract_name)) = req.contract_name.rsplit_once(':') {
+            contract_name.to_owned()
+        } else {
+            req.contract_name.clone()
+        };
+
+        let sources = match req.source_code_data {
+            SourceCodeData::VyperMultiFile(s) => s,
+            other => unreachable!("unexpected `SourceCodeData` variant: {other:?}"),
+        };
+        Ok(Self {
+            contract_name,
+            sources,
+            optimizer_mode: req.optimizer_mode,
+        })
+    }
+
+    fn standard_json(self) -> StandardJson {
+        let sources = self
+            .sources
+            .into_iter()
+            .map(|(name, content)| (name, Source { content }));
+
+        StandardJson {
+            language: "Vyper".to_owned(),
+            sources: sources.collect(),
+            settings: Settings {
+                output_selection: Some(serde_json::json!({
+                    "*": [ "abi", "evm.bytecode", "evm.deployedBytecode" ],
+                     "": [ "abi", "evm.bytecode", "evm.deployedBytecode" ],
+                })),
+                other: serde_json::json!({}),
+            },
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Vyper {
+    path: PathBuf,
+}
+
+impl Vyper {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+#[async_trait]
+impl Compiler<VyperInput> for Vyper {
+    async fn compile(
+        self: Box<Self>,
+        input: VyperInput,
+    ) -> Result<CompilationArtifacts, ContractVerifierError> {
+        let mut command = tokio::process::Command::new(&self.path);
+        let mut child = command
+            .arg("--standard-json")
+            .arg("-f")
+            .arg("combined_json")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .context("cannot spawn vyper")?;
+        let mut stdin = child.stdin.take().unwrap();
+        let standard_json = input.standard_json();
+        let content = serde_json::to_vec(&standard_json)
+            .context("cannot encode standard JSON input for vyper")?;
+        stdin
+            .write_all(&content)
+            .await
+            .context("failed writing standard JSON to vyper stdin")?;
+        stdin
+            .flush()
+            .await
+            .context("failed flushing standard JSON to vyper")?;
+        drop(stdin);
+
+        let output = child.wait_with_output().await.context("vyper failed")?;
+        if output.status.success() {
+            let output: serde_json::Value =
+                serde_json::from_slice(&output.stdout).context("vyper output is not valid JSON")?;
+            panic!("{output:?}");
+        } else {
+            Err(ContractVerifierError::CompilerError(
+                "vyper",
+                String::from_utf8_lossy(&output.stderr).to_string(),
+            ))
+        }
+    }
+}

--- a/core/lib/contract_verifier/src/compilers/zksolc.rs
+++ b/core/lib/contract_verifier/src/compilers/zksolc.rs
@@ -10,7 +10,7 @@ use zksync_types::contract_verification_api::{
     CompilationArtifacts, SourceCodeData, VerificationIncomingRequest,
 };
 
-use super::{parse_standard_json_output, Source};
+use super::{parse_standard_json_output, process_contract_name, Source};
 use crate::{
     error::ContractVerifierError,
     resolver::{Compiler, CompilerPaths},
@@ -85,17 +85,7 @@ impl ZkSolc {
     pub fn build_input(
         req: VerificationIncomingRequest,
     ) -> Result<ZkSolcInput, ContractVerifierError> {
-        // Users may provide either just contract name or
-        // source file name and contract name joined with ":".
-        let (file_name, contract_name) =
-            if let Some((file_name, contract_name)) = req.contract_name.rsplit_once(':') {
-                (file_name.to_string(), contract_name.to_string())
-            } else {
-                (
-                    format!("{}.sol", req.contract_name),
-                    req.contract_name.clone(),
-                )
-            };
+        let (file_name, contract_name) = process_contract_name(&req.contract_name, "sol");
         let default_output_selection = serde_json::json!({
             "*": {
                 "*": [ "abi" ],

--- a/core/lib/contract_verifier/src/compilers/zkvyper.rs
+++ b/core/lib/contract_verifier/src/compilers/zkvyper.rs
@@ -22,14 +22,7 @@ impl VyperInput {
 
             let path = root_dir.join(&name);
             if let Some(prefix) = path.parent() {
-                let canonical_prefix = fs::canonicalize(prefix)
-                    .await
-                    .context("failed to canonicalize path prefix")?;
-                anyhow::ensure!(
-                    canonical_prefix.starts_with(root_dir),
-                    "Invalid contract name: {name}"
-                );
-
+                // FIXME: needs to be sanitized (e.g., absolute /name, ../../../etc/shadow)
                 fs::create_dir_all(prefix)
                     .await
                     .with_context(|| format!("failed creating parent dir for `{name}`"))?;

--- a/core/lib/contract_verifier/src/tests/mod.rs
+++ b/core/lib/contract_verifier/src/tests/mod.rs
@@ -55,6 +55,19 @@ const COUNTER_CONTRACT_WITH_CONSTRUCTOR: &str = r#"
         }
     }
 "#;
+const COUNTER_CONTRACT_WITH_INTERFACE: &str = r#"
+    interface ICounter {
+        function increment(uint256 x) external;
+    }
+
+    contract Counter is ICounter {
+        uint256 value;
+
+        function increment(uint256 x) external override {
+            value += x;
+        }
+    }
+"#;
 const COUNTER_VYPER_CONTRACT: &str = r#"
 #pragma version ^0.3.10
 

--- a/core/lib/contract_verifier/src/tests/mod.rs
+++ b/core/lib/contract_verifier/src/tests/mod.rs
@@ -157,7 +157,7 @@ async fn mock_evm_deployment(
     calldata.extend_from_slice(&ethabi::encode(constructor_args));
     let deployment = Execute {
         contract_address: None,
-        calldata, // FIXME: check
+        calldata,
         value: 0.into(),
         factory_deps: vec![],
     };

--- a/core/lib/contract_verifier/src/tests/mod.rs
+++ b/core/lib/contract_verifier/src/tests/mod.rs
@@ -55,6 +55,15 @@ const COUNTER_CONTRACT_WITH_CONSTRUCTOR: &str = r#"
         }
     }
 "#;
+const COUNTER_VYPER_CONTRACT: &str = r#"
+#pragma version ^0.3.10
+
+value: uint256
+
+@external
+def increment(x: uint256):
+    self.value += x
+"#;
 
 #[derive(Debug, Clone, Copy)]
 enum TestContract {

--- a/core/lib/contract_verifier/src/tests/mod.rs
+++ b/core/lib/contract_verifier/src/tests/mod.rs
@@ -22,7 +22,7 @@ use zksync_vm_interface::{tracer::ValidationTraces, TransactionExecutionMetrics,
 
 use super::*;
 use crate::{
-    compilers::{SolcInput, ZkSolcInput, ZkVyperInput},
+    compilers::{SolcInput, VyperInput, ZkSolcInput},
     resolver::{Compiler, SupportedCompilerVersions},
 };
 
@@ -306,10 +306,17 @@ impl CompilerResolver for MockCompilerResolver {
         Ok(Box::new(self.clone()))
     }
 
+    async fn resolve_vyper(
+        &self,
+        _version: &str,
+    ) -> Result<Box<dyn Compiler<VyperInput>>, ContractVerifierError> {
+        unreachable!("not tested")
+    }
+
     async fn resolve_zkvyper(
         &self,
         _version: &ZkCompilerVersions,
-    ) -> Result<Box<dyn Compiler<ZkVyperInput>>, ContractVerifierError> {
+    ) -> Result<Box<dyn Compiler<VyperInput>>, ContractVerifierError> {
         unreachable!("not tested")
     }
 }

--- a/core/lib/contract_verifier/src/tests/mod.rs
+++ b/core/lib/contract_verifier/src/tests/mod.rs
@@ -64,6 +64,17 @@ value: uint256
 def increment(x: uint256):
     self.value += x
 "#;
+const EMPTY_YUL_CONTRACT: &str = r#"
+object "Empty" {
+    code {
+        mstore(0, 0)
+        return(0, 32)
+    }
+    object "Empty_deployed" {
+        code { }
+    }
+}
+"#;
 
 #[derive(Debug, Clone, Copy)]
 enum TestContract {

--- a/core/lib/contract_verifier/src/tests/real.rs
+++ b/core/lib/contract_verifier/src/tests/real.rs
@@ -152,7 +152,7 @@ async fn using_real_zkvyper() {
         )])),
         ..test_request(Address::repeat_byte(1), COUNTER_CONTRACT)
     };
-    let input = ZkVyper::build_input(req).unwrap();
+    let input = VyperInput::new(req).unwrap();
     let output = compiler.compile(input).await.unwrap();
 
     validate_bytecode(&output.bytecode).unwrap();

--- a/core/lib/types/src/contract_verification_api.rs
+++ b/core/lib/types/src/contract_verification_api.rs
@@ -137,6 +137,8 @@ pub struct VerificationIncomingRequest {
     #[serde(flatten)]
     pub compiler_versions: CompilerVersions,
     pub optimization_used: bool,
+    /// Optimization mode used for the contract. Semantics depends on the compiler used; e.g., for `vyper`,
+    /// allowed values are `gas` (default), `codesize` or `none`.
     pub optimizer_mode: Option<String>,
     #[serde(default)]
     pub constructor_arguments: Bytes,


### PR DESCRIPTION
## What ❔

- Supports the Vyper toolchain for EVM bytecodes in the contract verifier.
- Adds some more unit tests for the verifier (e.g., testing multi-file inputs, Yul contracts, abstract contract errors etc.).

## Why ❔

Part of preparations to support EVM bytecodes throughout the codebase.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.