### PR TITLE
ci: Remove unused CUDA_ARCH 60,70

### DIFF
--- a/.github/workflows/build-docker-from-tag.yml
+++ b/.github/workflows/build-docker-from-tag.yml
@@ -23,7 +23,7 @@ concurrency: docker-build
 jobs:
   setup:
     name: Setup
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ubuntu-latest]
     outputs:
       image_tag_suffix: ${{ steps.set.outputs.image_tag_suffix }}
       prover_fri_gpu_key_id: ${{ steps.extract-prover-fri-setup-key-ids.outputs.gpu_short_commit_sha }}
@@ -48,7 +48,7 @@ jobs:
 
   build-push-core-images:
     name: Build and push image
-    needs: [ setup ]
+    needs: [setup]
     uses: ./.github/workflows/new-build-core-template.yml
     if: contains(github.ref_name, 'core')
     secrets:
@@ -61,7 +61,7 @@ jobs:
 
   build-push-tee-prover-images:
     name: Build and push images
-    needs: [ setup ]
+    needs: [setup]
     uses: ./.github/workflows/build-tee-prover-template.yml
     if: contains(github.ref_name, 'core')
     secrets:
@@ -73,7 +73,7 @@ jobs:
 
   build-push-contract-verifier:
     name: Build and push image
-    needs: [ setup ]
+    needs: [setup]
     uses: ./.github/workflows/new-build-contract-verifier-template.yml
     if: contains(github.ref_name, 'contract_verifier')
     secrets:
@@ -85,13 +85,12 @@ jobs:
 
   build-push-prover-images:
     name: Build and push image
-    needs: [ setup ]
+    needs: [setup]
     uses: ./.github/workflows/new-build-prover-template.yml
     if: contains(github.ref_name, 'prover')
     with:
       image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}
       ERA_BELLMAN_CUDA_RELEASE: ${{ vars.ERA_BELLMAN_CUDA_RELEASE }}
-      CUDA_ARCH: "60;70;75;80;89"
       action: "push"
     secrets:
       DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
@@ -99,13 +98,12 @@ jobs:
 
   build-push-witness-generator-image-avx512:
     name: Build and push image
-    needs: [ setup ]
+    needs: [setup]
     uses: ./.github/workflows/new-build-witness-generator-template.yml
     if: contains(github.ref_name, 'prover')
     with:
       image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}-avx512
       ERA_BELLMAN_CUDA_RELEASE: ${{ vars.ERA_BELLMAN_CUDA_RELEASE }}
-      CUDA_ARCH: "60;70;75;80;89"
       WITNESS_GENERATOR_RUST_FLAGS: "-Ctarget_feature=+avx512bw,+avx512cd,+avx512dq,+avx512f,+avx512vl"
       action: "push"
     secrets:
@@ -114,7 +112,7 @@ jobs:
 
   build-gar-prover-fri-gpu-and-circuit-prover-gpu-gar:
     name: Build GAR prover FRI GPU
-    needs: [ setup, build-push-prover-images ]
+    needs: [setup, build-push-prover-images]
     uses: ./.github/workflows/build-prover-fri-gpu-gar-and-circuit-prover-gpu-gar.yml
     if: contains(github.ref_name, 'prover')
     with:

--- a/.github/workflows/build-prover-template.yml
+++ b/.github/workflows/build-prover-template.yml
@@ -30,7 +30,7 @@ on:
       CUDA_ARCH:
         description: "CUDA Arch to build"
         type: string
-        default: "89"
+        default: "75;80;89"
         required: false
     outputs:
       protocol_version:

--- a/.github/workflows/build-witness-generator-template.yml
+++ b/.github/workflows/build-witness-generator-template.yml
@@ -27,11 +27,6 @@ on:
         type: boolean
         default: false
         required: false
-      CUDA_ARCH:
-        description: "CUDA Arch to build"
-        type: string
-        default: "89"
-        required: false
       WITNESS_GENERATOR_RUST_FLAGS:
         description: "Rust flags for witness_generator compilation"
         type: string
@@ -49,10 +44,9 @@ jobs:
       IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
       RUNNER_COMPOSE_FILE: "docker-compose-runner-nightly.yml"
       ERA_BELLMAN_CUDA_RELEASE: ${{ inputs.ERA_BELLMAN_CUDA_RELEASE }}
-      CUDA_ARCH: ${{ inputs.CUDA_ARCH }}
       WITNESS_GENERATOR_RUST_FLAGS: ${{ inputs.WITNESS_GENERATOR_RUST_FLAGS }}
       ZKSYNC_USE_CUDA_STUBS: true
-    runs-on: [ matterlabs-ci-runner-c3d ]
+    runs-on: [matterlabs-ci-runner-c3d]
     strategy:
       matrix:
         component:
