### PR TITLE
fix BIN_DIR="${LOCAL_DIR}/bin" to prevent // in after run zkstackup =…

### DIFF
--- a/zkstack_cli/zkstackup/zkstackup
+++ b/zkstack_cli/zkstackup/zkstackup
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 LOCAL_DIR="$HOME/.local/"
-BIN_DIR="$LOCAL_DIR/bin"
+BIN_DIR="${LOCAL_DIR}/bin"
 
 BINS=()
 


### PR DESCRIPTION
…> Added $HOME/.local//bin to PATH in /$HOME/.bashrc.

## What ❔
after ```zkstackup``` on my archlinux based with bash shell. It adds 
=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

Added $HOME/.local//bin to PATH in $HOME/.bashrc.

Added zkstack to PATH.
Run 'source $HOME/.bashrc' or start a new terminal session to use zkstack.

