### PR TITLE
Fix documentation typos and redundant articles

### DIFF
--- a/docs/src/specs/data_availability/overview.md
+++ b/docs/src/specs/data_availability/overview.md
@@ -13,7 +13,7 @@ We also [compress](./compression.md) all the data that we send to L1, to reduce 
 By posting all the data to L1, we can [reconstruct](./reconstruction.md) the state of the chain from the data on L1.
 This is a key security property of the rollup.
 
-The the chain chooses not to post this data, they become a validium. This makes transactions there much cheaper, but
+If the chain chooses not to post this data, they become a validium. This makes transactions there much cheaper, but
 less secure. Because we use state diffs to post data, we can combine the rollup and validium features, by separating
 storage slots that need to post data from the ones that don't. This construction combines the benefits of rollups and
 validiums, and it is called a [zkPorter](./validium_zk_porter.md).

--- a/docs/src/specs/zk_chains/interop.md
+++ b/docs/src/specs/zk_chains/interop.md
@@ -19,7 +19,7 @@ The interop process has 7 main steps, each with its substeps:
 
 1. Starting the transaction on the sending chain
 
-   - The user/calls calls the Bridgehub contract. If they want to use a bridge they call
+   - The user/calls the Bridgehub contract. If they want to use a bridge they call
      `requestL2TransactionTwoBridges`, if they want to make a direct call they call `requestL2TransactionDirect`
      function.
    - The Bridgehub collects the base token fees necessary for the interop tx to be processed on the destination chain,
@@ -39,7 +39,7 @@ The interop process has 7 main steps, each with its substeps:
 6. Receiving the tx on the destination chain
 
    - On the destination chain the xL2 txs is verified. This means the merkle proof is checked agains the MessageRoot.
-     This shows the the xL2 txs was indeed sent.
+     This shows the xL2 txs was indeed sent.
    - After this the txs can be executed. The tx hash is stored in the L2Nullifier contract, so that the txs cannot be
      replayed.
    - The specified contract is called, with the calldata, and the message sender =

--- a/prover/crates/bin/witness_generator/src/precalculated_merkle_paths_provider.rs
+++ b/prover/crates/bin/witness_generator/src/precalculated_merkle_paths_provider.rs
@@ -9,7 +9,7 @@ use zksync_prover_interface::inputs::{StorageLogMetadata, WitnessInputMerklePath
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct PrecalculatedMerklePathsProvider {
-    // We keep the root hash of the last processed leaf, as it is needed by the the witness generator.
+    // We keep the root hash of the last processed leaf, as it is needed by the witness generator.
     pub root_hash: [u8; 32],
     // The ordered list of expected leaves to be interacted with
     pub pending_leaves: Vec<StorageLogMetadata>,


### PR DESCRIPTION


Changes:
1. docs/src/specs/data_availability/overview.md:
- "The the" -> "If the"

2. docs/src/specs/zk_chains/interop.md:
- "shows the the" -> "shows the"

3. prover/crates/bin/witness_generator/src/precalculated_merkle_paths_provider.rs:
- "by the the witness generator" -> "by the witness generator"

These changes improve documentation readability by removing redundant word usage while maintaining the original meaning. 
