### PR TITLE
ci: migrate docker from tag workflow to new templates

### DIFF
--- a/.github/workflows/new-build-prover-template.yml
+++ b/.github/workflows/new-build-prover-template.yml
@@ -170,6 +170,17 @@ jobs:
             matterlabs/${{ matrix.components }}:2.0-${{ env.IMAGE_TAG_SHA_TS }}
             us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/${{ matrix.components }}:latest
             matterlabs/${{ matrix.components }}:latest
+
+      - name: Push docker image
+        if: ${{ inputs.action == 'push' }}
+        run: |
+          docker push us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/${{ matrix.components }}:2.0-${{ env.PROTOCOL_VERSION }}-${{ env.IMAGE_TAG_SHA_TS }}
+          docker push matterlabs/${{ matrix.components }}:2.0-${{ env.PROTOCOL_VERSION }}-${{ env.IMAGE_TAG_SHA_TS }}
+          docker push us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/${{ matrix.components }}:2.0-${{ env.IMAGE_TAG_SHA_TS }}
+          docker push matterlabs/${{ matrix.components }}:2.0-${{ env.IMAGE_TAG_SHA_TS }}
+          docker push us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/${{ matrix.components }}:latest
+          docker push matterlabs/${{ matrix.components }}:latest
+
   copy-images:
     name: Copy images between docker registries
     needs: [build-images, get-protocol-version]


### PR DESCRIPTION
## What ❔
Migrate release workflows to new build templates

## Why ❔
For optimize speed of CI/CD

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
