### PR TITLE
code-Update tester.ts

### DIFF
--- a/core/tests/revert-test/tests/tester.ts
+++ b/core/tests/revert-test/tests/tester.ts
@@ -81,7 +81,7 @@ export class Tester {
     /// L2 RPC is active, but we need the L2 RPC to get the base token address.
     async fundSyncWallet() {
         const baseTokenAddress = await this.syncWallet.provider.getBaseTokenContractAddress();
-        if (!(baseTokenAddress === zksync.utils.ETH_ADDRESS_IN_CONTRACTS)) {
+        if (baseTokenAddress !== zksync.utils.ETH_ADDRESS_IN_CONTRACTS) {
             const l1Erc20ABI = ['function mint(address to, uint256 amount)'];
             const l1Erc20Contract = new ethers.Contract(baseTokenAddress, l1Erc20ABI, this.ethWallet);
             await (await l1Erc20Contract.mint(this.ethWallet.address, BASE_ERC20_TO_MINT)).wait();


### PR DESCRIPTION
# Fix: Replaced `!(...)` with `!==` for better readability

## Changes
- Updated the conditional statement to use the `!==` operator instead of wrapping the condition with `!(...)`.

  - **Before**:
    ```typescript
    if (!(baseTokenAddress === zksync.utils.ETH_ADDRESS_IN_CONTRACTS)) {
 

  - **After**:
    ```typescript
    if (baseTokenAddress !== zksync.utils.ETH_ADDRESS_IN_CONTRACTS) {

## Purpose
- Improved code readability and clarity by using the `!==` operator instead of a double negative.
- Addressed the linter suggestion to use the opposite operator (`!==`) for a cleaner and more maintainable codebase.

## Context
- **File**: `core/tests/revert-test/tests/tester.ts`
- **Issue**: Linter warning suggesting the replacement of `!(...)` with `!==`.

This change ensures better code clarity and follows recommended best practices for logical operations.
