### PR TITLE
feat: add da client can be initialized with the gcs seed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,7 +1493,7 @@ dependencies = [
  "celestia-tendermint-proto",
  "prost 0.12.6",
  "prost-build",
- "prost-types",
+ "prost-types 0.12.6",
  "protox 0.6.1",
  "serde",
 ]
@@ -1514,7 +1514,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "prost 0.12.6",
- "prost-types",
+ "prost-types 0.12.6",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -1538,7 +1538,7 @@ dependencies = [
  "num-derive 0.3.3",
  "num-traits",
  "prost 0.12.6",
- "prost-types",
+ "prost-types 0.12.6",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -3666,6 +3666,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "google-cloud-auth"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357160f51a60ec3e32169ad687f4abe0ee1e90c73b449aa5d11256c4f1cf2ff6"
+dependencies = [
+ "async-trait",
+ "base64 0.21.7",
+ "google-cloud-metadata",
+ "google-cloud-token",
+ "home",
+ "jsonwebtoken",
+ "reqwest 0.12.9",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "tokio",
+ "tracing",
+ "urlencoding",
+]
+
+[[package]]
+name = "google-cloud-gax"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c929076122a1839455cfe6c030278f10a400dd4dacc11d2ca46c20c47dc05996"
+dependencies = [
+ "google-cloud-token",
+ "http 1.1.0",
+ "thiserror",
+ "tokio",
+ "tokio-retry2",
+ "tonic 0.12.3",
+ "tower 0.4.13",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-googleapis"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae8ab26ef7c7c3f7dfb9cc3982293d031d8e78c85d00ddfb704b5c35aeff7c8"
+dependencies = [
+ "prost 0.13.3",
+ "prost-types 0.13.3",
+ "tonic 0.12.3",
+]
+
+[[package]]
+name = "google-cloud-kms"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed3ae94026ce6ee13f22ad0005cf19ea0de543b78b06583f267e23cb7839d1b"
+dependencies = [
+ "google-cloud-auth 0.17.1",
+ "google-cloud-gax",
+ "google-cloud-googleapis",
+ "google-cloud-token",
+ "prost-types 0.13.3",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "google-cloud-metadata"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3688,7 +3754,40 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "futures-util",
- "google-cloud-auth",
+ "google-cloud-auth 0.16.0",
+ "google-cloud-metadata",
+ "google-cloud-token",
+ "hex",
+ "once_cell",
+ "percent-encoding",
+ "pkcs8 0.10.2",
+ "regex",
+ "reqwest 0.12.9",
+ "reqwest-middleware",
+ "ring",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "thiserror",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7347a3d65cd64db51e5b4aebf0c68c484042948c6d53f856f58269bc9816360"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "base64 0.21.7",
+ "bytes",
+ "futures-util",
+ "google-cloud-auth 0.17.1",
  "google-cloud-metadata",
  "google-cloud-token",
  "hex",
@@ -6070,7 +6169,7 @@ dependencies = [
  "heck 0.4.1",
  "itertools 0.11.0",
  "prost 0.12.6",
- "prost-types",
+ "prost-types 0.12.6",
 ]
 
 [[package]]
@@ -6595,7 +6694,7 @@ dependencies = [
  "petgraph",
  "prettyplease",
  "prost 0.12.6",
- "prost-types",
+ "prost-types 0.12.6",
  "regex",
  "syn 2.0.85",
  "tempfile",
@@ -6638,7 +6737,7 @@ dependencies = [
  "miette 5.10.0",
  "once_cell",
  "prost 0.12.6",
- "prost-types",
+ "prost-types 0.12.6",
  "serde",
  "serde-value",
 ]
@@ -6653,7 +6752,7 @@ dependencies = [
  "miette 7.2.0",
  "once_cell",
  "prost 0.12.6",
- "prost-types",
+ "prost-types 0.12.6",
 ]
 
 [[package]]
@@ -6666,6 +6765,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
+dependencies = [
+ "prost 0.13.3",
+]
+
+[[package]]
 name = "protox"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6675,7 +6783,7 @@ dependencies = [
  "miette 5.10.0",
  "prost 0.12.6",
  "prost-reflect 0.12.0",
- "prost-types",
+ "prost-types 0.12.6",
  "protox-parse 0.5.0",
  "thiserror",
 ]
@@ -6690,7 +6798,7 @@ dependencies = [
  "miette 7.2.0",
  "prost 0.12.6",
  "prost-reflect 0.13.1",
- "prost-types",
+ "prost-types 0.12.6",
  "protox-parse 0.6.1",
  "thiserror",
 ]
@@ -6703,7 +6811,7 @@ checksum = "7b4581f441c58863525a3e6bec7b8de98188cf75239a56c725a3e7288450a33f"
 dependencies = [
  "logos 0.13.0",
  "miette 5.10.0",
- "prost-types",
+ "prost-types 0.12.6",
  "thiserror",
 ]
 
@@ -6715,7 +6823,7 @@ checksum = "7f6c33f43516fe397e2f930779d720ca12cd057f7da4cd6326a0ef78d69dee96"
 dependencies = [
  "logos 0.14.2",
  "miette 7.2.0",
- "prost-types",
+ "prost-types 0.12.6",
  "thiserror",
 ]
 
@@ -9594,6 +9702,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-retry2"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "903934dba1c4c2f2e9cb460ef10b5695e0b0ecad3bf9ee7c8675e540c5e8b2d1"
+dependencies = [
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9750,6 +9868,7 @@ dependencies = [
  "axum 0.7.7",
  "base64 0.22.1",
  "bytes",
+ "flate2",
  "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
@@ -9760,13 +9879,16 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost 0.13.3",
+ "rustls-pemfile 2.2.0",
  "socket2",
  "tokio",
+ "tokio-rustls 0.26.0",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -11698,7 +11820,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "envy",
+ "google-cloud-kms",
+ "google-cloud-storage 0.22.1",
+ "hex",
+ "rustls 0.23.16",
  "serde",
+ "tokio",
  "zksync_basic_types",
  "zksync_config",
  "zksync_system_constants",
@@ -12406,8 +12533,8 @@ dependencies = [
  "async-trait",
  "bincode",
  "flate2",
- "google-cloud-auth",
- "google-cloud-storage",
+ "google-cloud-auth 0.16.0",
+ "google-cloud-storage 0.20.0",
  "http 1.1.0",
  "prost 0.12.6",
  "rand 0.8.5",

--- a/core/lib/config/src/configs/da_client/avail.rs
+++ b/core/lib/config/src/configs/da_client/avail.rs
@@ -35,4 +35,5 @@ pub struct AvailGasRelayConfig {
 pub struct AvailSecrets {
     pub seed_phrase: Option<SeedPhrase>,
     pub gas_relay_api_key: Option<APIKey>,
+    pub private_key: Option<String>,
 }

--- a/core/lib/config/src/testonly.rs
+++ b/core/lib/config/src/testonly.rs
@@ -963,6 +963,7 @@ impl Distribution<configs::secrets::DataAvailabilitySecrets> for EncodeDist {
         configs::secrets::DataAvailabilitySecrets::Avail(configs::da_client::avail::AvailSecrets {
             seed_phrase: Some(SeedPhrase(Secret::new(self.sample(rng)))),
             gas_relay_api_key: Some(APIKey(Secret::new(self.sample(rng)))),
+            private_key: None,
         })
     }
 }

--- a/core/lib/env_config/Cargo.toml
+++ b/core/lib/env_config/Cargo.toml
@@ -18,5 +18,11 @@ anyhow.workspace = true
 serde.workspace = true
 envy.workspace = true
 
+google-cloud-kms = "0.5.1"
+google-cloud-storage = "0.22.1"
+hex = "0.4.3"
+tokio = { workspace = true, features = ["rt"] }
+rustls = "0.23"
+
 [dev-dependencies]
 zksync_system_constants.workspace = true

--- a/core/lib/env_config/src/da_client.rs
+++ b/core/lib/env_config/src/da_client.rs
@@ -50,7 +50,7 @@ impl FromEnv for DataAvailabilitySecrets {
         let client_tag = std::env::var("DA_CLIENT")?;
         let secrets = match client_tag.as_str() {
             AVAIL_CLIENT_CONFIG_NAME => {
-                let from_gcs = if let Some(secrets_from_gcs_tag) = env::var("DA_SECRETS_FROM_GCS").ok() {
+                let from_gcs = if let Ok(secrets_from_gcs_tag) = env::var("DA_SECRETS_FROM_GCS") {
                     secrets_from_gcs_tag == "true"
                 } else {
                     false
@@ -58,15 +58,13 @@ impl FromEnv for DataAvailabilitySecrets {
 
                 let _seed = match from_gcs {
                     true => {
-                       let gcs_bucket_name = std::env::var("DA_SECRETS_GCS_BUCKET_NAME")
-                       .ok()
-                       .expect("Failed to get DA client secrets from GCS bucket");
-                       let decrypt_key_name = std::env::var("DA_SECRETS_KMS_DECRYPT_KEY_NAME")
-                       .ok()
-                       .expect("Failed to get DA client secrets KMS decrypt key");
-        
-                       Some(retrieve_seed_from_gcloud(decrypt_key_name, gcs_bucket_name))
-                    },
+                        let gcs_bucket_name = std::env::var("DA_SECRETS_GCS_BUCKET_NAME")
+                            .expect("Failed to get DA client secrets from GCS bucket");
+                        let decrypt_key_name = std::env::var("DA_SECRETS_KMS_DECRYPT_KEY_NAME")
+                            .expect("Failed to get DA client secrets KMS decrypt key");
+
+                        Some(retrieve_seed_from_gcloud(decrypt_key_name, gcs_bucket_name))
+                    }
                     false => None,
                 };
 

--- a/core/lib/env_config/src/gcloud_encrypted_seed.rs
+++ b/core/lib/env_config/src/gcloud_encrypted_seed.rs
@@ -6,10 +6,8 @@ use google_cloud_storage::{
     client::{Client as storage_client, ClientConfig as storage_config},
     http::objects::{download::Range, get::GetObjectRequest},
 };
-use hex;
-use tokio;
 
-pub fn retrieve_seed_from_gcloud(decrypt_key: String, bucket_name: String)-> String {
+pub fn retrieve_seed_from_gcloud(decrypt_key: String, bucket_name: String) -> String {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let rt = tokio::runtime::Runtime::new().unwrap();
 
@@ -44,7 +42,8 @@ async fn download_seed_from_gcs(bucket_name: String) -> Vec<u8> {
     let client = storage_client::new(config);
 
     // Download the file
-    let encrypted_seed = client
+
+    client
         .download_object(
             &GetObjectRequest {
                 bucket: bucket_name,
@@ -54,6 +53,5 @@ async fn download_seed_from_gcs(bucket_name: String) -> Vec<u8> {
             &Range::default(),
         )
         .await
-        .expect("Failed to download seed");
-    encrypted_seed
+        .expect("Failed to download seed")
 }

--- a/core/lib/env_config/src/gcloud_encrypted_seed.rs
+++ b/core/lib/env_config/src/gcloud_encrypted_seed.rs
@@ -44,7 +44,7 @@ async fn download_seed_from_gcs(bucket_name: String) -> Vec<u8> {
     let client = storage_client::new(config);
 
     // Download the file
-    client
+    let encrypted_seed = client
         .download_object(
             &GetObjectRequest {
                 bucket: bucket_name,
@@ -54,5 +54,6 @@ async fn download_seed_from_gcs(bucket_name: String) -> Vec<u8> {
             &Range::default(),
         )
         .await
-        .unwrap()
+        .expect("Failed to download seed");
+    encrypted_seed
 }

--- a/core/lib/env_config/src/gcloud_encrypted_seed.rs
+++ b/core/lib/env_config/src/gcloud_encrypted_seed.rs
@@ -1,0 +1,58 @@
+use google_cloud_kms::{
+    client::{Client as kms_client, ClientConfig as kms_config},
+    grpc::kms::v1::DecryptRequest,
+};
+use google_cloud_storage::{
+    client::{Client as storage_client, ClientConfig as storage_config},
+    http::objects::{download::Range, get::GetObjectRequest},
+};
+use hex;
+use tokio;
+
+pub fn retrieve_seed_from_gcloud(decrypt_key: String, bucket_name: String)-> String {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    // Download encryped seed for google cloud storage
+    let encrypted_seed_from_gcs = rt.block_on(download_seed_from_gcs(bucket_name));
+    // Decrypt seed with kms key
+    let decrypted_seed = rt.block_on(decrypt_seed_with_kms(&encrypted_seed_from_gcs, decrypt_key));
+
+    decrypted_seed
+}
+
+async fn decrypt_seed_with_kms(encrypted_seed: &[u8], decrypt_key: String) -> String {
+    let config = kms_config::default().with_auth().await.unwrap();
+    let client = kms_client::new(config).await.unwrap();
+
+    let request = DecryptRequest {
+        name: decrypt_key,
+        ciphertext: encrypted_seed.to_vec(),
+        additional_authenticated_data: vec![],
+        ciphertext_crc32c: None,
+        additional_authenticated_data_crc32c: None,
+    };
+    let decrypted_seed = client
+        .decrypt(request, None)
+        .await
+        .expect("Failed to decrypt seed");
+    hex::encode(decrypted_seed.plaintext)
+}
+// Downloads the seed from the specified GCS bucket.
+async fn download_seed_from_gcs(bucket_name: String) -> Vec<u8> {
+    let config = storage_config::default().with_auth().await.unwrap();
+    let client = storage_client::new(config);
+
+    // Download the file
+    client
+        .download_object(
+            &GetObjectRequest {
+                bucket: bucket_name,
+                object: "seed.bin".to_string(),
+                ..Default::default()
+            },
+            &Range::default(),
+        )
+        .await
+        .unwrap()
+}

--- a/core/lib/env_config/src/lib.rs
+++ b/core/lib/env_config/src/lib.rs
@@ -34,6 +34,7 @@ mod wallets;
 
 mod da_client;
 mod timestamp_asserter;
+mod gcloud_encrypted_seed;
 
 pub trait FromEnv: Sized {
     fn from_env() -> anyhow::Result<Self>;

--- a/core/lib/env_config/src/lib.rs
+++ b/core/lib/env_config/src/lib.rs
@@ -33,8 +33,8 @@ mod vm_runner;
 mod wallets;
 
 mod da_client;
-mod timestamp_asserter;
 mod gcloud_encrypted_seed;
+mod timestamp_asserter;
 
 pub trait FromEnv: Sized {
     fn from_env() -> anyhow::Result<Self>;

--- a/core/lib/protobuf_config/src/secrets.rs
+++ b/core/lib/protobuf_config/src/secrets.rs
@@ -126,6 +126,7 @@ impl ProtoRepr for proto::DataAvailabilitySecrets {
                 DataAvailabilitySecrets::Avail(AvailSecrets {
                     seed_phrase,
                     gas_relay_api_key,
+                    private_key: None,
                 })
             }
             DaSecrets::Celestia(celestia) => DataAvailabilitySecrets::Celestia(CelestiaSecrets {

--- a/core/node/da_clients/src/avail/client.rs
+++ b/core/node/da_clients/src/avail/client.rs
@@ -2,6 +2,7 @@ use std::{fmt::Debug, sync::Arc, time::Duration};
 
 use anyhow::anyhow;
 use async_trait::async_trait;
+use hex::FromHex;
 use jsonrpsee::ws_client::WsClientBuilder;
 use serde::{Deserialize, Serialize};
 use subxt_signer::ExposeSecret;
@@ -20,7 +21,6 @@ use crate::{
     avail::sdk::{GasRelayClient, RawAvailClient},
     utils::{to_non_retriable_da_error, to_retriable_da_error},
 };
-use hex::FromHex;
 
 #[derive(Debug, Clone)]
 enum AvailClientMode {
@@ -119,18 +119,22 @@ impl AvailClient {
             }
             AvailClientConfig::FullClient(conf) => {
                 let sdk_client = if let Some(_pk) = &secrets.private_key {
-                    let bytes = Vec::from_hex(_pk).map_err(|e| anyhow::anyhow!("hex string convert failed: {}", e.to_string()))?;
+                    let bytes = Vec::from_hex(_pk).map_err(|e| {
+                        anyhow::anyhow!("hex string convert failed: {}", e.to_string())
+                    })?;
                     if bytes.len() != 32 {
-                        return Err(anyhow::anyhow!("Hex string must represent exactly 32 bytes."));
+                        return Err(anyhow::anyhow!(
+                            "Hex string must represent exactly 32 bytes."
+                        ));
                     }
                     let mut array = [0u8; 32];
                     array.copy_from_slice(&bytes);
-        
+
                     RawAvailClient::new_with_gcs_seed(conf.app_id, array).await?
                 } else {
                     let seed_phrase = secrets
-                    .seed_phrase
-                    .ok_or_else(|| anyhow::anyhow!("seed phrase is missing"))?;
+                        .seed_phrase
+                        .ok_or_else(|| anyhow::anyhow!("seed phrase is missing"))?;
                     RawAvailClient::new(conf.app_id, seed_phrase.0.expose_secret()).await?
                 };
 

--- a/core/node/da_clients/src/avail/sdk.rs
+++ b/core/node/da_clients/src/avail/sdk.rs
@@ -14,7 +14,7 @@ use scale_encode::EncodeAsFields;
 use serde::{Deserialize, Serialize};
 use subxt_signer::{
     bip39::Mnemonic,
-    sr25519::{Keypair, Signature},
+    sr25519::{Keypair, Seed, Signature},
 };
 use zksync_types::H256;
 
@@ -48,6 +48,11 @@ impl RawAvailClient {
         let mnemonic = Mnemonic::parse(seed)?;
         let keypair = Keypair::from_phrase(&mnemonic, None)?;
 
+        Ok(Self { app_id, keypair })
+    }
+
+    pub(crate) async fn new_with_gcs_seed(app_id: u32, seed: Seed) -> anyhow::Result<Self> {
+        let keypair = Keypair::from_seed(seed)?;
         Ok(Self { app_id, keypair })
     }
 


### PR DESCRIPTION
## What ❔

Implement DA client can init with a encrypted seed from google cloud storage. The encrypted seed has been encrypted by a HSM key stored in google KMS.

There are 3 environment variables need to be setup for enabling this feature.
DA_SECRETS_FROM_GCS="true"
DA_SECRETS_GCS_BUCKET_NAME=[gcs-bucket-name]
DA_SECRETS_KMS_DECRYPT_KEY_NAME=[google-kms-key-path]

## Why ❔

Can use the seed encrypted by KMS key and storing in gcs and able to use it in DA client without exposing the key details in the deploy node.  


## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
