### PR TITLE
refactor(utils): Move bytecode hashing to `basic_types`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9634,7 +9634,6 @@ dependencies = [
  "zksync_contracts",
  "zksync_multivm",
  "zksync_types",
- "zksync_utils",
  "zksync_vlog",
  "zksync_vm2",
 ]
@@ -10794,7 +10793,6 @@ dependencies = [
  "zksync_dal",
  "zksync_node_test_utils",
  "zksync_types",
- "zksync_utils",
 ]
 
 [[package]]
@@ -10999,7 +10997,6 @@ dependencies = [
  "zksync_system_constants",
  "zksync_test_account",
  "zksync_types",
- "zksync_utils",
  "zksync_vm_interface",
 ]
 
@@ -11480,7 +11477,6 @@ dependencies = [
  "zksync_state_keeper",
  "zksync_system_constants",
  "zksync_types",
- "zksync_utils",
  "zksync_vm_executor",
  "zksync_web3_decl",
 ]
@@ -11654,7 +11650,6 @@ dependencies = [
  "zksync_multivm",
  "zksync_system_constants",
  "zksync_types",
- "zksync_utils",
 ]
 
 [[package]]
@@ -11709,7 +11704,6 @@ dependencies = [
  "zksync_state_keeper",
  "zksync_system_constants",
  "zksync_types",
- "zksync_utils",
  "zksync_vm_executor",
  "zksync_web3_decl",
 ]
@@ -11956,7 +11950,6 @@ dependencies = [
  "zksync_health_check",
  "zksync_object_store",
  "zksync_types",
- "zksync_utils",
  "zksync_web3_decl",
 ]
 
@@ -12037,7 +12030,6 @@ dependencies = [
  "zksync_system_constants",
  "zksync_test_account",
  "zksync_types",
- "zksync_utils",
  "zksync_vm_executor",
 ]
 
@@ -12116,7 +12108,6 @@ dependencies = [
  "zksync_eth_signer",
  "zksync_system_constants",
  "zksync_types",
- "zksync_utils",
 ]
 
 [[package]]
@@ -12151,7 +12142,6 @@ dependencies = [
  "zksync_protobuf",
  "zksync_protobuf_build",
  "zksync_system_constants",
- "zksync_utils",
 ]
 
 [[package]]
@@ -12234,7 +12224,6 @@ dependencies = [
  "zksync_dal",
  "zksync_multivm",
  "zksync_types",
- "zksync_utils",
 ]
 
 [[package]]
@@ -12285,7 +12274,6 @@ dependencies = [
  "zksync_storage",
  "zksync_test_account",
  "zksync_types",
- "zksync_utils",
  "zksync_vm_executor",
  "zksync_vm_interface",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10451,6 +10451,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "chrono",
+ "const-decoder",
  "ethabi",
  "hex",
  "num_enum 0.7.3",
@@ -10458,6 +10459,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sha2 0.10.8",
  "strum",
  "thiserror",
  "tiny-keccak 2.0.2",
@@ -10845,11 +10847,11 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "envy",
- "ethabi",
  "hex",
  "once_cell",
  "serde",
  "serde_json",
+ "zksync_basic_types",
  "zksync_utils",
 ]
 
@@ -11426,7 +11428,6 @@ dependencies = [
  "zksync_system_constants",
  "zksync_test_account",
  "zksync_types",
- "zksync_utils",
  "zksync_vm2",
  "zksync_vm_interface",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12150,16 +12150,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "const-decoder",
  "futures 0.3.31",
  "once_cell",
  "reqwest 0.12.9",
  "serde_json",
- "thiserror",
  "tokio",
  "tracing",
- "zk_evm 0.133.0",
- "zksync_basic_types",
  "zksync_vlog",
 ]
 

