### PR TITLE
offcycle: Release circuit provers for v24.2

### DIFF
--- a/prover/crates/lib/prover_fri_types/src/lib.rs
+++ b/prover/crates/lib/prover_fri_types/src/lib.rs
@@ -28,8 +28,8 @@ pub mod keys;
 pub mod queue;
 
 // THESE VALUES SHOULD BE UPDATED ON ANY PROTOCOL UPGRADE OF PROVERS
-pub const PROVER_PROTOCOL_VERSION: ProtocolVersionId = ProtocolVersionId::Version25;
-pub const PROVER_PROTOCOL_PATCH: VersionPatch = VersionPatch(0);
+pub const PROVER_PROTOCOL_VERSION: ProtocolVersionId = ProtocolVersionId::Version24;
+pub const PROVER_PROTOCOL_PATCH: VersionPatch = VersionPatch(2);
 pub const PROVER_PROTOCOL_SEMANTIC_VERSION: ProtocolSemanticVersion = ProtocolSemanticVersion {
     minor: PROVER_PROTOCOL_VERSION,
     patch: PROVER_PROTOCOL_PATCH,


### PR DESCRIPTION
This is an impromptu PR to release a fork from v17.0.0, adjusted for protocol version v24.2. Whilst this exercise exposes multiple risks, it is done internally to derisk moving from v24.2 to v25 on mainnet.

This release is not mandatory and is done mostly to carry circuit provers to mainnet, without being blocked by protocol upgrade. The same changes will arrive to mainnet later on during the v25 protocol upgrade.

