### PR TITLE
fix: return min refund when gas_price=0

### DIFF
--- a/core/lib/multivm/src/versions/vm_latest/tracers/refunds.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tracers/refunds.rs
@@ -116,6 +116,9 @@ impl<S> RefundsTracer<S> {
 
         // For now, bootloader charges only for base fee.
         let effective_gas_price = get_batch_base_fee(&self.l1_batch);
+        if effective_gas_price == 0 {
+            return bootloader_refund;
+        }
 
         let bootloader_eth_price_per_pubdata_byte =
             U256::from(effective_gas_price) * U256::from(current_ergs_per_pubdata_byte);


### PR DESCRIPTION
## What ❔

Return the minimal possible refund when `effective_gas_price=0` to avoid division by zero

## Why ❔

When we set the gas fees to zero, the execution breaks at this point due to division by zero

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
