### PR TITLE
fix: Allow protobuf to clone contracts submodule recursively

### DIFF
--- a/.github/workflows/protobuf.yaml
+++ b/.github/workflows/protobuf.yaml
@@ -41,6 +41,7 @@ jobs:
           ref: ${{ env.BASE }}
           path: before
           fetch-depth: 0 # fetches all branches and tags, which is needed to compute the LCA.
+          submodules: "recursive"
       - name: checkout LCA
         run:
           git checkout $(git merge-base $BASE $HEAD) --recurse-submodules


### PR DESCRIPTION
CI is broken due to contracts not being recursively inited. This PR fixes it.