@@ -90,7 +84,6 @@ jobs:
         if: matrix.component == 'proof-fri-gpu-compressor'
         run: |
           ci_run run_retried curl -LO https://storage.googleapis.com/matterlabs-setup-keys-us/setup-keys/setup_2\^24.key
-
 
       - name: login to Docker registries
         if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
@@ -162,7 +155,7 @@ jobs:
           DOCKER_ACTION: ${{ inputs.action }}
           COMPONENT: ${{ matrix.component }}
         run: |
-          PASSED_ENV_VARS="ERA_BELLMAN_CUDA_RELEASE,CUDA_ARCH,PROTOCOL_VERSION,RUST_FLAGS" \
+          PASSED_ENV_VARS="ERA_BELLMAN_CUDA_RELEASE,PROTOCOL_VERSION,RUST_FLAGS" \
           ci_run zk docker $DOCKER_ACTION $COMPONENT
 
       - name: Show sccache stats

--- a/.github/workflows/new-build-prover-template.yml
+++ b/.github/workflows/new-build-prover-template.yml
@@ -30,8 +30,12 @@ on:
       CUDA_ARCH:
         description: "CUDA Arch to build"
         type: string
-        default: "89"
+        default: "75;80;89"
         required: false
+        # Details: https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
+        # L4: 89
+        # T4: 75
+        # A100: 80
     outputs:
       protocol_version:
         description: "Protocol version of the binary"
@@ -209,7 +213,6 @@ jobs:
           docker buildx imagetools create \
             --tag asia-docker.pkg.dev/matterlabs-infra/matterlabs-docker/${{ matrix.component }}:2.0-${{ inputs.image_tag_suffix }} \
             us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/${{ matrix.component }}:2.0-${{ inputs.image_tag_suffix }}
-
 
       - name: Login and push to Europe GAR
         run: |

--- a/.github/workflows/new-build-witness-generator-template.yml
+++ b/.github/workflows/new-build-witness-generator-template.yml
@@ -21,11 +21,6 @@ on:
         type: string
         default: non-push
         required: false
-      CUDA_ARCH:
-        description: "CUDA Arch to build"
-        type: string
-        default: "89"
-        required: false
       WITNESS_GENERATOR_RUST_FLAGS:
         description: "Rust flags for witness_generator compilation"
         type: string
@@ -39,7 +34,7 @@ on:
 jobs:
   get-protocol-version:
     name: Get protocol version
-    runs-on: [ matterlabs-ci-runner-high-performance ]
+    runs-on: [matterlabs-ci-runner-high-performance]
     outputs:
       protocol_version: ${{ steps.protocolversion.outputs.protocol_version }}
     steps:
@@ -85,7 +80,7 @@ jobs:
     needs: get-protocol-version
     env:
       PROTOCOL_VERSION: ${{ needs.get-protocol-version.outputs.protocol_version }}
-    runs-on: [ matterlabs-ci-runner-c3d ]
+    runs-on: [matterlabs-ci-runner-c3d]
     strategy:
       matrix:
         components:
@@ -126,7 +121,6 @@ jobs:
           context: .
           push: ${{ inputs.action == 'push' }}
           build-args: |
-            CUDA_ARCH=${{ inputs.CUDA_ARCH }}
             SCCACHE_GCS_BUCKET=matterlabs-infra-sccache-storage
             SCCACHE_GCS_SERVICE_ACCOUNT=gha-ci-runners@matterlabs-infra.iam.gserviceaccount.com
             SCCACHE_GCS_RW_MODE=READ_WRITE

--- a/.github/workflows/release-test-stage.yml
+++ b/.github/workflows/release-test-stage.yml
@@ -102,7 +102,6 @@ jobs:
     with:
       image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}
       ERA_BELLMAN_CUDA_RELEASE: ${{ vars.ERA_BELLMAN_CUDA_RELEASE }}
-      CUDA_ARCH: "60;70;75;80;89"
       action: "push"
     secrets:
       DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
@@ -116,7 +115,6 @@ jobs:
     with:
       image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}-avx512
       ERA_BELLMAN_CUDA_RELEASE: ${{ vars.ERA_BELLMAN_CUDA_RELEASE }}
-      CUDA_ARCH: "60;70;75;80;89"
       WITNESS_GENERATOR_RUST_FLAGS: "-Ctarget_feature=+avx512bw,+avx512cd,+avx512dq,+avx512f,+avx512vl "
       action: "push"
     secrets:


### PR DESCRIPTION
## What ❔

Remove unneeded CUDA_ARCH 60 and 70.
Move needed CUDA_ARCH to default, so actual list will be in a single place after old CI cleanup.
Remove CUDA_ARCH from witness-generator build, it isn't used there.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To decrease build time and binary size.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.

ref ZKD-2123
