### PR TITLE
fix(ci): Ability to publish zk-environment from manual trigger

### DIFF
--- a/.github/workflows/zk-environment-publish.yml
+++ b/.github/workflows/zk-environment-publish.yml
@@ -128,8 +128,7 @@ jobs:
           push: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch') }}
 
   zk_environment_multiarch_manifest:
-    # We'll update the 'latest' tag, only on environments generated from 'main'.
-    if: needs.changed_files.outputs.zk_environment == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: ${{ (needs.changed_files.outputs.zk_environment == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch') }}
     # Needed to push to Gihub Package Registry
     permissions:
       packages: write


### PR DESCRIPTION
## What ❔

Ability to publish zk-environment from manual trigger

## Why ❔

Sometimes we need to force-update zk-environment

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
