### PR TITLE
feat(eth-watch): Change protocol upgrade schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11981,6 +11981,7 @@ dependencies = [
  "tracing",
  "vise",
  "zksync_concurrency",
+ "zksync_config",
  "zksync_contracts",
  "zksync_dal",
  "zksync_eth_client",
@@ -13008,6 +13009,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "async-trait",
  "bigdecimal",
  "bincode",
  "blake2 0.10.6",

--- a/core/lib/types/Cargo.toml
+++ b/core/lib/types/Cargo.toml
@@ -19,6 +19,7 @@ zksync_mini_merkle_tree.workspace = true
 zksync_protobuf.workspace = true
 zksync_crypto_primitives.workspace = true
 
+async-trait.workspace = true
 anyhow.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 derive_more = { workspace = true, features = ["debug"] }

--- a/core/lib/types/src/abi.rs
+++ b/core/lib/types/src/abi.rs
@@ -1,4 +1,5 @@
 use anyhow::Context as _;
+use zksync_basic_types::protocol_version::ProtocolSemanticVersion;
 
 use crate::{
     bytecode::BytecodeHash,
@@ -185,7 +186,7 @@ impl NewPriorityRequest {
 }
 
 /// `VerifierParams` from `l1-contracts/contracts/state-transition/chain-interfaces/IVerifier.sol`.
-#[derive(Default, PartialEq)]
+#[derive(Debug, Default, PartialEq)]
 pub struct VerifierParams {
     pub recursion_node_level_vk_hash: [u8; 32],
     pub recursion_leaf_level_vk_hash: [u8; 32],
@@ -193,9 +194,10 @@ pub struct VerifierParams {
 }
 
 /// `ProposedUpgrade` from, `l1-contracts/contracts/upgrades/BazeZkSyncUpgrade.sol`.
+#[derive(Debug)]
 pub struct ProposedUpgrade {
     pub l2_protocol_upgrade_tx: Box<L2CanonicalTransaction>,
-    pub factory_deps: Vec<Vec<u8>>,
+    pub factory_deps: Option<Vec<Vec<u8>>>,
     pub bootloader_hash: [u8; 32],
     pub default_account_hash: [u8; 32],
     pub verifier: Address,
@@ -250,8 +252,8 @@ impl VerifierParams {
 }
 
 impl ProposedUpgrade {
-    /// RLP schema of the `ProposedUpgrade`.
-    pub fn schema() -> ParamType {
+    /// Pre-gateway RLP schema of the `ProposedUpgrade`.
+    pub fn schema_pre_gateway() -> ParamType {
         ParamType::Tuple(vec![
             L2CanonicalTransaction::schema(),          // transaction data
             ParamType::Array(ParamType::Bytes.into()), // factory deps
@@ -266,16 +268,39 @@ impl ProposedUpgrade {
         ])
     }
 
+    /// Post-gateway RLP schema of the `ProposedUpgrade`.
+    pub fn schema_post_gateway() -> ParamType {
+        ParamType::Tuple(vec![
+            L2CanonicalTransaction::schema(), // transaction data
+            ParamType::FixedBytes(32),        // bootloader code hash
+            ParamType::FixedBytes(32),        // default account code hash
+            ParamType::Address,               // verifier address
+            VerifierParams::schema(),         // verifier params
+            ParamType::Bytes,                 // l1 custom data
+            ParamType::Bytes,                 // l1 post-upgrade custom data
+            ParamType::Uint(256),             // timestamp
+            ParamType::Uint(256),             // version id
+        ])
+    }
+
     /// Encodes `ProposedUpgrade` to a RLP token.
     pub fn encode(&self) -> Token {
-        Token::Tuple(vec![
-            self.l2_protocol_upgrade_tx.encode(),
-            Token::Array(
+        let mut tokens = vec![self.l2_protocol_upgrade_tx.encode()];
+
+        let protocol_version = ProtocolSemanticVersion::try_from_packed(self.new_protocol_version)
+            .expect("Version is not supported")
+            .minor;
+        if protocol_version.is_pre_gateway() {
+            tokens.push(Token::Array(
                 self.factory_deps
-                    .iter()
-                    .map(|b| Token::Bytes(b.clone()))
+                    .clone()
+                    .expect("Factory deps should be present in pre-gateway upgrade data")
+                    .into_iter()
+                    .map(Token::Bytes)
                     .collect(),
-            ),
+            ));
+        }
+        tokens.extend([
             Token::FixedBytes(self.bootloader_hash.into()),
             Token::FixedBytes(self.default_account_hash.into()),
             Token::Address(self.verifier),
@@ -284,32 +309,52 @@ impl ProposedUpgrade {
             Token::Bytes(self.post_upgrade_calldata.clone()),
             Token::Uint(self.upgrade_timestamp),
             Token::Uint(self.new_protocol_version),
-        ])
+        ]);
+
+        Token::Tuple(tokens)
     }
 
     /// Decodes `ProposedUpgrade` from a RLP token.
     /// Returns an error if token doesn't match the `schema()`.
     pub fn decode(token: Token) -> anyhow::Result<Self> {
         let tokens = token.into_tuple().context("not a tuple")?;
-        anyhow::ensure!(tokens.len() == 10);
+        let tokens_len = tokens.len();
+        anyhow::ensure!(tokens_len >= 9);
         let mut t = tokens.into_iter();
         let mut next = || t.next().unwrap();
-        Ok(Self {
-            l2_protocol_upgrade_tx: L2CanonicalTransaction::decode(next())
-                .context("l2_protocol_upgrade_tx")?
-                .into(),
-            factory_deps: next()
-                .into_array()
-                .context("factory_deps")?
-                .into_iter()
-                .enumerate()
-                .map(|(i, b)| b.into_bytes().context(i))
-                .collect::<Result<_, _>>()
-                .context("factory_deps")?,
-            bootloader_hash: next()
-                .into_fixed_bytes()
-                .and_then(|b| b.try_into().ok())
-                .context("bootloader_hash")?,
+
+        let l2_protocol_upgrade_tx = L2CanonicalTransaction::decode(next())
+            .context("l2_protocol_upgrade_tx")?
+            .into();
+        let next_token = next();
+        let (factory_deps, bootloader_hash) = match next_token {
+            Token::Array(tokens) => {
+                anyhow::ensure!(tokens_len == 10);
+                (
+                    Some(
+                        tokens
+                            .into_iter()
+                            .enumerate()
+                            .map(|(i, b)| b.into_bytes().context(i))
+                            .collect::<Result<_, _>>()
+                            .context("factory_deps")?,
+                    ),
+                    next().into_fixed_bytes(),
+                )
+            }
+            Token::FixedBytes(bytes) => {
+                anyhow::ensure!(tokens_len == 9);
+                (None, Some(bytes))
+            }
+            _ => anyhow::bail!("Unexpected type of the second token"),
+        };
+        let bootloader_hash = bootloader_hash
+            .and_then(|b| b.try_into().ok())
+            .context("bootloader_hash")?;
+        let upgrade = Self {
+            l2_protocol_upgrade_tx,
+            factory_deps,
+            bootloader_hash,
             default_account_hash: next()
                 .into_fixed_bytes()
                 .and_then(|b| b.try_into().ok())
@@ -322,7 +367,16 @@ impl ProposedUpgrade {
             post_upgrade_calldata: next().into_bytes().context("post_upgrade_calldata")?,
             upgrade_timestamp: next().into_uint().context("upgrade_timestamp")?,
             new_protocol_version: next().into_uint().context("new_protocol_version")?,
-        })
+        };
+
+        let protocol_version =
+            ProtocolSemanticVersion::try_from_packed(upgrade.new_protocol_version)
+                .map_err(|err| anyhow::anyhow!(err))
+                .context("Version is not supported")?
+                .minor;
+        anyhow::ensure!(protocol_version.is_pre_gateway() == upgrade.factory_deps.is_some());
+
+        Ok(upgrade)
     }
 }
 
@@ -363,5 +417,168 @@ impl Transaction {
             }
             Self::L2(raw) => TransactionRequest::from_bytes_unverified(raw)?.1,
         })
+    }
+}
+
+pub struct ForceDeployment {
+    pub bytecode_hash: H256,
+    pub new_address: Address,
+    pub call_constructor: bool,
+    pub value: U256,
+    pub input: Vec<u8>,
+}
+
+impl ForceDeployment {
+    /// ABI schema of the `ForceDeployment`.
+    pub fn schema() -> ParamType {
+        ParamType::Tuple(vec![
+            ParamType::FixedBytes(32),
+            ParamType::Address,
+            ParamType::Bool,
+            ParamType::Uint(256),
+            ParamType::Bytes,
+        ])
+    }
+
+    /// Encodes `ForceDeployment` to a RLP token.
+    pub fn encode(&self) -> Token {
+        Token::Tuple(vec![
+            Token::FixedBytes(self.bytecode_hash.0.to_vec()),
+            Token::Address(self.new_address),
+            Token::Bool(self.call_constructor),
+            Token::Uint(self.value),
+            Token::Bytes(self.input.clone()),
+        ])
+    }
+
+    /// Decodes `ForceDeployment` from a RLP token.
+    /// Returns an error if token doesn't match the `schema()`.
+    pub fn decode(token: Token) -> anyhow::Result<Self> {
+        let tokens = token.into_tuple().context("not a tuple")?;
+        anyhow::ensure!(tokens.len() == 5);
+        let mut t = tokens.into_iter();
+        let mut next = || t.next().unwrap();
+        Ok(Self {
+            bytecode_hash: next()
+                .into_fixed_bytes()
+                .and_then(|b| Some(H256(b.try_into().ok()?)))
+                .context("bytecode_hash")?,
+            new_address: next().into_address().context("new_address")?,
+            call_constructor: next().into_bool().context("call_constructor")?,
+            value: next().into_uint().context("value")?,
+            input: next().into_bytes().context("input")?,
+        })
+    }
+}
+
+pub struct GatewayUpgradeEncodedInput {
+    pub force_deployments: Vec<ForceDeployment>,
+    pub l2_gateway_upgrade_position: usize,
+    pub fixed_force_deployments_data: Vec<u8>,
+    pub ctm_deployer: Address,
+    pub old_validator_timelock: Address,
+    pub new_validator_timelock: Address,
+    pub wrapped_base_token_store: Address,
+}
+
+impl GatewayUpgradeEncodedInput {
+    /// ABI schema of the `GatewayUpgradeEncodedInput`.
+    pub fn schema() -> ParamType {
+        ParamType::Tuple(vec![
+            ParamType::Array(Box::new(ForceDeployment::schema())),
+            ParamType::Uint(256),
+            ParamType::Bytes,
+            ParamType::Address,
+            ParamType::Address,
+            ParamType::Address,
+            ParamType::Address,
+        ])
+    }
+
+    /// Decodes `GatewayUpgradeEncodedInput` from a RLP token.
+    /// Returns an error if token doesn't match the `schema()`.
+    pub fn decode(token: Token) -> anyhow::Result<Self> {
+        let tokens = token.into_tuple().context("not a tuple")?;
+        anyhow::ensure!(tokens.len() == 7);
+        let mut t = tokens.into_iter();
+        let mut next = || t.next().unwrap();
+
+        let force_deployments_array = next().into_array().context("force_deployments_array")?;
+        let mut force_deployments = vec![];
+        for token in force_deployments_array {
+            force_deployments.push(ForceDeployment::decode(token)?);
+        }
+
+        Ok(Self {
+            force_deployments,
+            l2_gateway_upgrade_position: next()
+                .into_uint()
+                .context("l2_gateway_upgrade_position")?
+                .as_usize(),
+            fixed_force_deployments_data: next()
+                .into_bytes()
+                .context("fixed_force_deployments_data")?,
+            ctm_deployer: next().into_address().context("ctm_deployer")?,
+            old_validator_timelock: next().into_address().context("old_validator_timelock")?,
+            new_validator_timelock: next().into_address().context("new_validator_timelock")?,
+            wrapped_base_token_store: next().into_address().context("wrapped_base_token_store")?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ZkChainSpecificUpgradeData {
+    pub base_token_asset_id: H256,
+    pub l2_legacy_shared_bridge: Address,
+    pub predeployed_l2_weth_address: Address,
+    pub base_token_l1_address: Address,
+    pub base_token_name: String,
+    pub base_token_symbol: String,
+}
+
+impl ZkChainSpecificUpgradeData {
+    pub fn from_partial_components(
+        base_token_asset_id: Option<H256>,
+        l2_legacy_shared_bridge: Option<Address>,
+        predeployed_l2_weth_address: Option<Address>,
+        base_token_l1_address: Option<Address>,
+        base_token_name: Option<String>,
+        base_token_symbol: Option<String>,
+    ) -> Option<Self> {
+        Some(Self {
+            base_token_asset_id: base_token_asset_id?,
+            l2_legacy_shared_bridge: l2_legacy_shared_bridge?,
+            // Note, that some chains may not contain previous deployment of L2 wrapped base
+            // token. For those, zero address is used.
+            predeployed_l2_weth_address: predeployed_l2_weth_address.unwrap_or_default(),
+            base_token_l1_address: base_token_l1_address?,
+            base_token_name: base_token_name?,
+            base_token_symbol: base_token_symbol?,
+        })
+    }
+
+    /// ABI schema of the `ZkChainSpecificUpgradeData`.
+    pub fn schema() -> ParamType {
+        ParamType::Tuple(vec![
+            ParamType::FixedBytes(32),
+            ParamType::Address,
+            ParamType::Address,
+        ])
+    }
+
+    /// Encodes `ZkChainSpecificUpgradeData` to a RLP token.
+    pub fn encode(&self) -> Token {
+        Token::Tuple(vec![
+            Token::FixedBytes(self.base_token_asset_id.0.to_vec()),
+            Token::Address(self.l2_legacy_shared_bridge),
+            Token::Address(self.predeployed_l2_weth_address),
+            Token::Address(self.base_token_l1_address),
+            Token::String(self.base_token_name.clone()),
+            Token::String(self.base_token_symbol.clone()),
+        ])
+    }
+
+    pub fn encode_bytes(&self) -> Vec<u8> {
+        ethabi::encode(&[self.encode()])
     }
 }

--- a/core/lib/types/src/abi.rs
+++ b/core/lib/types/src/abi.rs
@@ -197,6 +197,7 @@ pub struct VerifierParams {
 #[derive(Debug)]
 pub struct ProposedUpgrade {
     pub l2_protocol_upgrade_tx: Box<L2CanonicalTransaction>,
+    // Factory deps are set only pre-gateway upgrades.
     pub factory_deps: Option<Vec<Vec<u8>>>,
     pub bootloader_hash: [u8; 32],
     pub default_account_hash: [u8; 32],

--- a/core/lib/types/src/protocol_upgrade.rs
+++ b/core/lib/types/src/protocol_upgrade.rs
@@ -2,20 +2,20 @@ use std::convert::{TryFrom, TryInto};
 
 use anyhow::Context as _;
 use serde::{Deserialize, Serialize};
-use zksync_basic_types::{
-    ethabi,
-    protocol_version::{
-        L1VerifierConfig, ProtocolSemanticVersion, ProtocolVersionId, VerifierParams,
-    },
+use zksync_basic_types::protocol_version::{
+    L1VerifierConfig, ProtocolSemanticVersion, ProtocolVersionId, VerifierParams,
 };
-use zksync_contracts::{
-    BaseSystemContractsHashes, ADMIN_EXECUTE_UPGRADE_FUNCTION,
-    ADMIN_UPGRADE_CHAIN_FROM_VERSION_FUNCTION, DIAMOND_CUT,
-};
+use zksync_contracts::{BaseSystemContractsHashes, DIAMOND_CUT};
 
 use crate::{
-    abi, ethabi::ParamType, h256_to_u256, web3::Log, Address, Execute, ExecuteTransactionCommon,
-    Transaction, TransactionType, H256, U256,
+    abi::{
+        self, ForceDeployment, GatewayUpgradeEncodedInput, ProposedUpgrade,
+        ZkChainSpecificUpgradeData,
+    },
+    ethabi::{self, decode, encode, ParamType, Token},
+    h256_to_u256, u256_to_h256,
+    web3::Log,
+    Address, Execute, ExecuteTransactionCommon, Transaction, TransactionType, H256, U256,
 };
 
 /// Represents a call to be made during governance operation.
@@ -93,29 +93,155 @@ impl From<abi::VerifierParams> for VerifierParams {
     }
 }
 
+/// Protocol upgrade transactions do not contain preimages within them.
+/// Instead, they are expected to be known and need to be fetched, typically from L1.
+#[async_trait::async_trait]
+pub trait ProtocolUpgradePreimageOracle: Send + Sync {
+    async fn get_protocol_upgrade_preimages(
+        &self,
+        hashes: Vec<H256>,
+    ) -> anyhow::Result<Vec<Vec<u8>>>;
+}
+
+/// Some upgrades have chain-dependent calldata that has to be prepared properly.
+async fn prepare_upgrade_call(
+    proposed_upgrade: &ProposedUpgrade,
+    chain_specific: Option<ZkChainSpecificUpgradeData>,
+) -> anyhow::Result<Vec<u8>> {
+    // No upgrade
+    if proposed_upgrade.l2_protocol_upgrade_tx.tx_type == U256::zero() {
+        return Ok(vec![]);
+    }
+
+    let minor_version = proposed_upgrade.l2_protocol_upgrade_tx.nonce;
+    if ProtocolVersionId::try_from(minor_version.as_u32() as u16).unwrap()
+        != ProtocolVersionId::gateway_upgrade()
+    {
+        // We'll just keep it the same for non-Gateway upgrades
+        return Ok(proposed_upgrade.l2_protocol_upgrade_tx.data.clone());
+    }
+
+    // For gateway upgrade, things are bit more complex.
+    // The source of truth for the code below is the one that is present in
+    // `GatewayUpgrade.sol`.
+    let mut encoded_input = GatewayUpgradeEncodedInput::decode(
+        decode(
+            &[GatewayUpgradeEncodedInput::schema()],
+            &proposed_upgrade.post_upgrade_calldata,
+        )?[0]
+            .clone(),
+    )?;
+
+    let gateway_upgrade_calldata = encode(&[
+        Token::Address(encoded_input.ctm_deployer),
+        Token::Bytes(encoded_input.fixed_force_deployments_data),
+        Token::Bytes(chain_specific.context("chain_specific")?.encode_bytes()),
+    ]);
+
+    // May not be very idiomatic, but we do it in the same way as it was done in Solidity
+    // for easier review
+    encoded_input.force_deployments[encoded_input.l2_gateway_upgrade_position].input =
+        gateway_upgrade_calldata;
+
+    let force_deployments_as_tokens: Vec<_> = encoded_input
+        .force_deployments
+        .iter()
+        .map(ForceDeployment::encode)
+        .collect();
+
+    let full_data = zksync_contracts::deployer_contract()
+        .function("forceDeployOnAddresses")
+        .unwrap()
+        .encode_input(&[Token::Array(force_deployments_as_tokens)])
+        .unwrap();
+
+    Ok(full_data)
+}
+
 impl ProtocolUpgrade {
-    pub fn try_from_diamond_cut(diamond_cut_data: &[u8]) -> anyhow::Result<Self> {
+    pub async fn try_from_diamond_cut(
+        diamond_cut_data: &[u8],
+        preimage_oracle: impl ProtocolUpgradePreimageOracle,
+        chain_specific: Option<ZkChainSpecificUpgradeData>,
+    ) -> anyhow::Result<Self> {
         // Unwraps are safe because we have validated the input against the function signature.
         let diamond_cut_tokens = DIAMOND_CUT.decode_input(diamond_cut_data)?[0]
             .clone()
             .into_tuple()
             .unwrap();
-        Self::try_from_init_calldata(&diamond_cut_tokens[2].clone().into_bytes().unwrap())
+        Self::try_from_init_calldata(
+            &diamond_cut_tokens[2].clone().into_bytes().unwrap(),
+            preimage_oracle,
+            chain_specific,
+        )
+        .await
     }
 
     /// `l1-contracts/contracts/state-transition/libraries/diamond.sol:DiamondCutData.initCalldata`
-    fn try_from_init_calldata(init_calldata: &[u8]) -> anyhow::Result<Self> {
-        let upgrade = ethabi::decode(
-            &[abi::ProposedUpgrade::schema()],
+    async fn try_from_init_calldata(
+        init_calldata: &[u8],
+        preimage_oracle: impl ProtocolUpgradePreimageOracle,
+        chain_specific: Option<ZkChainSpecificUpgradeData>,
+    ) -> anyhow::Result<Self> {
+        let upgrade = if let Ok(upgrade) = ethabi::decode(
+            &[abi::ProposedUpgrade::schema_pre_gateway()],
             init_calldata.get(4..).context("need >= 4 bytes")?,
-        )
-        .context("ethabi::decode()")?;
-        let upgrade = abi::ProposedUpgrade::decode(upgrade.into_iter().next().unwrap()).unwrap();
+        ) {
+            upgrade
+        } else {
+            ethabi::decode(
+                &[abi::ProposedUpgrade::schema_post_gateway()],
+                init_calldata.get(4..).context("need >= 4 bytes")?,
+            )
+            .context("ethabi::decode()")?
+        };
+
+        let mut upgrade = abi::ProposedUpgrade::decode(upgrade.into_iter().next().unwrap())
+            .context("ProposedUpgrade::decode()")?;
+
         let bootloader_hash = H256::from_slice(&upgrade.bootloader_hash);
         let default_account_hash = H256::from_slice(&upgrade.default_account_hash);
+
+        let version = ProtocolSemanticVersion::try_from_packed(upgrade.new_protocol_version)
+            .map_err(|err| anyhow::format_err!("Version is not supported: {err}"))?;
+        let tx = if upgrade.l2_protocol_upgrade_tx.tx_type != U256::zero() {
+            let factory_deps = if version.minor.is_pre_gateway() {
+                upgrade.factory_deps.clone().unwrap()
+            } else {
+                preimage_oracle
+                    .get_protocol_upgrade_preimages(
+                        upgrade
+                            .l2_protocol_upgrade_tx
+                            .factory_deps
+                            .iter()
+                            .map(|&x| u256_to_h256(x))
+                            .collect(),
+                    )
+                    .await?
+            };
+
+            upgrade.l2_protocol_upgrade_tx.data =
+                prepare_upgrade_call(&upgrade, chain_specific).await?;
+
+            Some(
+                Transaction::from_abi(
+                    abi::Transaction::L1 {
+                        tx: upgrade.l2_protocol_upgrade_tx,
+                        factory_deps,
+                        eth_block: 0,
+                    },
+                    false,
+                )
+                .context("Transaction::try_from()")?
+                .try_into()
+                .map_err(|err| anyhow::format_err!("try_into::<ProtocolUpgradeTx>(): {err}"))?,
+            )
+        } else {
+            None
+        };
+
         Ok(Self {
-            version: ProtocolSemanticVersion::try_from_packed(upgrade.new_protocol_version)
-                .map_err(|err| anyhow::format_err!("Version is not supported: {err}"))?,
+            version,
             bootloader_code_hash: (bootloader_hash != H256::zero()).then_some(bootloader_hash),
             default_account_code_hash: (default_account_hash != H256::zero())
                 .then_some(default_account_hash),
@@ -124,21 +250,7 @@ impl ProtocolUpgrade {
                 .then_some(upgrade.verifier_params.into()),
             verifier_address: (upgrade.verifier != Address::zero()).then_some(upgrade.verifier),
             timestamp: upgrade.upgrade_timestamp.try_into().unwrap(),
-            tx: (upgrade.l2_protocol_upgrade_tx.tx_type != U256::zero())
-                .then(|| {
-                    Transaction::from_abi(
-                        abi::Transaction::L1 {
-                            tx: upgrade.l2_protocol_upgrade_tx,
-                            factory_deps: upgrade.factory_deps,
-                            eth_block: 0,
-                        },
-                        true,
-                    )
-                    .context("Transaction::try_from()")?
-                    .try_into()
-                    .map_err(|err| anyhow::format_err!("try_into::<ProtocolUpgradeTx>(): {err}"))
-                })
-                .transpose()?,
+            tx,
         })
     }
 }
@@ -166,50 +278,6 @@ pub fn decode_set_chain_id_event(
         .try_into()
         .unwrap(),
     ))
-}
-
-impl TryFrom<Call> for ProtocolUpgrade {
-    type Error = anyhow::Error;
-
-    fn try_from(call: Call) -> Result<Self, Self::Error> {
-        anyhow::ensure!(call.data.len() >= 4);
-        let (signature, data) = call.data.split_at(4);
-
-        let diamond_cut_tokens =
-            if signature.to_vec() == ADMIN_EXECUTE_UPGRADE_FUNCTION.short_signature().to_vec() {
-                // Unwraps are safe, because we validate the input against the function signature.
-                ADMIN_EXECUTE_UPGRADE_FUNCTION
-                    .decode_input(data)?
-                    .pop()
-                    .unwrap()
-                    .into_tuple()
-                    .unwrap()
-            } else if signature.to_vec()
-                == ADMIN_UPGRADE_CHAIN_FROM_VERSION_FUNCTION
-                    .short_signature()
-                    .to_vec()
-            {
-                let mut data = ADMIN_UPGRADE_CHAIN_FROM_VERSION_FUNCTION.decode_input(data)?;
-
-                assert_eq!(
-                    data.len(),
-                    2,
-                    "The second method is expected to accept exactly 2 arguments"
-                );
-
-                // The second item must be a tuple of diamond cut data
-                // Unwraps are safe, because we validate the input against the function signature.
-                data.pop().unwrap().into_tuple().unwrap()
-            } else {
-                anyhow::bail!("unknown function");
-            };
-
-        ProtocolUpgrade::try_from_init_calldata(
-            // Unwrap is safe because we have validated the input against the function signature.
-            &diamond_cut_tokens[2].clone().into_bytes().unwrap(),
-        )
-        .context("ProtocolUpgrade::try_from_init_calldata()")
-    }
 }
 
 impl TryFrom<Log> for GovernanceOperation {

--- a/core/node/eth_watch/Cargo.toml
+++ b/core/node/eth_watch/Cargo.toml
@@ -19,6 +19,7 @@ zksync_system_constants.workspace = true
 zksync_eth_client.workspace = true
 zksync_shared_metrics.workspace = true
 zksync_mini_merkle_tree.workspace = true
+zksync_config.workspace = true
 zksync_web3_decl.workspace = true
 
 tokio = { workspace = true, features = ["time"] }

--- a/core/node/eth_watch/src/client.rs
+++ b/core/node/eth_watch/src/client.rs
@@ -1,4 +1,4 @@
-use std::{fmt, sync::Arc};
+use std::{collections::HashMap, fmt, sync::Arc};
 
 use anyhow::Context;
 use zksync_contracts::{
@@ -13,9 +13,11 @@ use zksync_eth_client::{
 use zksync_system_constants::L2_MESSAGE_ROOT_ADDRESS;
 use zksync_types::{
     api::{ChainAggProof, Log},
-    ethabi::Contract,
-    web3::{BlockId, BlockNumber, Filter, FilterBuilder},
-    Address, L1BatchNumber, L2ChainId, SLChainId, H256, U256, U64,
+    ethabi::{self, decode, Contract, ParamType},
+    tokens::TokenMetadata,
+    web3::{BlockId, BlockNumber, CallRequest, Filter, FilterBuilder},
+    Address, L1BatchNumber, L2ChainId, SLChainId, H256, SHARED_BRIDGE_ETHER_TOKEN_ADDRESS, U256,
+    U64,
 };
 use zksync_web3_decl::{
     client::{Network, L2},
@@ -57,6 +59,13 @@ pub trait EthClient: 'static + fmt::Debug + Send + Sync {
         packed_version: H256,
     ) -> EnrichedClientResult<Option<Vec<u8>>>;
 
+    async fn get_published_preimages(
+        &self,
+        hashes: Vec<H256>,
+    ) -> EnrichedClientResult<Vec<Option<Vec<u8>>>>;
+
+    async fn get_base_token_metadata(&self) -> Result<TokenMetadata, ContractCallError>;
+
     /// Returns ID of the chain.
     async fn chain_id(&self) -> EnrichedClientResult<SLChainId>;
 
@@ -70,6 +79,8 @@ pub trait EthClient: 'static + fmt::Debug + Send + Sync {
     ) -> Result<H256, ContractCallError>;
 }
 
+// This constant is used for reading auxiliary events
+const LOOK_BACK_BLOCK_RANGE: u64 = 1_000_000;
 pub const RETRY_LIMIT: usize = 5;
 const TOO_MANY_RESULTS_INFURA: &str = "query returned more than";
 const TOO_MANY_RESULTS_ALCHEMY: &str = "response size exceeded";
@@ -84,6 +95,8 @@ pub struct EthHttpQueryClient<Net: Network> {
     diamond_proxy_addr: Address,
     governance_address: Address,
     new_upgrade_cut_data_signature: H256,
+    bytecode_published_signature: H256,
+    bytecode_supplier_addr: Option<Address>,
     // Only present for post-shared bridge chains.
     state_transition_manager_address: Option<Address>,
     chain_admin_address: Option<Address>,
@@ -100,6 +113,7 @@ where
     pub fn new(
         client: Box<DynClient<Net>>,
         diamond_proxy_addr: Address,
+        bytecode_supplier_addr: Option<Address>,
         state_transition_manager_address: Option<Address>,
         chain_admin_address: Option<Address>,
         governance_address: Address,
@@ -116,11 +130,16 @@ where
             state_transition_manager_address,
             chain_admin_address,
             governance_address,
+            bytecode_supplier_addr,
             new_upgrade_cut_data_signature: state_transition_manager_contract()
                 .event("NewUpgradeCutData")
                 .context("NewUpgradeCutData event is missing in ABI")
                 .unwrap()
                 .signature(),
+            bytecode_published_signature: ethabi::long_signature(
+                "BytecodePublished",
+                &[ParamType::FixedBytes(32), ParamType::Bytes],
+            ),
             verifier_contract_abi: verifier_contract(),
             getters_facet_contract_abi: getters_facet_contract(),
             message_root_abi: MESSAGE_ROOT_CONTRACT.clone(),
@@ -264,6 +283,43 @@ where
             .await
     }
 
+    async fn get_published_preimages(
+        &self,
+        hashes: Vec<H256>,
+    ) -> EnrichedClientResult<Vec<Option<Vec<u8>>>> {
+        let Some(bytecode_supplier_addr) = self.bytecode_supplier_addr else {
+            return Ok(vec![None; hashes.len()]);
+        };
+
+        let to_block = self.client.block_number().await?;
+        let from_block = to_block.saturating_sub((LOOK_BACK_BLOCK_RANGE - 1).into());
+
+        let logs = self
+            .get_events_inner(
+                from_block.into(),
+                to_block.into(),
+                Some(vec![self.bytecode_published_signature]),
+                Some(hashes.clone()),
+                Some(vec![bytecode_supplier_addr]),
+                RETRY_LIMIT,
+            )
+            .await?;
+
+        let mut preimages = HashMap::new();
+        for log in logs {
+            let hash = log.topics[1];
+            let preimage = decode(&[ParamType::Bytes], &log.data.0).expect("Invalid encoding");
+            assert_eq!(preimage.len(), 1);
+            let preimage = preimage[0].clone().into_bytes().unwrap();
+            preimages.insert(hash, preimage);
+        }
+
+        Ok(hashes
+            .into_iter()
+            .map(|hash| preimages.get(&hash).cloned())
+            .collect())
+    }
+
     async fn get_events(
         &self,
         from: BlockNumber,
@@ -346,8 +402,6 @@ where
         &self,
         packed_version: H256,
     ) -> EnrichedClientResult<Option<Vec<u8>>> {
-        const LOOK_BACK_BLOCK_RANGE: u64 = 1_000_000;
-
         let Some(state_transition_manager_address) = self.state_transition_manager_address else {
             return Ok(None);
         };
@@ -383,6 +437,52 @@ where
             .for_contract(L2_MESSAGE_ROOT_ADDRESS, &self.message_root_abi)
             .call(&self.client)
             .await
+    }
+
+    async fn get_base_token_metadata(&self) -> Result<TokenMetadata, ContractCallError> {
+        let base_token_addr: Address = CallFunctionArgs::new("getBaseToken", ())
+            .for_contract(self.diamond_proxy_addr, &self.getters_facet_contract_abi)
+            .call(&self.client)
+            .await?;
+
+        if base_token_addr == SHARED_BRIDGE_ETHER_TOKEN_ADDRESS {
+            return Ok(TokenMetadata {
+                name: String::from("Ether"),
+                symbol: String::from("ETH"),
+                decimals: 18,
+            });
+        }
+
+        let selectors: [[u8; 4]; 3] = [
+            zksync_types::ethabi::short_signature("name", &[]),
+            zksync_types::ethabi::short_signature("symbol", &[]),
+            zksync_types::ethabi::short_signature("decimals", &[]),
+        ];
+        let types: [ParamType; 3] = [ParamType::String, ParamType::String, ParamType::Uint(32)];
+
+        let mut decoded_result = vec![];
+        for (selector, param_type) in selectors.into_iter().zip(types.into_iter()) {
+            let request = CallRequest {
+                to: Some(base_token_addr),
+                data: Some(selector.into()),
+                ..Default::default()
+            };
+            let result = self.client.call_contract_function(request, None).await?;
+            // Base tokens are expected to support erc20 metadata
+            let mut token = zksync_types::ethabi::decode(&[param_type], &result.0)
+                .expect("base token does not support erc20 metadata");
+            decoded_result.push(token.pop().unwrap());
+        }
+
+        Ok(TokenMetadata {
+            name: decoded_result[0].to_string(),
+            symbol: decoded_result[1].to_string(),
+            decimals: decoded_result[2]
+                .clone()
+                .into_uint()
+                .expect("decimals not supported")
+                .as_u32() as u8,
+        })
     }
 }
 
@@ -529,5 +629,16 @@ impl EthClient for L2EthClientW {
         l2_chain_id: L2ChainId,
     ) -> Result<H256, ContractCallError> {
         self.0.get_chain_root(block_number, l2_chain_id).await
+    }
+
+    async fn get_base_token_metadata(&self) -> Result<TokenMetadata, ContractCallError> {
+        self.0.get_base_token_metadata().await
+    }
+
+    async fn get_published_preimages(
+        &self,
+        hashes: Vec<H256>,
+    ) -> EnrichedClientResult<Vec<Option<Vec<u8>>>> {
+        self.0.get_published_preimages(hashes).await
     }
 }

--- a/core/node/eth_watch/src/client.rs
+++ b/core/node/eth_watch/src/client.rs
@@ -453,6 +453,7 @@ where
             });
         }
 
+        // TODO(EVM-934): support non-standard tokens.
         let selectors: [[u8; 4]; 3] = [
             zksync_types::ethabi::short_signature("name", &[]),
             zksync_types::ethabi::short_signature("symbol", &[]),

--- a/core/node/eth_watch/src/event_processors/decentralized_upgrades.rs
+++ b/core/node/eth_watch/src/event_processors/decentralized_upgrades.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 use anyhow::Context as _;
 use zksync_dal::{eth_watcher_dal::EventType, Connection, Core, CoreDal, DalError};
 use zksync_types::{
-    api::Log, ethabi::Contract, protocol_version::ProtocolSemanticVersion, ProtocolUpgrade, H256,
-    U256,
+    abi::ZkChainSpecificUpgradeData, api::Log, ethabi::Contract,
+    protocol_upgrade::ProtocolUpgradePreimageOracle, protocol_version::ProtocolSemanticVersion,
+    ProtocolUpgrade, H256, U256,
 };
 
 use crate::{
@@ -19,14 +20,18 @@ pub struct DecentralizedUpgradesEventProcessor {
     /// Last protocol version seen. Used to skip events for already known upgrade proposals.
     last_seen_protocol_version: ProtocolSemanticVersion,
     update_upgrade_timestamp_signature: H256,
+    chain_specific_data: Option<ZkChainSpecificUpgradeData>,
     sl_client: Arc<dyn EthClient>,
+    l1_client: Arc<dyn EthClient>,
 }
 
 impl DecentralizedUpgradesEventProcessor {
     pub fn new(
         last_seen_protocol_version: ProtocolSemanticVersion,
         chain_admin_contract: &Contract,
+        chain_specific_data: Option<ZkChainSpecificUpgradeData>,
         sl_client: Arc<dyn EthClient>,
+        l1_client: Arc<dyn EthClient>,
     ) -> Self {
         Self {
             last_seen_protocol_version,
@@ -35,8 +40,30 @@ impl DecentralizedUpgradesEventProcessor {
                 .context("UpdateUpgradeTimestamp event is missing in ABI")
                 .unwrap()
                 .signature(),
+            chain_specific_data,
             sl_client,
+            l1_client,
         }
+    }
+}
+
+#[async_trait::async_trait]
+impl ProtocolUpgradePreimageOracle for &dyn EthClient {
+    async fn get_protocol_upgrade_preimages(
+        &self,
+        hashes: Vec<H256>,
+    ) -> anyhow::Result<Vec<Vec<u8>>> {
+        let preimages = self.get_published_preimages(hashes.clone()).await?;
+
+        let mut result = vec![];
+        for (i, preimage) in preimages.into_iter().enumerate() {
+            let preimage = preimage.with_context(|| {
+                format!("Protocol upgrade preimage for {:#?} is missing", hashes[i])
+            })?;
+            result.push(preimage);
+        }
+
+        Ok(result)
     }
 }
 
@@ -63,8 +90,14 @@ impl EventProcessor for DecentralizedUpgradesEventProcessor {
 
             let upgrade = ProtocolUpgrade {
                 timestamp,
-                ..ProtocolUpgrade::try_from_diamond_cut(&diamond_cut)?
+                ..ProtocolUpgrade::try_from_diamond_cut(
+                    &diamond_cut,
+                    self.l1_client.as_ref(),
+                    self.chain_specific_data.clone(),
+                )
+                .await?
             };
+
             // Scheduler VK is not present in proposal event. It is hard coded in verifier contract.
             let scheduler_vk_hash = if let Some(address) = upgrade.verifier_address {
                 Some(self.sl_client.scheduler_vk_hash(address).await?)

--- a/core/node/eth_watch/src/lib.rs
+++ b/core/node/eth_watch/src/lib.rs
@@ -6,12 +6,14 @@ use std::{sync::Arc, time::Duration};
 
 use anyhow::Context as _;
 use tokio::sync::watch;
+use zksync_config::ContractsConfig;
 use zksync_dal::{Connection, ConnectionPool, Core, CoreDal, DalError};
 use zksync_mini_merkle_tree::MiniMerkleTree;
 use zksync_system_constants::PRIORITY_EXPIRATION;
 use zksync_types::{
-    ethabi::Contract, protocol_version::ProtocolSemanticVersion,
-    web3::BlockNumber as Web3BlockNumber, L1BatchNumber, L2ChainId, PriorityOpId,
+    abi::ZkChainSpecificUpgradeData, ethabi::Contract, protocol_version::ProtocolSemanticVersion,
+    tokens::TokenMetadata, web3::BlockNumber as Web3BlockNumber, L1BatchNumber, L2ChainId,
+    PriorityOpId,
 };
 
 pub use self::client::{EthClient, EthHttpQueryClient, L2EthClient};
@@ -56,6 +58,7 @@ impl EthWatch {
         sl_l2_client: Option<Box<dyn L2EthClient>>,
         pool: ConnectionPool<Core>,
         poll_interval: Duration,
+        contracts_config: &ContractsConfig,
         chain_id: L2ChainId,
     ) -> anyhow::Result<Self> {
         let mut storage = pool.connection_tagged("eth_watch").await?;
@@ -76,7 +79,9 @@ impl EthWatch {
         let decentralized_upgrades_processor = DecentralizedUpgradesEventProcessor::new(
             state.last_seen_protocol_version,
             chain_admin_contract,
+            get_chain_specific_upgrade_params(&l1_client, contracts_config).await?,
             sl_client.clone(),
+            l1_client.clone(),
         );
         let mut event_processors: Vec<Box<dyn EventProcessor>> = vec![
             Box::new(priority_ops_processor),
@@ -240,4 +245,20 @@ impl EthWatch {
         }
         Ok(())
     }
+}
+
+async fn get_chain_specific_upgrade_params(
+    l1_client: &Arc<dyn EthClient>,
+    contracts_config: &ContractsConfig,
+) -> anyhow::Result<Option<ZkChainSpecificUpgradeData>> {
+    let TokenMetadata { name, symbol, .. } = l1_client.get_base_token_metadata().await?;
+
+    Ok(ZkChainSpecificUpgradeData::from_partial_components(
+        contracts_config.l1_base_token_asset_id,
+        contracts_config.l2_legacy_shared_bridge_addr,
+        contracts_config.l2_predeployed_wrapped_base_token_address,
+        contracts_config.base_token_addr,
+        Some(name),
+        Some(symbol),
+    ))
 }

--- a/core/node/eth_watch/src/tests/client.rs
+++ b/core/node/eth_watch/src/tests/client.rs
@@ -6,12 +6,13 @@ use zksync_contracts::{
 };
 use zksync_eth_client::{ContractCallError, EnrichedClientResult};
 use zksync_types::{
-    abi,
-    abi::ProposedUpgrade,
+    abi::{self, ProposedUpgrade},
     api::{ChainAggProof, Log},
-    ethabi,
-    ethabi::Token,
+    bytecode::BytecodeHash,
+    ethabi::{self, Token},
     l1::L1Tx,
+    protocol_upgrade::ProtocolUpgradeTx,
+    tokens::TokenMetadata,
     u256_to_h256,
     web3::{contract::Tokenizable, BlockNumber},
     Address, L1BatchNumber, L2ChainId, ProtocolUpgrade, SLChainId, Transaction, H256, U256, U64,
@@ -30,6 +31,7 @@ pub struct FakeEthClientData {
     chain_log_proofs: HashMap<L1BatchNumber, ChainAggProof>,
     batch_roots: HashMap<u64, Vec<Log>>,
     chain_roots: HashMap<u64, H256>,
+    bytecode_preimages: HashMap<H256, Vec<u8>>,
 }
 
 impl FakeEthClientData {
@@ -44,6 +46,7 @@ impl FakeEthClientData {
             chain_log_proofs: Default::default(),
             batch_roots: Default::default(),
             chain_roots: Default::default(),
+            bytecode_preimages: Default::default(),
         }
     }
 
@@ -68,6 +71,7 @@ impl FakeEthClientData {
                 .entry(*eth_block)
                 .or_default()
                 .push(diamond_upgrade_log(upgrade.clone(), *eth_block));
+            self.add_bytecode_preimages(&upgrade.tx);
         }
     }
 
@@ -97,6 +101,22 @@ impl FakeEthClientData {
     fn add_chain_log_proofs(&mut self, chain_log_proofs: Vec<(L1BatchNumber, ChainAggProof)>) {
         for (batch, proof) in chain_log_proofs {
             self.chain_log_proofs.insert(batch, proof);
+        }
+    }
+
+    fn get_bytecode_preimage(&self, hash: H256) -> Option<Vec<u8>> {
+        self.bytecode_preimages.get(&hash).cloned()
+    }
+
+    fn add_bytecode_preimages(&mut self, upgrade_tx: &Option<ProtocolUpgradeTx>) {
+        let Some(tx) = upgrade_tx.as_ref() else {
+            // Nothing to add
+            return;
+        };
+
+        for dep in tx.execute.factory_deps.iter() {
+            self.bytecode_preimages
+                .insert(BytecodeHash::for_bytecode(dep).value(), dep.clone());
         }
     }
 }
@@ -273,6 +293,27 @@ impl EthClient for MockEthClient {
         unimplemented!()
     }
 
+    async fn get_published_preimages(
+        &self,
+        hashes: Vec<H256>,
+    ) -> EnrichedClientResult<Vec<Option<Vec<u8>>>> {
+        let mut result = vec![];
+
+        for hash in hashes {
+            result.push(self.inner.read().await.get_bytecode_preimage(hash));
+        }
+
+        Ok(result)
+    }
+
+    async fn get_base_token_metadata(&self) -> Result<TokenMetadata, ContractCallError> {
+        Ok(TokenMetadata {
+            name: "ETH".to_string(),
+            symbol: "Ether".to_string(),
+            decimals: 18,
+        })
+    }
+
     async fn fflonk_scheduler_vk_hash(
         &self,
         _verifier_address: Address,
@@ -435,9 +476,7 @@ fn upgrade_timestamp_log(eth_block: u64) -> Log {
 }
 
 fn upgrade_into_diamond_cut(upgrade: ProtocolUpgrade) -> Token {
-    let abi::Transaction::L1 {
-        tx, factory_deps, ..
-    } = upgrade
+    let abi::Transaction::L1 { tx, .. } = upgrade
         .tx
         .map(|tx| Transaction::from(tx).try_into().unwrap())
         .unwrap_or(abi::Transaction::L1 {
@@ -448,6 +487,7 @@ fn upgrade_into_diamond_cut(upgrade: ProtocolUpgrade) -> Token {
     else {
         unreachable!()
     };
+    let factory_deps = upgrade.version.minor.is_pre_gateway().then(Vec::new);
     ProposedUpgrade {
         l2_protocol_upgrade_tx: tx,
         factory_deps,

--- a/core/node/node_framework/src/implementations/layers/eth_watch.rs
+++ b/core/node/node_framework/src/implementations/layers/eth_watch.rs
@@ -97,6 +97,10 @@ impl WiringLayer for EthWatchLayer {
             self.contracts_config
                 .ecosystem_contracts
                 .as_ref()
+                .and_then(|a| a.l1_bytecodes_supplier_addr),
+            self.contracts_config
+                .ecosystem_contracts
+                .as_ref()
                 .map(|a| a.state_transition_proxy_addr),
             self.contracts_config.chain_admin_addr,
             self.contracts_config.governance_addr,
@@ -109,6 +113,8 @@ impl WiringLayer for EthWatchLayer {
                 Some(Box::new(EthHttpQueryClient::new(
                     gateway_client.0,
                     contracts_config.diamond_proxy_addr,
+                    // Bytecode supplier is only present on L1
+                    None,
                     Some(contracts_config.state_transition_proxy_addr),
                     contracts_config.chain_admin_addr,
                     contracts_config.governance_addr,
@@ -124,6 +130,7 @@ impl WiringLayer for EthWatchLayer {
             sl_l2_client,
             main_pool,
             self.eth_watch_config.poll_interval(),
+            &self.contracts_config,
             self.chain_id,
         )
         .await?;

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -8895,6 +8895,7 @@ name = "zksync_types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bigdecimal",
  "blake2 0.10.6",
  "chrono",

--- a/zkstack_cli/Cargo.lock
+++ b/zkstack_cli/Cargo.lock
@@ -7378,6 +7378,7 @@ name = "zksync_types"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bigdecimal",
  "blake2",
  "chrono",


### PR DESCRIPTION
## What ❔

Copies protocol upgrade schema changes from sync-layer-stable in a non-breaking way.

## Why ❔

Support post-gateway upgrade schema.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
