### PR TITLE
Fix typos and grammatical errors

### DIFF
--- a/docs/src/guides/advanced/90_advanced_debugging.md
+++ b/docs/src/guides/advanced/90_advanced_debugging.md
@@ -11,7 +11,7 @@ You should create the following file in your `$workspaceFolder/.vscode/` called 
 import os
 import lldb
 
-# Read the .env file and store the key-value pairs in a array with format ["key=value"]
+# Read the .env file and store the key-value pairs in an array with format ["key=value"]
 env_array = []
 with open(os.path.join("etc/env/l2-inits/dev.init.env")) as f:
     for line in f:
@@ -64,7 +64,7 @@ Afterwards you need to add something like this to your launch.json:
 
 ## Debugging contracts in vscode (using hardhat)
 
-Assuming that you created project in hardhat, that you'd normally test with `hardhat test` - you also also test it with
+Assuming that you created project in hardhat, that you'd normally test with `hardhat test` - you also test it with
 vscode (which is super powerful - especially as you can have both binaries' debug sessions running in VSCode at the same
 time).
 

--- a/docs/src/specs/l1_smart_contracts.md
+++ b/docs/src/specs/l1_smart_contracts.md
@@ -211,7 +211,7 @@ The owner of the L2SharedBridge and the contracts related to it is the Governanc
 
 ## Governance
 
-This contract manages calls for all governed zkEVM contracts on L1 and L2. Mostly, it is used for upgradability an
+This contract manages calls for all governed zkEVM contracts on L1 and L2. Mostly, it is used for upgradability a
 changing critical system parameters. The contract has minimum delay settings for the call execution.
 
 Each upgrade consists of two steps:

--- a/prover/docs/src/04_flow.md
+++ b/prover/docs/src/04_flow.md
@@ -163,7 +163,7 @@ Finally, even within the same level, there may be different circuit types. Under
 different parts of computations. From a purely applied point of view, it mostly means that initially we receive X jobs
 of N types, which cause Y jobs of M types, and so on.
 
-So, in addition to the aggregation layer, we also have a circuit ID. A tuple of aggregation round and circuit ID form an
+So, in addition to the aggregation layer, we also have a circuit ID. A tuple of aggregation round and circuit ID form a
 unique job identifier, which allows us to understand which inputs we should receive, what processing logic we should
 run, and which outputs we should produce.
 


### PR DESCRIPTION
### What ❔  
This PR addresses several typos and grammatical inconsistencies across the documentation:  
1. **Fixed article usage errors**: Corrected "a array" to "an array", "an changing" to "a changing", and "an unique" to "a unique".  
2. **Removed duplicated word**: Fixed "also also" to "also".  

### Why ❔  
- Improves the clarity and professionalism of the documentation.  
- Aligns the text with standard English grammar rules for better readability.  

---

## Checklist  
- [x] PR title corresponds to the body of PR.  
- [x] Documentation errors have been reviewed and corrected.  
- [x] No functionality is affected; these changes are purely editorial.  

---

## Notes  
This PR ensures that the documentation is more accessible to readers, avoiding potential confusion caused by grammatical mistakes or typos.  
