### PR TITLE
ci: fix missed build args for docker

### DIFF
--- a/.github/workflows/new-build-prover-template.yml
+++ b/.github/workflows/new-build-prover-template.yml
@@ -155,13 +155,13 @@ jobs:
           context: .
           load: true
           build-args: |
-            CUDA_ARCH='${{ inputs.CUDA_ARCH }}'
+            CUDA_ARCH="${{ inputs.CUDA_ARCH }}"
             SCCACHE_GCS_BUCKET=matterlabs-infra-sccache-storage
             SCCACHE_GCS_SERVICE_ACCOUNT=gha-ci-runners@matterlabs-infra.iam.gserviceaccount.com
             SCCACHE_GCS_RW_MODE=READ_WRITE
             RUSTC_WRAPPER=sccache
-            PROTOCOL_VERSION='${{ env.PROTOCOL_VERSION }}'
-            ERA_BELLMAN_CUDA_RELEASE='${{ inputs.ERA_BELLMAN_CUDA_RELEASE }}'
+            PROTOCOL_VERSION="${{ env.PROTOCOL_VERSION }}"
+            ERA_BELLMAN_CUDA_RELEASE="${{ inputs.ERA_BELLMAN_CUDA_RELEASE }}"
           file: docker/${{ matrix.components }}/Dockerfile
           tags: |
             us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/${{ matrix.components }}:2.0-${{ env.PROTOCOL_VERSION }}-${{ env.IMAGE_TAG_SHA_TS }}

--- a/.github/workflows/new-build-witness-generator-template.yml
+++ b/.github/workflows/new-build-witness-generator-template.yml
@@ -126,14 +126,14 @@ jobs:
           context: .
           push: ${{ inputs.action == 'push' }}
           build-args: |
-            CUDA_ARCH='${{ inputs.CUDA_ARCH }}'
+            CUDA_ARCH="${{ inputs.CUDA_ARCH }}"
             SCCACHE_GCS_BUCKET=matterlabs-infra-sccache-storage
             SCCACHE_GCS_SERVICE_ACCOUNT=gha-ci-runners@matterlabs-infra.iam.gserviceaccount.com
             SCCACHE_GCS_RW_MODE=READ_WRITE
             RUSTC_WRAPPER=sccache
-            PROTOCOL_VERSION='${{ env.PROTOCOL_VERSION }}'
-            ERA_BELLMAN_CUDA_RELEASE='${{ inputs.ERA_BELLMAN_CUDA_RELEASE }}'
-            RUST_FLAGS='${{ inputs.WITNESS_GENERATOR_RUST_FLAGS }}'
+            PROTOCOL_VERSION="${{ env.PROTOCOL_VERSION }}"
+            ERA_BELLMAN_CUDA_RELEASE="${{ inputs.ERA_BELLMAN_CUDA_RELEASE }}"
+            RUST_FLAGS="${{ inputs.WITNESS_GENERATOR_RUST_FLAGS }}"
           file: docker/${{ matrix.components }}/Dockerfile
           tags: |
             us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/${{ matrix.components }}:2.0-${{ env.PROTOCOL_VERSION }}-${{ env.IMAGE_TAG_SHA_TS }}


### PR DESCRIPTION
## What ❔
Fix for missed build args for docker build

## Why ❔
It's missed

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
