### PR TITLE
chore(consensus): updated EN config templates

### DIFF
--- a/docs/guides/external-node/docker-compose-examples/configs/mainnet_consensus_config.yaml
+++ b/docs/guides/external-node/docker-compose-examples/configs/mainnet_consensus_config.yaml
@@ -3,9 +3,3 @@ public_addr: '127.0.0.1:3054'
 debug_page_addr: '0.0.0.0:5000'
 max_payload_size: 5000000
 gossip_dynamic_inbound_limit: 100
-gossip_static_outbound:
-  # preconfigured ENs owned by Matterlabs that you can connect to
-  - key: 'node:public:ed25519:68d29127ab03408bf5c838553b19c32bdb3aaaae9bf293e5e078c3a0d265822a'
-    addr: 'external-node-consensus-mainnet.zksync.dev:3054'
-  - key: 'node:public:ed25519:b521e1bb173d04bc83d46b859d1296378e94a40427a6beb9e7fdd17cbd934c11'
-    addr: 'external-node-moby-consensus-mainnet.zksync.dev:3054'

--- a/docs/guides/external-node/docker-compose-examples/configs/testnet_consensus_config.yaml
+++ b/docs/guides/external-node/docker-compose-examples/configs/testnet_consensus_config.yaml
@@ -3,9 +3,3 @@ public_addr: '127.0.0.1:3054'
 debug_page_addr: '0.0.0.0:5000'
 max_payload_size: 5000000
 gossip_dynamic_inbound_limit: 100
-gossip_static_outbound:
-  # preconfigured ENs owned by Matterlabs that you can connect to
-  - key: 'node:public:ed25519:4a94067664e7b8d0927ab1443491dab71a1d0c63f861099e1852f2b6d0831c3e'
-    addr: 'external-node-consensus-sepolia.zksync.dev:3054'
-  - key: 'node:public:ed25519:cfbbebc74127099680584f07a051a2573e2dd7463abdd000d31aaa44a7985045'
-    addr: 'external-node-moby-consensus-sepolia.zksync.dev:3054'

--- a/docs/guides/external-node/docker-compose-examples/mainnet-external-node-docker-compose.yml
+++ b/docs/guides/external-node/docker-compose-examples/mainnet-external-node-docker-compose.yml
@@ -52,7 +52,7 @@ services:
   # Generation of consensus secrets.
   # The secrets are generated iff the secrets file doesn't already exist.
   generate-secrets:
-    image: "matterlabs/external-node:2.0-v24.16.0"
+    image: "matterlabs/external-node:2.0-v25.1.0"
     entrypoint:
       [
       "/configs/generate_secrets.sh",
@@ -61,7 +61,7 @@ services:
     volumes:
       - ./configs:/configs
   external-node:
-    image: "matterlabs/external-node:2.0-v24.16.0"
+    image: "matterlabs/external-node:2.0-v25.1.0"
     entrypoint:
       [
       "/usr/bin/entrypoint.sh",

--- a/docs/guides/external-node/prepared_configs/mainnet_consensus_config.yaml
+++ b/docs/guides/external-node/prepared_configs/mainnet_consensus_config.yaml
@@ -2,13 +2,3 @@ server_addr: '0.0.0.0:3054'
 public_addr: '<your public IP goes here>:3054'
 max_payload_size: 5000000
 gossip_dynamic_inbound_limit: 100
-gossip_static_outbound:
-  # preconfigured ENs owned by Matterlabs that you can connect to
-  - key: 'node:public:ed25519:68d29127ab03408bf5c838553b19c32bdb3aaaae9bf293e5e078c3a0d265822a'
-    addr: 'external-node-consensus-mainnet.zksync.dev:3054'
-  - key: 'node:public:ed25519:b521e1bb173d04bc83d46b859d1296378e94a40427a6beb9e7fdd17cbd934c11'
-    addr: 'external-node-moby-consensus-mainnet.zksync.dev:3054'
-  - key: 'node:public:ed25519:45d23515008b5121484eb774507df63ff4ce9f4b65e6a03b7c9ec4e0474d3044'
-    addr: 'consensus-mainnet-1.zksync-nodes.com:3054'
-  - key: 'node:public:ed25519:c278bb0831e8d0dcd3aaf0b7af7c3dca048d50b28c578ceecce61a412986b883'
-    addr: 'consensus-mainnet-2.zksync-nodes.com:3054'

--- a/docs/guides/external-node/prepared_configs/testnet_consensus_config.yaml
+++ b/docs/guides/external-node/prepared_configs/testnet_consensus_config.yaml
@@ -2,13 +2,3 @@ server_addr: '0.0.0.0:3054'
 public_addr: '<your public IP goes here>:3054'
 max_payload_size: 5000000
 gossip_dynamic_inbound_limit: 100
-gossip_static_outbound:
-  # preconfigured ENs owned by Matterlabs that you can connect to
-  - key: 'node:public:ed25519:4a94067664e7b8d0927ab1443491dab71a1d0c63f861099e1852f2b6d0831c3e'
-    addr: 'external-node-consensus-sepolia.zksync.dev:3054'
-  - key: 'node:public:ed25519:cfbbebc74127099680584f07a051a2573e2dd7463abdd000d31aaa44a7985045'
-    addr: 'external-node-moby-consensus-sepolia.zksync.dev:3054'
-  - key: 'node:public:ed25519:f48616db5965ada49dcbd51b1de11068a27c9886c900d3522607f16dff2e66fc'
-    addr: 'consensus-sepolia-1.zksync-nodes.com:3054'
-  - key: 'node:public:ed25519:3789d49293792755a9c1c2a7ed9b0e210e92994606dcf76388b5635d7ed676cb'
-    addr: 'consensus-sepolia-2.zksync-nodes.com:3054'


### PR DESCRIPTION
Removed the default gossip outbound peers list, obsoleted in favor of seed_peers.