### PR TITLE
docs: fix incorrect docker and Makefile path

### DIFF
--- a/docs/src/guides/build-docker.md
+++ b/docs/src/guides/build-docker.md
@@ -10,7 +10,7 @@ Install prerequisites: see
 
 ## Build docker files
 
-You may build all images with [Makefile](../../docker/Makefile) located in [docker](../../docker) directory in this
+You may build all images with [Makefile](../../../docker/Makefile) located in [docker](../../../docker) directory in this
 repository
 
 > All commands should be run from the root directory of the repository


### PR DESCRIPTION
## What ❔

The guide should link to the makefile and docker folder of this repo.

## Why ❔

Can be confusing when trying to find the folders mentioned in the guide.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
