### PR TITLE
ci: fix gsutil command for download fflonk key for proof-fri-gpu-compressor

### DIFF
--- a/.github/workflows/build-proof-fri-gpu-compressor-gar.yml
+++ b/.github/workflows/build-proof-fri-gpu-compressor-gar.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Download FFLONK key and setup data
         run: |
-          gsutil -m rsync -r gs://matterlabs-setup-keys-us/setup-keys/setup_fflonk_compact.key docker/proof-fri-gpu-compressor-gar
           gsutil -m rsync -r gs://matterlabs-setup-data-us/${{ inputs.setup_keys_id }} docker/proof-fri-gpu-compressor-gar
+          gsutil -m cp -r gs://matterlabs-setup-keys-us/setup-keys/setup_fflonk_compact.key docker/proof-fri-gpu-compressor-gar
 
       - name: Login to us-central1 GAR
         run: |


### PR DESCRIPTION
## What ❔
Fix gsutil command for download fflonk key

## Why ❔
It's broken

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
