### PR TITLE
feat(en): remove `user_facing_*` addresses

### DIFF
--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -101,11 +101,11 @@ impl ConfigurationSource for Environment {
 /// This part of the external node config is fetched directly from the main node.
 #[derive(Debug, Deserialize)]
 pub(crate) struct RemoteENConfig {
-    pub bridgehub_proxy_addr: Option<Address>,
-    pub state_transition_proxy_addr: Option<Address>,
-    pub transparent_proxy_admin_addr: Option<Address>,
-    /// Should not be accessed directly. Use [`ExternalNodeConfig::diamond_proxy_address`] instead.
-    pub user_facing_diamond_proxy: Address,
+    pub l1_bridgehub_proxy_addr: Option<Address>,
+    pub l1_state_transition_proxy_addr: Option<Address>,
+    pub l1_transparent_proxy_admin_addr: Option<Address>,
+    /// Should not be accessed directly. Use [`ExternalNodeConfig::l1_diamond_proxy_address`] instead.
+    pub l1_diamond_proxy_addr: Address,
     // While on L1 shared bridge and legacy bridge are different contracts with different addresses,
     // the `l2_erc20_bridge_addr` and `l2_shared_bridge_addr` are basically the same contract, but with
     // a different name, with names adapted only for consistency.
@@ -124,8 +124,6 @@ pub(crate) struct RemoteENConfig {
     pub base_token_addr: Address,
     pub l1_batch_commit_data_generator_mode: L1BatchCommitmentMode,
     pub dummy_verifier: bool,
-
-    pub user_facing_bridgehub: Option<Address>,
 }
 
 impl RemoteENConfig {
@@ -144,14 +142,9 @@ impl RemoteENConfig {
             .rpc_context("ecosystem_contracts")
             .await
             .ok();
-        let user_facing_diamond_proxy = client
+        let l1_diamond_proxy_addr = client
             .get_main_contract()
             .rpc_context("get_main_contract")
-            .await?;
-
-        let user_facing_bridgehub = client
-            .get_bridgehub_contract()
-            .rpc_context("get_bridgehub_contract")
             .await?;
 
         let base_token_addr = match client.get_base_token_l1_address().await {
@@ -189,15 +182,14 @@ impl RemoteENConfig {
         }
 
         Ok(Self {
-            bridgehub_proxy_addr: ecosystem_contracts.as_ref().map(|a| a.bridgehub_proxy_addr),
-            state_transition_proxy_addr: ecosystem_contracts
+            l1_bridgehub_proxy_addr: ecosystem_contracts.as_ref().map(|a| a.bridgehub_proxy_addr),
+            l1_state_transition_proxy_addr: ecosystem_contracts
                 .as_ref()
                 .map(|a| a.state_transition_proxy_addr),
-            transparent_proxy_admin_addr: ecosystem_contracts
+            l1_transparent_proxy_admin_addr: ecosystem_contracts
                 .as_ref()
                 .map(|a| a.transparent_proxy_admin_addr),
-            user_facing_diamond_proxy,
-            user_facing_bridgehub,
+            l1_diamond_proxy_addr,
             l2_testnet_paymaster_addr,
             l1_erc20_bridge_proxy_addr: bridges.l1_erc20_default_bridge,
             l2_erc20_bridge_addr: l2_erc20_default_bridge,
@@ -221,11 +213,10 @@ impl RemoteENConfig {
     #[cfg(test)]
     fn mock() -> Self {
         Self {
-            bridgehub_proxy_addr: None,
-            state_transition_proxy_addr: None,
-            transparent_proxy_admin_addr: None,
-            user_facing_diamond_proxy: Address::repeat_byte(1),
-            user_facing_bridgehub: None,
+            l1_bridgehub_proxy_addr: None,
+            l1_state_transition_proxy_addr: None,
+            l1_transparent_proxy_admin_addr: None,
+            l1_diamond_proxy_addr: Address::repeat_byte(1),
             l1_erc20_bridge_proxy_addr: Some(Address::repeat_byte(2)),
             l2_erc20_bridge_addr: Some(Address::repeat_byte(3)),
             l2_weth_bridge_addr: None,
@@ -1353,16 +1344,16 @@ impl ExternalNodeConfig<()> {
         let remote = RemoteENConfig::fetch(main_node_client)
             .await
             .context("Unable to fetch required config values from the main node")?;
-        let remote_diamond_proxy_addr = remote.user_facing_diamond_proxy;
+        let remote_diamond_proxy_addr = remote.l1_diamond_proxy_addr;
         if let Some(local_diamond_proxy_addr) = self.optional.contracts_diamond_proxy_addr {
             anyhow::ensure!(
                 local_diamond_proxy_addr == remote_diamond_proxy_addr,
-                "Diamond proxy address {local_diamond_proxy_addr:?} specified in config doesn't match one returned \
+                "L1 diamond proxy address {local_diamond_proxy_addr:?} specified in config doesn't match one returned \
                 by main node ({remote_diamond_proxy_addr:?})"
             );
         } else {
             tracing::info!(
-                "Diamond proxy address is not specified in config; will use address \
+                "L1 diamond proxy address is not specified in config; will use address \
                 returned by main node: {remote_diamond_proxy_addr:?}"
             );
         }
@@ -1400,15 +1391,14 @@ impl ExternalNodeConfig {
         }
     }
 
-    /// Returns a verified diamond proxy address.
+    /// Returns verified L1 diamond proxy address.
     /// If local configuration contains the address, it will be checked against the one returned by the main node.
     /// Otherwise, the remote value will be used. However, using remote value has trust implications for the main
     /// node so relying on it solely is not recommended.
-    /// FIXME: This method is not used as of now, it should be used just like in the main branch
-    pub fn _diamond_proxy_address(&self) -> Address {
+    pub fn l1_diamond_proxy_address(&self) -> Address {
         self.optional
             .contracts_diamond_proxy_addr
-            .unwrap_or(self.remote.user_facing_diamond_proxy)
+            .unwrap_or(self.remote.l1_diamond_proxy_addr)
     }
 }
 
@@ -1435,11 +1425,10 @@ impl From<&ExternalNodeConfig> for InternalApiConfig {
                 l1_weth_bridge: config.remote.l1_weth_bridge_addr,
                 l2_weth_bridge: config.remote.l2_weth_bridge_addr,
             },
-            bridgehub_proxy_addr: config.remote.bridgehub_proxy_addr,
-            state_transition_proxy_addr: config.remote.state_transition_proxy_addr,
-            transparent_proxy_admin_addr: config.remote.transparent_proxy_admin_addr,
-            user_facing_diamond_proxy_addr: config.remote.user_facing_diamond_proxy,
-            user_facing_bridgehub_addr: config.remote.user_facing_bridgehub,
+            l1_bridgehub_proxy_addr: config.remote.l1_bridgehub_proxy_addr,
+            l1_state_transition_proxy_addr: config.remote.l1_state_transition_proxy_addr,
+            l1_transparent_proxy_admin_addr: config.remote.l1_transparent_proxy_admin_addr,
+            l1_diamond_proxy_addr: config.l1_diamond_proxy_address(),
             l2_testnet_paymaster_addr: config.remote.l2_testnet_paymaster_addr,
             req_entities_limit: config.optional.req_entities_limit,
             fee_history_limit: config.optional.fee_history_limit,

--- a/core/bin/external_node/src/node_builder.rs
+++ b/core/bin/external_node/src/node_builder.rs
@@ -276,7 +276,7 @@ impl ExternalNodeBuilder {
 
     fn add_l1_batch_commitment_mode_validation_layer(mut self) -> anyhow::Result<Self> {
         let layer = L1BatchCommitmentModeValidationLayer::new(
-            self.config.remote.user_facing_diamond_proxy,
+            self.config.l1_diamond_proxy_address(),
             self.config.optional.l1_batch_commit_data_generator_mode,
         );
         self.node.add_layer(layer);
@@ -295,7 +295,7 @@ impl ExternalNodeBuilder {
     fn add_consistency_checker_layer(mut self) -> anyhow::Result<Self> {
         let max_batches_to_recheck = 10; // TODO (BFT-97): Make it a part of a proper EN config
         let layer = ConsistencyCheckerLayer::new(
-            self.config.remote.user_facing_diamond_proxy,
+            self.config.l1_diamond_proxy_address(),
             max_batches_to_recheck,
             self.config.optional.l1_batch_commit_data_generator_mode,
             self.config.required.l2_chain_id,
@@ -324,7 +324,7 @@ impl ExternalNodeBuilder {
 
     fn add_tree_data_fetcher_layer(mut self) -> anyhow::Result<Self> {
         let layer = TreeDataFetcherLayer::new(
-            self.config.remote.user_facing_diamond_proxy,
+            self.config.l1_diamond_proxy_address(),
             self.config.required.l2_chain_id,
         );
         self.node.add_layer(layer);

--- a/core/bin/external_node/src/tests/mod.rs
+++ b/core/bin/external_node/src/tests/mod.rs
@@ -35,7 +35,7 @@ async fn external_node_basics(components_str: &'static str) {
     }
 
     let l2_client = utils::mock_l2_client(&env);
-    let eth_client = utils::mock_eth_client(env.config.remote.user_facing_diamond_proxy);
+    let eth_client = utils::mock_eth_client(env.config.l1_diamond_proxy_address());
 
     let node_handle = tokio::task::spawn_blocking(move || {
         std::thread::spawn(move || {
@@ -104,7 +104,7 @@ async fn node_reacts_to_stop_signal_during_initial_reorg_detection() {
     let (env, env_handles) = utils::TestEnvironment::with_genesis_block("core").await;
 
     let l2_client = utils::mock_l2_client_hanging();
-    let eth_client = utils::mock_eth_client(env.config.remote.user_facing_diamond_proxy);
+    let eth_client = utils::mock_eth_client(env.config.l1_diamond_proxy_address());
 
     let mut node_handle = tokio::task::spawn_blocking(move || {
         std::thread::spawn(move || {
@@ -140,7 +140,7 @@ async fn running_tree_without_core_is_not_allowed() {
     let (env, _env_handles) = utils::TestEnvironment::with_genesis_block("tree").await;
 
     let l2_client = utils::mock_l2_client(&env);
-    let eth_client = utils::mock_eth_client(env.config.remote.user_facing_diamond_proxy);
+    let eth_client = utils::mock_eth_client(env.config.l1_diamond_proxy_address());
 
     let node_handle = tokio::task::spawn_blocking(move || {
         std::thread::spawn(move || {

--- a/core/lib/config/src/configs/contracts.rs
+++ b/core/lib/config/src/configs/contracts.rs
@@ -45,9 +45,6 @@ pub struct ContractsConfig {
     pub ecosystem_contracts: Option<EcosystemContracts>,
     // Used by the RPC API and by the node builder in wiring the BaseTokenRatioProvider layer.
     pub base_token_addr: Option<Address>,
-    // FIXME: maybe refactor
-    pub user_facing_bridgehub_proxy_addr: Option<Address>,
-    pub user_facing_diamond_proxy_addr: Option<Address>,
     pub chain_admin_addr: Option<Address>,
     pub settlement_layer: Option<u64>,
     pub l2_da_validator_addr: Option<Address>,
@@ -72,8 +69,6 @@ impl ContractsConfig {
             governance_addr: Address::repeat_byte(0x13),
             base_token_addr: Some(Address::repeat_byte(0x14)),
             ecosystem_contracts: Some(EcosystemContracts::for_tests()),
-            user_facing_bridgehub_proxy_addr: Some(Address::repeat_byte(0x15)),
-            user_facing_diamond_proxy_addr: Some(Address::repeat_byte(0x16)),
             chain_admin_addr: Some(Address::repeat_byte(0x18)),
             settlement_layer: Some(0),
             l2_da_validator_addr: Some(Address::repeat_byte(0x1a)),

--- a/core/lib/config/src/testonly.rs
+++ b/core/lib/config/src/testonly.rs
@@ -269,8 +269,6 @@ impl Distribution<configs::ContractsConfig> for EncodeDist {
             l2_testnet_paymaster_addr: self.sample_opt(|| rng.gen()),
             l1_multicall3_addr: rng.gen(),
             ecosystem_contracts: self.sample(rng),
-            user_facing_bridgehub_proxy_addr: rng.gen(),
-            user_facing_diamond_proxy_addr: rng.gen(),
             base_token_addr: self.sample_opt(|| rng.gen()),
             chain_admin_addr: self.sample_opt(|| rng.gen()),
             settlement_layer: self.sample_opt(|| rng.gen()),

--- a/core/lib/env_config/src/contracts.rs
+++ b/core/lib/env_config/src/contracts.rs
@@ -90,12 +90,6 @@ mod tests {
                 transparent_proxy_admin_addr: addr("0xdd6fa5c14e7550b4caf2aa2818d24c69cbc347e5"),
             }),
             base_token_addr: Some(SHARED_BRIDGE_ETHER_TOKEN_ADDRESS),
-            user_facing_bridgehub_proxy_addr: Some(addr(
-                "0x35ea7f92f4c5f433efe15284e99c040110cf6297",
-            )),
-            user_facing_diamond_proxy_addr: Some(addr(
-                "0xF00B988a98Ca742e7958DeF9F7823b5908715f4a",
-            )),
             chain_admin_addr: Some(addr("0xdd6fa5c14e7550b4caf2aa2818d24c69cbc347ff")),
             l2_da_validator_addr: Some(addr("0xed6fa5c14e7550b4caf2aa2818d24c69cbc347ff")),
             settlement_layer: Some(0),
@@ -125,8 +119,6 @@ CONTRACTS_BRIDGEHUB_PROXY_ADDR="0x35ea7f92f4c5f433efe15284e99c040110cf6297"
 CONTRACTS_STATE_TRANSITION_PROXY_ADDR="0xd90f1c081c6117241624e97cb6147257c3cb2097"
 CONTRACTS_TRANSPARENT_PROXY_ADMIN_ADDR="0xdd6fa5c14e7550b4caf2aa2818d24c69cbc347e5"
 CONTRACTS_BASE_TOKEN_ADDR="0x0000000000000000000000000000000000000001"
-CONTRACTS_USER_FACING_BRIDGEHUB_PROXY_ADDR="0x35ea7f92f4c5f433efe15284e99c040110cf6297"
-CONTRACTS_USER_FACING_DIAMOND_PROXY_ADDR="0xF00B988a98Ca742e7958DeF9F7823b5908715f4a
 CONTRACTS_L2_NATIVE_TOKEN_VAULT_PROXY_ADDR="0xfc073319977e314f251eae6ae6be76b0b3baeecf"
 CONTRACTS_CHAIN_ADMIN_ADDR="0xdd6fa5c14e7550b4caf2aa2818d24c69cbc347ff"
 CONTRACTS_SETTLEMENT_LAYER="0"

--- a/core/lib/protobuf_config/src/contracts.rs
+++ b/core/lib/protobuf_config/src/contracts.rs
@@ -107,18 +107,6 @@ impl ProtoRepr for proto::Contracts {
                 .map(|x| parse_h160(x))
                 .transpose()
                 .context("base_token_addr")?,
-            user_facing_bridgehub_proxy_addr: self
-                .user_facing_bridgehub
-                .as_ref()
-                .map(|x| parse_h160(x))
-                .transpose()
-                .context("base_token_addr")?,
-            user_facing_diamond_proxy_addr: self
-                .user_facing_diamond_proxy
-                .as_ref()
-                .map(|x| parse_h160(x))
-                .transpose()
-                .context("base_token_addr")?,
             chain_admin_addr: l1
                 .chain_admin_addr
                 .as_ref()
@@ -186,12 +174,6 @@ impl ProtoRepr for proto::Contracts {
                     l2_address: this.l2_weth_bridge_addr.map(|a| format!("{:?}", a)),
                 }),
             }),
-            user_facing_bridgehub: this
-                .user_facing_bridgehub_proxy_addr
-                .map(|a| format!("{:?}", a)),
-            user_facing_diamond_proxy: this
-                .user_facing_diamond_proxy_addr
-                .map(|a| format!("{:?}", a)),
             settlement_layer: this.settlement_layer,
         }
     }

--- a/core/lib/protobuf_config/src/proto/config/contracts.proto
+++ b/core/lib/protobuf_config/src/proto/config/contracts.proto
@@ -41,7 +41,5 @@ message Contracts {
   optional L2 l2 = 2;
   optional Bridges bridges = 3;
   optional EcosystemContracts ecosystem_contracts = 4;
-  optional string user_facing_bridgehub = 5;
-  optional string user_facing_diamond_proxy = 6;
-  optional uint64 settlement_layer = 7;
+  optional uint64 settlement_layer = 5;
 }

--- a/core/node/api_server/src/web3/namespaces/en.rs
+++ b/core/node/api_server/src/web3/namespaces/en.rs
@@ -151,18 +151,18 @@ impl EnNamespace {
         Ok(self
             .state
             .api_config
-            .bridgehub_proxy_addr
+            .l1_bridgehub_proxy_addr
             .map(|bridgehub_proxy_addr| EcosystemContracts {
                 bridgehub_proxy_addr,
                 state_transition_proxy_addr: self
                     .state
                     .api_config
-                    .state_transition_proxy_addr
+                    .l1_state_transition_proxy_addr
                     .unwrap(),
                 transparent_proxy_admin_addr: self
                     .state
                     .api_config
-                    .transparent_proxy_admin_addr
+                    .l1_transparent_proxy_admin_addr
                     .unwrap(),
             })
             .context("Shared bridge doesn't supported")?)

--- a/core/node/api_server/src/web3/namespaces/zks.rs
+++ b/core/node/api_server/src/web3/namespaces/zks.rs
@@ -141,11 +141,11 @@ impl ZksNamespace {
     }
 
     pub fn get_bridgehub_contract_impl(&self) -> Option<Address> {
-        self.state.api_config.user_facing_bridgehub_addr
+        self.state.api_config.l1_bridgehub_proxy_addr
     }
 
     pub fn get_main_contract_impl(&self) -> Address {
-        self.state.api_config.user_facing_diamond_proxy_addr
+        self.state.api_config.l1_diamond_proxy_addr
     }
 
     pub fn get_testnet_paymaster_impl(&self) -> Option<Address> {

--- a/core/node/api_server/src/web3/state.rs
+++ b/core/node/api_server/src/web3/state.rs
@@ -109,10 +109,10 @@ pub struct InternalApiConfig {
     pub estimate_gas_acceptable_overestimation: u32,
     pub estimate_gas_optimize_search: bool,
     pub bridge_addresses: api::BridgeAddresses,
-    pub bridgehub_proxy_addr: Option<Address>,
-    pub state_transition_proxy_addr: Option<Address>,
-    pub transparent_proxy_admin_addr: Option<Address>,
-    pub user_facing_diamond_proxy_addr: Address,
+    pub l1_bridgehub_proxy_addr: Option<Address>,
+    pub l1_state_transition_proxy_addr: Option<Address>,
+    pub l1_transparent_proxy_admin_addr: Option<Address>,
+    pub l1_diamond_proxy_addr: Address,
     pub l2_testnet_paymaster_addr: Option<Address>,
     pub req_entities_limit: usize,
     pub fee_history_limit: u64,
@@ -120,7 +120,6 @@ pub struct InternalApiConfig {
     pub filters_disabled: bool,
     pub dummy_verifier: bool,
     pub l1_batch_commit_data_generator_mode: L1BatchCommitmentMode,
-    pub user_facing_bridgehub_addr: Option<Address>,
 }
 
 impl InternalApiConfig {
@@ -129,14 +128,6 @@ impl InternalApiConfig {
         contracts_config: &ContractsConfig,
         genesis_config: &GenesisConfig,
     ) -> Self {
-        println!(
-            "contracts_config.user_facing_bridgehub_proxy_addr = {:#?}, 
-            contracts_config.user_facing_diamond_proxy_addr = {:#?}, 
-            contracts_config.diamond_proxy_addr = {:#?}",
-            contracts_config.user_facing_bridgehub_proxy_addr,
-            contracts_config.user_facing_diamond_proxy_addr,
-            contracts_config.diamond_proxy_addr
-        );
         Self {
             l1_chain_id: genesis_config.l1_chain_id,
             l2_chain_id: genesis_config.l2_chain_id,
@@ -164,21 +155,19 @@ impl InternalApiConfig {
                 ),
                 l2_legacy_shared_bridge: contracts_config.l2_legacy_shared_bridge_addr,
             },
-            bridgehub_proxy_addr: contracts_config
+            l1_bridgehub_proxy_addr: contracts_config
                 .ecosystem_contracts
                 .as_ref()
                 .map(|a| a.bridgehub_proxy_addr),
-            state_transition_proxy_addr: contracts_config
+            l1_state_transition_proxy_addr: contracts_config
                 .ecosystem_contracts
                 .as_ref()
                 .map(|a| a.state_transition_proxy_addr),
-            transparent_proxy_admin_addr: contracts_config
+            l1_transparent_proxy_admin_addr: contracts_config
                 .ecosystem_contracts
                 .as_ref()
                 .map(|a| a.transparent_proxy_admin_addr),
-            user_facing_diamond_proxy_addr: contracts_config
-                .user_facing_diamond_proxy_addr
-                .unwrap_or(contracts_config.diamond_proxy_addr),
+            l1_diamond_proxy_addr: contracts_config.diamond_proxy_addr,
             l2_testnet_paymaster_addr: contracts_config.l2_testnet_paymaster_addr,
             req_entities_limit: web3_config.req_entities_limit(),
             fee_history_limit: web3_config.fee_history_limit(),
@@ -186,12 +175,6 @@ impl InternalApiConfig {
             filters_disabled: web3_config.filters_disabled,
             dummy_verifier: genesis_config.dummy_verifier,
             l1_batch_commit_data_generator_mode: genesis_config.l1_batch_commit_data_generator_mode,
-            user_facing_bridgehub_addr: contracts_config.user_facing_bridgehub_proxy_addr.or(
-                contracts_config
-                    .ecosystem_contracts
-                    .as_ref()
-                    .map(|a| a.bridgehub_proxy_addr),
-            ),
         }
     }
 }

--- a/zkstack_cli/crates/config/src/contracts.rs
+++ b/zkstack_cli/crates/config/src/contracts.rs
@@ -23,9 +23,6 @@ pub struct ContractsConfig {
     pub bridges: BridgesContracts,
     pub l1: L1Contracts,
     pub l2: L2Contracts,
-    // TODO: maybe move these guys to L1
-    pub user_facing_bridgehub: Address,
-    pub user_facing_diamond_proxy: Address,
     #[serde(flatten)]
     pub other: serde_json::Value,
 }
@@ -95,15 +92,6 @@ impl ContractsConfig {
             .deployed_addresses
             .validium_l1_da_validator_addr;
         self.l1.chain_admin_addr = deploy_l1_output.deployed_addresses.chain_admin;
-
-        self.user_facing_bridgehub = deploy_l1_output
-            .deployed_addresses
-            .bridgehub
-            .bridgehub_proxy_addr;
-        self.user_facing_diamond_proxy = deploy_l1_output
-            .deployed_addresses
-            .state_transition
-            .diamond_proxy_addr;
     }
 
     pub fn set_chain_contracts(&mut self, register_chain_output: &RegisterChainOutput) {
@@ -115,8 +103,6 @@ impl ContractsConfig {
         self.l1.chain_proxy_admin_addr = register_chain_output.chain_proxy_admin_addr;
         self.l2.legacy_shared_bridge_addr =
             Some(register_chain_output.l2_legacy_shared_bridge_addr);
-
-        self.user_facing_diamond_proxy = register_chain_output.diamond_proxy_addr;
     }
 
     pub fn set_l2_shared_bridge(


### PR DESCRIPTION
## What ❔

for en: 
- renames prefixes: `user_facing_` -> `l1_`
- `ExternalNodeConfig::l1_diamond_proxy_address` is used instead of remote.diamon_proxy

for main node:
- remove `user_facing_diamond_proxy` and `user_facing_bridgehub` as duplicates for corresponding fields from l1 contracts config

## Why ❔

Renaming for clarity (IMO l1_ prefix providers better understanding of what is put under variable)
Removing for config simplicity and avoiding duplication

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
