### PR TITLE
chore: Pin dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,18 +228,18 @@ tokio-stream = "0.1.16"
 # We *always* pin the latest version of protocol to disallow accidental changes in the execution logic.
 # However, for the historical version of protocol crates, we have lax requirements. Otherwise,
 # Bumping a crypto dependency like `boojum` would require us to republish all the historical packages.
-circuit_encodings = "0.150.19"
-circuit_sequencer_api = "0.150.19"
-circuit_definitions = "0.150.19"
-crypto_codegen = { package = "zksync_solidity_vk_codegen",version = "0.30.12" }
-kzg = { package = "zksync_kzg", version = "0.150.19" }
+circuit_encodings = "=0.150.19"
+circuit_sequencer_api = "=0.150.19"
+circuit_definitions = "=0.150.19"
+crypto_codegen = { package = "zksync_solidity_vk_codegen",version = "=0.30.12" }
+kzg = { package = "zksync_kzg", version = "=0.150.19" }
 zk_evm = { version = "=0.133.0" }
 zk_evm_1_3_1 = { package = "zk_evm", version = "0.131.0-rc.2" }
 zk_evm_1_3_3 = { package = "zk_evm", version = "0.133" }
 zk_evm_1_4_0 = { package = "zk_evm", version = "0.140" }
 zk_evm_1_4_1 = { package = "zk_evm", version = "0.141" }
-zk_evm_1_5_0 = { package = "zk_evm", version = "0.150.19" }
-fflonk = "0.30.12"
+zk_evm_1_5_0 = { package = "zk_evm", version = "=0.150.19" }
+fflonk = "=0.30.12"
 
 # New VM; pinned to a specific commit because of instability
 zksync_vm2 = { git = "https://github.com/matter-labs/vm2.git", rev = "457d8a7eea9093af9440662e33e598c13ba41633" }

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -73,8 +73,8 @@ circuit_sequencer_api = "=0.150.19"
 zkevm_test_harness = "=0.150.19"
 proof-compression-gpu = { package = "proof-compression", version = "=0.152.10"}
 fflonk-gpu = { package = "fflonk-cuda", version = "=0.152.10"}
-fflonk = "0.30.12"
-franklin-crypto = "0.30.12"
+fflonk = "=0.30.12"
+franklin-crypto = "=0.30.12"
 
 # GPU proving dependencies
 wrapper_prover = { package = "zksync-wrapper-prover", version = "=0.152.10"}


### PR DESCRIPTION
During FFLONK commit, dependencies got unpinned. This PR repins the dependencies to declared versions.
