### PR TITLE
Fix Typo in `README.md`

### DIFF
--- a/zkstack_cli/crates/zkstack/README.md
+++ b/zkstack_cli/crates/zkstack/README.md
@@ -545,7 +545,7 @@ Setup keys
 
 - `--mode`
 
-  Possible valuess: `download`, `generate`
+  Possible values: `download`, `generate`
 
 - `--region`
 


### PR DESCRIPTION
# Fix Typo in `README.md`

## Description
This pull request resolves a typo in the `README.md` file located in the `zkstack_cli/crates/zkstack` directory.  
- Corrected the spelling of "valuess" to "values" in the list of possible options for the `--mode` flag.

### Changes Made:
- **File Modified:** `zkstack_cli/crates/zkstack/README.md`
- **Summary of Changes:**
  - Line 545: Corrected "valuess" to "values."

## Related Issues
<!-- If applicable, link to any issues this PR addresses. -->
N/A

## Checklist
- [x] Code comments updated for clarity and professionalism.
- [x] Verified adherence to the project's [Contributing Guidelines](link-to-guidelines) and [Security Policy](link-to-security-policy).

## Testing
<!-- Describe how you validated the change, if applicable. -->
- N/A (Comment typo fix only)

## Additional Notes
This update does not affect any functionality and is strictly related to improving the clarity and accuracy of the documentation.

---

**Allow edits by maintainers:** [x]  
<!-- Check this box to allow maintainers to modify the pull request if needed. -->
