### PR TITLE
offcycle: Release circuit provers for v24.2 try 2

### DIFF
--- a/prover/crates/lib/prover_fri_types/src/lib.rs
+++ b/prover/crates/lib/prover_fri_types/src/lib.rs
@@ -28,8 +28,8 @@ pub mod keys;
 pub mod queue;
 
 // THESE VALUES SHOULD BE UPDATED ON ANY PROTOCOL UPGRADE OF PROVERS
-pub const PROVER_PROTOCOL_VERSION: ProtocolVersionId = ProtocolVersionId::Version25;
-pub const PROVER_PROTOCOL_PATCH: VersionPatch = VersionPatch(0);
+pub const PROVER_PROTOCOL_VERSION: ProtocolVersionId = ProtocolVersionId::Version24;
+pub const PROVER_PROTOCOL_PATCH: VersionPatch = VersionPatch(2);
 pub const PROVER_PROTOCOL_SEMANTIC_VERSION: ProtocolSemanticVersion = ProtocolSemanticVersion {
     minor: PROVER_PROTOCOL_VERSION,
     patch: PROVER_PROTOCOL_PATCH,


### PR DESCRIPTION
Same as previous [try](https://github.com/matter-labs/zksync-era/releases/tag/prover-v16.7.0-rc.1), but rebasing on 17.1.0. Non-mandatory release, internal interests only.
