### PR TITLE
docs: fix typos in interop docs

### DIFF
--- a/docs/src/specs/interop/interopmessages.md
+++ b/docs/src/specs/interop/interopmessages.md
@@ -39,7 +39,7 @@ contract InteropCenter {
    uint256 messageNum; // a 'nonce' to guarantee different hashes.
  }
 
- // Verifies if such interop message was ever producted.
+ // Verifies if such interop message was ever produced.
  function verifyInteropMessage(bytes32 interopHash, Proof merkleProof) return bool;
 }
 ```
@@ -79,7 +79,7 @@ only if someone has first called `signup_open()` on chain A.
 ```solidity
 // Contract deployed on chain A.
 contract SignupManager {
-  public bytes32 sigup_open_msg_hash;
+  public bytes32 signup_open_msg_hash;
   function signup_open() onlyOwner {
     // We are open for business
     signup_open_msg_hash = InteropCenter(INTEROP_CENTER_ADDRESS).sendInteropMessage("We are open");


### PR DESCRIPTION
## What ❔

Typos in function name and comments are corrected.

## Why ❔

Improve quality of documentation

## Checklist

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
