### PR TITLE
chore: create base_token_ratios_ratio_timestamp_idx index

### DIFF
--- a/core/lib/dal/migrations/20241226161705_add_ratio_timestamp_index.down.sql
+++ b/core/lib/dal/migrations/20241226161705_add_ratio_timestamp_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS base_token_ratios_ratio_timestamp_idx;

--- a/core/lib/dal/migrations/20241226161705_add_ratio_timestamp_index.up.sql
+++ b/core/lib/dal/migrations/20241226161705_add_ratio_timestamp_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS base_token_ratios_ratio_timestamp_idx ON base_token_ratios (ratio_timestamp);


### PR DESCRIPTION
## What ❔

This PR adds a migration that creates an index on `ratio_timestamp` field of `base_token_ratios` table.

## Why ❔

Queries to this table are currently much heavier than they should be, that has to be optimized.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