--- a/core/bin/system-constants-generator/src/utils.rs
+++ b/core/bin/system-constants-generator/src/utils.rs
@@ -21,14 +21,13 @@ use zksync_multivm::{
     zk_evm_latest::aux_structures::Timestamp,
 };
 use zksync_types::{
-    block::L2BlockHasher, ethabi::Token, fee::Fee, fee_model::BatchFeeInput, l1::L1Tx, l2::L2Tx,
-    u256_to_h256, utils::storage_key_for_eth_balance, AccountTreeId, Address, Execute,
-    K256PrivateKey, L1BatchNumber, L1TxCommonData, L2BlockNumber, L2ChainId, Nonce,
-    ProtocolVersionId, StorageKey, Transaction, BOOTLOADER_ADDRESS, SYSTEM_CONTEXT_ADDRESS,
-    SYSTEM_CONTEXT_GAS_PRICE_POSITION, SYSTEM_CONTEXT_TX_ORIGIN_POSITION, U256,
-    ZKPORTER_IS_AVAILABLE,
+    block::L2BlockHasher, bytecode::BytecodeHash, ethabi::Token, fee::Fee,
+    fee_model::BatchFeeInput, l1::L1Tx, l2::L2Tx, u256_to_h256, utils::storage_key_for_eth_balance,
+    AccountTreeId, Address, Execute, K256PrivateKey, L1BatchNumber, L1TxCommonData, L2BlockNumber,
+    L2ChainId, Nonce, ProtocolVersionId, StorageKey, Transaction, BOOTLOADER_ADDRESS,
+    SYSTEM_CONTEXT_ADDRESS, SYSTEM_CONTEXT_GAS_PRICE_POSITION, SYSTEM_CONTEXT_TX_ORIGIN_POSITION,
+    U256, ZKPORTER_IS_AVAILABLE,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::intrinsic_costs::VmSpentResourcesResult;
 
@@ -63,7 +62,7 @@ impl<S: WriteStorage, H: HistoryMode> VmTracer<S, H> for SpecialBootloaderTracer
 
 pub static GAS_TEST_SYSTEM_CONTRACTS: Lazy<BaseSystemContracts> = Lazy::new(|| {
     let bytecode = read_bootloader_code("gas_test");
-    let hash = hash_bytecode(&bytecode);
+    let hash = BytecodeHash::for_bytecode(&bytecode).value();
 
     let bootloader = SystemContractCode {
         code: bytecode,
@@ -71,7 +70,7 @@ pub static GAS_TEST_SYSTEM_CONTRACTS: Lazy<BaseSystemContracts> = Lazy::new(|| {
     };
 
     let bytecode = read_sys_contract_bytecode("", "DefaultAccount", ContractLanguage::Sol);
-    let hash = hash_bytecode(&bytecode);
+    let hash = BytecodeHash::for_bytecode(&bytecode).value();
 
     BaseSystemContracts {
         default_aa: SystemContractCode {
@@ -208,12 +207,12 @@ fn default_l1_batch() -> L1BatchEnv {
 /// returns the amount of gas needed to perform and internal transfer, assuming no gas price
 /// per pubdata, i.e. under assumption that the refund will not touch any new slots.
 pub(super) fn execute_internal_transfer_test() -> u32 {
-    let raw_storage = InMemoryStorage::with_system_contracts(hash_bytecode);
+    let raw_storage = InMemoryStorage::with_system_contracts();
     let mut storage_view = StorageView::new(raw_storage);
     let bootloader_balance_key = storage_key_for_eth_balance(&BOOTLOADER_ADDRESS);
     storage_view.set_value(bootloader_balance_key, u256_to_h256(U256([0, 0, 1, 0])));
     let bytecode = read_bootloader_test_code("transfer_test");
-    let hash = hash_bytecode(&bytecode);
+    let hash = BytecodeHash::for_bytecode(&bytecode).value();
     let bootloader = SystemContractCode {
         code: bytecode,
         hash,
@@ -222,7 +221,7 @@ pub(super) fn execute_internal_transfer_test() -> u32 {
     let l1_batch = default_l1_batch();
 
     let bytecode = read_sys_contract_bytecode("", "DefaultAccount", ContractLanguage::Sol);
-    let hash = hash_bytecode(&bytecode);
+    let hash = BytecodeHash::for_bytecode(&bytecode).value();
     let default_aa = SystemContractCode {
         code: bytecode,
         hash,
@@ -293,7 +292,7 @@ pub(super) fn execute_user_txs_in_test_gas_vm(
         .iter()
         .fold(U256::zero(), |sum, elem| sum + elem.gas_limit());
 
-    let raw_storage = InMemoryStorage::with_system_contracts(hash_bytecode);
+    let raw_storage = InMemoryStorage::with_system_contracts();
     let mut storage_view = StorageView::new(raw_storage);
 
     for tx in txs.iter() {

--- a/core/lib/basic_types/Cargo.toml
+++ b/core/lib/basic_types/Cargo.toml
@@ -11,8 +11,10 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+const-decoder.workspace = true
 ethabi.workspace = true
 hex.workspace = true
+sha2.workspace = true # FIXME: is this dep OK?
 tiny-keccak.workspace = true
 thiserror.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/core/lib/basic_types/Cargo.toml
+++ b/core/lib/basic_types/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 const-decoder.workspace = true
 ethabi.workspace = true
 hex.workspace = true
-sha2.workspace = true # FIXME: is this dep OK?
+sha2.workspace = true
 tiny-keccak.workspace = true
 thiserror.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/core/lib/basic_types/src/lib.rs
+++ b/core/lib/basic_types/src/lib.rs
@@ -29,6 +29,7 @@ pub use self::conversions::{
 #[macro_use]
 mod macros;
 pub mod basic_fri_types;
+pub mod bytecode;
 pub mod commitment;
 mod conversions;
 pub mod network;

--- a/core/lib/contract_verifier/src/lib.rs
+++ b/core/lib/contract_verifier/src/lib.rs
@@ -13,7 +13,7 @@ use tokio::time;
 use zksync_dal::{contract_verification_dal::DeployedContractData, ConnectionPool, Core, CoreDal};
 use zksync_queued_job_processor::{async_trait, JobProcessor};
 use zksync_types::{
-    bytecode::{prepare_evm_bytecode, BytecodeMarker},
+    bytecode::{trim_padded_evm_bytecode, BytecodeMarker},
     contract_verification_api::{
         self as api, CompilationArtifacts, VerificationIncomingRequest, VerificationInfo,
         VerificationRequest,
@@ -231,7 +231,7 @@ impl ContractVerifier {
 
         let deployed_bytecode = match bytecode_marker {
             BytecodeMarker::EraVm => deployed_contract.bytecode.as_slice(),
-            BytecodeMarker::Evm => prepare_evm_bytecode(&deployed_contract.bytecode)
+            BytecodeMarker::Evm => trim_padded_evm_bytecode(&deployed_contract.bytecode)
                 .context("invalid stored EVM bytecode")?,
         };
 

--- a/core/lib/contract_verifier/src/lib.rs
+++ b/core/lib/contract_verifier/src/lib.rs
@@ -13,13 +13,13 @@ use tokio::time;
 use zksync_dal::{contract_verification_dal::DeployedContractData, ConnectionPool, Core, CoreDal};
 use zksync_queued_job_processor::{async_trait, JobProcessor};
 use zksync_types::{
+    bytecode::{prepare_evm_bytecode, BytecodeMarker},
     contract_verification_api::{
         self as api, CompilationArtifacts, VerificationIncomingRequest, VerificationInfo,
         VerificationRequest,
     },
     Address, CONTRACT_DEPLOYER_ADDRESS,
 };
-use zksync_utils::bytecode::{prepare_evm_bytecode, BytecodeMarker};
 
 use crate::{
     compilers::{Solc, ZkSolc, ZkVyper},

--- a/core/lib/contract_verifier/src/tests/mod.rs
+++ b/core/lib/contract_verifier/src/tests/mod.rs
@@ -8,6 +8,7 @@ use zksync_dal::Connection;
 use zksync_node_test_utils::{create_l1_batch, create_l2_block};
 use zksync_types::{
     address_to_h256,
+    bytecode::BytecodeHash,
     contract_verification_api::{CompilerVersions, SourceCodeData, VerificationIncomingRequest},
     get_code_key, get_known_code_key,
     l2::L2Tx,
@@ -15,7 +16,6 @@ use zksync_types::{
     Execute, L1BatchNumber, L2BlockNumber, ProtocolVersion, StorageLog, CONTRACT_DEPLOYER_ADDRESS,
     H256, U256,
 };
-use zksync_utils::bytecode::{hash_bytecode, hash_evm_bytecode};
 use zksync_vm_interface::{tracer::ValidationTraces, TransactionExecutionMetrics, VmEvent};
 
 use super::*;
@@ -106,7 +106,7 @@ async fn mock_deployment(
     bytecode: Vec<u8>,
     constructor_args: &[Token],
 ) {
-    let bytecode_hash = hash_bytecode(&bytecode);
+    let bytecode_hash = BytecodeHash::for_bytecode(&bytecode).value();
     let deployment = Execute::for_deploy(H256::zero(), bytecode.clone(), constructor_args);
     mock_deployment_inner(storage, address, bytecode_hash, bytecode, deployment).await;
 }
@@ -127,7 +127,7 @@ async fn mock_evm_deployment(
         factory_deps: vec![],
     };
     let bytecode = pad_evm_bytecode(deployed_bytecode);
-    let bytecode_hash = hash_evm_bytecode(&bytecode);
+    let bytecode_hash = BytecodeHash::for_evm_bytecode(&bytecode).value();
     mock_deployment_inner(storage, address, bytecode_hash, bytecode, deployment).await;
 }
 

--- a/core/lib/contract_verifier/src/tests/real.rs
+++ b/core/lib/contract_verifier/src/tests/real.rs
@@ -4,7 +4,7 @@
 
 use std::{env, sync::Arc, time::Duration};
 
-use zksync_utils::bytecode::validate_bytecode;
+use zksync_types::bytecode::validate_bytecode;
 
 use super::*;
 

--- a/core/lib/contracts/Cargo.toml
+++ b/core/lib/contracts/Cargo.toml
@@ -11,9 +11,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+zksync_basic_types.workspace = true
 zksync_utils.workspace = true
 
-ethabi.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 once_cell.workspace = true

--- a/core/lib/contracts/src/lib.rs
+++ b/core/lib/contracts/src/lib.rs
@@ -10,10 +10,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use ethabi::{ethereum_types::H256, Contract, Event, Function};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use zksync_utils::{bytecode::hash_bytecode, env::Workspace};
+use zksync_basic_types::{
+    bytecode::BytecodeHash,
+    ethabi::{Contract, Event, Function},
+    H256,
+};
+use zksync_utils::env::Workspace;
 
 mod serde_bytecode;
 pub mod test_contracts;
@@ -408,14 +412,14 @@ impl PartialEq for BaseSystemContracts {
 
 impl BaseSystemContracts {
     fn load_with_bootloader(bootloader_bytecode: Vec<u8>) -> Self {
-        let hash = hash_bytecode(&bootloader_bytecode);
+        let hash = BytecodeHash::for_bytecode(&bootloader_bytecode).value();
         let bootloader = SystemContractCode {
             code: bootloader_bytecode,
             hash,
         };
 
         let bytecode = read_sys_contract_bytecode("", "DefaultAccount", ContractLanguage::Sol);
-        let hash = hash_bytecode(&bytecode);
+        let hash = BytecodeHash::for_bytecode(&bytecode).value();
         let default_aa = SystemContractCode {
             code: bytecode,
             hash,
@@ -437,7 +441,7 @@ impl BaseSystemContracts {
     /// Loads the latest EVM emulator for these base system contracts. Logically, it only makes sense to do for the latest protocol version.
     pub fn with_latest_evm_emulator(mut self) -> Self {
         let bytecode = read_sys_contract_bytecode("", "EvmEmulator", ContractLanguage::Yul);
-        let hash = hash_bytecode(&bytecode);
+        let hash = BytecodeHash::for_bytecode(&bytecode).value();
         self.evm_emulator = Some(SystemContractCode {
             code: bytecode,
             hash,

--- a/core/lib/contracts/src/serde_bytecode.rs
+++ b/core/lib/contracts/src/serde_bytecode.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
-use ethabi::ethereum_types::U256;
 use serde::{de, de::SeqAccess, ser, ser::SerializeSeq, Deserializer, Serializer};
+use zksync_basic_types::U256;
 
 pub(super) fn serialize<S: Serializer>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
     if bytes.len() % 32 != 0 {
@@ -43,8 +43,8 @@ pub(super) fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<
 
 #[cfg(test)]
 mod tests {
-    use ethabi::ethereum_types::{H256, U256};
     use serde::{Deserialize, Serialize};
+    use zksync_basic_types::{H256, U256};
 
     use crate::SystemContractCode;
 

--- a/core/lib/contracts/src/test_contracts.rs
+++ b/core/lib/contracts/src/test_contracts.rs
@@ -1,5 +1,8 @@
-use ethabi::{ethereum_types::U256, Bytes, Token};
 use serde::Deserialize;
+use zksync_basic_types::{
+    ethabi::{Bytes, Token},
+    U256,
+};
 
 use crate::get_loadnext_contract;
 

--- a/core/lib/dal/Cargo.toml
+++ b/core/lib/dal/Cargo.toml
@@ -15,7 +15,6 @@ links = "zksync_dal_proto"
 [dependencies]
 vise.workspace = true
 zksync_vm_interface.workspace = true
-zksync_utils.workspace = true
 zksync_system_constants.workspace = true
 zksync_contracts.workspace = true
 zksync_types.workspace = true

--- a/core/lib/dal/src/contract_verification_dal.rs
+++ b/core/lib/dal/src/contract_verification_dal.rs
@@ -567,11 +567,11 @@ mod tests {
     use std::collections::HashMap;
 
     use zksync_types::{
+        bytecode::BytecodeHash,
         contract_verification_api::{CompilerVersions, SourceCodeData},
         tx::IncludedTxLocation,
         Execute, L1BatchNumber, L2BlockNumber, ProtocolVersion,
     };
-    use zksync_utils::bytecode::hash_bytecode;
     use zksync_vm_interface::{tracer::ValidationTraces, TransactionExecutionMetrics};
 
     use super::*;
@@ -598,7 +598,7 @@ mod tests {
         let deployed_address = Address::repeat_byte(12);
         let mut tx = mock_l2_transaction();
         let bytecode = vec![1; 32];
-        let bytecode_hash = hash_bytecode(&bytecode);
+        let bytecode_hash = BytecodeHash::for_bytecode(&bytecode).value();
         tx.execute = Execute::for_deploy(H256::zero(), bytecode.clone(), &[]);
         conn.transactions_dal()
             .insert_transaction_l2(

--- a/core/lib/multivm/Cargo.toml
+++ b/core/lib/multivm/Cargo.toml
@@ -26,7 +26,6 @@ circuit_sequencer_api_1_5_0.workspace = true
 
 zksync_types.workspace = true
 zksync_contracts.workspace = true
-zksync_utils.workspace = true
 zksync_system_constants.workspace = true
 zksync_vm_interface.workspace = true
 zksync_mini_merkle_tree.workspace = true

--- a/core/lib/multivm/src/pubdata_builders/utils.rs
+++ b/core/lib/multivm/src/pubdata_builders/utils.rs
@@ -1,6 +1,5 @@
 use zksync_mini_merkle_tree::MiniMerkleTree;
-use zksync_types::web3::keccak256;
-use zksync_utils::bytecode::hash_bytecode;
+use zksync_types::{bytecode::BytecodeHash, web3::keccak256};
 
 use crate::interface::pubdata::L1MessengerL2ToL1Log;
 
@@ -49,8 +48,9 @@ pub(crate) fn build_chained_bytecode_hash(published_bytecodes: &[Vec<u8>]) -> Ve
     let mut chained_bytecode_hash = vec![0u8; 32];
 
     for bytecode in published_bytecodes {
-        let hash = hash_bytecode(bytecode).to_fixed_bytes();
-
+        let hash = BytecodeHash::for_bytecode(bytecode)
+            .value()
+            .to_fixed_bytes();
         chained_bytecode_hash =
             keccak256(&[chained_bytecode_hash, hash.to_vec()].concat()).to_vec();
     }

--- a/core/lib/multivm/src/versions/shadow/mod.rs
+++ b/core/lib/multivm/src/versions/shadow/mod.rs
@@ -12,7 +12,6 @@ use zksync_types::{
     block::L2BlockHasher, fee::Fee, AccountTreeId, Address, Execute, L1BatchNumber, L2BlockNumber,
     ProtocolVersionId, StorageKey, H256, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::{
     interface::{
@@ -207,7 +206,7 @@ where
 {
     let system_env = default_system_env();
     let l1_batch_env = default_l1_batch(L1BatchNumber(1));
-    let mut storage = InMemoryStorage::with_system_contracts(hash_bytecode);
+    let mut storage = InMemoryStorage::with_system_contracts();
     let mut harness = Harness::new(&l1_batch_env);
     harness.setup_storage(&mut storage);
 
@@ -231,7 +230,7 @@ fn sanity_check_harness_on_new_vm() {
 fn sanity_check_shadow_vm() {
     let system_env = default_system_env();
     let l1_batch_env = default_l1_batch(L1BatchNumber(1));
-    let mut storage = InMemoryStorage::with_system_contracts(hash_bytecode);
+    let mut storage = InMemoryStorage::with_system_contracts();
     let mut harness = Harness::new(&l1_batch_env);
     harness.setup_storage(&mut storage);
 
@@ -258,7 +257,7 @@ fn shadow_vm_basics() {
     pretty_assertions::assert_eq!(replayed_dump, dump);
 
     // Check that the VM executes identically when reading from the original storage and one restored from the dump.
-    let mut storage = InMemoryStorage::with_system_contracts(hash_bytecode);
+    let mut storage = InMemoryStorage::with_system_contracts();
     harness.setup_storage(&mut storage);
     let storage = StorageView::new(storage).to_rc_ptr();
 

--- a/core/lib/multivm/src/versions/testonly/block_tip.rs
+++ b/core/lib/multivm/src/versions/testonly/block_tip.rs
@@ -5,10 +5,10 @@ use zksync_system_constants::{
     CONTRACT_FORCE_DEPLOYER_ADDRESS, KNOWN_CODES_STORAGE_ADDRESS, L1_MESSENGER_ADDRESS,
 };
 use zksync_types::{
-    commitment::SerializeCommitment, fee_model::BatchFeeInput, get_code_key,
-    l2_to_l1_log::L2ToL1Log, u256_to_h256, writes::StateDiffRecord, Address, Execute, H256, U256,
+    bytecode::BytecodeHash, commitment::SerializeCommitment, fee_model::BatchFeeInput,
+    get_code_key, l2_to_l1_log::L2ToL1Log, u256_to_h256, writes::StateDiffRecord, Address, Execute,
+    H256, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use super::{
     default_pubdata_builder, get_complex_upgrade_abi, get_empty_storage, read_complex_upgrade,
@@ -72,7 +72,9 @@ fn populate_mimic_calls(data: L1MessengerTestData) -> Vec<Vec<u8>> {
         data: l1_messenger
             .function("requestBytecodeL1Publication")
             .unwrap()
-            .encode_input(&[Token::FixedBytes(hash_bytecode(bytecode).0.to_vec())])
+            .encode_input(&[Token::FixedBytes(
+                BytecodeHash::for_bytecode(bytecode).value().0.to_vec(),
+            )])
             .unwrap(),
     });
 
@@ -118,9 +120,12 @@ fn execute_test<VM: TestedVm>(test_data: L1MessengerTestData) -> TestStatistics 
     // For this test we'll just put the bytecode onto the force deployer address
     storage.set_value(
         get_code_key(&CONTRACT_FORCE_DEPLOYER_ADDRESS),
-        hash_bytecode(&complex_upgrade_code),
+        BytecodeHash::for_bytecode(&complex_upgrade_code).value(),
     );
-    storage.store_factory_dep(hash_bytecode(&complex_upgrade_code), complex_upgrade_code);
+    storage.store_factory_dep(
+        BytecodeHash::for_bytecode(&complex_upgrade_code).value(),
+        complex_upgrade_code,
+    );
 
     // We are measuring computational cost, so prices for pubdata don't matter, while they artificially dilute
     // the gas limit

--- a/core/lib/multivm/src/versions/testonly/code_oracle.rs
+++ b/core/lib/multivm/src/versions/testonly/code_oracle.rs
@@ -1,9 +1,8 @@
 use ethabi::Token;
 use zksync_types::{
-    get_known_code_key, h256_to_u256, u256_to_h256, web3::keccak256, Address, Execute,
-    StorageLogWithPreviousValue, U256,
+    bytecode::BytecodeHash, get_known_code_key, h256_to_u256, u256_to_h256, web3::keccak256,
+    Address, Execute, StorageLogWithPreviousValue, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use super::{
     get_empty_storage, load_precompiles_contract, read_precompiles_contract, read_test_contract,
@@ -25,7 +24,7 @@ pub(crate) fn test_code_oracle<VM: TestedVm>() {
 
     // Filling the zkevm bytecode
     let normal_zkevm_bytecode = read_test_contract();
-    let normal_zkevm_bytecode_hash = hash_bytecode(&normal_zkevm_bytecode);
+    let normal_zkevm_bytecode_hash = BytecodeHash::for_bytecode(&normal_zkevm_bytecode).value();
     let normal_zkevm_bytecode_keccak_hash = keccak256(&normal_zkevm_bytecode);
     let mut storage = get_empty_storage();
     storage.set_value(
@@ -115,7 +114,7 @@ pub(crate) fn test_code_oracle_big_bytecode<VM: TestedVm>() {
     let precompile_contract_bytecode = read_precompiles_contract();
 
     let big_zkevm_bytecode = generate_large_bytecode();
-    let big_zkevm_bytecode_hash = hash_bytecode(&big_zkevm_bytecode);
+    let big_zkevm_bytecode_hash = BytecodeHash::for_bytecode(&big_zkevm_bytecode).value();
     let big_zkevm_bytecode_keccak_hash = keccak256(&big_zkevm_bytecode);
 
     let mut storage = get_empty_storage();
@@ -173,7 +172,7 @@ pub(crate) fn test_refunds_in_code_oracle<VM: TestedVm>() {
     let precompile_contract_bytecode = read_precompiles_contract();
 
     let normal_zkevm_bytecode = read_test_contract();
-    let normal_zkevm_bytecode_hash = hash_bytecode(&normal_zkevm_bytecode);
+    let normal_zkevm_bytecode_hash = BytecodeHash::for_bytecode(&normal_zkevm_bytecode).value();
     let normal_zkevm_bytecode_keccak_hash = keccak256(&normal_zkevm_bytecode);
     let mut storage = get_empty_storage();
     storage.set_value(

--- a/core/lib/multivm/src/versions/testonly/get_used_contracts.rs
+++ b/core/lib/multivm/src/versions/testonly/get_used_contracts.rs
@@ -5,8 +5,9 @@ use ethabi::Token;
 use zk_evm_1_3_1::zkevm_opcode_defs::decoding::{EncodingModeProduction, VmEncodingMode};
 use zksync_system_constants::CONTRACT_DEPLOYER_ADDRESS;
 use zksync_test_account::{Account, TxType};
-use zksync_types::{h256_to_u256, AccountTreeId, Address, Execute, StorageKey, H256, U256};
-use zksync_utils::bytecode::hash_bytecode;
+use zksync_types::{
+    bytecode::BytecodeHash, h256_to_u256, AccountTreeId, Address, Execute, StorageKey, H256, U256,
+};
 
 use super::{
     read_proxy_counter_contract, read_test_contract,
@@ -76,8 +77,7 @@ pub(crate) fn test_get_used_contracts<VM: TestedVm>() {
     assert!(res2.result.is_failed());
 
     for factory_dep in tx2.execute.factory_deps {
-        let hash = hash_bytecode(&factory_dep);
-        let hash_to_u256 = h256_to_u256(hash);
+        let hash_to_u256 = BytecodeHash::for_bytecode(&factory_dep).value_u256();
         assert!(vm.vm.known_bytecode_hashes().contains(&hash_to_u256));
         assert!(!vm.vm.decommitted_hashes().contains(&hash_to_u256));
     }
@@ -105,7 +105,7 @@ fn execute_proxy_counter<VM: TestedVm>(
     gas: u32,
 ) -> (VmTester<VM>, ProxyCounterData, VmExecutionResultAndLogs) {
     let counter_bytecode = inflated_counter_bytecode();
-    let counter_bytecode_hash = h256_to_u256(hash_bytecode(&counter_bytecode));
+    let counter_bytecode_hash = BytecodeHash::for_bytecode(&counter_bytecode).value_u256();
     let counter_address = Address::repeat_byte(0x23);
 
     let mut vm = VmTesterBuilder::new()

--- a/core/lib/multivm/src/versions/testonly/upgrade.rs
+++ b/core/lib/multivm/src/versions/testonly/upgrade.rs
@@ -1,6 +1,7 @@
 use zksync_contracts::{deployer_contract, load_sys_contract, read_bytecode};
 use zksync_test_account::TxType;
 use zksync_types::{
+    bytecode::BytecodeHash,
     ethabi::{Contract, Token},
     get_code_key, get_known_code_key, h256_to_u256,
     protocol_upgrade::ProtocolUpgradeTxCommonData,
@@ -8,7 +9,6 @@ use zksync_types::{
     COMPLEX_UPGRADER_ADDRESS, CONTRACT_DEPLOYER_ADDRESS, CONTRACT_FORCE_DEPLOYER_ADDRESS, H256,
     REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use super::{
     get_complex_upgrade_abi, get_empty_storage, read_complex_upgrade, read_test_contract,
@@ -23,7 +23,7 @@ use crate::interface::{
 /// - If present, this transaction must be the first one in block
 pub(crate) fn test_protocol_upgrade_is_first<VM: TestedVm>() {
     let mut storage = get_empty_storage();
-    let bytecode_hash = hash_bytecode(&read_test_contract());
+    let bytecode_hash = BytecodeHash::for_bytecode(&read_test_contract()).value();
     storage.set_value(get_known_code_key(&bytecode_hash), u256_to_h256(1.into()));
 
     let mut vm = VmTesterBuilder::new()
@@ -111,7 +111,7 @@ pub(crate) fn test_protocol_upgrade_is_first<VM: TestedVm>() {
 /// In this test we try to test how force deployments could be done via protocol upgrade transactions.
 pub(crate) fn test_force_deploy_upgrade<VM: TestedVm>() {
     let mut storage = get_empty_storage();
-    let bytecode_hash = hash_bytecode(&read_test_contract());
+    let bytecode_hash = BytecodeHash::for_bytecode(&read_test_contract()).value();
     let known_code_key = get_known_code_key(&bytecode_hash);
     // It is generally expected that all the keys will be set as known prior to the protocol upgrade.
     storage.set_value(known_code_key, u256_to_h256(1.into()));
@@ -156,8 +156,8 @@ pub(crate) fn test_force_deploy_upgrade<VM: TestedVm>() {
 /// Here we show how the work with the complex upgrader could be done.
 pub(crate) fn test_complex_upgrader<VM: TestedVm>() {
     let mut storage = get_empty_storage();
-    let bytecode_hash = hash_bytecode(&read_complex_upgrade());
-    let msg_sender_test_hash = hash_bytecode(&read_msg_sender_test());
+    let bytecode_hash = BytecodeHash::for_bytecode(&read_complex_upgrade()).value();
+    let msg_sender_test_hash = BytecodeHash::for_bytecode(&read_msg_sender_test()).value();
     // Let's assume that the bytecode for the implementation of the complex upgrade
     // is already deployed in some address in user space
     let upgrade_impl = Address::repeat_byte(1);

--- a/core/lib/multivm/src/versions/vm_1_3_2/oracles/decommitter.rs
+++ b/core/lib/multivm/src/versions/vm_1_3_2/oracles/decommitter.rs
@@ -7,12 +7,11 @@ use zk_evm_1_3_3::{
     },
 };
 use zksync_types::{u256_to_h256, U256};
-use zksync_utils::bytecode::bytecode_len_in_words;
 
 use super::OracleWithHistory;
 use crate::{
     interface::storage::{StoragePtr, WriteStorage},
-    utils::bytecode::bytes_to_be_words,
+    utils::bytecode::{bytecode_len_in_words, bytes_to_be_words},
     vm_1_3_2::history_recorder::{HistoryEnabled, HistoryMode, HistoryRecorder, WithHistory},
 };
 

--- a/core/lib/multivm/src/versions/vm_1_3_2/pubdata_utils.rs
+++ b/core/lib/multivm/src/versions/vm_1_3_2/pubdata_utils.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use circuit_sequencer_api_1_3_3::sort_storage_access::sort_storage_access_queries;
 use zk_evm_1_3_3::aux_structures::Timestamp;
 use zksync_types::{StorageKey, PUBLISH_BYTECODE_OVERHEAD, SYSTEM_CONTEXT_ADDRESS};
-use zksync_utils::bytecode::bytecode_len_in_bytes;
 
 use crate::{
     interface::{storage::WriteStorage, VmEvent},
+    utils::bytecode::bytecode_len_in_bytes,
     vm_1_3_2::{history_recorder::HistoryMode, oracles::storage::storage_key_of_log, VmInstance},
 };
 
@@ -30,9 +30,7 @@ impl<H: HistoryMode, S: WriteStorage> VmInstance<S, H> {
 
         let published_bytecode_bytes: u32 = VmEvent::extract_published_bytecodes(&events)
             .iter()
-            .map(|bytecodehash| {
-                bytecode_len_in_bytes(*bytecodehash) as u32 + PUBLISH_BYTECODE_OVERHEAD
-            })
+            .map(|bytecode_hash| bytecode_len_in_bytes(bytecode_hash) + PUBLISH_BYTECODE_OVERHEAD)
             .sum();
 
         storage_writes_pubdata_published

--- a/core/lib/multivm/src/versions/vm_1_3_2/test_utils.rs
+++ b/core/lib/multivm/src/versions/vm_1_3_2/test_utils.rs
@@ -13,12 +13,12 @@ use zk_evm_1_3_3::{aux_structures::Timestamp, vm_state::VmLocalState};
 use zksync_contracts::deployer_contract;
 use zksync_types::{
     address_to_h256,
+    bytecode::BytecodeHash,
     ethabi::{Address, Token},
     h256_to_address, u256_to_h256,
     web3::keccak256,
     Execute, Nonce, StorageKey, StorageValue, CONTRACT_DEPLOYER_ADDRESS, H256, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::interface::storage::WriteStorage;
 /// The tests here help us with the testing the VM
@@ -145,7 +145,7 @@ pub fn get_create_execute(code: &[u8], calldata: &[u8]) -> Execute {
 
     let params = [
         Token::FixedBytes(vec![0u8; 32]),
-        Token::FixedBytes(hash_bytecode(code).0.to_vec()),
+        Token::FixedBytes(BytecodeHash::for_bytecode(code).value().0.to_vec()),
         Token::Bytes(calldata.to_vec()),
     ];
     let calldata = contract_function

--- a/core/lib/multivm/src/versions/vm_1_3_2/transaction_data.rs
+++ b/core/lib/multivm/src/versions/vm_1_3_2/transaction_data.rs
@@ -1,6 +1,8 @@
 use zk_evm_1_3_3::zkevm_opcode_defs::system_params::MAX_TX_ERGS_LIMIT;
 use zksync_types::{
-    address_to_h256, ceil_div_u256,
+    address_to_h256,
+    bytecode::BytecodeHash,
+    ceil_div_u256,
     ethabi::{encode, Address, Token},
     fee::encoding_len,
     h256_to_u256,
@@ -8,7 +10,6 @@ use zksync_types::{
     l2::TransactionType,
     ExecuteTransactionCommon, Transaction, MAX_L2_TX_GAS_LIMIT, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use super::vm_with_bootloader::MAX_TXS_IN_BLOCK;
 use crate::{
@@ -194,7 +195,7 @@ impl TransactionData {
         let factory_deps_hashes = self
             .factory_deps
             .iter()
-            .map(|dep| h256_to_u256(hash_bytecode(dep)))
+            .map(|dep| BytecodeHash::for_bytecode(dep).value_u256())
             .collect();
         self.abi_encode_with_custom_factory_deps(factory_deps_hashes)
     }

--- a/core/lib/multivm/src/versions/vm_1_3_2/vm.rs
+++ b/core/lib/multivm/src/versions/vm_1_3_2/vm.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashSet, rc::Rc};
 
-use zksync_types::{h256_to_u256, Transaction};
-use zksync_utils::bytecode::hash_bytecode;
+use zksync_types::{bytecode::BytecodeHash, h256_to_u256, Transaction};
 use zksync_vm_interface::{pubdata::PubdataBuilder, InspectExecutionMode};
 
 use crate::{
@@ -119,7 +118,7 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
             let mut deps_hashes = HashSet::with_capacity(deps.len());
             let mut bytecode_hashes = vec![];
             let filtered_deps = deps.iter().filter_map(|bytecode| {
-                let bytecode_hash = hash_bytecode(bytecode);
+                let bytecode_hash = BytecodeHash::for_bytecode(bytecode).value();
                 let is_known =
                     !deps_hashes.insert(bytecode_hash) || self.vm.is_bytecode_known(&bytecode_hash);
 

--- a/core/lib/multivm/src/versions/vm_1_3_2/vm_with_bootloader.rs
+++ b/core/lib/multivm/src/versions/vm_1_3_2/vm_with_bootloader.rs
@@ -15,10 +15,10 @@ use zk_evm_1_3_3::{
 use zksync_contracts::BaseSystemContracts;
 use zksync_system_constants::MAX_L2_TX_GAS_LIMIT;
 use zksync_types::{
-    address_to_u256, fee_model::L1PeggedBatchFeeModelInput, h256_to_u256, l1::is_l1_tx_type,
-    Address, Transaction, BOOTLOADER_ADDRESS, L1_GAS_PER_PUBDATA_BYTE, MAX_NEW_FACTORY_DEPS, U256,
+    address_to_u256, bytecode::BytecodeHash, fee_model::L1PeggedBatchFeeModelInput, h256_to_u256,
+    l1::is_l1_tx_type, Address, Transaction, BOOTLOADER_ADDRESS, L1_GAS_PER_PUBDATA_BYTE,
+    MAX_NEW_FACTORY_DEPS, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::{
     interface::{storage::WriteStorage, CompressedBytecodeInfo, L1BatchEnv},
@@ -518,7 +518,7 @@ pub fn push_raw_transaction_to_bootloader_memory<H: HistoryMode, S: WriteStorage
             .enumerate()
             .sorted_by_key(|(_idx, dep)| *dep)
             .dedup_by(|x, y| x.1 == y.1)
-            .filter(|(_idx, dep)| !vm.is_bytecode_known(&hash_bytecode(dep)))
+            .filter(|(_idx, dep)| !vm.is_bytecode_known(&BytecodeHash::for_bytecode(dep).value()))
             .sorted_by_key(|(idx, _dep)| *idx)
             .filter_map(|(_idx, dep)| bytecode::compress(dep.clone()).ok())
             .collect()
@@ -728,10 +728,8 @@ fn formal_calldata_abi() -> PrimitiveValue {
     }
 }
 
-// FIXME: &[u8]
 pub(crate) fn bytecode_to_factory_dep(bytecode: Vec<u8>) -> (U256, Vec<U256>) {
-    let bytecode_hash = hash_bytecode(&bytecode);
-    let bytecode_hash = U256::from_big_endian(bytecode_hash.as_bytes());
+    let bytecode_hash = BytecodeHash::for_bytecode(&bytecode).value_u256();
     let bytecode_words = bytes_to_be_words(&bytecode);
     (bytecode_hash, bytecode_words)
 }

--- a/core/lib/multivm/src/versions/vm_1_4_1/implementation/bytecode.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_1/implementation/bytecode.rs
@@ -1,6 +1,5 @@
 use itertools::Itertools;
-use zksync_types::U256;
-use zksync_utils::bytecode::hash_bytecode;
+use zksync_types::{bytecode::BytecodeHash, U256};
 
 use crate::{
     interface::{
@@ -25,15 +24,14 @@ impl<S: WriteStorage, H: HistoryMode> Vm<S, H> {
                     .storage
                     .get_ptr()
                     .borrow_mut()
-                    .is_bytecode_known(&hash_bytecode(&info.original))
+                    .is_bytecode_known(&BytecodeHash::for_bytecode(&info.original).value())
             })
     }
 }
 
 /// Converts bytecode to tokens and hashes it.
 pub(crate) fn bytecode_to_factory_dep(bytecode: Vec<u8>) -> (U256, Vec<U256>) {
-    let bytecode_hash = hash_bytecode(&bytecode);
-    let bytecode_hash = U256::from_big_endian(bytecode_hash.as_bytes());
+    let bytecode_hash = BytecodeHash::for_bytecode(&bytecode).value_u256();
     let bytecode_words = bytecode::bytes_to_be_words(&bytecode);
     (bytecode_hash, bytecode_words)
 }
@@ -47,7 +45,11 @@ pub(crate) fn compress_bytecodes<S: WriteStorage>(
         .enumerate()
         .sorted_by_key(|(_idx, dep)| *dep)
         .dedup_by(|x, y| x.1 == y.1)
-        .filter(|(_idx, dep)| !storage.borrow_mut().is_bytecode_known(&hash_bytecode(dep)))
+        .filter(|(_idx, dep)| {
+            !storage
+                .borrow_mut()
+                .is_bytecode_known(&BytecodeHash::for_bytecode(dep).value())
+        })
         .sorted_by_key(|(idx, _dep)| *idx)
         .filter_map(|(_idx, dep)| bytecode::compress(dep.clone()).ok())
         .collect()

--- a/core/lib/multivm/src/versions/vm_1_4_1/old_vm/oracles/decommitter.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_1/old_vm/oracles/decommitter.rs
@@ -7,12 +7,11 @@ use zk_evm_1_4_1::{
     },
 };
 use zksync_types::{u256_to_h256, U256};
-use zksync_utils::bytecode::bytecode_len_in_words;
 
 use super::OracleWithHistory;
 use crate::{
     interface::storage::{ReadStorage, StoragePtr},
-    utils::bytecode::bytes_to_be_words,
+    utils::bytecode::{bytecode_len_in_words, bytes_to_be_words},
     vm_1_4_1::old_vm::history_recorder::{
         HistoryEnabled, HistoryMode, HistoryRecorder, WithHistory,
     },

--- a/core/lib/multivm/src/versions/vm_1_4_1/tracers/refunds.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_1/tracers/refunds.rs
@@ -11,7 +11,6 @@ use zksync_system_constants::{PUBLISH_BYTECODE_OVERHEAD, SYSTEM_CONTEXT_ADDRESS}
 use zksync_types::{
     ceil_div_u256, l2_to_l1_log::L2ToL1Log, u256_to_h256, L1BatchNumber, H256, U256,
 };
-use zksync_utils::bytecode::bytecode_len_in_bytes;
 
 use crate::{
     interface::{
@@ -20,6 +19,7 @@ use crate::{
         L1BatchEnv, Refunds, VmEvent,
     },
     tracers::dynamic::vm_1_4_1::DynTracer,
+    utils::bytecode::bytecode_len_in_bytes,
     vm_1_4_1::{
         bootloader_state::BootloaderState,
         constants::{BOOTLOADER_HEAP_PAGE, OPERATOR_REFUNDS_OFFSET, TX_GAS_LIMIT_OFFSET},
@@ -350,7 +350,7 @@ pub(crate) fn pubdata_published<S: WriteStorage, H: HistoryMode>(
 
     let published_bytecode_bytes: u32 = VmEvent::extract_published_bytecodes(&events)
         .iter()
-        .map(|bytecodehash| bytecode_len_in_bytes(*bytecodehash) as u32 + PUBLISH_BYTECODE_OVERHEAD)
+        .map(|bytecode_hash| bytecode_len_in_bytes(bytecode_hash) + PUBLISH_BYTECODE_OVERHEAD)
         .sum();
 
     storage_writes_pubdata_published

--- a/core/lib/multivm/src/versions/vm_1_4_1/types/internals/transaction_data.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_1/types/internals/transaction_data.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 use zksync_types::{
     address_to_h256,
+    bytecode::BytecodeHash,
     ethabi::{encode, Address, Token},
     fee::{encoding_len, Fee},
     h256_to_u256,
@@ -11,7 +12,6 @@ use zksync_types::{
     web3::Bytes,
     Execute, ExecuteTransactionCommon, L2ChainId, L2TxCommonData, Nonce, Transaction, H256, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::{
     utils::bytecode::bytes_to_be_words,
@@ -195,7 +195,7 @@ impl TransactionData {
         let factory_deps_hashes = self
             .factory_deps
             .iter()
-            .map(|dep| h256_to_u256(hash_bytecode(dep)))
+            .map(|dep| BytecodeHash::for_bytecode(dep).value_u256())
             .collect();
         self.abi_encode_with_custom_factory_deps(factory_deps_hashes)
     }

--- a/core/lib/multivm/src/versions/vm_1_4_2/implementation/bytecode.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_2/implementation/bytecode.rs
@@ -1,6 +1,5 @@
 use itertools::Itertools;
-use zksync_types::U256;
-use zksync_utils::bytecode::hash_bytecode;
+use zksync_types::{bytecode::BytecodeHash, U256};
 
 use crate::{
     interface::{
@@ -25,15 +24,14 @@ impl<S: WriteStorage, H: HistoryMode> Vm<S, H> {
                     .storage
                     .get_ptr()
                     .borrow_mut()
-                    .is_bytecode_known(&hash_bytecode(&info.original))
+                    .is_bytecode_known(&BytecodeHash::for_bytecode(&info.original).value())
             })
     }
 }
 
 /// Converts bytecode to tokens and hashes it.
 pub(crate) fn bytecode_to_factory_dep(bytecode: Vec<u8>) -> (U256, Vec<U256>) {
-    let bytecode_hash = hash_bytecode(&bytecode);
-    let bytecode_hash = U256::from_big_endian(bytecode_hash.as_bytes());
+    let bytecode_hash = BytecodeHash::for_bytecode(&bytecode).value_u256();
     let bytecode_words = bytes_to_be_words(&bytecode);
     (bytecode_hash, bytecode_words)
 }
@@ -47,7 +45,11 @@ pub(crate) fn compress_bytecodes<S: WriteStorage>(
         .enumerate()
         .sorted_by_key(|(_idx, dep)| *dep)
         .dedup_by(|x, y| x.1 == y.1)
-        .filter(|(_idx, dep)| !storage.borrow_mut().is_bytecode_known(&hash_bytecode(dep)))
+        .filter(|(_idx, dep)| {
+            !storage
+                .borrow_mut()
+                .is_bytecode_known(&BytecodeHash::for_bytecode(dep).value())
+        })
         .sorted_by_key(|(idx, _dep)| *idx)
         .filter_map(|(_idx, dep)| bytecode::compress(dep.clone()).ok())
         .collect()

--- a/core/lib/multivm/src/versions/vm_1_4_2/old_vm/oracles/decommitter.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_2/old_vm/oracles/decommitter.rs
@@ -7,12 +7,11 @@ use zk_evm_1_4_1::{
     },
 };
 use zksync_types::{u256_to_h256, U256};
-use zksync_utils::bytecode::bytecode_len_in_words;
 
 use super::OracleWithHistory;
 use crate::{
     interface::storage::{ReadStorage, StoragePtr},
-    utils::bytecode::bytes_to_be_words,
+    utils::bytecode::{bytecode_len_in_words, bytes_to_be_words},
     vm_1_4_2::old_vm::history_recorder::{
         HistoryEnabled, HistoryMode, HistoryRecorder, WithHistory,
     },

--- a/core/lib/multivm/src/versions/vm_1_4_2/tracers/refunds.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_2/tracers/refunds.rs
@@ -11,7 +11,6 @@ use zksync_system_constants::{PUBLISH_BYTECODE_OVERHEAD, SYSTEM_CONTEXT_ADDRESS}
 use zksync_types::{
     ceil_div_u256, l2_to_l1_log::L2ToL1Log, u256_to_h256, L1BatchNumber, H256, U256,
 };
-use zksync_utils::bytecode::bytecode_len_in_bytes;
 
 use crate::{
     interface::{
@@ -20,6 +19,7 @@ use crate::{
         L1BatchEnv, Refunds, VmEvent,
     },
     tracers::dynamic::vm_1_4_1::DynTracer,
+    utils::bytecode::bytecode_len_in_bytes,
     vm_1_4_2::{
         bootloader_state::BootloaderState,
         constants::{BOOTLOADER_HEAP_PAGE, OPERATOR_REFUNDS_OFFSET, TX_GAS_LIMIT_OFFSET},
@@ -350,7 +350,7 @@ pub(crate) fn pubdata_published<S: WriteStorage, H: HistoryMode>(
 
     let published_bytecode_bytes: u32 = VmEvent::extract_published_bytecodes(&events)
         .iter()
-        .map(|bytecodehash| bytecode_len_in_bytes(*bytecodehash) as u32 + PUBLISH_BYTECODE_OVERHEAD)
+        .map(|bytecode_hash| bytecode_len_in_bytes(bytecode_hash) + PUBLISH_BYTECODE_OVERHEAD)
         .sum();
 
     storage_writes_pubdata_published

--- a/core/lib/multivm/src/versions/vm_1_4_2/types/internals/transaction_data.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_2/types/internals/transaction_data.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 use zksync_types::{
     address_to_h256,
+    bytecode::BytecodeHash,
     ethabi::{encode, Address, Token},
     fee::{encoding_len, Fee},
     h256_to_u256,
@@ -11,7 +12,6 @@ use zksync_types::{
     web3::Bytes,
     Execute, ExecuteTransactionCommon, L2ChainId, L2TxCommonData, Nonce, Transaction, H256, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::{
     utils::bytecode::bytes_to_be_words,
@@ -195,7 +195,7 @@ impl TransactionData {
         let factory_deps_hashes = self
             .factory_deps
             .iter()
-            .map(|dep| h256_to_u256(hash_bytecode(dep)))
+            .map(|dep| BytecodeHash::for_bytecode(dep).value_u256())
             .collect();
         self.abi_encode_with_custom_factory_deps(factory_deps_hashes)
     }

--- a/core/lib/multivm/src/versions/vm_boojum_integration/implementation/bytecode.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/implementation/bytecode.rs
@@ -1,6 +1,5 @@
 use itertools::Itertools;
-use zksync_types::U256;
-use zksync_utils::bytecode::hash_bytecode;
+use zksync_types::{bytecode::BytecodeHash, U256};
 
 use crate::{
     interface::{
@@ -25,15 +24,14 @@ impl<S: WriteStorage, H: HistoryMode> Vm<S, H> {
                     .storage
                     .get_ptr()
                     .borrow_mut()
-                    .is_bytecode_known(&hash_bytecode(&info.original))
+                    .is_bytecode_known(&BytecodeHash::for_bytecode(&info.original).value())
             })
     }
 }
 
 /// Converts bytecode to tokens and hashes it.
 pub(crate) fn bytecode_to_factory_dep(bytecode: Vec<u8>) -> (U256, Vec<U256>) {
-    let bytecode_hash = hash_bytecode(&bytecode);
-    let bytecode_hash = U256::from_big_endian(bytecode_hash.as_bytes());
+    let bytecode_hash = BytecodeHash::for_bytecode(&bytecode).value_u256();
     let bytecode_words = bytes_to_be_words(&bytecode);
     (bytecode_hash, bytecode_words)
 }
@@ -47,7 +45,11 @@ pub(crate) fn compress_bytecodes<S: WriteStorage>(
         .enumerate()
         .sorted_by_key(|(_idx, dep)| *dep)
         .dedup_by(|x, y| x.1 == y.1)
-        .filter(|(_idx, dep)| !storage.borrow_mut().is_bytecode_known(&hash_bytecode(dep)))
+        .filter(|(_idx, dep)| {
+            !storage
+                .borrow_mut()
+                .is_bytecode_known(&BytecodeHash::for_bytecode(dep).value())
+        })
         .sorted_by_key(|(idx, _dep)| *idx)
         .filter_map(|(_idx, dep)| bytecode::compress(dep.clone()).ok())
         .collect()

--- a/core/lib/multivm/src/versions/vm_boojum_integration/old_vm/oracles/decommitter.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/old_vm/oracles/decommitter.rs
@@ -7,12 +7,11 @@ use zk_evm_1_4_0::{
     },
 };
 use zksync_types::{u256_to_h256, U256};
-use zksync_utils::bytecode::bytecode_len_in_words;
 
 use super::OracleWithHistory;
 use crate::{
     interface::storage::{ReadStorage, StoragePtr},
-    utils::bytecode::bytes_to_be_words,
+    utils::bytecode::{bytecode_len_in_words, bytes_to_be_words},
     vm_boojum_integration::old_vm::history_recorder::{
         HistoryEnabled, HistoryMode, HistoryRecorder, WithHistory,
     },

--- a/core/lib/multivm/src/versions/vm_boojum_integration/tracers/refunds.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/tracers/refunds.rs
@@ -8,7 +8,6 @@ use zk_evm_1_4_0::{
 };
 use zksync_system_constants::{PUBLISH_BYTECODE_OVERHEAD, SYSTEM_CONTEXT_ADDRESS};
 use zksync_types::{ceil_div_u256, l2_to_l1_log::L2ToL1Log, u256_to_h256, L1BatchNumber, U256};
-use zksync_utils::bytecode::bytecode_len_in_bytes;
 
 use crate::{
     interface::{
@@ -17,6 +16,7 @@ use crate::{
         L1BatchEnv, Refunds, VmEvent,
     },
     tracers::dynamic::vm_1_4_0::DynTracer,
+    utils::bytecode::bytecode_len_in_bytes,
     vm_boojum_integration::{
         bootloader_state::BootloaderState,
         constants::{BOOTLOADER_HEAP_PAGE, OPERATOR_REFUNDS_OFFSET, TX_GAS_LIMIT_OFFSET},
@@ -339,7 +339,7 @@ pub(crate) fn pubdata_published<S: WriteStorage, H: HistoryMode>(
 
     let published_bytecode_bytes: u32 = VmEvent::extract_published_bytecodes(&events)
         .iter()
-        .map(|bytecodehash| bytecode_len_in_bytes(*bytecodehash) as u32 + PUBLISH_BYTECODE_OVERHEAD)
+        .map(|bytecode_hash| bytecode_len_in_bytes(bytecode_hash) + PUBLISH_BYTECODE_OVERHEAD)
         .sum();
 
     storage_writes_pubdata_published

--- a/core/lib/multivm/src/versions/vm_boojum_integration/types/internals/transaction_data.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/types/internals/transaction_data.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 use zksync_types::{
     address_to_h256,
+    bytecode::BytecodeHash,
     ethabi::{encode, Address, Token},
     fee::{encoding_len, Fee},
     h256_to_u256,
@@ -11,7 +12,6 @@ use zksync_types::{
     web3::Bytes,
     Execute, ExecuteTransactionCommon, L2ChainId, L2TxCommonData, Nonce, Transaction, H256, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::{
     utils::bytecode::bytes_to_be_words,
@@ -195,7 +195,7 @@ impl TransactionData {
         let factory_deps_hashes = self
             .factory_deps
             .iter()
-            .map(|dep| h256_to_u256(hash_bytecode(dep)))
+            .map(|dep| BytecodeHash::for_bytecode(dep).value_u256())
             .collect();
         self.abi_encode_with_custom_factory_deps(factory_deps_hashes)
     }

--- a/core/lib/multivm/src/versions/vm_fast/bytecode.rs
+++ b/core/lib/multivm/src/versions/vm_fast/bytecode.rs
@@ -1,6 +1,5 @@
 use itertools::Itertools;
-use zksync_types::{h256_to_u256, H256};
-use zksync_utils::bytecode::hash_bytecode;
+use zksync_types::{bytecode::BytecodeHash, h256_to_u256, H256};
 
 use super::Vm;
 use crate::{
@@ -15,7 +14,7 @@ impl<S: ReadStorage, Tr> Vm<S, Tr> {
             .get_last_tx_compressed_bytecodes()
             .iter()
             .any(|info| {
-                let hash_bytecode = hash_bytecode(&info.original);
+                let hash_bytecode = BytecodeHash::for_bytecode(&info.original).value();
                 let is_bytecode_known = self.world.storage.is_bytecode_known(&hash_bytecode);
 
                 let is_bytecode_known_cache = self
@@ -36,7 +35,7 @@ pub(crate) fn compress_bytecodes(
         .enumerate()
         .sorted_by_key(|(_idx, dep)| *dep)
         .dedup_by(|x, y| x.1 == y.1)
-        .filter(|(_idx, dep)| !is_bytecode_known(hash_bytecode(dep)))
+        .filter(|(_idx, dep)| !is_bytecode_known(BytecodeHash::for_bytecode(dep).value()))
         .sorted_by_key(|(idx, _dep)| *idx)
         .filter_map(|(_idx, dep)| bytecode::compress(dep.clone()).ok())
         .collect()

--- a/core/lib/multivm/src/versions/vm_fast/evm_deploy_tracer.rs
+++ b/core/lib/multivm/src/versions/vm_fast/evm_deploy_tracer.rs
@@ -3,8 +3,7 @@
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use zksync_system_constants::{CONTRACT_DEPLOYER_ADDRESS, KNOWN_CODES_STORAGE_ADDRESS};
-use zksync_types::{h256_to_u256, U256};
-use zksync_utils::bytecode::hash_evm_bytecode;
+use zksync_types::{bytecode::BytecodeHash, U256};
 use zksync_vm2::interface::{
     CallframeInterface, CallingMode, GlobalStateInterface, Opcode, OpcodeType, ShouldStop, Tracer,
 };
@@ -66,7 +65,8 @@ impl EvmDeployTracer {
             Ok(decoded) => {
                 // `unwrap`s should be safe since the function signature is checked above.
                 let published_bytecode = decoded.into_iter().next().unwrap().into_bytes().unwrap();
-                let bytecode_hash = h256_to_u256(hash_evm_bytecode(&published_bytecode));
+                let bytecode_hash =
+                    BytecodeHash::for_evm_bytecode(&published_bytecode).value_u256();
                 self.bytecodes.insert(bytecode_hash, published_bytecode);
             }
             Err(err) => tracing::error!("Unable to decode `publishEVMBytecode` call: {err}"),

--- a/core/lib/multivm/src/versions/vm_fast/transaction_data.rs
+++ b/core/lib/multivm/src/versions/vm_fast/transaction_data.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 use zksync_types::{
     address_to_h256,
+    bytecode::BytecodeHash,
     ethabi::{encode, Address, Token},
     fee::{encoding_len, Fee},
     h256_to_u256,
@@ -11,7 +12,6 @@ use zksync_types::{
     web3::Bytes,
     Execute, ExecuteTransactionCommon, L2ChainId, L2TxCommonData, Nonce, Transaction, H256, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::{
     utils::bytecode::bytes_to_be_words,
@@ -195,7 +195,7 @@ impl TransactionData {
         let factory_deps_hashes = self
             .factory_deps
             .iter()
-            .map(|dep| h256_to_u256(hash_bytecode(dep)))
+            .map(|dep| BytecodeHash::for_bytecode(dep).value_u256())
             .collect();
         self.abi_encode_with_custom_factory_deps(factory_deps_hashes)
     }

--- a/core/lib/multivm/src/versions/vm_fast/vm.rs
+++ b/core/lib/multivm/src/versions/vm_fast/vm.rs
@@ -5,6 +5,7 @@ use zk_evm_1_5_0::{
 };
 use zksync_contracts::SystemContractCode;
 use zksync_types::{
+    bytecode::BytecodeHash,
     h256_to_u256,
     l1::is_l1_tx_type,
     l2_to_l1_log::UserL2ToL1Log,
@@ -18,7 +19,6 @@ use zksync_types::{
     Transaction, BOOTLOADER_ADDRESS, H160, H256, KNOWN_CODES_STORAGE_ADDRESS, L1_MESSENGER_ADDRESS,
     L2_BASE_TOKEN_ADDRESS, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 use zksync_vm2::{
     interface::{CallframeInterface, HeapId, StateInterface, Tracer},
     ExecutionEnd, FatPointer, Program, Settings, StorageSlot, VirtualMachine,
@@ -457,7 +457,7 @@ impl<S: ReadStorage, Tr: Tracer + Default> Vm<S, Tr> {
 
     pub(crate) fn insert_bytecodes<'a>(&mut self, bytecodes: impl IntoIterator<Item = &'a [u8]>) {
         for code in bytecodes {
-            let hash = h256_to_u256(hash_bytecode(code));
+            let hash = BytecodeHash::for_bytecode(code).value_u256();
             self.world.bytecode_cache.insert(hash, code.into());
         }
     }

--- a/core/lib/multivm/src/versions/vm_latest/implementation/bytecode.rs
+++ b/core/lib/multivm/src/versions/vm_latest/implementation/bytecode.rs
@@ -1,6 +1,5 @@
 use itertools::Itertools;
-use zksync_types::U256;
-use zksync_utils::bytecode::hash_bytecode;
+use zksync_types::{bytecode::BytecodeHash, U256};
 
 use crate::{
     interface::{
@@ -25,15 +24,14 @@ impl<S: WriteStorage, H: HistoryMode> Vm<S, H> {
                     .storage
                     .get_ptr()
                     .borrow_mut()
-                    .is_bytecode_known(&hash_bytecode(&info.original))
+                    .is_bytecode_known(&BytecodeHash::for_bytecode(&info.original).value())
             })
     }
 }
 
 /// Converts bytecode to tokens and hashes it.
 pub(crate) fn bytecode_to_factory_dep(bytecode: Vec<u8>) -> (U256, Vec<U256>) {
-    let bytecode_hash = hash_bytecode(&bytecode);
-    let bytecode_hash = U256::from_big_endian(bytecode_hash.as_bytes());
+    let bytecode_hash = BytecodeHash::for_bytecode(&bytecode).value_u256();
     let bytecode_words = bytes_to_be_words(&bytecode);
     (bytecode_hash, bytecode_words)
 }
@@ -47,7 +45,11 @@ pub(crate) fn compress_bytecodes<S: WriteStorage>(
         .enumerate()
         .sorted_by_key(|(_idx, dep)| *dep)
         .dedup_by(|x, y| x.1 == y.1)
-        .filter(|(_idx, dep)| !storage.borrow_mut().is_bytecode_known(&hash_bytecode(dep)))
+        .filter(|(_idx, dep)| {
+            !storage
+                .borrow_mut()
+                .is_bytecode_known(&BytecodeHash::for_bytecode(dep).value())
+        })
         .sorted_by_key(|(idx, _dep)| *idx)
         .filter_map(|(_idx, dep)| bytecode::compress(dep.clone()).ok())
         .collect()

--- a/core/lib/multivm/src/versions/vm_latest/tests/mod.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/mod.rs
@@ -9,9 +9,9 @@ use zk_evm_1_5_0::{
     zkevm_opcode_defs::{ContractCodeSha256Format, VersionedHashLen32},
 };
 use zksync_types::{
-    h256_to_u256, writes::StateDiffRecord, StorageKey, StorageValue, Transaction, H256, U256,
+    bytecode::BytecodeHash, writes::StateDiffRecord, StorageKey, StorageValue, Transaction, H256,
+    U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 use zksync_vm_interface::pubdata::PubdataBuilder;
 
 use super::{HistoryEnabled, Vm};
@@ -113,9 +113,9 @@ impl TestedVm for TestedLatestVm {
         let bytecodes = bytecodes
             .iter()
             .map(|&bytecode| {
-                let hash = hash_bytecode(bytecode);
+                let hash = BytecodeHash::for_bytecode(bytecode).value_u256();
                 let words = bytes_to_be_words(bytecode);
-                (h256_to_u256(hash), words)
+                (hash, words)
             })
             .collect();
         self.state

--- a/core/lib/multivm/src/versions/vm_latest/tracers/evm_deploy_tracer.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tracers/evm_deploy_tracer.rs
@@ -7,8 +7,9 @@ use zk_evm_1_5_0::{
         FarCallOpcode, FatPointer, Opcode, CALL_IMPLICIT_CALLDATA_FAT_PTR_REGISTER,
     },
 };
-use zksync_types::{h256_to_u256, CONTRACT_DEPLOYER_ADDRESS, KNOWN_CODES_STORAGE_ADDRESS};
-use zksync_utils::bytecode::hash_evm_bytecode;
+use zksync_types::{
+    bytecode::BytecodeHash, CONTRACT_DEPLOYER_ADDRESS, KNOWN_CODES_STORAGE_ADDRESS,
+};
 
 use super::{traits::VmTracer, utils::read_pointer};
 use crate::{
@@ -94,7 +95,7 @@ impl<S: WriteStorage, H: HistoryMode> VmTracer<S, H> for EvmDeployTracer<S> {
     ) -> TracerExecutionStatus {
         let timestamp = Timestamp(state.local_state.timestamp);
         for published_bytecode in mem::take(&mut self.pending_bytecodes) {
-            let hash = h256_to_u256(hash_evm_bytecode(&published_bytecode));
+            let hash = BytecodeHash::for_bytecode(&published_bytecode).value_u256();
             let as_words = bytes_to_be_words(&published_bytecode);
             state
                 .decommittment_processor

--- a/core/lib/multivm/src/versions/vm_latest/tracers/evm_deploy_tracer.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tracers/evm_deploy_tracer.rs
@@ -95,7 +95,7 @@ impl<S: WriteStorage, H: HistoryMode> VmTracer<S, H> for EvmDeployTracer<S> {
     ) -> TracerExecutionStatus {
         let timestamp = Timestamp(state.local_state.timestamp);
         for published_bytecode in mem::take(&mut self.pending_bytecodes) {
-            let hash = BytecodeHash::for_bytecode(&published_bytecode).value_u256();
+            let hash = BytecodeHash::for_evm_bytecode(&published_bytecode).value_u256();
             let as_words = bytes_to_be_words(&published_bytecode);
             state
                 .decommittment_processor

--- a/core/lib/multivm/src/versions/vm_latest/types/internals/transaction_data.rs
+++ b/core/lib/multivm/src/versions/vm_latest/types/internals/transaction_data.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 use zksync_types::{
     address_to_h256,
+    bytecode::BytecodeHash,
     ethabi::{encode, Address, Token},
     fee::{encoding_len, Fee},
     h256_to_u256,
@@ -11,7 +12,6 @@ use zksync_types::{
     web3::Bytes,
     Execute, ExecuteTransactionCommon, L2ChainId, L2TxCommonData, Nonce, Transaction, H256, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::{
     utils::bytecode::bytes_to_be_words,
@@ -208,7 +208,7 @@ impl TransactionData {
         let factory_deps_hashes = self
             .factory_deps
             .iter()
-            .map(|dep| h256_to_u256(hash_bytecode(dep)))
+            .map(|dep| BytecodeHash::for_bytecode(dep).value_u256())
             .collect();
         self.abi_encode_with_custom_factory_deps(factory_deps_hashes)
     }

--- a/core/lib/multivm/src/versions/vm_m5/oracles/decommitter.rs
+++ b/core/lib/multivm/src/versions/vm_m5/oracles/decommitter.rs
@@ -7,11 +7,10 @@ use zk_evm_1_3_1::{
     },
 };
 use zksync_types::{u256_to_h256, U256};
-use zksync_utils::bytecode::bytecode_len_in_words;
 
 use super::OracleWithHistory;
 use crate::{
-    utils::bytecode::bytes_to_be_words,
+    utils::bytecode::{bytecode_len_in_words, bytes_to_be_words},
     vm_m5::{
         history_recorder::HistoryRecorder,
         storage::{Storage, StoragePtr},

--- a/core/lib/multivm/src/versions/vm_m5/pubdata_utils.rs
+++ b/core/lib/multivm/src/versions/vm_m5/pubdata_utils.rs
@@ -4,11 +4,11 @@ use circuit_sequencer_api_1_3_3::sort_storage_access::sort_storage_access_querie
 use itertools::Itertools;
 use zk_evm_1_3_1::aux_structures::{LogQuery, Timestamp};
 use zksync_types::{StorageKey, PUBLISH_BYTECODE_OVERHEAD, SYSTEM_CONTEXT_ADDRESS};
-use zksync_utils::bytecode::bytecode_len_in_bytes;
 
 use crate::{
     glue::GlueInto,
     interface::VmEvent,
+    utils::bytecode::bytecode_len_in_bytes,
     vm_m5::{
         oracles::storage::storage_key_of_log, storage::Storage,
         utils::collect_storage_log_queries_after_timestamp, vm_instance::VmInstance,
@@ -35,9 +35,7 @@ impl<S: Storage> VmInstance<S> {
 
         let published_bytecode_bytes: u32 = VmEvent::extract_published_bytecodes(&events)
             .iter()
-            .map(|bytecodehash| {
-                bytecode_len_in_bytes(*bytecodehash) as u32 + PUBLISH_BYTECODE_OVERHEAD
-            })
+            .map(|bytecode_hash| bytecode_len_in_bytes(bytecode_hash) + PUBLISH_BYTECODE_OVERHEAD)
             .sum();
 
         storage_writes_pubdata_published

--- a/core/lib/multivm/src/versions/vm_m5/test_utils.rs
+++ b/core/lib/multivm/src/versions/vm_m5/test_utils.rs
@@ -15,12 +15,12 @@ use zk_evm_1_3_1::{
 use zksync_contracts::deployer_contract;
 use zksync_types::{
     address_to_h256,
+    bytecode::BytecodeHash,
     ethabi::{Address, Token},
     h256_to_address, u256_to_h256,
     web3::keccak256,
     Execute, Nonce, StorageKey, StorageValue, CONTRACT_DEPLOYER_ADDRESS, H256, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use super::utils::StorageLogQuery;
 use crate::vm_m5::{
@@ -143,7 +143,7 @@ pub fn get_create_execute(code: &[u8], calldata: &[u8]) -> Execute {
 
     let params = [
         Token::FixedBytes(vec![0u8; 32]),
-        Token::FixedBytes(hash_bytecode(code).0.to_vec()),
+        Token::FixedBytes(BytecodeHash::for_bytecode(code).value().0.to_vec()),
         Token::Bytes(calldata.to_vec()),
     ];
     let calldata = contract_function

--- a/core/lib/multivm/src/versions/vm_m5/transaction_data.rs
+++ b/core/lib/multivm/src/versions/vm_m5/transaction_data.rs
@@ -1,13 +1,14 @@
 use zk_evm_1_3_1::zkevm_opcode_defs::system_params::{MAX_PUBDATA_PER_BLOCK, MAX_TX_ERGS_LIMIT};
 use zksync_types::{
-    address_to_h256, ceil_div_u256,
+    address_to_h256,
+    bytecode::BytecodeHash,
+    ceil_div_u256,
     ethabi::{encode, Address, Token},
     fee::encoding_len,
     h256_to_u256,
     l2::TransactionType,
     ExecuteTransactionCommon, Transaction, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use super::vm_with_bootloader::MAX_GAS_PER_PUBDATA_BYTE;
 use crate::{
@@ -168,7 +169,7 @@ impl TransactionData {
         let factory_deps_hashes = self
             .factory_deps
             .iter()
-            .map(|dep| h256_to_u256(hash_bytecode(dep)))
+            .map(|dep| BytecodeHash::for_bytecode(dep).value_u256())
             .collect();
         self.abi_encode_with_custom_factory_deps(factory_deps_hashes)
     }

--- a/core/lib/multivm/src/versions/vm_m5/vm_with_bootloader.rs
+++ b/core/lib/multivm/src/versions/vm_m5/vm_with_bootloader.rs
@@ -14,10 +14,9 @@ use zk_evm_1_3_1::{
 use zksync_contracts::BaseSystemContracts;
 use zksync_system_constants::MAX_L2_TX_GAS_LIMIT;
 use zksync_types::{
-    address_to_u256, fee_model::L1PeggedBatchFeeModelInput, h256_to_u256, Address, Transaction,
-    BOOTLOADER_ADDRESS, L1_GAS_PER_PUBDATA_BYTE, MAX_NEW_FACTORY_DEPS, U256,
+    address_to_u256, bytecode::BytecodeHash, fee_model::L1PeggedBatchFeeModelInput, h256_to_u256,
+    Address, Transaction, BOOTLOADER_ADDRESS, L1_GAS_PER_PUBDATA_BYTE, MAX_NEW_FACTORY_DEPS, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::{
     interface::L1BatchEnv,
@@ -585,8 +584,7 @@ fn formal_calldata_abi() -> PrimitiveValue {
 }
 
 pub(crate) fn bytecode_to_factory_dep(bytecode: Vec<u8>) -> (U256, Vec<U256>) {
-    let bytecode_hash = hash_bytecode(&bytecode);
-    let bytecode_hash = U256::from_big_endian(bytecode_hash.as_bytes());
+    let bytecode_hash = BytecodeHash::for_bytecode(&bytecode).value_u256();
     let bytecode_words = bytes_to_be_words(&bytecode);
     (bytecode_hash, bytecode_words)
 }

--- a/core/lib/multivm/src/versions/vm_m6/oracles/decommitter.rs
+++ b/core/lib/multivm/src/versions/vm_m6/oracles/decommitter.rs
@@ -7,11 +7,10 @@ use zk_evm_1_3_1::{
     },
 };
 use zksync_types::{u256_to_h256, U256};
-use zksync_utils::bytecode::bytecode_len_in_words;
 
 use super::OracleWithHistory;
 use crate::{
-    utils::bytecode::bytes_to_be_words,
+    utils::bytecode::{bytecode_len_in_words, bytes_to_be_words},
     vm_m6::{
         history_recorder::{HistoryEnabled, HistoryMode, HistoryRecorder, WithHistory},
         storage::{Storage, StoragePtr},

--- a/core/lib/multivm/src/versions/vm_m6/pubdata_utils.rs
+++ b/core/lib/multivm/src/versions/vm_m6/pubdata_utils.rs
@@ -4,11 +4,11 @@ use circuit_sequencer_api_1_3_3::sort_storage_access::sort_storage_access_querie
 use itertools::Itertools;
 use zk_evm_1_3_1::aux_structures::{LogQuery, Timestamp};
 use zksync_types::{StorageKey, PUBLISH_BYTECODE_OVERHEAD, SYSTEM_CONTEXT_ADDRESS};
-use zksync_utils::bytecode::bytecode_len_in_bytes;
 
 use crate::{
     glue::GlueInto,
     interface::VmEvent,
+    utils::bytecode::bytecode_len_in_bytes,
     vm_m6::{
         history_recorder::HistoryMode, oracles::storage::storage_key_of_log, storage::Storage,
         utils::collect_storage_log_queries_after_timestamp, VmInstance,
@@ -35,9 +35,7 @@ impl<H: HistoryMode, S: Storage> VmInstance<S, H> {
 
         let published_bytecode_bytes: u32 = VmEvent::extract_published_bytecodes(&events)
             .iter()
-            .map(|bytecodehash| {
-                bytecode_len_in_bytes(*bytecodehash) as u32 + PUBLISH_BYTECODE_OVERHEAD
-            })
+            .map(|bytecode_hash| bytecode_len_in_bytes(bytecode_hash) + PUBLISH_BYTECODE_OVERHEAD)
             .sum();
 
         storage_writes_pubdata_published

--- a/core/lib/multivm/src/versions/vm_m6/test_utils.rs
+++ b/core/lib/multivm/src/versions/vm_m6/test_utils.rs
@@ -13,12 +13,12 @@ use zk_evm_1_3_1::{aux_structures::Timestamp, vm_state::VmLocalState};
 use zksync_contracts::deployer_contract;
 use zksync_types::{
     address_to_h256,
+    bytecode::BytecodeHash,
     ethabi::{Address, Token},
     h256_to_address, u256_to_h256,
     web3::keccak256,
     Execute, Nonce, StorageKey, StorageValue, CONTRACT_DEPLOYER_ADDRESS, H256, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use super::utils::StorageLogQuery;
 use crate::vm_m6::{
@@ -143,7 +143,7 @@ pub fn get_create_execute(code: &[u8], calldata: &[u8]) -> Execute {
 
     let params = [
         Token::FixedBytes(vec![0u8; 32]),
-        Token::FixedBytes(hash_bytecode(code).0.to_vec()),
+        Token::FixedBytes(BytecodeHash::for_bytecode(code).value().0.to_vec()),
         Token::Bytes(calldata.to_vec()),
     ];
     let calldata = contract_function

--- a/core/lib/multivm/src/versions/vm_m6/transaction_data.rs
+++ b/core/lib/multivm/src/versions/vm_m6/transaction_data.rs
@@ -1,6 +1,8 @@
 use zk_evm_1_3_1::zkevm_opcode_defs::system_params::MAX_TX_ERGS_LIMIT;
 use zksync_types::{
-    address_to_h256, ceil_div_u256,
+    address_to_h256,
+    bytecode::BytecodeHash,
+    ceil_div_u256,
     ethabi::{encode, Address, Token},
     fee::encoding_len,
     h256_to_u256,
@@ -8,7 +10,6 @@ use zksync_types::{
     l2::TransactionType,
     ExecuteTransactionCommon, Transaction, MAX_L2_TX_GAS_LIMIT, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use super::vm_with_bootloader::{MAX_GAS_PER_PUBDATA_BYTE, MAX_TXS_IN_BLOCK};
 use crate::{
@@ -195,7 +196,7 @@ impl TransactionData {
         let factory_deps_hashes = self
             .factory_deps
             .iter()
-            .map(|dep| h256_to_u256(hash_bytecode(dep)))
+            .map(|dep| BytecodeHash::for_bytecode(dep).value_u256())
             .collect();
         self.abi_encode_with_custom_factory_deps(factory_deps_hashes)
     }

--- a/core/lib/multivm/src/versions/vm_m6/vm.rs
+++ b/core/lib/multivm/src/versions/vm_m6/vm.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashSet, rc::Rc};
 
-use zksync_types::{h256_to_u256, vm::VmVersion, Transaction};
-use zksync_utils::bytecode::hash_bytecode;
+use zksync_types::{bytecode::BytecodeHash, h256_to_u256, vm::VmVersion, Transaction};
 use zksync_vm_interface::{pubdata::PubdataBuilder, InspectExecutionMode};
 
 use crate::{
@@ -143,7 +142,7 @@ impl<S: Storage, H: HistoryMode> VmInterface for Vm<S, H> {
             let mut deps_hashes = HashSet::with_capacity(deps.len());
             let mut bytecode_hashes = vec![];
             let filtered_deps = deps.iter().filter_map(|bytecode| {
-                let bytecode_hash = hash_bytecode(bytecode);
+                let bytecode_hash = BytecodeHash::for_bytecode(bytecode).value();
                 let is_known = !deps_hashes.insert(bytecode_hash)
                     || self.vm.is_bytecode_exists(&bytecode_hash);
 

--- a/core/lib/multivm/src/versions/vm_m6/vm_with_bootloader.rs
+++ b/core/lib/multivm/src/versions/vm_m6/vm_with_bootloader.rs
@@ -14,10 +14,9 @@ use zk_evm_1_3_1::{
 use zksync_contracts::BaseSystemContracts;
 use zksync_system_constants::MAX_L2_TX_GAS_LIMIT;
 use zksync_types::{
-    address_to_u256, fee_model::L1PeggedBatchFeeModelInput, h256_to_u256, Address, Transaction,
-    BOOTLOADER_ADDRESS, L1_GAS_PER_PUBDATA_BYTE, MAX_NEW_FACTORY_DEPS, U256,
+    address_to_u256, bytecode::BytecodeHash, fee_model::L1PeggedBatchFeeModelInput, h256_to_u256,
+    Address, Transaction, BOOTLOADER_ADDRESS, L1_GAS_PER_PUBDATA_BYTE, MAX_NEW_FACTORY_DEPS, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::{
     interface::{CompressedBytecodeInfo, L1BatchEnv},
@@ -620,7 +619,7 @@ fn push_raw_transaction_to_bootloader_memory_v1<S: Storage, H: HistoryMode>(
         tx.factory_deps
             .iter()
             .filter_map(|bytecode| {
-                if vm.is_bytecode_exists(&hash_bytecode(bytecode)) {
+                if vm.is_bytecode_exists(&BytecodeHash::for_bytecode(bytecode).value()) {
                     return None;
                 }
                 bytecode::compress(bytecode.clone()).ok()
@@ -692,7 +691,7 @@ fn push_raw_transaction_to_bootloader_memory_v2<S: Storage, H: HistoryMode>(
         tx.factory_deps
             .iter()
             .filter_map(|bytecode| {
-                if vm.is_bytecode_exists(&hash_bytecode(bytecode)) {
+                if vm.is_bytecode_exists(&BytecodeHash::for_bytecode(bytecode).value()) {
                     return None;
                 }
                 bytecode::compress(bytecode.clone()).ok()
@@ -905,8 +904,7 @@ fn formal_calldata_abi() -> PrimitiveValue {
 }
 
 pub(crate) fn bytecode_to_factory_dep(bytecode: Vec<u8>) -> (U256, Vec<U256>) {
-    let bytecode_hash = hash_bytecode(&bytecode);
-    let bytecode_hash = U256::from_big_endian(bytecode_hash.as_bytes());
+    let bytecode_hash = BytecodeHash::for_bytecode(&bytecode).value_u256();
     let bytecode_words = bytes_to_be_words(&bytecode);
     (bytecode_hash, bytecode_words)
 }

--- a/core/lib/multivm/src/versions/vm_refunds_enhancement/implementation/bytecode.rs
+++ b/core/lib/multivm/src/versions/vm_refunds_enhancement/implementation/bytecode.rs
@@ -1,6 +1,5 @@
 use itertools::Itertools;
-use zksync_types::U256;
-use zksync_utils::bytecode::hash_bytecode;
+use zksync_types::{bytecode::BytecodeHash, U256};
 
 use crate::{
     interface::{
@@ -25,15 +24,14 @@ impl<S: WriteStorage, H: HistoryMode> Vm<S, H> {
                     .storage
                     .get_ptr()
                     .borrow_mut()
-                    .is_bytecode_known(&hash_bytecode(&info.original))
+                    .is_bytecode_known(&BytecodeHash::for_bytecode(&info.original).value())
             })
     }
 }
 
 /// Converts bytecode to tokens and hashes it.
 pub(crate) fn bytecode_to_factory_dep(bytecode: Vec<u8>) -> (U256, Vec<U256>) {
-    let bytecode_hash = hash_bytecode(&bytecode);
-    let bytecode_hash = U256::from_big_endian(bytecode_hash.as_bytes());
+    let bytecode_hash = BytecodeHash::for_bytecode(&bytecode).value_u256();
     let bytecode_words = bytes_to_be_words(&bytecode);
     (bytecode_hash, bytecode_words)
 }
@@ -47,7 +45,11 @@ pub(crate) fn compress_bytecodes<S: WriteStorage>(
         .enumerate()
         .sorted_by_key(|(_idx, dep)| *dep)
         .dedup_by(|x, y| x.1 == y.1)
-        .filter(|(_idx, dep)| !storage.borrow_mut().is_bytecode_known(&hash_bytecode(dep)))
+        .filter(|(_idx, dep)| {
+            !storage
+                .borrow_mut()
+                .is_bytecode_known(&BytecodeHash::for_bytecode(dep).value())
+        })
         .sorted_by_key(|(idx, _dep)| *idx)
         .filter_map(|(_idx, dep)| bytecode::compress(dep.clone()).ok())
         .collect()

--- a/core/lib/multivm/src/versions/vm_refunds_enhancement/old_vm/oracles/decommitter.rs
+++ b/core/lib/multivm/src/versions/vm_refunds_enhancement/old_vm/oracles/decommitter.rs
@@ -7,12 +7,11 @@ use zk_evm_1_3_3::{
     },
 };
 use zksync_types::{u256_to_h256, U256};
-use zksync_utils::bytecode::bytecode_len_in_words;
 
 use super::OracleWithHistory;
 use crate::{
     interface::storage::{ReadStorage, StoragePtr},
-    utils::bytecode::bytes_to_be_words,
+    utils::bytecode::{bytecode_len_in_words, bytes_to_be_words},
     vm_refunds_enhancement::old_vm::history_recorder::{
         HistoryEnabled, HistoryMode, HistoryRecorder, WithHistory,
     },

--- a/core/lib/multivm/src/versions/vm_refunds_enhancement/tracers/refunds.rs
+++ b/core/lib/multivm/src/versions/vm_refunds_enhancement/tracers/refunds.rs
@@ -6,7 +6,6 @@ use zk_evm_1_3_3::{
 };
 use zksync_system_constants::{PUBLISH_BYTECODE_OVERHEAD, SYSTEM_CONTEXT_ADDRESS};
 use zksync_types::{ceil_div_u256, l2_to_l1_log::L2ToL1Log, u256_to_h256, L1BatchNumber, U256};
-use zksync_utils::bytecode::bytecode_len_in_bytes;
 
 use crate::{
     interface::{
@@ -15,6 +14,7 @@ use crate::{
         L1BatchEnv, Refunds, VmEvent,
     },
     tracers::dynamic::vm_1_3_3::DynTracer,
+    utils::bytecode::bytecode_len_in_bytes,
     vm_refunds_enhancement::{
         bootloader_state::BootloaderState,
         constants::{BOOTLOADER_HEAP_PAGE, OPERATOR_REFUNDS_OFFSET, TX_GAS_LIMIT_OFFSET},
@@ -335,7 +335,7 @@ pub(crate) fn pubdata_published<S: WriteStorage, H: HistoryMode>(
 
     let published_bytecode_bytes: u32 = VmEvent::extract_published_bytecodes(&events)
         .iter()
-        .map(|bytecodehash| bytecode_len_in_bytes(*bytecodehash) as u32 + PUBLISH_BYTECODE_OVERHEAD)
+        .map(|bytecode_hash| bytecode_len_in_bytes(bytecode_hash) + PUBLISH_BYTECODE_OVERHEAD)
         .sum();
 
     storage_writes_pubdata_published

--- a/core/lib/multivm/src/versions/vm_refunds_enhancement/types/internals/transaction_data.rs
+++ b/core/lib/multivm/src/versions/vm_refunds_enhancement/types/internals/transaction_data.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 use zksync_types::{
     address_to_h256,
+    bytecode::BytecodeHash,
     ethabi::{encode, Address, Token},
     fee::{encoding_len, Fee},
     h256_to_u256,
@@ -11,7 +12,6 @@ use zksync_types::{
     web3::Bytes,
     Execute, ExecuteTransactionCommon, L2ChainId, L2TxCommonData, Nonce, Transaction, H256, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::{
     utils::bytecode::bytes_to_be_words,
@@ -195,7 +195,7 @@ impl TransactionData {
         let factory_deps_hashes = self
             .factory_deps
             .iter()
-            .map(|dep| h256_to_u256(hash_bytecode(dep)))
+            .map(|dep| BytecodeHash::for_bytecode(dep).value_u256())
             .collect();
         self.abi_encode_with_custom_factory_deps(factory_deps_hashes)
     }

--- a/core/lib/multivm/src/versions/vm_virtual_blocks/implementation/bytecode.rs
+++ b/core/lib/multivm/src/versions/vm_virtual_blocks/implementation/bytecode.rs
@@ -1,6 +1,5 @@
 use itertools::Itertools;
-use zksync_types::U256;
-use zksync_utils::bytecode::hash_bytecode;
+use zksync_types::{bytecode::BytecodeHash, U256};
 
 use crate::{
     interface::{
@@ -25,15 +24,14 @@ impl<S: WriteStorage, H: HistoryMode> Vm<S, H> {
                     .storage
                     .get_ptr()
                     .borrow_mut()
-                    .is_bytecode_known(&hash_bytecode(&info.original))
+                    .is_bytecode_known(&BytecodeHash::for_bytecode(&info.original).value())
             })
     }
 }
 
 /// Converts bytecode to tokens and hashes it.
 pub(crate) fn bytecode_to_factory_dep(bytecode: Vec<u8>) -> (U256, Vec<U256>) {
-    let bytecode_hash = hash_bytecode(&bytecode);
-    let bytecode_hash = U256::from_big_endian(bytecode_hash.as_bytes());
+    let bytecode_hash = BytecodeHash::for_bytecode(&bytecode).value_u256();
     let bytecode_words = bytes_to_be_words(&bytecode);
     (bytecode_hash, bytecode_words)
 }
@@ -47,7 +45,11 @@ pub(crate) fn compress_bytecodes<S: WriteStorage>(
         .enumerate()
         .sorted_by_key(|(_idx, dep)| *dep)
         .dedup_by(|x, y| x.1 == y.1)
-        .filter(|(_idx, dep)| !storage.borrow_mut().is_bytecode_known(&hash_bytecode(dep)))
+        .filter(|(_idx, dep)| {
+            !storage
+                .borrow_mut()
+                .is_bytecode_known(&BytecodeHash::for_bytecode(dep).value())
+        })
         .sorted_by_key(|(idx, _dep)| *idx)
         .filter_map(|(_idx, dep)| bytecode::compress(dep.clone()).ok())
         .collect()

--- a/core/lib/multivm/src/versions/vm_virtual_blocks/old_vm/oracles/decommitter.rs
+++ b/core/lib/multivm/src/versions/vm_virtual_blocks/old_vm/oracles/decommitter.rs
@@ -7,12 +7,11 @@ use zk_evm_1_3_3::{
     },
 };
 use zksync_types::{u256_to_h256, U256};
-use zksync_utils::bytecode::bytecode_len_in_words;
 
 use super::OracleWithHistory;
 use crate::{
     interface::storage::{ReadStorage, StoragePtr},
-    utils::bytecode::bytes_to_be_words,
+    utils::bytecode::{bytecode_len_in_words, bytes_to_be_words},
     vm_virtual_blocks::old_vm::history_recorder::{
         HistoryEnabled, HistoryMode, HistoryRecorder, WithHistory,
     },

--- a/core/lib/multivm/src/versions/vm_virtual_blocks/tracers/refunds.rs
+++ b/core/lib/multivm/src/versions/vm_virtual_blocks/tracers/refunds.rs
@@ -11,7 +11,6 @@ use zksync_system_constants::{PUBLISH_BYTECODE_OVERHEAD, SYSTEM_CONTEXT_ADDRESS}
 use zksync_types::{
     ceil_div_u256, l2_to_l1_log::L2ToL1Log, u256_to_h256, L1BatchNumber, StorageKey, U256,
 };
-use zksync_utils::bytecode::bytecode_len_in_bytes;
 
 use crate::{
     interface::{
@@ -19,6 +18,7 @@ use crate::{
         L1BatchEnv, Refunds, VmEvent, VmExecutionResultAndLogs,
     },
     tracers::dynamic::vm_1_3_3::DynTracer,
+    utils::bytecode::bytecode_len_in_bytes,
     vm_virtual_blocks::{
         bootloader_state::BootloaderState,
         constants::{BOOTLOADER_HEAP_PAGE, OPERATOR_REFUNDS_OFFSET, TX_GAS_LIMIT_OFFSET},
@@ -329,7 +329,7 @@ pub(crate) fn pubdata_published<S: WriteStorage, H: HistoryMode>(
 
     let published_bytecode_bytes: u32 = VmEvent::extract_published_bytecodes(&events)
         .iter()
-        .map(|bytecodehash| bytecode_len_in_bytes(*bytecodehash) as u32 + PUBLISH_BYTECODE_OVERHEAD)
+        .map(|bytecode_hash| bytecode_len_in_bytes(bytecode_hash) + PUBLISH_BYTECODE_OVERHEAD)
         .sum();
 
     storage_writes_pubdata_published

--- a/core/lib/multivm/src/versions/vm_virtual_blocks/types/internals/transaction_data.rs
+++ b/core/lib/multivm/src/versions/vm_virtual_blocks/types/internals/transaction_data.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 
 use zksync_types::{
     address_to_h256,
+    bytecode::BytecodeHash,
     ethabi::{encode, Address, Token},
     fee::{encoding_len, Fee},
     h256_to_u256,
@@ -11,7 +12,6 @@ use zksync_types::{
     web3::Bytes,
     Execute, ExecuteTransactionCommon, L2ChainId, L2TxCommonData, Nonce, Transaction, H256, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::{
     utils::bytecode::bytes_to_be_words,
@@ -195,7 +195,7 @@ impl TransactionData {
         let factory_deps_hashes = self
             .factory_deps
             .iter()
-            .map(|dep| h256_to_u256(hash_bytecode(dep)))
+            .map(|dep| BytecodeHash::for_bytecode(dep).value_u256())
             .collect();
         self.abi_encode_with_custom_factory_deps(factory_deps_hashes)
     }

--- a/core/lib/snapshots_applier/Cargo.toml
+++ b/core/lib/snapshots_applier/Cargo.toml
@@ -17,7 +17,6 @@ zksync_health_check.workspace = true
 zksync_types.workspace = true
 zksync_object_store.workspace = true
 zksync_web3_decl.workspace = true
-zksync_utils.workspace = true
 
 vise.workspace = true
 

--- a/core/lib/types/Cargo.toml
+++ b/core/lib/types/Cargo.toml
@@ -13,7 +13,6 @@ categories.workspace = true
 [dependencies]
 # **IMPORTANT.** Please do not add dependency on `zksync_config` etc. This crate has a heavy dependency graph as is.
 zksync_system_constants.workspace = true
-zksync_utils.workspace = true
 zksync_basic_types.workspace = true
 zksync_contracts.workspace = true
 zksync_mini_merkle_tree.workspace = true

--- a/core/lib/types/src/abi.rs
+++ b/core/lib/types/src/abi.rs
@@ -1,10 +1,9 @@
 use anyhow::Context as _;
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::{
+    bytecode::BytecodeHash,
     ethabi,
     ethabi::{ParamType, Token},
-    h256_to_u256,
     transaction_request::TransactionRequest,
     web3, Address, H256, U256,
 };
@@ -357,7 +356,7 @@ impl Transaction {
                 // verify data integrity
                 let factory_deps_hashes: Vec<_> = factory_deps
                     .iter()
-                    .map(|b| h256_to_u256(hash_bytecode(b)))
+                    .map(|b| BytecodeHash::for_bytecode(b).value_u256())
                     .collect();
                 anyhow::ensure!(tx.factory_deps == factory_deps_hashes);
                 tx.hash()

--- a/core/lib/types/src/api/state_override.rs
+++ b/core/lib/types/src/api/state_override.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-use zksync_basic_types::{web3::Bytes, H256, U256};
-use zksync_utils::bytecode::{hash_bytecode, validate_bytecode, InvalidBytecodeError};
+use zksync_basic_types::{bytecode::BytecodeHash, web3::Bytes, H256, U256};
 
-use crate::Address;
+use crate::{
+    bytecode::{validate_bytecode, InvalidBytecodeError},
+    Address,
+};
 
 /// Collection of overridden accounts.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -44,7 +46,7 @@ impl Bytecode {
 
     /// Returns the canonical hash of this bytecode.
     pub fn hash(&self) -> H256 {
-        hash_bytecode(&self.0 .0)
+        BytecodeHash::for_bytecode(&self.0 .0).value()
     }
 
     /// Converts this bytecode into bytes.

--- a/core/lib/types/src/l1/mod.rs
+++ b/core/lib/types/src/l1/mod.rs
@@ -1,21 +1,21 @@
 //! Definition of ZKsync network priority operations: operations initiated from the L1.
 
-use std::convert::TryFrom;
-
 use serde::{Deserialize, Serialize};
-use zksync_basic_types::{web3::Log, Address, L1BlockNumber, PriorityOpId, H256, U256};
-use zksync_utils::bytecode::hash_bytecode;
 
 use super::Transaction;
 use crate::{
-    abi, address_to_u256, ethabi, h256_to_u256,
+    abi, address_to_u256,
+    bytecode::BytecodeHash,
+    ethabi,
     helpers::unix_timestamp_ms,
     l1::error::L1TxParseError,
     l2::TransactionType,
     priority_op_onchain_data::{PriorityOpOnchainData, PriorityOpOnchainMetadata},
     tx::Execute,
-    u256_to_address, ExecuteTransactionCommon, PRIORITY_OPERATION_L2_TX_TYPE,
-    PROTOCOL_UPGRADE_TX_TYPE,
+    u256_to_address,
+    web3::Log,
+    Address, ExecuteTransactionCommon, L1BlockNumber, PriorityOpId, H256,
+    PRIORITY_OPERATION_L2_TX_TYPE, PROTOCOL_UPGRADE_TX_TYPE, U256,
 };
 
 pub mod error;
@@ -293,7 +293,7 @@ impl From<L1Tx> for abi::NewPriorityRequest {
                 signature: vec![],
                 factory_deps: factory_deps
                     .iter()
-                    .map(|b| h256_to_u256(hash_bytecode(b)))
+                    .map(|b| BytecodeHash::for_bytecode(b).value_u256())
                     .collect(),
                 paymaster_input: vec![],
                 reserved_dynamic: vec![],
@@ -318,7 +318,7 @@ impl TryFrom<abi::NewPriorityRequest> for L1Tx {
         let factory_deps_hashes: Vec<_> = req
             .factory_deps
             .iter()
-            .map(|b| h256_to_u256(hash_bytecode(b)))
+            .map(|b| BytecodeHash::for_bytecode(b).value_u256())
             .collect();
         anyhow::ensure!(req.transaction.factory_deps == factory_deps_hashes);
         for item in &req.transaction.reserved[2..] {

--- a/core/lib/types/src/lib.rs
+++ b/core/lib/types/src/lib.rs
@@ -15,9 +15,9 @@ pub use protocol_upgrade::{ProtocolUpgrade, ProtocolVersion};
 use serde::{Deserialize, Serialize};
 pub use storage::*;
 pub use tx::Execute;
+use zksync_basic_types::bytecode::BytecodeHash;
 pub use zksync_basic_types::{protocol_version::ProtocolVersionId, vm, *};
 pub use zksync_crypto_primitives::*;
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::{
     l2::{L2Tx, TransactionType},
@@ -284,7 +284,7 @@ impl TryFrom<Transaction> for abi::Transaction {
                     signature: vec![],
                     factory_deps: factory_deps
                         .iter()
-                        .map(|b| h256_to_u256(hash_bytecode(b)))
+                        .map(|b| BytecodeHash::for_bytecode(b).value_u256())
                         .collect(),
                     paymaster_input: vec![],
                     reserved_dynamic: vec![],
@@ -315,7 +315,7 @@ impl TryFrom<Transaction> for abi::Transaction {
                     signature: vec![],
                     factory_deps: factory_deps
                         .iter()
-                        .map(|b| h256_to_u256(hash_bytecode(b)))
+                        .map(|b| BytecodeHash::for_bytecode(b).value_u256())
                         .collect(),
                     paymaster_input: vec![],
                     reserved_dynamic: vec![],
@@ -344,7 +344,7 @@ impl Transaction {
             } => {
                 let factory_deps_hashes: Vec<_> = factory_deps
                     .iter()
-                    .map(|b| h256_to_u256(hash_bytecode(b)))
+                    .map(|b| BytecodeHash::for_bytecode(b).value_u256())
                     .collect();
                 anyhow::ensure!(tx.factory_deps == factory_deps_hashes);
                 for item in &tx.reserved[2..] {

--- a/core/lib/types/src/transaction_request.rs
+++ b/core/lib/types/src/transaction_request.rs
@@ -3,19 +3,18 @@ use std::convert::{TryFrom, TryInto};
 use rlp::{DecoderError, Rlp, RlpStream};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use zksync_basic_types::H256;
 use zksync_system_constants::{DEFAULT_L2_TX_GAS_PER_PUBDATA_BYTE, MAX_ENCODED_TX_SIZE};
-use zksync_utils::bytecode::{hash_bytecode, validate_bytecode, InvalidBytecodeError};
 
 use super::{EIP_1559_TX_TYPE, EIP_2930_TX_TYPE, EIP_712_TX_TYPE};
 use crate::{
+    bytecode::{validate_bytecode, BytecodeHash, InvalidBytecodeError},
     fee::Fee,
     l1::L1Tx,
     l2::{L2Tx, TransactionType},
     u256_to_h256,
     web3::{keccak256, keccak256_concat, AccessList, Bytes},
     Address, EIP712TypedStructure, Eip712Domain, L1TxCommonData, L2ChainId, Nonce,
-    PackedEthSignature, StructBuilder, LEGACY_TX_TYPE, U256, U64,
+    PackedEthSignature, StructBuilder, H256, LEGACY_TX_TYPE, U256, U64,
 };
 
 /// Call contract request (eth_call / eth_estimateGas)
@@ -353,7 +352,7 @@ impl EIP712TypedStructure for TransactionRequest {
         let factory_dep_hashes: Vec<_> = self
             .get_factory_deps()
             .into_iter()
-            .map(|dep| hash_bytecode(&dep))
+            .map(|dep| BytecodeHash::for_bytecode(&dep).value())
             .collect();
         builder.add_member("factoryDeps", &factory_dep_hashes.as_slice());
 

--- a/core/lib/types/src/transaction_request.rs
+++ b/core/lib/types/src/transaction_request.rs
@@ -173,7 +173,7 @@ impl CallRequestBuilder {
     }
 }
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error)]
 pub enum SerializationTransactionError {
     #[error("transaction type is not supported")]
     UnknownTransactionFormat,
@@ -1157,9 +1157,9 @@ mod tests {
 
         let decoded_tx =
             TransactionRequest::from_bytes(encoded_tx.as_slice(), L2ChainId::from(272));
-        assert_eq!(
-            decoded_tx,
-            Err(SerializationTransactionError::WrongChainId(Some(270)))
+        assert_matches!(
+            decoded_tx.unwrap_err(),
+            SerializationTransactionError::WrongChainId(Some(270))
         );
     }
 
@@ -1235,9 +1235,9 @@ mod tests {
         data.insert(0, EIP_1559_TX_TYPE);
 
         let decoded_tx = TransactionRequest::from_bytes(data.as_slice(), L2ChainId::from(270));
-        assert_eq!(
-            decoded_tx,
-            Err(SerializationTransactionError::WrongChainId(Some(272)))
+        assert_matches!(
+            decoded_tx.unwrap_err(),
+            SerializationTransactionError::WrongChainId(Some(272))
         );
     }
 
@@ -1275,9 +1275,9 @@ mod tests {
         data.insert(0, EIP_1559_TX_TYPE);
 
         let res = TransactionRequest::from_bytes(data.as_slice(), L2ChainId::from(270));
-        assert_eq!(
-            res,
-            Err(SerializationTransactionError::AccessListsNotSupported)
+        assert_matches!(
+            res.unwrap_err(),
+            SerializationTransactionError::AccessListsNotSupported
         );
     }
 
@@ -1312,9 +1312,9 @@ mod tests {
         data.insert(0, EIP_2930_TX_TYPE);
 
         let res = TransactionRequest::from_bytes(data.as_slice(), L2ChainId::from(270));
-        assert_eq!(
-            res,
-            Err(SerializationTransactionError::AccessListsNotSupported)
+        assert_matches!(
+            res.unwrap_err(),
+            SerializationTransactionError::AccessListsNotSupported
         );
     }
 
@@ -1340,7 +1340,7 @@ mod tests {
         };
         let execute_tx2: Result<L2Tx, SerializationTransactionError> =
             L2Tx::from_request(tx2, usize::MAX, true);
-        assert_eq!(
+        assert_matches!(
             execute_tx2.unwrap_err(),
             SerializationTransactionError::TooBigNonce
         );
@@ -1357,7 +1357,7 @@ mod tests {
         };
         let execute_tx1: Result<L2Tx, SerializationTransactionError> =
             L2Tx::from_request(tx1, usize::MAX, true);
-        assert_eq!(
+        assert_matches!(
             execute_tx1.unwrap_err(),
             SerializationTransactionError::MaxFeePerGasNotU64
         );
@@ -1371,7 +1371,7 @@ mod tests {
         };
         let execute_tx2: Result<L2Tx, SerializationTransactionError> =
             L2Tx::from_request(tx2, usize::MAX, true);
-        assert_eq!(
+        assert_matches!(
             execute_tx2.unwrap_err(),
             SerializationTransactionError::MaxPriorityFeePerGasNotU64
         );
@@ -1389,7 +1389,7 @@ mod tests {
 
         let execute_tx3: Result<L2Tx, SerializationTransactionError> =
             L2Tx::from_request(tx3, usize::MAX, true);
-        assert_eq!(
+        assert_matches!(
             execute_tx3.unwrap_err(),
             SerializationTransactionError::MaxFeePerPubdataByteNotU64
         );

--- a/core/lib/types/src/tx/execute.rs
+++ b/core/lib/types/src/tx/execute.rs
@@ -1,7 +1,7 @@
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use zksync_basic_types::bytecode::BytecodeHash;
 use zksync_system_constants::CONTRACT_DEPLOYER_ADDRESS;
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::{
     ethabi, serde_wrappers::ZeroPrefixHexSerde, Address, EIP712TypedStructure, StructBuilder, H256,
@@ -127,7 +127,7 @@ impl Execute {
         contract_bytecode: Vec<u8>,
         constructor_input: &[ethabi::Token],
     ) -> Self {
-        let bytecode_hash = hash_bytecode(&contract_bytecode);
+        let bytecode_hash = BytecodeHash::for_bytecode(&contract_bytecode).value();
         Self {
             contract_address: Some(CONTRACT_DEPLOYER_ADDRESS),
             calldata: Self::encode_deploy_params_create(

--- a/core/lib/utils/Cargo.toml
+++ b/core/lib/utils/Cargo.toml
@@ -11,15 +11,11 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-zksync_basic_types.workspace = true
-zk_evm.workspace = true
 zksync_vlog.workspace = true
 
-const-decoder.workspace = true
 tokio = { workspace = true, features = ["time"] }
 tracing.workspace = true
 anyhow.workspace = true
-thiserror.workspace = true
 futures.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
 serde_json.workspace = true

--- a/core/lib/utils/src/lib.rs
+++ b/core/lib/utils/src/lib.rs
@@ -1,6 +1,5 @@
 //! Various helpers used in the ZKsync stack.
 
-pub mod bytecode;
 pub mod env;
 pub mod http_with_retries;
 pub mod panic_extractor;

--- a/core/lib/vm_executor/Cargo.toml
+++ b/core/lib/vm_executor/Cargo.toml
@@ -15,7 +15,6 @@ zksync_contracts.workspace = true
 zksync_dal.workspace = true
 zksync_types.workspace = true
 zksync_multivm.workspace = true
-zksync_utils.workspace = true
 
 async-trait.workspace = true
 once_cell.workspace = true

--- a/core/lib/vm_executor/src/oneshot/tests.rs
+++ b/core/lib/vm_executor/src/oneshot/tests.rs
@@ -4,7 +4,6 @@ use assert_matches::assert_matches;
 use test_casing::{test_casing, Product};
 use zksync_multivm::interface::storage::InMemoryStorage;
 use zksync_types::{ProtocolVersionId, H256};
-use zksync_utils::bytecode::hash_bytecode;
 
 use super::*;
 use crate::testonly::{
@@ -75,7 +74,7 @@ fn setting_up_nonce_and_balance_in_storage() {
 #[tokio::test]
 async fn inspecting_transfer(exec_mode: TxExecutionMode, fast_vm_mode: FastVmMode) {
     let tx = create_l2_transaction(1_000_000_000.into(), Nonce(0));
-    let mut storage = InMemoryStorage::with_system_contracts(hash_bytecode);
+    let mut storage = InMemoryStorage::with_system_contracts();
     storage.set_value(
         storage_key_for_eth_balance(&tx.initiator_account()),
         u256_to_h256(u64::MAX.into()),

--- a/core/node/api_server/Cargo.toml
+++ b/core/node/api_server/Cargo.toml
@@ -25,7 +25,6 @@ zksync_state.workspace = true
 zksync_system_constants.workspace = true
 zksync_metadata_calculator.workspace = true
 zksync_web3_decl = { workspace = true, features = ["server"] }
-zksync_utils.workspace = true
 zksync_protobuf.workspace = true
 zksync_mini_merkle_tree.workspace = true
 zksync_multivm.workspace = true

--- a/core/node/api_server/src/execution_sandbox/vm_metrics.rs
+++ b/core/node/api_server/src/execution_sandbox/vm_metrics.rs
@@ -7,8 +7,7 @@ use zksync_multivm::{
     interface::{TransactionExecutionMetrics, VmEvent, VmExecutionResultAndLogs},
     utils::StorageWritesDeduplicator,
 };
-use zksync_types::H256;
-use zksync_utils::bytecode::bytecode_len_in_bytes;
+use zksync_types::{bytecode::BytecodeHash, H256};
 
 use crate::utils::ReportFilter;
 
@@ -149,7 +148,11 @@ pub(super) fn collect_tx_execution_metrics(
         .sum();
     let published_bytecode_bytes = VmEvent::extract_published_bytecodes(&result.logs.events)
         .iter()
-        .map(|bytecode_hash| bytecode_len_in_bytes(*bytecode_hash))
+        .map(|&bytecode_hash| {
+            BytecodeHash::try_from(bytecode_hash)
+                .expect("published unparseable bytecode hash")
+                .len_in_bytes()
+        })
         .sum();
 
     TransactionExecutionMetrics {

--- a/core/node/api_server/src/tx_sender/tests/gas_estimation.rs
+++ b/core/node/api_server/src/tx_sender/tests/gas_estimation.rs
@@ -7,10 +7,10 @@ use test_casing::{test_casing, Product};
 use zksync_system_constants::CODE_ORACLE_ADDRESS;
 use zksync_types::{
     api::state_override::{OverrideAccount, OverrideState},
+    bytecode::BytecodeHash,
     web3::keccak256,
     K256PrivateKey,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use super::*;
 use crate::{
@@ -216,7 +216,7 @@ async fn initial_estimate_for_code_oracle_tx() {
     // Add another contract that is never executed, but has a large bytecode.
     let huge_contact_address = Address::repeat_byte(23);
     let huge_contract_bytecode = vec![0_u8; 10_001 * 32];
-    let huge_contract_bytecode_hash = hash_bytecode(&huge_contract_bytecode);
+    let huge_contract_bytecode_hash = BytecodeHash::for_bytecode(&huge_contract_bytecode).value();
     let huge_contract_keccak_hash = H256(keccak256(&huge_contract_bytecode));
 
     let state_override = StateBuilder::default()
@@ -240,7 +240,7 @@ async fn initial_estimate_for_code_oracle_tx() {
             (*contract.account_id.address() == CODE_ORACLE_ADDRESS).then_some(&contract.bytecode)
         })
         .expect("no code oracle");
-    let code_oracle_bytecode_hash = hash_bytecode(code_oracle_bytecode);
+    let code_oracle_bytecode_hash = BytecodeHash::for_bytecode(code_oracle_bytecode).value();
     let code_oracle_keccak_hash = H256(keccak256(code_oracle_bytecode));
 
     let warm_bytecode_hashes = [
@@ -444,7 +444,7 @@ async fn estimating_gas_for_code_oracle_tx() {
     // Add another contract that is never executed, but has a large bytecode.
     let huge_contact_address = Address::repeat_byte(23);
     let huge_contract_bytecode = vec![0_u8; 10_001 * 32];
-    let huge_contract_bytecode_hash = hash_bytecode(&huge_contract_bytecode);
+    let huge_contract_bytecode_hash = BytecodeHash::for_bytecode(&huge_contract_bytecode).value();
     let huge_contract_keccak_hash = H256(keccak256(&huge_contract_bytecode));
 
     let state_override = StateBuilder::default()

--- a/core/node/api_server/src/web3/namespaces/eth.rs
+++ b/core/node/api_server/src/web3/namespaces/eth.rs
@@ -6,6 +6,7 @@ use zksync_types::{
         state_override::StateOverride, BlockId, BlockNumber, FeeHistory, GetLogsFilter,
         Transaction, TransactionId, TransactionReceipt, TransactionVariant,
     },
+    bytecode::{prepare_evm_bytecode, BytecodeMarker},
     l2::{L2Tx, TransactionType},
     transaction_request::CallRequest,
     u256_to_h256,
@@ -13,7 +14,6 @@ use zksync_types::{
     web3::{self, Bytes, SyncInfo, SyncState},
     AccountTreeId, L2BlockNumber, StorageKey, H256, L2_BASE_TOKEN_ADDRESS, U256,
 };
-use zksync_utils::bytecode::{prepare_evm_bytecode, BytecodeMarker};
 use zksync_web3_decl::{
     error::Web3Error,
     types::{Address, Block, Filter, FilterChanges, Log, U64},

--- a/core/node/api_server/src/web3/namespaces/eth.rs
+++ b/core/node/api_server/src/web3/namespaces/eth.rs
@@ -6,7 +6,7 @@ use zksync_types::{
         state_override::StateOverride, BlockId, BlockNumber, FeeHistory, GetLogsFilter,
         Transaction, TransactionId, TransactionReceipt, TransactionVariant,
     },
-    bytecode::{prepare_evm_bytecode, BytecodeMarker},
+    bytecode::{trim_padded_evm_bytecode, BytecodeMarker},
     l2::{L2Tx, TransactionType},
     transaction_request::CallRequest,
     u256_to_h256,
@@ -404,7 +404,7 @@ impl EthNamespace {
         // Check if the bytecode is an EVM bytecode, and if so, pre-process it correspondingly.
         let marker = BytecodeMarker::new(contract_code.bytecode_hash);
         let prepared_bytecode = if marker == Some(BytecodeMarker::Evm) {
-            prepare_evm_bytecode(&contract_code.bytecode)
+            trim_padded_evm_bytecode(&contract_code.bytecode)
                 .with_context(|| {
                     format!(
                         "malformed EVM bytecode at address {address:?}, hash = {:?}",

--- a/core/node/api_server/src/web3/tests/mod.rs
+++ b/core/node/api_server/src/web3/tests/mod.rs
@@ -33,6 +33,10 @@ use zksync_system_constants::{
 use zksync_types::{
     api,
     block::{pack_block_info, L2BlockHasher, L2BlockHeader},
+    bytecode::{
+        testonly::{PROCESSED_EVM_BYTECODE, RAW_EVM_BYTECODE},
+        BytecodeHash,
+    },
     fee_model::{BatchFeeInput, FeeParams},
     get_nonce_key,
     l2::L2Tx,
@@ -44,10 +48,6 @@ use zksync_types::{
     utils::{storage_key_for_eth_balance, storage_key_for_standard_token_balance},
     AccountTreeId, Address, L1BatchNumber, Nonce, ProtocolVersionId, StorageKey, StorageLog, H256,
     U256, U64,
-};
-use zksync_utils::bytecode::{
-    hash_bytecode, hash_evm_bytecode,
-    testonly::{PROCESSED_EVM_BYTECODE, RAW_EVM_BYTECODE},
 };
 use zksync_vm_executor::oneshot::MockOneshotExecutor;
 use zksync_web3_decl::{
@@ -676,7 +676,7 @@ impl HttpTest for StorageAccessWithSnapshotRecovery {
     fn storage_initialization(&self) -> StorageInitialization {
         let address = Address::repeat_byte(1);
         let code_key = get_code_key(&address);
-        let code_hash = hash_bytecode(&[0; 32]);
+        let code_hash = BytecodeHash::for_bytecode(&[0; 32]).value();
         let balance_key = storage_key_for_eth_balance(&address);
         let logs = vec![
             StorageLog::new_write_log(code_key, code_hash),
@@ -1171,7 +1171,7 @@ impl GetBytecodeTest {
         at_block: L2BlockNumber,
         address: Address,
     ) -> anyhow::Result<()> {
-        let evm_bytecode_hash = hash_evm_bytecode(RAW_EVM_BYTECODE);
+        let evm_bytecode_hash = BytecodeHash::for_evm_bytecode(RAW_EVM_BYTECODE).value();
         let code_log = StorageLog::new_write_log(get_code_key(&address), evm_bytecode_hash);
         connection
             .storage_logs_dal()

--- a/core/node/contract_verification_server/Cargo.toml
+++ b/core/node/contract_verification_server/Cargo.toml
@@ -13,7 +13,6 @@ categories.workspace = true
 [dependencies]
 zksync_dal.workspace = true
 zksync_types.workspace = true
-zksync_utils.workspace = true
 vise.workspace = true
 
 anyhow.workspace = true

--- a/core/node/contract_verification_server/src/api_impl.rs
+++ b/core/node/contract_verification_server/src/api_impl.rs
@@ -9,12 +9,12 @@ use axum::{
 };
 use zksync_dal::{CoreDal, DalError};
 use zksync_types::{
+    bytecode::BytecodeMarker,
     contract_verification_api::{
         CompilerVersions, VerificationIncomingRequest, VerificationInfo, VerificationRequestStatus,
     },
     Address,
 };
-use zksync_utils::bytecode::BytecodeMarker;
 
 use super::{api_decl::RestApi, metrics::METRICS};
 

--- a/core/node/contract_verification_server/src/tests.rs
+++ b/core/node/contract_verification_server/src/tests.rs
@@ -12,10 +12,10 @@ use tower::ServiceExt;
 use zksync_dal::{Connection, Core, CoreDal};
 use zksync_node_test_utils::create_l2_block;
 use zksync_types::{
-    contract_verification_api::CompilerVersions, get_code_key, Address, L2BlockNumber,
-    ProtocolVersion, StorageLog,
+    bytecode::{BytecodeHash, BytecodeMarker},
+    contract_verification_api::CompilerVersions,
+    get_code_key, Address, L2BlockNumber, ProtocolVersion, StorageLog,
 };
-use zksync_utils::bytecode::{hash_bytecode, hash_evm_bytecode, BytecodeMarker};
 
 use super::*;
 use crate::api_impl::ApiError;
@@ -53,8 +53,8 @@ async fn mock_deploy_contract(
     kind: BytecodeMarker,
 ) {
     let bytecode_hash = match kind {
-        BytecodeMarker::EraVm => hash_bytecode(&[0; 32]),
-        BytecodeMarker::Evm => hash_evm_bytecode(&[0; 96]),
+        BytecodeMarker::EraVm => BytecodeHash::for_bytecode(&[0; 32]).value(),
+        BytecodeMarker::Evm => BytecodeHash::for_evm_bytecode(&[0; 96]).value(),
     };
     let deploy_log = StorageLog::new_write_log(get_code_key(&address), bytecode_hash);
     storage

--- a/core/node/genesis/Cargo.toml
+++ b/core/node/genesis/Cargo.toml
@@ -20,7 +20,6 @@ zksync_contracts.workspace = true
 zksync_eth_client.workspace = true
 zksync_merkle_tree.workspace = true
 zksync_system_constants.workspace = true
-zksync_utils.workspace = true
 
 tokio = { workspace = true, features = ["time"] }
 anyhow.workspace = true

--- a/core/node/genesis/src/lib.rs
+++ b/core/node/genesis/src/lib.rs
@@ -17,6 +17,7 @@ use zksync_multivm::utils::get_max_gas_per_pubdata_byte;
 use zksync_system_constants::PRIORITY_EXPIRATION;
 use zksync_types::{
     block::{BlockGasCount, DeployedContract, L1BatchHeader, L2BlockHasher, L2BlockHeader},
+    bytecode::BytecodeHash,
     commitment::{CommitmentInput, L1BatchCommitment},
     fee_model::BatchFeeInput,
     protocol_upgrade::decode_set_chain_id_event,
@@ -27,7 +28,6 @@ use zksync_types::{
     AccountTreeId, Address, Bloom, L1BatchNumber, L1ChainId, L2BlockNumber, L2ChainId,
     ProtocolVersion, ProtocolVersionId, StorageKey, H256, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::utils::{
     add_eth_token, get_deduped_log_queries, get_storage_logs,
@@ -447,7 +447,12 @@ pub async fn create_genesis_l1_batch(
 
     let factory_deps = system_contracts
         .iter()
-        .map(|c| (hash_bytecode(&c.bytecode), c.bytecode.clone()))
+        .map(|c| {
+            (
+                BytecodeHash::for_bytecode(&c.bytecode).value(),
+                c.bytecode.clone(),
+            )
+        })
         .collect();
 
     insert_base_system_contracts_to_factory_deps(&mut transaction, base_system_contracts).await?;

--- a/core/node/genesis/src/utils.rs
+++ b/core/node/genesis/src/utils.rs
@@ -10,6 +10,7 @@ use zksync_multivm::{
 use zksync_system_constants::{DEFAULT_ERA_CHAIN_ID, ETHEREUM_ADDRESS};
 use zksync_types::{
     block::{DeployedContract, L1BatchTreeData},
+    bytecode::BytecodeHash,
     commitment::L1BatchCommitment,
     get_code_key, get_known_code_key, get_system_context_init_logs, h256_to_u256,
     tokens::{TokenInfo, TokenMetadata},
@@ -17,7 +18,6 @@ use zksync_types::{
     zk_evm_types::{LogQuery, Timestamp},
     AccountTreeId, L1BatchNumber, L2BlockNumber, L2ChainId, StorageKey, StorageLog, H256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::GenesisError;
 
@@ -51,7 +51,7 @@ pub(super) fn get_storage_logs(system_contracts: &[DeployedContract]) -> Vec<Sto
     let known_code_storage_logs: Vec<_> = system_contracts
         .iter()
         .map(|contract| {
-            let hash = hash_bytecode(&contract.bytecode);
+            let hash = BytecodeHash::for_bytecode(&contract.bytecode).value();
             let known_code_key = get_known_code_key(&hash);
             let marked_known_value = H256::from_low_u64_be(1u64);
 
@@ -63,7 +63,7 @@ pub(super) fn get_storage_logs(system_contracts: &[DeployedContract]) -> Vec<Sto
     let storage_logs: Vec<_> = system_contracts
         .iter()
         .map(|contract| {
-            let hash = hash_bytecode(&contract.bytecode);
+            let hash = BytecodeHash::for_bytecode(&contract.bytecode).value();
             let code_key = get_code_key(contract.account_id.address());
             StorageLog::new_write_log(code_key, hash)
         })

--- a/core/node/node_sync/Cargo.toml
+++ b/core/node/node_sync/Cargo.toml
@@ -21,7 +21,6 @@ zksync_state_keeper.workspace = true
 zksync_shared_metrics.workspace = true
 zksync_web3_decl.workspace = true
 zksync_health_check.workspace = true
-zksync_utils.workspace = true
 zksync_eth_client.workspace = true
 zksync_concurrency.workspace = true
 vise.workspace = true

--- a/core/node/node_sync/src/client.rs
+++ b/core/node/node_sync/src/client.rs
@@ -8,6 +8,7 @@ use zksync_health_check::{CheckHealth, Health, HealthStatus};
 use zksync_system_constants::ACCOUNT_CODE_STORAGE_ADDRESS;
 use zksync_types::{
     api::{self, en},
+    bytecode::BytecodeHash,
     get_code_key, h256_to_u256, Address, L2BlockNumber, ProtocolVersionId, H256, U64,
 };
 use zksync_web3_decl::{
@@ -57,7 +58,7 @@ impl MainNodeClient for Box<DynClient<L2>> {
             .with_arg("hash", &hash)
             .await?;
         if let Some(bytecode) = &bytecode {
-            let actual_bytecode_hash = zksync_utils::bytecode::hash_bytecode(bytecode);
+            let actual_bytecode_hash = BytecodeHash::for_bytecode(bytecode).value();
             if actual_bytecode_hash != hash {
                 return Err(EnrichedClientError::custom(
                     "Got invalid base system contract bytecode from main node",

--- a/core/node/state_keeper/Cargo.toml
+++ b/core/node/state_keeper/Cargo.toml
@@ -22,7 +22,6 @@ zksync_mempool.workspace = true
 zksync_shared_metrics.workspace = true
 zksync_config.workspace = true
 zksync_node_fee_model.workspace = true
-zksync_utils.workspace = true
 zksync_contracts.workspace = true
 zksync_protobuf.workspace = true
 zksync_test_account.workspace = true
@@ -31,7 +30,6 @@ zksync_node_test_utils.workspace = true
 zksync_vm_executor.workspace = true
 zksync_system_constants.workspace = true
 zksync_base_token_adjuster.workspace = true
-
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/core/node/state_keeper/src/io/tests/mod.rs
+++ b/core/node/state_keeper/src/io/tests/mod.rs
@@ -14,13 +14,13 @@ use zksync_node_test_utils::prepare_recovery_snapshot;
 use zksync_system_constants::KNOWN_CODES_STORAGE_ADDRESS;
 use zksync_types::{
     block::{BlockGasCount, L2BlockHasher},
+    bytecode::BytecodeHash,
     commitment::{L1BatchCommitmentMode, PubdataParams},
     fee_model::{BatchFeeInput, PubdataIndependentBatchFeeModelInput},
     l2::L2Tx,
     AccountTreeId, Address, L1BatchNumber, L2BlockNumber, L2ChainId, ProtocolVersion,
     ProtocolVersionId, StorageKey, TransactionTimeRangeConstraint, H256, U256,
 };
-use zksync_utils::bytecode::{hash_bytecode, hash_evm_bytecode};
 
 use self::tester::Tester;
 use crate::{
@@ -438,13 +438,19 @@ async fn processing_dynamic_factory_deps_when_sealing_l2_block() {
     let static_factory_deps: Vec<_> = (0_u8..10)
         .map(|byte| {
             let era_bytecode = vec![byte; 32];
-            (hash_bytecode(&era_bytecode), era_bytecode)
+            (
+                BytecodeHash::for_bytecode(&era_bytecode).value(),
+                era_bytecode,
+            )
         })
         .collect();
     let dynamic_factory_deps: Vec<_> = (0_u8..10)
         .map(|byte| {
             let evm_bytecode = vec![byte; 96];
-            (hash_evm_bytecode(&evm_bytecode), evm_bytecode)
+            (
+                BytecodeHash::for_evm_bytecode(&evm_bytecode).value(),
+                evm_bytecode,
+            )
         })
         .collect();
     let mut all_factory_deps = static_factory_deps.clone();

--- a/core/node/state_keeper/src/updates/l2_block_updates.rs
+++ b/core/node/state_keeper/src/updates/l2_block_updates.rs
@@ -9,10 +9,10 @@ use zksync_multivm::{
 };
 use zksync_types::{
     block::{BlockGasCount, L2BlockHasher},
+    bytecode::BytecodeHash,
     l2_to_l1_log::{SystemL2ToL1Log, UserL2ToL1Log},
     L2BlockNumber, ProtocolVersionId, StorageLogWithPreviousValue, Transaction, H256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::metrics::KEEPER_METRICS;
 
@@ -119,7 +119,12 @@ impl L2BlockUpdates {
         let factory_deps = &tx.execute.factory_deps;
         let mut tx_factory_deps: HashMap<_, _> = factory_deps
             .iter()
-            .map(|bytecode| (hash_bytecode(bytecode), bytecode.clone()))
+            .map(|bytecode| {
+                (
+                    BytecodeHash::for_bytecode(bytecode).value(),
+                    bytecode.clone(),
+                )
+            })
             .collect();
         // Ensure that *dynamic* factory deps (ones that may be created when executing EVM contracts)
         // are added into the lookup map as well.

--- a/core/node/vm_runner/Cargo.toml
+++ b/core/node/vm_runner/Cargo.toml
@@ -17,7 +17,6 @@ zksync_dal.workspace = true
 zksync_contracts.workspace = true
 zksync_state.workspace = true
 zksync_storage.workspace = true
-zksync_utils.workspace = true
 zksync_prover_interface.workspace = true
 zksync_object_store.workspace = true
 zksync_vm_executor.workspace = true

--- a/core/node/vm_runner/src/tests/mod.rs
+++ b/core/node/vm_runner/src/tests/mod.rs
@@ -12,6 +12,7 @@ use zksync_node_test_utils::{
 use zksync_test_account::Account;
 use zksync_types::{
     block::{L1BatchHeader, L2BlockHasher},
+    bytecode::BytecodeHash,
     fee::Fee,
     get_intrinsic_constants, h256_to_u256,
     l2::L2Tx,
@@ -20,7 +21,6 @@ use zksync_types::{
     AccountTreeId, Address, Execute, L1BatchNumber, L2BlockNumber, ProtocolVersionId, StorageKey,
     StorageLog, StorageLogKind, StorageValue, H160, H256, L2_BASE_TOKEN_ADDRESS, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 use zksync_vm_interface::{
     tracer::ValidationTraces, L1BatchEnv, L2BlockEnv, SystemEnv, TransactionExecutionMetrics,
 };
@@ -327,7 +327,7 @@ async fn store_l1_batches(
         header.used_contract_hashes = genesis_params
             .system_contracts()
             .iter()
-            .map(|contract| hash_bytecode(&contract.bytecode))
+            .map(|contract| BytecodeHash::for_bytecode(&contract.bytecode).value())
             .chain([genesis_params.base_system_contracts().hashes().default_aa])
             .chain(genesis_params.base_system_contracts().hashes().evm_emulator)
             .map(h256_to_u256)

--- a/core/tests/loadnext/src/sdk/operations/deploy_contract.rs
+++ b/core/tests/loadnext/src/sdk/operations/deploy_contract.rs
@@ -1,8 +1,8 @@
 use zksync_eth_signer::EthereumSigner;
 use zksync_types::{
-    l2::L2Tx, transaction_request::PaymasterParams, Execute, Nonce, CONTRACT_DEPLOYER_ADDRESS, U256,
+    bytecode::BytecodeHash, l2::L2Tx, transaction_request::PaymasterParams, Execute, Nonce,
+    CONTRACT_DEPLOYER_ADDRESS, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 use zksync_web3_decl::namespaces::EthNamespaceClient;
 
 use crate::sdk::{
@@ -60,7 +60,7 @@ where
             None => Nonce(self.wallet.get_nonce().await?),
         };
 
-        let main_contract_hash = hash_bytecode(&bytecode);
+        let main_contract_hash = BytecodeHash::for_bytecode(&bytecode).value();
         let execute_calldata =
             Execute::encode_deploy_params_create(Default::default(), main_contract_hash, calldata);
 
@@ -141,7 +141,7 @@ where
             .unwrap_or_default();
 
         let calldata = self.calldata.clone().unwrap_or_default();
-        let main_contract_hash = hash_bytecode(&bytecode);
+        let main_contract_hash = BytecodeHash::for_bytecode(&bytecode).value();
         let mut factory_deps = self.factory_deps.clone().unwrap_or_default();
         factory_deps.push(bytecode);
         let l2_tx = L2Tx::new(

--- a/core/tests/test_account/Cargo.toml
+++ b/core/tests/test_account/Cargo.toml
@@ -13,7 +13,6 @@ categories.workspace = true
 [dependencies]
 zksync_types.workspace = true
 zksync_system_constants.workspace = true
-zksync_utils.workspace = true
 zksync_eth_signer.workspace = true
 zksync_contracts.workspace = true
 

--- a/core/tests/test_account/src/lib.rs
+++ b/core/tests/test_account/src/lib.rs
@@ -8,11 +8,10 @@ use zksync_system_constants::{
     REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE,
 };
 use zksync_types::{
-    abi, address_to_u256, fee::Fee, h256_to_u256, l2::L2Tx, utils::deployed_address_create,
-    Address, Execute, K256PrivateKey, L2ChainId, Nonce, Transaction, H256,
-    PRIORITY_OPERATION_L2_TX_TYPE, U256,
+    abi, address_to_u256, bytecode::BytecodeHash, fee::Fee, l2::L2Tx,
+    utils::deployed_address_create, Address, Execute, K256PrivateKey, L2ChainId, Nonce,
+    Transaction, H256, PRIORITY_OPERATION_L2_TX_TYPE, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 pub const L1_TEST_GAS_PER_PUBDATA_BYTE: u32 = 800;
 const BASE_FEE: u64 = 2_000_000_000;
@@ -124,7 +123,7 @@ impl Account {
         let contract_function = deployer.function("create").unwrap();
 
         let calldata = calldata.map(ethabi::encode);
-        let code_hash = hash_bytecode(code);
+        let code_hash = BytecodeHash::for_bytecode(code).value();
         let params = [
             Token::FixedBytes(vec![0u8; 32]),
             Token::FixedBytes(code_hash.0.to_vec()),
@@ -185,7 +184,7 @@ impl Account {
                 signature: vec![],
                 factory_deps: factory_deps
                     .iter()
-                    .map(|b| h256_to_u256(hash_bytecode(b)))
+                    .map(|b| BytecodeHash::for_bytecode(b).value_u256())
                     .collect(),
                 paymaster_input: vec![],
                 reserved_dynamic: vec![],

--- a/core/tests/vm-benchmark/Cargo.toml
+++ b/core/tests/vm-benchmark/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 zksync_contracts.workspace = true
 zksync_multivm.workspace = true
 zksync_types.workspace = true
-zksync_utils.workspace = true
 zksync_vlog.workspace = true
 zksync_vm2.workspace = true
 

--- a/core/tests/vm-benchmark/src/transaction.rs
+++ b/core/tests/vm-benchmark/src/transaction.rs
@@ -3,6 +3,7 @@ pub use zksync_contracts::test_contracts::LoadnextContractExecutionParams as Loa
 use zksync_contracts::{deployer_contract, TestContract};
 use zksync_multivm::utils::get_max_gas_per_pubdata_byte;
 use zksync_types::{
+    bytecode::BytecodeHash,
     ethabi::{encode, Token},
     fee::Fee,
     l2::L2Tx,
@@ -10,7 +11,6 @@ use zksync_types::{
     Address, K256PrivateKey, L2ChainId, Nonce, ProtocolVersionId, Transaction,
     CONTRACT_DEPLOYER_ADDRESS, H256, U256,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 const LOAD_TEST_MAX_READS: usize = 3000;
 
@@ -37,7 +37,7 @@ pub fn get_deploy_tx_with_gas_limit(code: &[u8], gas_limit: u32, nonce: u32) -> 
     salt[28..32].copy_from_slice(&nonce.to_be_bytes());
     let params = [
         Token::FixedBytes(salt),
-        Token::FixedBytes(hash_bytecode(code).0.to_vec()),
+        Token::FixedBytes(BytecodeHash::for_bytecode(code).value().0.to_vec()),
         Token::Bytes([].to_vec()),
     ];
     let calldata = CREATE_FUNCTION_SIGNATURE
@@ -96,7 +96,12 @@ pub fn get_load_test_deploy_tx() -> Transaction {
     let calldata = [Token::Uint(LOAD_TEST_MAX_READS.into())];
     let params = [
         Token::FixedBytes(vec![0_u8; 32]),
-        Token::FixedBytes(hash_bytecode(&LOAD_TEST_CONTRACT.bytecode).0.to_vec()),
+        Token::FixedBytes(
+            BytecodeHash::for_bytecode(&LOAD_TEST_CONTRACT.bytecode)
+                .value()
+                .0
+                .to_vec(),
+        ),
         Token::Bytes(encode(&calldata)),
     ];
     let create_calldata = CREATE_FUNCTION_SIGNATURE

--- a/core/tests/vm-benchmark/src/vm.rs
+++ b/core/tests/vm-benchmark/src/vm.rs
@@ -18,14 +18,13 @@ use zksync_types::{
     utils::storage_key_for_eth_balance, L1BatchNumber, L2BlockNumber, L2ChainId, ProtocolVersionId,
     Transaction,
 };
-use zksync_utils::bytecode::hash_bytecode;
 
 use crate::{instruction_counter::InstructionCounter, transaction::PRIVATE_KEY};
 
 static SYSTEM_CONTRACTS: Lazy<BaseSystemContracts> = Lazy::new(BaseSystemContracts::load_from_disk);
 
 static STORAGE: Lazy<InMemoryStorage> = Lazy::new(|| {
-    let mut storage = InMemoryStorage::with_system_contracts(hash_bytecode);
+    let mut storage = InMemoryStorage::with_system_contracts();
     // Give `PRIVATE_KEY` some money
     let balance = U256::from(10u32).pow(U256::from(32)); //10^32 wei
     let key = storage_key_for_eth_balance(&PRIVATE_KEY.address());

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -8078,7 +8078,6 @@ dependencies = [
  "zksync_protobuf_build",
  "zksync_system_constants",
  "zksync_types",
- "zksync_utils",
  "zksync_vm_interface",
 ]
 
@@ -8623,7 +8622,6 @@ dependencies = [
  "zksync_protobuf",
  "zksync_protobuf_build",
  "zksync_system_constants",
- "zksync_utils",
 ]
 
 [[package]]

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -7816,6 +7816,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "const-decoder 0.4.0",
  "ethabi",
  "hex",
  "num_enum 0.7.2",
@@ -7823,6 +7824,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sha2 0.10.8",
  "strum",
  "thiserror",
  "tiny-keccak 2.0.2",
@@ -7994,11 +7996,11 @@ name = "zksync_contracts"
 version = "0.1.0"
 dependencies = [
  "envy",
- "ethabi",
  "hex",
  "once_cell",
  "serde",
  "serde_json",
+ "zksync_basic_types",
  "zksync_utils",
 ]
 
@@ -8230,7 +8232,6 @@ dependencies = [
  "zksync_mini_merkle_tree",
  "zksync_system_constants",
  "zksync_types",
- "zksync_utils",
  "zksync_vm2",
  "zksync_vm_interface",
 ]

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -8629,16 +8629,12 @@ name = "zksync_utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "const-decoder 0.4.0",
  "futures 0.3.30",
  "once_cell",
  "reqwest 0.12.5",
  "serde_json",
- "thiserror",
  "tokio",
  "tracing",
- "zk_evm 0.133.0",
- "zksync_basic_types",
  "zksync_vlog",
 ]
 

--- a/zkstack_cli/Cargo.lock
+++ b/zkstack_cli/Cargo.lock
@@ -6767,6 +6767,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "const-decoder",
  "ethabi",
  "hex",
  "num_enum 0.7.3",
@@ -6774,6 +6775,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sha2",
  "strum",
  "thiserror",
  "tiny-keccak",
@@ -6873,11 +6875,11 @@ name = "zksync_contracts"
 version = "0.1.0"
 dependencies = [
  "envy",
- "ethabi",
  "hex",
  "once_cell",
  "serde",
  "serde_json",
+ "zksync_basic_types",
  "zksync_utils",
 ]
 

--- a/zkstack_cli/Cargo.lock
+++ b/zkstack_cli/Cargo.lock
@@ -299,12 +299,6 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
-name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
@@ -659,7 +653,7 @@ dependencies = [
  "coins-core",
  "digest",
  "hmac",
- "k256 0.13.4",
+ "k256",
  "serde",
  "sha2",
  "thiserror",
@@ -940,18 +934,6 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
-dependencies = [
- "generic-array",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
@@ -1067,16 +1049,6 @@ checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "serde",
  "uuid 1.10.0",
-]
-
-[[package]]
-name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "zeroize",
 ]
 
 [[package]]
@@ -1223,28 +1195,16 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
-dependencies = [
- "der 0.6.1",
- "elliptic-curve 0.12.3",
- "rfc6979 0.3.1",
- "signature 1.6.4",
-]
-
-[[package]]
-name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.9",
+ "der",
  "digest",
- "elliptic-curve 0.13.8",
- "rfc6979 0.4.0",
- "signature 2.2.0",
- "spki 0.7.3",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -1253,8 +1213,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8 0.10.2",
- "signature 2.2.0",
+ "pkcs8",
+ "signature",
 ]
 
 [[package]]
@@ -1283,39 +1243,19 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
-dependencies = [
- "base16ct 0.1.1",
- "crypto-bigint 0.4.9",
- "der 0.6.1",
- "digest",
- "ff 0.12.1",
- "generic-array",
- "group 0.12.1",
- "pkcs8 0.9.0",
- "rand_core",
- "sec1 0.3.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.5",
+ "base16ct",
+ "crypto-bigint",
  "digest",
- "ff 0.13.0",
+ "ff",
  "generic-array",
- "group 0.13.0",
- "pkcs8 0.10.2",
+ "group",
+ "pkcs8",
  "rand_core",
- "sec1 0.7.3",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -1362,7 +1302,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "hex",
- "k256 0.13.4",
+ "k256",
  "log",
  "rand",
  "rlp",
@@ -1587,11 +1527,11 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "const-hex",
- "elliptic-curve 0.13.8",
+ "elliptic-curve",
  "ethabi",
  "generic-array",
- "k256 0.13.4",
- "num_enum 0.7.3",
+ "k256",
+ "num_enum",
  "once_cell",
  "open-fastrlp",
  "rand",
@@ -1696,7 +1636,7 @@ dependencies = [
  "coins-bip32",
  "coins-bip39",
  "const-hex",
- "elliptic-curve 0.13.8",
+ "elliptic-curve",
  "eth-keystore",
  "ethers-core",
  "rand",
@@ -1774,16 +1714,6 @@ name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
-
-[[package]]
-name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "rand_core",
- "subtle",
-]
 
 [[package]]
 name = "ff"
@@ -2084,22 +2014,11 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.0",
+ "ff",
  "rand_core",
  "subtle",
 ]
@@ -2681,28 +2600,16 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
-dependencies = [
- "cfg-if",
- "ecdsa 0.14.8",
- "elliptic-curve 0.12.3",
- "sha2",
-]
-
-[[package]]
-name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
+ "ecdsa",
+ "elliptic-curve",
  "once_cell",
  "sha2",
- "signature 2.2.0",
+ "signature",
 ]
 
 [[package]]
@@ -3132,32 +3039,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
-dependencies = [
- "num_enum_derive 0.6.1",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
- "num_enum_derive 0.7.3",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 2.0.79",
+ "num_enum_derive",
 ]
 
 [[package]]
@@ -3166,7 +3052,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -3412,7 +3298,7 @@ version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3627,19 +3513,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.7.9",
- "pkcs8 0.10.2",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
+ "der",
+ "pkcs8",
+ "spki",
 ]
 
 [[package]]
@@ -3648,8 +3524,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.9",
- "spki 0.7.3",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -3721,21 +3597,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.22.22",
+ "toml_edit",
 ]
 
 [[package]]
@@ -4142,17 +4008,6 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
-dependencies = [
- "crypto-bigint 0.4.9",
- "hmac",
- "zeroize",
-]
-
-[[package]]
-name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
@@ -4234,10 +4089,10 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand_core",
- "signature 2.2.0",
- "spki 0.7.3",
+ "signature",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -4400,7 +4255,7 @@ version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4445,28 +4300,14 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
-dependencies = [
- "base16ct 0.1.1",
- "der 0.6.1",
- "generic-array",
- "pkcs8 0.9.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct 0.2.0",
- "der 0.7.9",
+ "base16ct",
+ "der",
  "generic-array",
- "pkcs8 0.10.2",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -4772,31 +4613,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2_ce"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca2daa77078f4ddff27e75c4bf59e4c2697525f56dbb3c842d34a5d1f2b04a2"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha3"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
-dependencies = [
- "digest",
- "keccak",
-]
-
-[[package]]
-name = "sha3_ce"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c9a08202c50378d8a07a5f458193a5f542d2828ac6640263dbc0c2533ea25e"
 dependencies = [
  "digest",
  "keccak",
@@ -4824,16 +4644,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-dependencies = [
- "digest",
- "rand_core",
 ]
 
 [[package]]
@@ -4955,22 +4765,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.9",
+ "der",
 ]
 
 [[package]]
@@ -5700,7 +5500,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.22",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5714,17 +5514,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.6.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
@@ -5733,7 +5522,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.20",
+ "winnow",
 ]
 
 [[package]]
@@ -6532,15 +6321,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
@@ -6675,50 +6455,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zk_evm"
-version = "0.133.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af08e9284686a1b0c89ec4931eb915ac0729367f1247abd06164874fe738106"
-dependencies = [
- "anyhow",
- "lazy_static",
- "num",
- "serde",
- "serde_json",
- "static_assertions",
- "zk_evm_abstractions",
- "zkevm_opcode_defs",
-]
-
-[[package]]
-name = "zk_evm_abstractions"
-version = "0.140.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be696258861eba4e6625a5665084b2266720bb67f4ba69819469700ac5c6a401"
-dependencies = [
- "anyhow",
- "num_enum 0.6.1",
- "serde",
- "static_assertions",
- "zkevm_opcode_defs",
-]
-
-[[package]]
-name = "zkevm_opcode_defs"
-version = "0.132.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0769f7b27d8fb06e715da3290c575cac5d04d10a557faef180e847afce50ac4"
-dependencies = [
- "bitflags 2.6.0",
- "blake2",
- "ethereum-types",
- "k256 0.11.6",
- "lazy_static",
- "sha2_ce",
- "sha3_ce",
-]
-
-[[package]]
 name = "zkstack"
 version = "0.1.0"
 dependencies = [
@@ -6770,7 +6506,7 @@ dependencies = [
  "const-decoder",
  "ethabi",
  "hex",
- "num_enum 0.7.3",
+ "num_enum",
  "secrecy",
  "serde",
  "serde_json",
@@ -6824,9 +6560,9 @@ dependencies = [
  "anyhow",
  "blst",
  "ed25519-dalek",
- "elliptic-curve 0.13.8",
+ "elliptic-curve",
  "hex",
- "k256 0.13.4",
+ "k256",
  "num-bigint",
  "num-traits",
  "rand",
@@ -6985,7 +6721,7 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "num",
- "num_enum 0.7.3",
+ "num_enum",
  "once_cell",
  "prost 0.12.6",
  "rlp",
@@ -7009,16 +6745,12 @@ name = "zksync_utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "const-decoder",
  "futures",
  "once_cell",
  "reqwest 0.12.8",
  "serde_json",
- "thiserror",
  "tokio",
  "tracing",
- "zk_evm",
- "zksync_basic_types",
  "zksync_vlog",
 ]
 

--- a/zkstack_cli/Cargo.lock
+++ b/zkstack_cli/Cargo.lock
@@ -7002,7 +7002,6 @@ dependencies = [
  "zksync_protobuf",
  "zksync_protobuf_build",
  "zksync_system_constants",
- "zksync_utils",
 ]
 
 [[package]]


### PR DESCRIPTION
## What ❔

Moves bytecode hashing logic to `zksync_basic_types`.

## Why ❔

It belongs there by domain and further simplifies the dependency graph.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.