### PR TITLE
refactor: rename zkstack crates with unique names for publishing

### DIFF
--- a/zkstack_cli/Cargo.lock
+++ b/zkstack_cli/Cargo.lock
@@ -799,35 +799,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "common"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "clap",
- "cliclack",
- "console",
- "ethers",
- "futures",
- "git_version_macro",
- "once_cell",
- "serde",
- "serde_json",
- "serde_yaml",
- "sqlx",
- "strum",
- "thiserror",
- "tokio",
- "toml",
- "types",
- "url",
- "xshell",
- "zksync_system_constants",
- "zksync_types",
- "zksync_web3_decl",
-]
-
-[[package]]
 name = "common-path"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,29 +817,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "config"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "clap",
- "common",
- "ethers",
- "rand",
- "serde",
- "serde_json",
- "serde_yaml",
- "strum",
- "thiserror",
- "types",
- "url",
- "xshell",
- "zksync_basic_types",
- "zksync_config",
- "zksync_protobuf",
- "zksync_protobuf_config",
 ]
 
 [[package]]
@@ -2093,13 +2041,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "git_version_macro"
-version = "0.1.0"
-dependencies = [
- "chrono",
-]
 
 [[package]]
 name = "glob"
@@ -6283,18 +6224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
-name = "types"
-version = "0.1.0"
-dependencies = [
- "clap",
- "ethers",
- "serde",
- "strum",
- "thiserror",
- "zksync_basic_types",
-]
-
-[[package]]
 name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7124,8 +7053,6 @@ dependencies = [
  "clap-markdown",
  "clap_complete",
  "cliclack",
- "common",
- "config",
  "dirs",
  "ethers",
  "futures",
@@ -7144,9 +7071,11 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
- "types",
  "url",
  "xshell",
+ "zkstack_cli_common",
+ "zkstack_cli_config",
+ "zkstack_cli_types",
  "zksync_basic_types",
  "zksync_config",
  "zksync_consensus_crypto",
@@ -7158,6 +7087,77 @@ dependencies = [
  "zksync_system_constants",
  "zksync_types",
  "zksync_web3_decl",
+]
+
+[[package]]
+name = "zkstack_cli_common"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "cliclack",
+ "console",
+ "ethers",
+ "futures",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sqlx",
+ "strum",
+ "thiserror",
+ "tokio",
+ "toml",
+ "url",
+ "xshell",
+ "zkstack_cli_git_version_macro",
+ "zkstack_cli_types",
+ "zksync_system_constants",
+ "zksync_types",
+ "zksync_web3_decl",
+]
+
+[[package]]
+name = "zkstack_cli_config"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ethers",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "strum",
+ "thiserror",
+ "url",
+ "xshell",
+ "zkstack_cli_common",
+ "zkstack_cli_types",
+ "zksync_basic_types",
+ "zksync_config",
+ "zksync_protobuf",
+ "zksync_protobuf_config",
+]
+
+[[package]]
+name = "zkstack_cli_git_version_macro"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
+name = "zkstack_cli_types"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "ethers",
+ "serde",
+ "strum",
+ "thiserror",
+ "zksync_basic_types",
 ]
 
 [[package]]

--- a/zkstack_cli/Cargo.toml
+++ b/zkstack_cli/Cargo.toml
@@ -21,10 +21,10 @@ keywords = ["zk", "cryptography", "blockchain", "ZKStack", "ZKsync"]
 
 [workspace.dependencies]
 # Local dependencies
-common = { path = "crates/common" }
-config = { path = "crates/config" }
-types = { path = "crates/types" }
-git_version_macro = { path = "crates/git_version_macro" }
+zkstack_cli_common = { path = "crates/common" }
+zkstack_cli_config = { path = "crates/config" }
+zkstack_cli_types = { path = "crates/types" }
+zkstack_cli_git_version_macro = { path = "crates/git_version_macro" }
 
 # ZkSync deps
 zksync_config = { path = "../core/lib/config" }

--- a/zkstack_cli/crates/common/Cargo.toml
+++ b/zkstack_cli/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "common"
-version = "0.1.0"
+name = "zkstack_cli_common"
+version.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
@@ -24,12 +24,12 @@ serde_yaml.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
 toml.workspace = true
-types.workspace = true
+zkstack_cli_types.workspace = true
 url.workspace = true
 xshell.workspace = true
 thiserror.workspace = true
 strum.workspace = true
-git_version_macro.workspace = true
+zkstack_cli_git_version_macro.workspace = true
 async-trait.workspace = true
 zksync_system_constants.workspace = true
 zksync_types.workspace = true

--- a/zkstack_cli/crates/common/src/ethereum.rs
+++ b/zkstack_cli/crates/common/src/ethereum.rs
@@ -8,7 +8,7 @@ use ethers::{
     providers::Middleware,
     types::{Address, TransactionRequest},
 };
-use types::TokenInfo;
+use zkstack_cli_types::TokenInfo;
 
 use crate::{logger, wallets::Wallet};
 

--- a/zkstack_cli/crates/common/src/version.rs
+++ b/zkstack_cli/crates/common/src/version.rs
@@ -1,7 +1,7 @@
-const GIT_VERSION: &str = git_version_macro::build_git_revision!();
-const GIT_BRANCH: &str = git_version_macro::build_git_branch!();
-const GIT_SUBMODULES: &[(&str, &str)] = git_version_macro::build_git_submodules!();
-const BUILD_TIMESTAMP: &str = git_version_macro::build_timestamp!();
+const GIT_VERSION: &str = zkstack_cli_git_version_macro::build_git_revision!();
+const GIT_BRANCH: &str = zkstack_cli_git_version_macro::build_git_branch!();
+const GIT_SUBMODULES: &[(&str, &str)] = zkstack_cli_git_version_macro::build_git_submodules!();
+const BUILD_TIMESTAMP: &str = zkstack_cli_git_version_macro::build_timestamp!();
 
 /// Returns a multi-line version message that includes:
 /// - provided crate version

--- a/zkstack_cli/crates/common/src/wallets.rs
+++ b/zkstack_cli/crates/common/src/wallets.rs
@@ -4,7 +4,7 @@ use ethers::{
     types::{Address, H256},
 };
 use serde::{Deserialize, Serialize};
-use types::parse_h256;
+use zkstack_cli_types::parse_h256;
 
 #[derive(Serialize, Deserialize)]
 struct WalletSerde {

--- a/zkstack_cli/crates/config/Cargo.toml
+++ b/zkstack_cli/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "config"
-version = "0.1.0"
+name = "zkstack_cli_config"
+version.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
@@ -13,7 +13,7 @@ keywords.workspace = true
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-common.workspace = true
+zkstack_cli_common.workspace = true
 ethers.workspace = true
 rand.workspace = true
 serde.workspace = true
@@ -21,7 +21,7 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 strum.workspace = true
 thiserror.workspace = true
-types.workspace = true
+zkstack_cli_types.workspace = true
 url.workspace = true
 xshell.workspace = true
 

--- a/zkstack_cli/crates/config/src/chain.rs
+++ b/zkstack_cli/crates/config/src/chain.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize, Serializer};
-use types::{BaseToken, L1BatchCommitmentMode, L1Network, ProverMode, WalletCreation};
 use xshell::Shell;
+use zkstack_cli_types::{BaseToken, L1BatchCommitmentMode, L1Network, ProverMode, WalletCreation};
 use zksync_basic_types::L2ChainId;
 use zksync_config::configs::{GatewayChainConfig, GatewayConfig};
 

--- a/zkstack_cli/crates/config/src/ecosystem.rs
+++ b/zkstack_cli/crates/config/src/ecosystem.rs
@@ -3,11 +3,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use common::{config::global_config, logger};
 use serde::{Deserialize, Serialize, Serializer};
 use thiserror::Error;
-use types::{L1Network, ProverMode, WalletCreation};
 use xshell::Shell;
+use zkstack_cli_common::{config::global_config, logger};
+use zkstack_cli_types::{L1Network, ProverMode, WalletCreation};
 use zksync_basic_types::L2ChainId;
 
 use crate::{

--- a/zkstack_cli/crates/config/src/explorer_compose.rs
+++ b/zkstack_cli/crates/config/src/explorer_compose.rs
@@ -4,9 +4,9 @@ use std::{
 };
 
 use anyhow::Context;
-use common::{db, docker::adjust_localhost_for_docker};
 use serde::{Deserialize, Serialize};
 use url::Url;
+use zkstack_cli_common::{db, docker::adjust_localhost_for_docker};
 
 use crate::{
     consts::{

--- a/zkstack_cli/crates/config/src/forge_interface/deploy_gateway_ctm/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/deploy_gateway_ctm/input.rs
@@ -1,7 +1,7 @@
 /// TODO(EVM-927): Note that the contents of this file are not useable without Gateway contracts.
 use ethers::abi::Address;
 use serde::{Deserialize, Serialize};
-use types::ProverMode;
+use zkstack_cli_types::ProverMode;
 use zksync_basic_types::{H256, U256};
 use zksync_config::GenesisConfig;
 

--- a/zkstack_cli/crates/config/src/forge_interface/gateway_chain_upgrade/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/gateway_chain_upgrade/input.rs
@@ -1,7 +1,7 @@
 /// TODO(EVM-927): Note that the contents of this file are not useable without Gateway contracts.
 use ethers::types::Address;
 use serde::{Deserialize, Serialize};
-use types::L1BatchCommitmentMode;
+use zkstack_cli_types::L1BatchCommitmentMode;
 use zksync_basic_types::L2ChainId;
 
 use crate::{traits::ZkStackConfig, ChainConfig};

--- a/zkstack_cli/crates/config/src/forge_interface/register_chain/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/register_chain/input.rs
@@ -1,7 +1,7 @@
 use ethers::types::Address;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use types::L1BatchCommitmentMode;
+use zkstack_cli_types::L1BatchCommitmentMode;
 use zksync_basic_types::L2ChainId;
 
 use crate::{traits::ZkStackConfig, ChainConfig, ContractsConfig};

--- a/zkstack_cli/crates/config/src/general.rs
+++ b/zkstack_cli/crates/config/src/general.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
-use common::yaml::merge_yaml;
 use url::Url;
 use xshell::Shell;
+use zkstack_cli_common::yaml::merge_yaml;
 use zksync_config::configs::object_store::ObjectStoreMode;
 pub use zksync_config::configs::GeneralConfig;
 use zksync_protobuf_config::{encode_yaml_repr, read_yaml_repr};

--- a/zkstack_cli/crates/config/src/portal.rs
+++ b/zkstack_cli/crates/config/src/portal.rs
@@ -1,8 +1,8 @@
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
-use types::TokenInfo;
 use xshell::Shell;
+use zkstack_cli_types::TokenInfo;
 
 use crate::{
     consts::{

--- a/zkstack_cli/crates/config/src/secrets.rs
+++ b/zkstack_cli/crates/config/src/secrets.rs
@@ -1,8 +1,8 @@
 use std::{path::Path, str::FromStr};
 
 use anyhow::Context;
-use common::db::DatabaseConfig;
 use xshell::Shell;
+use zkstack_cli_common::db::DatabaseConfig;
 use zksync_basic_types::url::SensitiveUrl;
 pub use zksync_config::configs::Secrets as SecretsConfig;
 use zksync_protobuf_config::{encode_yaml_repr, read_yaml_repr};

--- a/zkstack_cli/crates/config/src/traits.rs
+++ b/zkstack_cli/crates/config/src/traits.rs
@@ -1,12 +1,12 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context};
-use common::files::{
-    read_json_file, read_toml_file, read_yaml_file, save_json_file, save_toml_file, save_yaml_file,
-};
 use serde::{de::DeserializeOwned, Serialize};
 use url::Url;
 use xshell::Shell;
+use zkstack_cli_common::files::{
+    read_json_file, read_toml_file, read_yaml_file, save_json_file, save_toml_file, save_yaml_file,
+};
 
 // Configs that we use only inside ZK Stack CLI, we don't have protobuf implementation for them.
 pub trait ZkStackConfig {}

--- a/zkstack_cli/crates/config/src/wallet_creation.rs
+++ b/zkstack_cli/crates/config/src/wallet_creation.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
 
-use common::wallets::Wallet;
 use rand::thread_rng;
-use types::WalletCreation;
 use xshell::Shell;
+use zkstack_cli_common::wallets::Wallet;
+use zkstack_cli_types::WalletCreation;
 
 use crate::{
     consts::{BASE_PATH, TEST_CONFIG_PATH},

--- a/zkstack_cli/crates/config/src/wallets.rs
+++ b/zkstack_cli/crates/config/src/wallets.rs
@@ -1,6 +1,6 @@
-use common::wallets::Wallet;
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
+use zkstack_cli_common::wallets::Wallet;
 
 use crate::{
     consts::WALLETS_FILE,

--- a/zkstack_cli/crates/git_version_macro/Cargo.toml
+++ b/zkstack_cli/crates/git_version_macro/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "git_version_macro"
+name = "zkstack_cli_git_version_macro"
 edition = "2021"
 description = "Procedural macro to generate metainformation about build in compile time"
 version.workspace = true

--- a/zkstack_cli/crates/types/Cargo.toml
+++ b/zkstack_cli/crates/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "types"
-version = "0.1.0"
+name = "zkstack_cli_types"
+version.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/zkstack_cli/crates/zkstack/Cargo.toml
+++ b/zkstack_cli/crates/zkstack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zkstack"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
@@ -17,8 +17,8 @@ clap.workspace = true
 clap_complete.workspace = true
 clap-markdown.workspace = true
 cliclack.workspace = true
-common.workspace = true
-config.workspace = true
+zkstack_cli_common.workspace = true
+zkstack_cli_config.workspace = true
 dirs.workspace = true
 ethers.workspace = true
 futures.workspace = true
@@ -34,7 +34,7 @@ sqruff-lib = "0.19.0"
 thiserror.workspace = true
 tokio.workspace = true
 toml.workspace = true
-types.workspace = true
+zkstack_cli_types.workspace = true
 url.workspace = true
 xshell.workspace = true
 zksync_basic_types.workspace = true

--- a/zkstack_cli/crates/zkstack/src/accept_ownership.rs
+++ b/zkstack_cli/crates/zkstack/src/accept_ownership.rs
@@ -1,13 +1,4 @@
 use anyhow::Context;
-use common::{
-    forge::{Forge, ForgeScript, ForgeScriptArgs},
-    spinner::Spinner,
-    wallets::Wallet,
-};
-use config::{
-    forge_interface::script_params::ACCEPT_GOVERNANCE_SCRIPT_PARAMS, ChainConfig, ContractsConfig,
-    EcosystemConfig,
-};
 use ethers::{
     abi::{parse_abi, Token},
     contract::BaseContract,
@@ -15,6 +6,15 @@ use ethers::{
 };
 use lazy_static::lazy_static;
 use xshell::Shell;
+use zkstack_cli_common::{
+    forge::{Forge, ForgeScript, ForgeScriptArgs},
+    spinner::Spinner,
+    wallets::Wallet,
+};
+use zkstack_cli_config::{
+    forge_interface::script_params::ACCEPT_GOVERNANCE_SCRIPT_PARAMS, ChainConfig, ContractsConfig,
+    EcosystemConfig,
+};
 use zksync_basic_types::U256;
 
 use crate::{

--- a/zkstack_cli/crates/zkstack/src/commands/args/containers.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/args/containers.rs
@@ -16,7 +16,7 @@ pub struct ContainersArgsFinal {
 impl ContainersArgs {
     pub fn fill_values_with_prompt(self) -> ContainersArgsFinal {
         let observability = self.observability.unwrap_or_else(|| {
-            common::PromptConfirm::new(MSG_OBSERVABILITY_RUN_PROMPT)
+            zkstack_cli_common::PromptConfirm::new(MSG_OBSERVABILITY_RUN_PROMPT)
                 .default(true)
                 .ask()
         });

--- a/zkstack_cli/crates/zkstack/src/commands/args/wait.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/args/wait.rs
@@ -2,10 +2,10 @@ use std::{fmt, future::Future, time::Duration};
 
 use anyhow::Context as _;
 use clap::Parser;
-use common::logger;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use tokio::time::MissedTickBehavior;
+use zkstack_cli_common::logger;
 
 use crate::messages::{
     msg_wait_connect_err, msg_wait_non_successful_response, msg_wait_not_healthy,

--- a/zkstack_cli/crates/zkstack/src/commands/autocomplete.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/autocomplete.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::Context;
 use clap::CommandFactory;
 use clap_complete::{generate, Generator};
-use common::logger;
+use zkstack_cli_common::logger;
 
 use super::args::AutocompleteArgs;
 use crate::{

--- a/zkstack_cli/crates/zkstack/src/commands/chain/accept_chain_ownership.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/accept_chain_ownership.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
-use common::{forge::ForgeScriptArgs, logger, spinner::Spinner};
-use config::EcosystemConfig;
 use xshell::Shell;
+use zkstack_cli_common::{forge::ForgeScriptArgs, logger, spinner::Spinner};
+use zkstack_cli_config::EcosystemConfig;
 
 use crate::{
     accept_ownership::accept_admin,

--- a/zkstack_cli/crates/zkstack/src/commands/chain/args/build_transactions.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/args/build_transactions.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use common::{config::global_config, forge::ForgeScriptArgs, Prompt};
 use serde::{Deserialize, Serialize};
 use url::Url;
+use zkstack_cli_common::{config::global_config, forge::ForgeScriptArgs, Prompt};
 
 use crate::{
     consts::DEFAULT_UNSIGNED_TRANSACTIONS_DIR,

--- a/zkstack_cli/crates/zkstack/src/commands/chain/args/create.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/args/create.rs
@@ -2,12 +2,12 @@ use std::{path::PathBuf, str::FromStr};
 
 use anyhow::{bail, Context};
 use clap::{Parser, ValueEnum, ValueHint};
-use common::{Prompt, PromptConfirm, PromptSelect};
-use config::forge_interface::deploy_ecosystem::output::Erc20Token;
 use serde::{Deserialize, Serialize};
 use slugify_rs::slugify;
 use strum::{Display, EnumIter, IntoEnumIterator};
-use types::{BaseToken, L1BatchCommitmentMode, L1Network, ProverMode, WalletCreation};
+use zkstack_cli_common::{Prompt, PromptConfirm, PromptSelect};
+use zkstack_cli_config::forge_interface::deploy_ecosystem::output::Erc20Token;
+use zkstack_cli_types::{BaseToken, L1BatchCommitmentMode, L1Network, ProverMode, WalletCreation};
 use zksync_basic_types::H160;
 
 use crate::{

--- a/zkstack_cli/crates/zkstack/src/commands/chain/args/genesis.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/args/genesis.rs
@@ -1,10 +1,10 @@
 use anyhow::Context;
 use clap::Parser;
-use common::{db::DatabaseConfig, Prompt};
-use config::ChainConfig;
 use serde::{Deserialize, Serialize};
 use slugify_rs::slugify;
 use url::Url;
+use zkstack_cli_common::{db::DatabaseConfig, Prompt};
+use zkstack_cli_config::ChainConfig;
 
 use crate::{
     defaults::{generate_db_names, DBNames, DATABASE_SERVER_URL},

--- a/zkstack_cli/crates/zkstack/src/commands/chain/args/init/configs.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/args/init/configs.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
-use common::Prompt;
-use config::ChainConfig;
 use serde::{Deserialize, Serialize};
-use types::L1Network;
 use url::Url;
+use zkstack_cli_common::Prompt;
+use zkstack_cli_config::ChainConfig;
+use zkstack_cli_types::L1Network;
 
 use crate::{
     commands::chain::args::{

--- a/zkstack_cli/crates/zkstack/src/commands/chain/args/init/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/args/init/mod.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
-use common::{forge::ForgeScriptArgs, Prompt};
-use config::ChainConfig;
 use serde::{Deserialize, Serialize};
-use types::L1Network;
 use url::Url;
+use zkstack_cli_common::{forge::ForgeScriptArgs, Prompt};
+use zkstack_cli_config::ChainConfig;
+use zkstack_cli_types::L1Network;
 
 use crate::{
     commands::chain::args::genesis::{GenesisArgs, GenesisArgsFinal},
@@ -58,7 +58,7 @@ impl InitArgs {
             true
         } else {
             self.deploy_paymaster.unwrap_or_else(|| {
-                common::PromptConfirm::new(MSG_DEPLOY_PAYMASTER_PROMPT)
+                zkstack_cli_common::PromptConfirm::new(MSG_DEPLOY_PAYMASTER_PROMPT)
                     .default(true)
                     .ask()
             })

--- a/zkstack_cli/crates/zkstack/src/commands/chain/build_transactions.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/build_transactions.rs
@@ -1,10 +1,10 @@
 use anyhow::Context;
-use common::{git, logger, spinner::Spinner};
-use config::{
-    copy_configs, traits::SaveConfigWithBasePath, update_from_chain_config, EcosystemConfig,
-};
 use ethers::utils::hex::ToHex;
 use xshell::Shell;
+use zkstack_cli_common::{git, logger, spinner::Spinner};
+use zkstack_cli_config::{
+    copy_configs, traits::SaveConfigWithBasePath, update_from_chain_config, EcosystemConfig,
+};
 
 use crate::{
     commands::chain::{

--- a/zkstack_cli/crates/zkstack/src/commands/chain/common.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/common.rs
@@ -1,6 +1,6 @@
-use common::spinner::Spinner;
-use config::{ChainConfig, EcosystemConfig};
-use types::{BaseToken, L1Network, WalletCreation};
+use zkstack_cli_common::spinner::Spinner;
+use zkstack_cli_config::{ChainConfig, EcosystemConfig};
+use zkstack_cli_types::{BaseToken, L1Network, WalletCreation};
 
 use crate::{
     consts::AMOUNT_FOR_DISTRIBUTION_TO_WALLETS,
@@ -30,7 +30,7 @@ pub async fn distribute_eth(
         if let Some(setter) = chain_wallets.token_multiplier_setter {
             addresses.push(setter.address)
         }
-        common::ethereum::distribute_eth(
+        zkstack_cli_common::ethereum::distribute_eth(
             wallets.operator,
             addresses,
             l1_rpc_url,
@@ -59,7 +59,7 @@ pub async fn mint_base_token(
         let addresses = vec![wallets.governor.address, chain_wallets.governor.address];
         let amount = AMOUNT_FOR_DISTRIBUTION_TO_WALLETS * base_token.nominator as u128
             / base_token.denominator as u128;
-        common::ethereum::mint_token(
+        zkstack_cli_common::ethereum::mint_token(
             wallets.governor,
             base_token.address,
             addresses,

--- a/zkstack_cli/crates/zkstack/src/commands/chain/convert_to_gateway.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/convert_to_gateway.rs
@@ -1,11 +1,14 @@
 /// TODO(EVM-927): Note that the contents of this file are not useable without Gateway contracts.
 use anyhow::Context;
-use common::{
+use ethers::{abi::parse_abi, contract::BaseContract, types::Bytes, utils::hex};
+use lazy_static::lazy_static;
+use xshell::Shell;
+use zkstack_cli_common::{
     config::global_config,
     forge::{Forge, ForgeScriptArgs},
     wallets::Wallet,
 };
-use config::{
+use zkstack_cli_config::{
     forge_interface::{
         deploy_ecosystem::input::InitialDeploymentConfig,
         deploy_gateway_ctm::{input::DeployGatewayCTMInput, output::DeployGatewayCTMOutput},
@@ -15,9 +18,6 @@ use config::{
     traits::{ReadConfig, SaveConfig, SaveConfigWithBasePath},
     ChainConfig, EcosystemConfig, GenesisConfig,
 };
-use ethers::{abi::parse_abi, contract::BaseContract, types::Bytes, utils::hex};
-use lazy_static::lazy_static;
-use xshell::Shell;
 use zksync_basic_types::H256;
 use zksync_config::configs::GatewayConfig;
 

--- a/zkstack_cli/crates/zkstack/src/commands/chain/create.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/create.rs
@@ -1,13 +1,13 @@
 use std::cell::OnceCell;
 
 use anyhow::Context;
-use common::{logger, spinner::Spinner};
-use config::{
+use xshell::Shell;
+use zkstack_cli_common::{logger, spinner::Spinner};
+use zkstack_cli_config::{
     create_local_configs_dir, create_wallets,
     traits::{ReadConfigWithBasePath, SaveConfigWithBasePath},
     ChainConfig, EcosystemConfig, GenesisConfig,
 };
-use xshell::Shell;
 use zksync_basic_types::L2ChainId;
 
 use crate::{

--- a/zkstack_cli/crates/zkstack/src/commands/chain/deploy_l2_contracts.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/deploy_l2_contracts.rs
@@ -1,12 +1,13 @@
 use std::path::Path;
 
 use anyhow::Context;
-use common::{
+use xshell::Shell;
+use zkstack_cli_common::{
     contracts::build_l2_contracts,
     forge::{Forge, ForgeScriptArgs},
     spinner::Spinner,
 };
-use config::{
+use zkstack_cli_config::{
     forge_interface::{
         deploy_l2_contracts::{
             input::DeployL2ContractsInput,
@@ -20,7 +21,6 @@ use config::{
     traits::{ReadConfig, SaveConfig, SaveConfigWithBasePath},
     ChainConfig, ContractsConfig, EcosystemConfig,
 };
-use xshell::Shell;
 
 use crate::{
     messages::{

--- a/zkstack_cli/crates/zkstack/src/commands/chain/deploy_paymaster.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/deploy_paymaster.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
-use common::forge::{Forge, ForgeScriptArgs};
-use config::{
+use xshell::Shell;
+use zkstack_cli_common::forge::{Forge, ForgeScriptArgs};
+use zkstack_cli_config::{
     forge_interface::{
         paymaster::{DeployPaymasterInput, DeployPaymasterOutput},
         script_params::DEPLOY_PAYMASTER_SCRIPT_PARAMS,
@@ -8,7 +9,6 @@ use config::{
     traits::{ReadConfig, SaveConfig, SaveConfigWithBasePath},
     ChainConfig, ContractsConfig, EcosystemConfig,
 };
-use xshell::Shell;
 
 use crate::{
     messages::{MSG_CHAIN_NOT_INITIALIZED, MSG_L1_SECRETS_MUST_BE_PRESENTED},

--- a/zkstack_cli/crates/zkstack/src/commands/chain/enable_evm_emulator.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/enable_evm_emulator.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
-use common::{forge::ForgeScriptArgs, logger};
-use config::{traits::ReadConfigWithBasePath, EcosystemConfig, GenesisConfig};
 use xshell::Shell;
+use zkstack_cli_common::{forge::ForgeScriptArgs, logger};
+use zkstack_cli_config::{traits::ReadConfigWithBasePath, EcosystemConfig, GenesisConfig};
 
 use crate::{
     enable_evm_emulator::enable_evm_emulator,

--- a/zkstack_cli/crates/zkstack/src/commands/chain/gateway_upgrade.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/gateway_upgrade.rs
@@ -1,11 +1,20 @@
 /// TODO(EVM-927): Note that the contents of this file are not useable without Gateway contracts.
 use anyhow::Context;
 use clap::{Parser, ValueEnum};
-use common::{
+use ethers::{
+    abi::{encode, parse_abi},
+    contract::BaseContract,
+    utils::hex,
+};
+use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
+use strum::EnumIter;
+use xshell::Shell;
+use zkstack_cli_common::{
     config::global_config,
     forge::{Forge, ForgeScriptArgs},
 };
-use config::{
+use zkstack_cli_config::{
     forge_interface::{
         gateway_chain_upgrade::{
             input::GatewayChainUpgradeInput, output::GatewayChainUpgradeOutput,
@@ -16,16 +25,7 @@ use config::{
     traits::{ReadConfig, ReadConfigWithBasePath, SaveConfig, SaveConfigWithBasePath},
     ChainConfig, EcosystemConfig,
 };
-use ethers::{
-    abi::{encode, parse_abi},
-    contract::BaseContract,
-    utils::hex,
-};
-use lazy_static::lazy_static;
-use serde::{Deserialize, Serialize};
-use strum::EnumIter;
-use types::L1BatchCommitmentMode;
-use xshell::Shell;
+use zkstack_cli_types::L1BatchCommitmentMode;
 use zksync_basic_types::{H256, U256};
 use zksync_types::{web3::keccak256, Address, L2_NATIVE_TOKEN_VAULT_ADDRESS};
 

--- a/zkstack_cli/crates/zkstack/src/commands/chain/genesis/database.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/genesis/database.rs
@@ -1,17 +1,17 @@
 use std::path::PathBuf;
 
 use anyhow::Context;
-use common::{
+use xshell::Shell;
+use zkstack_cli_common::{
     config::global_config,
     db::{drop_db_if_exists, init_db, migrate_db, DatabaseConfig},
     logger,
 };
-use config::{
+use zkstack_cli_config::{
     override_config, set_file_artifacts, set_rocks_db_config, set_server_database,
     traits::SaveConfigWithBasePath, ChainConfig, EcosystemConfig, FileArtifacts,
 };
-use types::ProverMode;
-use xshell::Shell;
+use zkstack_cli_types::ProverMode;
 use zksync_basic_types::commitment::L1BatchCommitmentMode;
 
 use crate::{

--- a/zkstack_cli/crates/zkstack/src/commands/chain/genesis/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/genesis/mod.rs
@@ -1,8 +1,8 @@
 use anyhow::Context;
 use clap::{command, Parser, Subcommand};
-use common::{logger, spinner::Spinner};
-use config::{ChainConfig, EcosystemConfig};
 use xshell::Shell;
+use zkstack_cli_common::{logger, spinner::Spinner};
+use zkstack_cli_config::{ChainConfig, EcosystemConfig};
 
 use crate::{
     commands::chain::{

--- a/zkstack_cli/crates/zkstack/src/commands/chain/genesis/server.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/genesis/server.rs
@@ -1,14 +1,14 @@
 use anyhow::Context;
-use common::{
+use xshell::Shell;
+use zkstack_cli_common::{
     logger,
     server::{Server, ServerMode},
     spinner::Spinner,
 };
-use config::{
+use zkstack_cli_config::{
     traits::FileConfigWithDefaultName, ChainConfig, ContractsConfig, EcosystemConfig,
     GeneralConfig, GenesisConfig, SecretsConfig, WalletsConfig,
 };
-use xshell::Shell;
 
 use crate::messages::{
     MSG_CHAIN_NOT_INITIALIZED, MSG_FAILED_TO_RUN_SERVER_ERR, MSG_GENESIS_COMPLETED,

--- a/zkstack_cli/crates/zkstack/src/commands/chain/init/configs.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/init/configs.rs
@@ -1,11 +1,11 @@
 use anyhow::Context;
-use common::logger;
-use config::{
+use ethers::types::Address;
+use xshell::Shell;
+use zkstack_cli_common::logger;
+use zkstack_cli_config::{
     copy_configs, set_l1_rpc_url, traits::SaveConfigWithBasePath, update_from_chain_config,
     ChainConfig, ContractsConfig, EcosystemConfig,
 };
-use ethers::types::Address;
-use xshell::Shell;
 
 use crate::{
     commands::{

--- a/zkstack_cli/crates/zkstack/src/commands/chain/init/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/init/mod.rs
@@ -1,9 +1,9 @@
 use anyhow::Context;
 use clap::{command, Parser, Subcommand};
-use common::{git, logger, spinner::Spinner};
-use config::{traits::SaveConfigWithBasePath, ChainConfig, EcosystemConfig};
-use types::BaseToken;
 use xshell::Shell;
+use zkstack_cli_common::{git, logger, spinner::Spinner};
+use zkstack_cli_config::{traits::SaveConfigWithBasePath, ChainConfig, EcosystemConfig};
+use zkstack_cli_types::BaseToken;
 
 use crate::{
     accept_ownership::accept_admin,

--- a/zkstack_cli/crates/zkstack/src/commands/chain/migrate_from_gateway.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/migrate_from_gateway.rs
@@ -1,20 +1,6 @@
 /// TODO(EVM-927): Note that the contents of this file are not useable without Gateway contracts.
 use anyhow::Context;
 use clap::Parser;
-use common::{
-    config::global_config,
-    forge::{Forge, ForgeScriptArgs},
-    wallets::Wallet,
-    zks_provider::ZKSProvider,
-};
-use config::{
-    forge_interface::{
-        gateway_preparation::{input::GatewayPreparationConfig, output::GatewayPreparationOutput},
-        script_params::GATEWAY_PREPARATION,
-    },
-    traits::{ReadConfig, SaveConfig, SaveConfigWithBasePath},
-    EcosystemConfig,
-};
 use ethers::{
     abi::parse_abi,
     contract::BaseContract,
@@ -24,8 +10,22 @@ use ethers::{
 };
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
-use types::L1BatchCommitmentMode;
 use xshell::Shell;
+use zkstack_cli_common::{
+    config::global_config,
+    forge::{Forge, ForgeScriptArgs},
+    wallets::Wallet,
+    zks_provider::ZKSProvider,
+};
+use zkstack_cli_config::{
+    forge_interface::{
+        gateway_preparation::{input::GatewayPreparationConfig, output::GatewayPreparationOutput},
+        script_params::GATEWAY_PREPARATION,
+    },
+    traits::{ReadConfig, SaveConfig, SaveConfigWithBasePath},
+    EcosystemConfig,
+};
+use zkstack_cli_types::L1BatchCommitmentMode;
 use zksync_basic_types::{
     pubdata_da::PubdataSendingMode, settlement::SettlementMode, H256, U256, U64,
 };

--- a/zkstack_cli/crates/zkstack/src/commands/chain/migrate_to_gateway.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/migrate_to_gateway.rs
@@ -1,18 +1,5 @@
 use anyhow::Context;
 use clap::Parser;
-use common::{
-    config::global_config,
-    forge::{Forge, ForgeScriptArgs},
-    wallets::Wallet,
-};
-use config::{
-    forge_interface::{
-        gateway_preparation::{input::GatewayPreparationConfig, output::GatewayPreparationOutput},
-        script_params::GATEWAY_PREPARATION,
-    },
-    traits::{ReadConfig, SaveConfig, SaveConfigWithBasePath},
-    EcosystemConfig,
-};
 use ethers::{
     abi::parse_abi,
     contract::BaseContract,
@@ -22,8 +9,21 @@ use ethers::{
 };
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
-use types::L1BatchCommitmentMode;
 use xshell::Shell;
+use zkstack_cli_common::{
+    config::global_config,
+    forge::{Forge, ForgeScriptArgs},
+    wallets::Wallet,
+};
+use zkstack_cli_config::{
+    forge_interface::{
+        gateway_preparation::{input::GatewayPreparationConfig, output::GatewayPreparationOutput},
+        script_params::GATEWAY_PREPARATION,
+    },
+    traits::{ReadConfig, SaveConfig, SaveConfigWithBasePath},
+    EcosystemConfig,
+};
+use zkstack_cli_types::L1BatchCommitmentMode;
 use zksync_basic_types::{
     pubdata_da::PubdataSendingMode, settlement::SettlementMode, Address, H256, U256, U64,
 };

--- a/zkstack_cli/crates/zkstack/src/commands/chain/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/mod.rs
@@ -1,4 +1,4 @@
-use ::common::forge::ForgeScriptArgs;
+use ::zkstack_cli_common::forge::ForgeScriptArgs;
 use args::build_transactions::BuildTransactionsArgs;
 pub(crate) use args::create::ChainCreateArgsFinal;
 use clap::{command, Subcommand};

--- a/zkstack_cli/crates/zkstack/src/commands/chain/register_chain.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/register_chain.rs
@@ -1,10 +1,11 @@
 use anyhow::Context;
-use common::{
+use xshell::Shell;
+use zkstack_cli_common::{
     forge::{Forge, ForgeScriptArgs},
     logger,
     spinner::Spinner,
 };
-use config::{
+use zkstack_cli_config::{
     forge_interface::{
         register_chain::{input::RegisterChainL1Config, output::RegisterChainOutput},
         script_params::REGISTER_CHAIN_SCRIPT_PARAMS,
@@ -12,7 +13,6 @@ use config::{
     traits::{ReadConfig, SaveConfig, SaveConfigWithBasePath},
     ChainConfig, ContractsConfig, EcosystemConfig,
 };
-use xshell::Shell;
 
 use crate::{
     messages::{

--- a/zkstack_cli/crates/zkstack/src/commands/chain/set_token_multiplier_setter.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/set_token_multiplier_setter.rs
@@ -1,14 +1,16 @@
 use anyhow::Context;
-use common::{
+use ethers::{abi::parse_abi, contract::BaseContract, utils::hex};
+use lazy_static::lazy_static;
+use xshell::Shell;
+use zkstack_cli_common::{
     forge::{Forge, ForgeScript, ForgeScriptArgs},
     logger,
     spinner::Spinner,
     wallets::Wallet,
 };
-use config::{forge_interface::script_params::ACCEPT_GOVERNANCE_SCRIPT_PARAMS, EcosystemConfig};
-use ethers::{abi::parse_abi, contract::BaseContract, utils::hex};
-use lazy_static::lazy_static;
-use xshell::Shell;
+use zkstack_cli_config::{
+    forge_interface::script_params::ACCEPT_GOVERNANCE_SCRIPT_PARAMS, EcosystemConfig,
+};
 use zksync_basic_types::Address;
 
 use crate::{

--- a/zkstack_cli/crates/zkstack/src/commands/chain/setup_legacy_bridge.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/setup_legacy_bridge.rs
@@ -1,16 +1,16 @@
 use anyhow::Context;
-use common::{
+use xshell::Shell;
+use zkstack_cli_common::{
     forge::{Forge, ForgeScriptArgs},
     spinner::Spinner,
 };
-use config::{
+use zkstack_cli_config::{
     forge_interface::{
         script_params::SETUP_LEGACY_BRIDGE, setup_legacy_bridge::SetupLegacyBridgeInput,
     },
     traits::SaveConfig,
     ChainConfig, ContractsConfig, EcosystemConfig,
 };
-use xshell::Shell;
 
 use crate::{
     messages::{MSG_DEPLOYING_PAYMASTER, MSG_L1_SECRETS_MUST_BE_PRESENTED},

--- a/zkstack_cli/crates/zkstack/src/commands/consensus/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/consensus/mod.rs
@@ -3,8 +3,6 @@ use std::{borrow::Borrow, collections::HashMap, path::PathBuf, sync::Arc};
 /// Consensus registry contract operations.
 /// Includes code duplicated from `zksync_node_consensus::registry::abi`.
 use anyhow::Context as _;
-use common::{config::global_config, logger, wallets::Wallet};
-use config::EcosystemConfig;
 use conv::*;
 use ethers::{
     abi::Detokenize,
@@ -16,6 +14,8 @@ use ethers::{
 };
 use tokio::time::MissedTickBehavior;
 use xshell::Shell;
+use zkstack_cli_common::{config::global_config, logger, wallets::Wallet};
+use zkstack_cli_config::EcosystemConfig;
 use zksync_consensus_crypto::ByteFmt;
 use zksync_consensus_roles::{attester, validator};
 
@@ -144,10 +144,10 @@ fn print_attesters(committee: &attester::Committee) {
 }
 
 struct Setup {
-    chain: config::ChainConfig,
-    contracts: config::ContractsConfig,
-    general: config::GeneralConfig,
-    genesis: config::GenesisConfig,
+    chain: zkstack_cli_config::ChainConfig,
+    contracts: zkstack_cli_config::ContractsConfig,
+    general: zkstack_cli_config::GeneralConfig,
+    genesis: zkstack_cli_config::GenesisConfig,
 }
 
 impl Setup {

--- a/zkstack_cli/crates/zkstack/src/commands/containers.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/containers.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Context};
-use common::{docker, logger, spinner::Spinner};
-use config::{EcosystemConfig, DOCKER_COMPOSE_FILE, ERA_OBSERVABILITY_COMPOSE_FILE};
 use xshell::Shell;
+use zkstack_cli_common::{docker, logger, spinner::Spinner};
+use zkstack_cli_config::{EcosystemConfig, DOCKER_COMPOSE_FILE, ERA_OBSERVABILITY_COMPOSE_FILE};
 
 use super::args::ContainersArgs;
 use crate::{
@@ -46,7 +46,10 @@ pub fn initialize_docker(shell: &Shell, ecosystem: &EcosystemConfig) -> anyhow::
 fn start_container(shell: &Shell, compose_file: &str, retry_msg: &str) -> anyhow::Result<()> {
     while let Err(err) = docker::up(shell, compose_file, true) {
         logger::error(err.to_string());
-        if !common::PromptConfirm::new(retry_msg).default(true).ask() {
+        if !zkstack_cli_common::PromptConfirm::new(retry_msg)
+            .default(true)
+            .ask()
+        {
             return Err(err);
         }
     }

--- a/zkstack_cli/crates/zkstack/src/commands/contract_verifier/args/init.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/contract_verifier/args/init.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use clap::Parser;
-use common::PromptSelect;
 use xshell::Shell;
+use zkstack_cli_common::PromptSelect;
 
 use super::releases::{get_releases_with_arch, Arch, Version};
 use crate::messages::{

--- a/zkstack_cli/crates/zkstack/src/commands/contract_verifier/args/releases.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/contract_verifier/args/releases.rs
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 
-use common::spinner::Spinner;
 use serde::Deserialize;
 use xshell::Shell;
+use zkstack_cli_common::spinner::Spinner;
 
 use crate::messages::{MSG_INVALID_ARCH_ERR, MSG_NO_RELEASES_FOUND_ERR};
 

--- a/zkstack_cli/crates/zkstack/src/commands/contract_verifier/build.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/contract_verifier/build.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
-use common::{cmd::Cmd, logger};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger};
+use zkstack_cli_config::EcosystemConfig;
 
 use crate::messages::{
     MSG_BUILDING_CONTRACT_VERIFIER, MSG_CHAIN_NOT_FOUND_ERR,

--- a/zkstack_cli/crates/zkstack/src/commands/contract_verifier/init.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/contract_verifier/init.rs
@@ -1,8 +1,8 @@
 use std::path::{Path, PathBuf};
 
-use common::{cmd::Cmd, logger, spinner::Spinner};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
+use zkstack_cli_config::EcosystemConfig;
 
 use super::args::{init::InitContractVerifierArgs, releases::Version};
 use crate::messages::{msg_binary_already_exists, msg_downloading_binary_spinner};

--- a/zkstack_cli/crates/zkstack/src/commands/contract_verifier/run.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/contract_verifier/run.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
-use common::{cmd::Cmd, logger};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger};
+use zkstack_cli_config::EcosystemConfig;
 
 use crate::messages::{
     MSG_CHAIN_NOT_FOUND_ERR, MSG_FAILED_TO_RUN_CONTRACT_VERIFIER_ERR, MSG_RUNNING_CONTRACT_VERIFIER,

--- a/zkstack_cli/crates/zkstack/src/commands/contract_verifier/wait.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/contract_verifier/wait.rs
@@ -1,7 +1,7 @@
 use anyhow::Context as _;
-use common::{config::global_config, logger};
-use config::EcosystemConfig;
 use xshell::Shell;
+use zkstack_cli_common::{config::global_config, logger};
+use zkstack_cli_config::EcosystemConfig;
 
 use crate::{commands::args::WaitArgs, messages::MSG_CHAIN_NOT_FOUND_ERR};
 

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/clean/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/clean/mod.rs
@@ -1,8 +1,8 @@
 use anyhow::Context;
 use clap::Subcommand;
-use common::{docker, logger};
-use config::{EcosystemConfig, DOCKER_COMPOSE_FILE};
 use xshell::Shell;
+use zkstack_cli_common::{docker, logger};
+use zkstack_cli_config::{EcosystemConfig, DOCKER_COMPOSE_FILE};
 
 use crate::commands::dev::messages::{
     MSG_CONTRACTS_CLEANING, MSG_CONTRACTS_CLEANING_FINISHED, MSG_DOCKER_COMPOSE_DOWN,

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/config_writer.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/config_writer.rs
@@ -1,8 +1,8 @@
 use anyhow::Context;
 use clap::Parser;
-use common::{logger, Prompt};
-use config::{override_config, EcosystemConfig};
 use xshell::Shell;
+use zkstack_cli_common::{logger, Prompt};
+use zkstack_cli_config::{override_config, EcosystemConfig};
 
 use crate::commands::dev::messages::{
     msg_overriding_config, MSG_CHAIN_NOT_FOUND_ERR, MSG_OVERRIDE_CONFIG_PATH_HELP,

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/contracts.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/contracts.rs
@@ -1,13 +1,13 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use common::{
+use xshell::Shell;
+use zkstack_cli_common::{
     contracts::{build_l1_contracts, build_l2_contracts, build_system_contracts},
     logger,
     spinner::Spinner,
 };
-use config::EcosystemConfig;
-use xshell::Shell;
+use zkstack_cli_config::EcosystemConfig;
 
 use crate::commands::dev::messages::{
     MSG_BUILDING_CONTRACTS, MSG_BUILDING_CONTRACTS_SUCCESS, MSG_BUILDING_L1_CONTRACTS_SPINNER,

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/args/new_migration.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/args/new_migration.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, ValueEnum};
-use common::{Prompt, PromptSelect};
 use strum::{Display, EnumIter, IntoEnumIterator};
+use zkstack_cli_common::{Prompt, PromptSelect};
 
 use crate::commands::dev::messages::{
     MSG_DATABASE_NEW_MIGRATION_DATABASE_HELP, MSG_DATABASE_NEW_MIGRATION_DB_PROMPT,

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/check_sqlx_data.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/check_sqlx_data.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
-use common::{cmd::Cmd, logger, spinner::Spinner};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
+use zkstack_cli_config::EcosystemConfig;
 
 use super::args::DatabaseCommonArgs;
 use crate::commands::dev::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/drop.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/drop.rs
@@ -1,9 +1,9 @@
-use common::{
+use xshell::Shell;
+use zkstack_cli_common::{
     db::{drop_db_if_exists, DatabaseConfig},
     logger,
     spinner::Spinner,
 };
-use xshell::Shell;
 
 use super::args::DatabaseCommonArgs;
 use crate::commands::dev::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/migrate.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/migrate.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
-use common::{cmd::Cmd, logger, spinner::Spinner};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
+use zkstack_cli_config::EcosystemConfig;
 
 use super::args::DatabaseCommonArgs;
 use crate::commands::dev::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/new_migration.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/new_migration.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
-use common::{cmd::Cmd, logger, spinner::Spinner};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
+use zkstack_cli_config::EcosystemConfig;
 
 use super::args::new_migration::{DatabaseNewMigrationArgs, SelectedDatabase};
 use crate::commands::dev::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/prepare.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/prepare.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
-use common::{cmd::Cmd, logger, spinner::Spinner};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
+use zkstack_cli_config::EcosystemConfig;
 
 use super::args::DatabaseCommonArgs;
 use crate::commands::dev::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/reset.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/reset.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
-use common::logger;
-use config::EcosystemConfig;
 use xshell::Shell;
+use zkstack_cli_common::logger;
+use zkstack_cli_config::EcosystemConfig;
 
 use super::{args::DatabaseCommonArgs, drop::drop_database, setup::setup_database};
 use crate::commands::dev::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/setup.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/setup.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
-use common::{cmd::Cmd, logger, spinner::Spinner};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
+use zkstack_cli_config::EcosystemConfig;
 
 use super::args::DatabaseCommonArgs;
 use crate::commands::dev::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/fmt.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/fmt.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use common::{cmd::Cmd, logger, spinner::Spinner};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
+use zkstack_cli_config::EcosystemConfig;
 
 use super::sql_fmt::format_sql;
 use crate::commands::dev::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/genesis.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/genesis.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
-use common::{cmd::Cmd, spinner::Spinner};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, spinner::Spinner};
+use zkstack_cli_config::EcosystemConfig;
 
 use crate::{
     commands::dev::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/lint.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/lint.rs
@@ -6,9 +6,9 @@ use std::{
 
 use anyhow::{bail, Context};
 use clap::Parser;
-use common::{cmd::Cmd, logger, spinner::Spinner};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
+use zkstack_cli_config::EcosystemConfig;
 
 use crate::commands::{
     autocomplete::{autocomplete_file_name, generate_completions},

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/prover/args/insert_batch.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/prover/args/insert_batch.rs
@@ -19,7 +19,7 @@ pub struct InsertBatchArgsFinal {
 impl InsertBatchArgs {
     pub(crate) fn fill_values_with_prompts(self, era_version: String) -> InsertBatchArgsFinal {
         let number = self.number.unwrap_or_else(|| {
-            common::Prompt::new("Enter the number of the batch to insert").ask()
+            zkstack_cli_common::Prompt::new("Enter the number of the batch to insert").ask()
         });
 
         if self.default {
@@ -30,7 +30,7 @@ impl InsertBatchArgs {
         }
 
         let version = self.version.unwrap_or_else(|| {
-            common::Prompt::new("Enter the version of the batch to insert")
+            zkstack_cli_common::Prompt::new("Enter the version of the batch to insert")
                 .default(&era_version)
                 .ask()
         });

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/prover/args/insert_version.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/prover/args/insert_version.rs
@@ -35,21 +35,23 @@ impl InsertVersionArgs {
         }
 
         let version = self.version.unwrap_or_else(|| {
-            common::Prompt::new("Enter the version of the protocol to insert")
+            zkstack_cli_common::Prompt::new("Enter the version of the protocol to insert")
                 .default(&era_version)
                 .ask()
         });
 
         let snark_wrapper = self.snark_wrapper.unwrap_or_else(|| {
-            common::Prompt::new("Enter the snark wrapper of the protocol to insert")
+            zkstack_cli_common::Prompt::new("Enter the snark wrapper of the protocol to insert")
                 .default(&snark_wrapper)
                 .ask()
         });
 
         let fflonk_snark_wrapper = self.fflonk_snark_wrapper.unwrap_or_else(|| {
-            common::Prompt::new("Enter the fflonk snark wrapper of the protocol to insert")
-                .default(&fflonk_snark_wrapper)
-                .ask()
+            zkstack_cli_common::Prompt::new(
+                "Enter the fflonk snark wrapper of the protocol to insert",
+            )
+            .default(&fflonk_snark_wrapper)
+            .ask()
         });
 
         InsertVersionArgsFinal {

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/prover/info.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/prover/info.rs
@@ -4,9 +4,9 @@ use std::{
 };
 
 use anyhow::Context as _;
-use common::logger;
-use config::{ChainConfig, EcosystemConfig};
 use xshell::{cmd, Shell};
+use zkstack_cli_common::logger;
+use zkstack_cli_config::{ChainConfig, EcosystemConfig};
 
 use crate::commands::dev::messages::MSG_CHAIN_NOT_FOUND_ERR;
 

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/prover/insert_batch.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/prover/insert_batch.rs
@@ -1,6 +1,6 @@
-use common::{check_prerequisites, cmd::Cmd, logger, PROVER_CLI_PREREQUISITE};
-use config::{get_link_to_prover, EcosystemConfig};
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{check_prerequisites, cmd::Cmd, logger, PROVER_CLI_PREREQUISITE};
+use zkstack_cli_config::{get_link_to_prover, EcosystemConfig};
 
 use crate::commands::dev::{
     commands::prover::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/prover/insert_version.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/prover/insert_version.rs
@@ -1,6 +1,6 @@
-use common::{check_prerequisites, cmd::Cmd, logger, PROVER_CLI_PREREQUISITE};
-use config::{get_link_to_prover, EcosystemConfig};
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{check_prerequisites, cmd::Cmd, logger, PROVER_CLI_PREREQUISITE};
+use zkstack_cli_config::{get_link_to_prover, EcosystemConfig};
 
 use crate::commands::dev::{
     commands::prover::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/send_transactions/args/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/send_transactions/args/mod.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use common::Prompt;
 use url::Url;
+use zkstack_cli_common::Prompt;
 
 use crate::commands::dev::{
     defaults::LOCAL_RPC_URL,

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/send_transactions/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/send_transactions/mod.rs
@@ -9,12 +9,12 @@ use std::{
 use anyhow::Context;
 use args::SendTransactionsArgs;
 use chrono::Local;
-use common::{ethereum::create_ethers_client, logger};
-use config::EcosystemConfig;
 use ethers::{abi::Bytes, providers::Middleware, types::TransactionRequest, utils::hex};
 use serde::Deserialize;
 use tokio::time::sleep;
 use xshell::Shell;
+use zkstack_cli_common::{ethereum::create_ethers_client, logger};
+use zkstack_cli_config::EcosystemConfig;
 use zksync_basic_types::{H160, U256};
 
 use crate::commands::dev::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/snapshot.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/snapshot.rs
@@ -1,8 +1,8 @@
 use anyhow::Context;
 use clap::Subcommand;
-use common::{cmd::Cmd, logger};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger};
+use zkstack_cli_config::EcosystemConfig;
 
 use crate::commands::dev::messages::{MSG_CHAIN_NOT_FOUND_ERR, MSG_RUNNING_SNAPSHOT_CREATOR};
 

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/sql_fmt.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/sql_fmt.rs
@@ -1,9 +1,9 @@
 use std::mem::take;
 
 use anyhow::{bail, Result};
-use common::spinner::Spinner;
 use sqruff_lib::{api::simple::get_simple_config, core::linter::core::Linter};
 use xshell::Shell;
+use zkstack_cli_common::spinner::Spinner;
 
 use super::lint_utils::{get_unignored_files, IgnoredData, Target};
 use crate::commands::dev::messages::{msg_file_is_not_formatted, MSG_RUNNING_SQL_FMT_SPINNER};

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/status/args.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/status/args.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use clap::Parser;
-use config::EcosystemConfig;
 use xshell::Shell;
+use zkstack_cli_config::EcosystemConfig;
 
 use crate::{
     commands::dev::messages::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/status/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/status/mod.rs
@@ -2,12 +2,12 @@ use std::collections::HashMap;
 
 use anyhow::Context;
 use args::{StatusArgs, StatusSubcommands};
-use common::logger;
 use draw::{bordered_boxes, format_port_info};
 use serde::Deserialize;
 use serde_json::Value;
 use utils::deslugify;
 use xshell::Shell;
+use zkstack_cli_common::logger;
 
 use crate::{
     commands::dev::messages::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/build.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/build.rs
@@ -1,5 +1,5 @@
-use config::EcosystemConfig;
 use xshell::Shell;
+use zkstack_cli_config::EcosystemConfig;
 
 use super::utils::{build_contracts, install_and_build_dependencies};
 

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/db.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/db.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use common::{cmd::Cmd, db::wait_for_db, logger};
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, db::wait_for_db, logger};
 
 use crate::commands::dev::{commands::database, dals::Dal, messages::MSG_RESETTING_TEST_DATABASES};
 

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/fees.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/fees.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
 use anyhow::Context;
-use common::{cmd::Cmd, config::global_config, logger};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, config::global_config, logger};
+use zkstack_cli_config::EcosystemConfig;
 
 use super::{
     args::fees::FeesArgs,

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/integration.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/integration.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
 use anyhow::Context;
-use common::{cmd::Cmd, config::global_config, logger};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, config::global_config, logger};
+use zkstack_cli_config::EcosystemConfig;
 
 use super::{
     args::integration::IntegrationArgs,

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/l1_contracts.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/l1_contracts.rs
@@ -1,6 +1,6 @@
-use common::{cmd::Cmd, logger};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger};
+use zkstack_cli_config::EcosystemConfig;
 
 use crate::commands::dev::messages::MSG_L1_CONTRACTS_TEST_SUCCESS;
 

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/loadtest.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/loadtest.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
-use common::{cmd::Cmd, config::global_config, logger};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, config::global_config, logger};
+use zkstack_cli_config::EcosystemConfig;
 
 use crate::commands::dev::messages::MSG_CHAIN_NOT_FOUND_ERR;
 

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/prover.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/prover.rs
@@ -1,9 +1,9 @@
 use std::str::FromStr;
 
-use common::{cmd::Cmd, logger};
-use config::EcosystemConfig;
 use url::Url;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger};
+use zkstack_cli_config::EcosystemConfig;
 
 use crate::commands::dev::{
     commands::test::db::reset_test_databases,

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/recovery.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/recovery.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
 use anyhow::Context;
-use common::{cmd::Cmd, logger, server::Server, spinner::Spinner};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger, server::Server, spinner::Spinner};
+use zkstack_cli_config::EcosystemConfig;
 
 use super::{
     args::recovery::RecoveryArgs,

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/revert.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/revert.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
 use anyhow::Context;
-use common::{cmd::Cmd, logger, spinner::Spinner};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
+use zkstack_cli_config::EcosystemConfig;
 
 use super::{
     args::revert::RevertArgs,

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/rust.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/rust.rs
@@ -1,10 +1,10 @@
 use std::str::FromStr;
 
 use anyhow::Context;
-use common::{cmd::Cmd, logger};
-use config::EcosystemConfig;
 use url::Url;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger};
+use zkstack_cli_config::EcosystemConfig;
 
 use super::args::rust::RustArgs;
 use crate::commands::dev::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/upgrade.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/upgrade.rs
@@ -1,6 +1,6 @@
-use common::{cmd::Cmd, logger, spinner::Spinner};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
+use zkstack_cli_config::EcosystemConfig;
 
 use super::{args::upgrade::UpgradeArgs, utils::install_and_build_dependencies};
 use crate::commands::dev::messages::{MSG_UPGRADE_TEST_RUN_INFO, MSG_UPGRADE_TEST_RUN_SUCCESS};

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/utils.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/utils.rs
@@ -1,14 +1,14 @@
 use std::collections::HashMap;
 
 use anyhow::Context;
-use common::{cmd::Cmd, spinner::Spinner, wallets::Wallet};
-use config::{ChainConfig, EcosystemConfig};
 use ethers::{
     providers::{Http, Middleware, Provider},
     utils::hex::ToHex,
 };
 use serde::Deserialize;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, spinner::Spinner, wallets::Wallet};
+use zkstack_cli_config::{ChainConfig, EcosystemConfig};
 
 use crate::commands::dev::messages::{
     MSG_INTEGRATION_TESTS_BUILDING_CONTRACTS, MSG_INTEGRATION_TESTS_BUILDING_DEPENDENCIES,
@@ -67,7 +67,7 @@ impl TestWallets {
         let balance = provider.get_balance(wallet.address, None).await?;
 
         if balance.is_zero() {
-            common::ethereum::distribute_eth(
+            zkstack_cli_common::ethereum::distribute_eth(
                 self.get_main_wallet()?,
                 vec![wallet.address],
                 l1_rpc,

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/wallet.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/wallet.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
 use anyhow::Context;
-use common::logger;
-use config::EcosystemConfig;
 use xshell::Shell;
+use zkstack_cli_common::logger;
+use zkstack_cli_config::EcosystemConfig;
 
 use super::utils::{TestWallets, TEST_WALLETS_PATH};
 use crate::commands::dev::messages::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/dals.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/dals.rs
@@ -1,7 +1,7 @@
 use anyhow::Context as _;
-use config::{EcosystemConfig, SecretsConfig};
 use url::Url;
 use xshell::Shell;
+use zkstack_cli_config::{EcosystemConfig, SecretsConfig};
 
 use super::{
     commands::database::args::DalUrls,

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/build_transactions.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/build_transactions.rs
@@ -1,9 +1,9 @@
 use std::{path::PathBuf, str::FromStr};
 
 use clap::Parser;
-use common::{forge::ForgeScriptArgs, Prompt};
 use serde::{Deserialize, Serialize};
 use url::Url;
+use zkstack_cli_common::{forge::ForgeScriptArgs, Prompt};
 use zksync_basic_types::H160;
 
 use crate::{

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/create.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/create.rs
@@ -1,12 +1,12 @@
 use std::path::PathBuf;
 
 use clap::{Parser, ValueHint};
-use common::{Prompt, PromptConfirm, PromptSelect};
 use serde::{Deserialize, Serialize};
 use slugify_rs::slugify;
 use strum::IntoEnumIterator;
-use types::{L1Network, WalletCreation};
 use xshell::Shell;
+use zkstack_cli_common::{Prompt, PromptConfirm, PromptSelect};
+use zkstack_cli_types::{L1Network, WalletCreation};
 
 use crate::{
     commands::chain::{args::create::ChainCreateArgs, ChainCreateArgsFinal},

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/gateway_upgrade.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/gateway_upgrade.rs
@@ -2,11 +2,11 @@
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
-use common::{forge::ForgeScriptArgs, Prompt};
 use serde::{Deserialize, Serialize};
 use strum::EnumIter;
-use types::L1Network;
 use url::Url;
+use zkstack_cli_common::{forge::ForgeScriptArgs, Prompt};
+use zkstack_cli_types::L1Network;
 
 use crate::{
     defaults::LOCAL_RPC_URL,

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/init.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/init.rs
@@ -1,10 +1,10 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use common::{forge::ForgeScriptArgs, Prompt, PromptConfirm};
 use serde::{Deserialize, Serialize};
-use types::L1Network;
 use url::Url;
+use zkstack_cli_common::{forge::ForgeScriptArgs, Prompt, PromptConfirm};
+use zkstack_cli_types::L1Network;
 
 use crate::{
     commands::chain::args::genesis::GenesisArgs,

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/build_transactions.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/build_transactions.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
-use common::{git, logger, spinner::Spinner};
-use config::{traits::SaveConfigWithBasePath, EcosystemConfig};
 use xshell::Shell;
+use zkstack_cli_common::{git, logger, spinner::Spinner};
+use zkstack_cli_config::{traits::SaveConfigWithBasePath, EcosystemConfig};
 
 use super::{
     args::build_transactions::BuildTransactionsArgs,

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/change_default.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/change_default.rs
@@ -1,6 +1,6 @@
-use common::PromptSelect;
-use config::{traits::SaveConfigWithBasePath, EcosystemConfig};
 use xshell::Shell;
+use zkstack_cli_common::PromptSelect;
+use zkstack_cli_config::{traits::SaveConfigWithBasePath, EcosystemConfig};
 
 use crate::{
     commands::ecosystem::args::change_default::ChangeDefaultChain,

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/common.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/common.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
-use common::forge::{Forge, ForgeScriptArgs};
-use config::{
+use xshell::Shell;
+use zkstack_cli_common::forge::{Forge, ForgeScriptArgs};
+use zkstack_cli_config::{
     forge_interface::{
         deploy_ecosystem::{
             input::{DeployL1Config, InitialDeploymentConfig},
@@ -11,8 +12,7 @@ use config::{
     traits::{ReadConfig, ReadConfigWithBasePath, SaveConfig},
     ContractsConfig, EcosystemConfig, GenesisConfig,
 };
-use types::{L1Network, ProverMode};
-use xshell::Shell;
+use zkstack_cli_types::{L1Network, ProverMode};
 
 use crate::utils::forge::{check_the_balance, fill_forge_private_key, WalletOwner};
 

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/create.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/create.rs
@@ -1,10 +1,10 @@
 use anyhow::{bail, Context};
-use common::{logger, spinner::Spinner};
-use config::{
+use xshell::Shell;
+use zkstack_cli_common::{logger, spinner::Spinner};
+use zkstack_cli_config::{
     create_local_configs_dir, create_wallets, get_default_era_chain_id,
     traits::SaveConfigWithBasePath, EcosystemConfig, EcosystemConfigFromFileError,
 };
-use xshell::Shell;
 
 use crate::{
     commands::{

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/create_configs.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/create_configs.rs
@@ -1,11 +1,11 @@
 use std::path::Path;
 
-use config::{
+use xshell::Shell;
+use zkstack_cli_config::{
     forge_interface::deploy_ecosystem::input::{Erc20DeploymentConfig, InitialDeploymentConfig},
     traits::{SaveConfigWithBasePath, SaveConfigWithCommentAndBasePath},
     AppsEcosystemConfig,
 };
-use xshell::Shell;
 
 use crate::messages::{MSG_SAVE_ERC20_CONFIG_ATTENTION, MSG_SAVE_INITIAL_CONFIG_ATTENTION};
 

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/init.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/init.rs
@@ -1,7 +1,8 @@
 use std::{path::PathBuf, str::FromStr};
 
 use anyhow::Context;
-use common::{
+use xshell::Shell;
+use zkstack_cli_common::{
     config::global_config,
     contracts::build_system_contracts,
     forge::{Forge, ForgeScriptArgs},
@@ -9,7 +10,7 @@ use common::{
     spinner::Spinner,
     Prompt,
 };
-use config::{
+use zkstack_cli_config::{
     forge_interface::{
         deploy_ecosystem::{
             input::{DeployErc20Config, Erc20DeploymentConfig, InitialDeploymentConfig},
@@ -20,8 +21,7 @@ use config::{
     traits::{FileConfigWithDefaultName, ReadConfig, SaveConfig, SaveConfigWithBasePath},
     ContractsConfig, EcosystemConfig,
 };
-use types::L1Network;
-use xshell::Shell;
+use zkstack_cli_types::L1Network;
 
 use super::{
     args::init::{EcosystemArgsFinal, EcosystemInitArgs, EcosystemInitArgsFinal},

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/setup_observability.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/setup_observability.rs
@@ -1,6 +1,6 @@
-use common::{git, logger, spinner::Spinner};
-use config::{ERA_OBSERBAVILITY_DIR, ERA_OBSERBAVILITY_GIT_REPO};
 use xshell::Shell;
+use zkstack_cli_common::{git, logger, spinner::Spinner};
+use zkstack_cli_config::{ERA_OBSERBAVILITY_DIR, ERA_OBSERBAVILITY_GIT_REPO};
 
 use crate::messages::{
     MSG_DOWNLOADING_ERA_OBSERVABILITY_SPINNER, MSG_ERA_OBSERVABILITY_ALREADY_SETUP,

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/utils.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/utils.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use common::cmd::Cmd;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::cmd::Cmd;
 
 pub(super) fn install_yarn_dependencies(shell: &Shell, link_to_code: &Path) -> anyhow::Result<()> {
     let _dir_guard = shell.push_dir(link_to_code);

--- a/zkstack_cli/crates/zkstack/src/commands/explorer/backend.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/explorer/backend.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
 use anyhow::Context;
-use common::docker;
-use config::{explorer_compose::ExplorerBackendComposeConfig, EcosystemConfig};
 use xshell::Shell;
+use zkstack_cli_common::docker;
+use zkstack_cli_config::{explorer_compose::ExplorerBackendComposeConfig, EcosystemConfig};
 
 use crate::messages::{
     msg_explorer_chain_not_initialized, MSG_CHAIN_NOT_FOUND_ERR,

--- a/zkstack_cli/crates/zkstack/src/commands/explorer/init.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/explorer/init.rs
@@ -1,14 +1,14 @@
 use anyhow::Context;
-use common::{config::global_config, db, logger, Prompt};
-use config::{
+use slugify_rs::slugify;
+use url::Url;
+use xshell::Shell;
+use zkstack_cli_common::{config::global_config, db, logger, Prompt};
+use zkstack_cli_config::{
     explorer::{ExplorerChainConfig, ExplorerConfig},
     explorer_compose::{ExplorerBackendComposeConfig, ExplorerBackendConfig, ExplorerBackendPorts},
     traits::{ConfigWithL2RpcUrl, SaveConfig},
     ChainConfig, EcosystemConfig,
 };
-use slugify_rs::slugify;
-use url::Url;
-use xshell::Shell;
 
 use crate::{
     consts::L2_BASE_TOKEN_ADDRESS,

--- a/zkstack_cli/crates/zkstack/src/commands/explorer/run.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/explorer/run.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
 use anyhow::Context;
-use common::{config::global_config, docker, logger};
-use config::{explorer::*, traits::SaveConfig, AppsEcosystemConfig, EcosystemConfig};
 use xshell::Shell;
+use zkstack_cli_common::{config::global_config, docker, logger};
+use zkstack_cli_config::{explorer::*, traits::SaveConfig, AppsEcosystemConfig, EcosystemConfig};
 
 use crate::{
     consts::{EXPLORER_APP_DOCKER_CONFIG_PATH, EXPLORER_APP_DOCKER_IMAGE},

--- a/zkstack_cli/crates/zkstack/src/commands/external_node/args/prepare_configs.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/external_node/args/prepare_configs.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
-use common::{db::DatabaseConfig, Prompt};
-use config::ChainConfig;
 use serde::{Deserialize, Serialize};
 use slugify_rs::slugify;
 use url::Url;
+use zkstack_cli_common::{db::DatabaseConfig, Prompt};
+use zkstack_cli_config::ChainConfig;
 
 use crate::{
     defaults::{generate_external_node_db_name, DATABASE_SERVER_URL, LOCAL_RPC_URL},

--- a/zkstack_cli/crates/zkstack/src/commands/external_node/build.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/external_node/build.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
-use common::{cmd::Cmd, logger};
-use config::EcosystemConfig;
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{cmd::Cmd, logger};
+use zkstack_cli_config::EcosystemConfig;
 
 use crate::messages::{MSG_BUILDING_EN, MSG_CHAIN_NOT_FOUND_ERR, MSG_FAILED_TO_BUILD_EN_ERR};
 

--- a/zkstack_cli/crates/zkstack/src/commands/external_node/init.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/external_node/init.rs
@@ -1,10 +1,12 @@
 use anyhow::Context;
-use common::{
+use xshell::Shell;
+use zkstack_cli_common::{
     db::{drop_db_if_exists, init_db, migrate_db, DatabaseConfig},
     spinner::Spinner,
 };
-use config::{traits::ReadConfigWithBasePath, ChainConfig, EcosystemConfig, SecretsConfig};
-use xshell::Shell;
+use zkstack_cli_config::{
+    traits::ReadConfigWithBasePath, ChainConfig, EcosystemConfig, SecretsConfig,
+};
 
 use crate::{
     consts::SERVER_MIGRATIONS,

--- a/zkstack_cli/crates/zkstack/src/commands/external_node/prepare_configs.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/external_node/prepare_configs.rs
@@ -1,14 +1,14 @@
 use std::{collections::BTreeMap, path::Path, str::FromStr};
 
 use anyhow::Context;
-use common::logger;
-use config::{
+use xshell::Shell;
+use zkstack_cli_common::logger;
+use zkstack_cli_config::{
     external_node::ENConfig,
     set_rocks_db_config,
     traits::{FileConfigWithDefaultName, SaveConfigWithBasePath},
     ChainConfig, EcosystemConfig, GeneralConfig, SecretsConfig,
 };
-use xshell::Shell;
 use zksync_basic_types::url::SensitiveUrl;
 use zksync_config::configs::{
     consensus::{ConsensusConfig, ConsensusSecrets, NodeSecretKey, Secret},

--- a/zkstack_cli/crates/zkstack/src/commands/external_node/run.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/external_node/run.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
-use common::logger;
-use config::{ChainConfig, EcosystemConfig};
 use xshell::Shell;
+use zkstack_cli_common::logger;
+use zkstack_cli_config::{ChainConfig, EcosystemConfig};
 
 use crate::{
     commands::external_node::{args::run::RunExternalNodeArgs, init},

--- a/zkstack_cli/crates/zkstack/src/commands/external_node/wait.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/external_node/wait.rs
@@ -1,7 +1,7 @@
 use anyhow::Context as _;
-use common::{config::global_config, logger};
-use config::{traits::ReadConfigWithBasePath, EcosystemConfig};
 use xshell::Shell;
+use zkstack_cli_common::{config::global_config, logger};
+use zkstack_cli_config::{traits::ReadConfigWithBasePath, EcosystemConfig};
 use zksync_config::configs::GeneralConfig;
 
 use crate::{

--- a/zkstack_cli/crates/zkstack/src/commands/portal.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/portal.rs
@@ -1,15 +1,15 @@
 use std::path::Path;
 
 use anyhow::Context;
-use common::{config::global_config, docker, ethereum, logger};
-use config::{
+use ethers::types::Address;
+use xshell::Shell;
+use zkstack_cli_common::{config::global_config, docker, ethereum, logger};
+use zkstack_cli_config::{
     portal::*,
     traits::{ConfigWithL2RpcUrl, SaveConfig},
     AppsEcosystemConfig, ChainConfig, EcosystemConfig,
 };
-use ethers::types::Address;
-use types::{BaseToken, TokenInfo};
-use xshell::Shell;
+use zkstack_cli_types::{BaseToken, TokenInfo};
 
 use crate::{
     consts::{L2_BASE_TOKEN_ADDRESS, PORTAL_DOCKER_CONFIG_PATH, PORTAL_DOCKER_IMAGE},

--- a/zkstack_cli/crates/zkstack/src/commands/prover/args/compressor_keys.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/args/compressor_keys.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, ValueEnum};
-use common::Prompt;
 use strum::EnumIter;
+use zkstack_cli_common::Prompt;
 
 use crate::messages::MSG_SETUP_COMPRESSOR_KEY_PATH_PROMPT;
 

--- a/zkstack_cli/crates/zkstack/src/commands/prover/args/init.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/args/init.rs
@@ -1,11 +1,11 @@
 use clap::{Parser, ValueEnum};
-use common::{db::DatabaseConfig, logger, Prompt, PromptConfirm, PromptSelect};
-use config::ChainConfig;
 use serde::{Deserialize, Serialize};
 use slugify_rs::slugify;
 use strum::{EnumIter, IntoEnumIterator};
 use url::Url;
 use xshell::Shell;
+use zkstack_cli_common::{db::DatabaseConfig, logger, Prompt, PromptConfirm, PromptSelect};
+use zkstack_cli_config::ChainConfig;
 use zksync_config::configs::fri_prover::CloudConnectionMode;
 
 use super::{

--- a/zkstack_cli/crates/zkstack/src/commands/prover/args/init_bellman_cuda.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/args/init_bellman_cuda.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
-use common::{Prompt, PromptSelect};
 use serde::{Deserialize, Serialize};
 use strum::{EnumIter, IntoEnumIterator};
+use zkstack_cli_common::{Prompt, PromptSelect};
 
 use crate::messages::{
     MSG_BELLMAN_CUDA_DIR_PROMPT, MSG_BELLMAN_CUDA_ORIGIN_SELECT, MSG_BELLMAN_CUDA_SELECTION_CLONE,

--- a/zkstack_cli/crates/zkstack/src/commands/prover/args/run.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/args/run.rs
@@ -2,10 +2,10 @@ use std::path::Path;
 
 use anyhow::anyhow;
 use clap::{Parser, ValueEnum};
-use common::{Prompt, PromptSelect};
-use config::ChainConfig;
 use serde::{Deserialize, Serialize};
 use strum::{EnumIter, IntoEnumIterator};
+use zkstack_cli_common::{Prompt, PromptSelect};
+use zkstack_cli_config::ChainConfig;
 
 use crate::{
     consts::{

--- a/zkstack_cli/crates/zkstack/src/commands/prover/args/setup_keys.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/args/setup_keys.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, ValueEnum};
-use common::PromptSelect;
 use strum::{EnumIter, IntoEnumIterator};
+use zkstack_cli_common::PromptSelect;
 
 use crate::messages::{MSG_SETUP_KEYS_DOWNLOAD_SELECTION_PROMPT, MSG_SETUP_KEYS_REGION_PROMPT};
 

--- a/zkstack_cli/crates/zkstack/src/commands/prover/compressor_keys.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/compressor_keys.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
-use common::{logger, spinner::Spinner};
-use config::{get_link_to_prover, EcosystemConfig, GeneralConfig};
 use xshell::Shell;
+use zkstack_cli_common::{logger, spinner::Spinner};
+use zkstack_cli_config::{get_link_to_prover, EcosystemConfig, GeneralConfig};
 
 use super::args::compressor_keys::{CompressorKeysArgs, CompressorType};
 use crate::messages::{

--- a/zkstack_cli/crates/zkstack/src/commands/prover/gcs.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/gcs.rs
@@ -1,5 +1,7 @@
-use common::{check_prerequisites, cmd::Cmd, logger, spinner::Spinner, GCLOUD_PREREQUISITE};
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{
+    check_prerequisites, cmd::Cmd, logger, spinner::Spinner, GCLOUD_PREREQUISITE,
+};
 use zksync_config::{configs::object_store::ObjectStoreMode, ObjectStoreConfig};
 
 use super::args::init::ProofStorageGCSCreateBucket;

--- a/zkstack_cli/crates/zkstack/src/commands/prover/init.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/init.rs
@@ -1,18 +1,18 @@
 use std::path::PathBuf;
 
 use anyhow::Context;
-use common::{
+use xshell::{cmd, Shell};
+use zkstack_cli_common::{
     cmd::Cmd,
     config::global_config,
     db::{drop_db_if_exists, init_db, migrate_db, DatabaseConfig},
     logger,
     spinner::Spinner,
 };
-use config::{
+use zkstack_cli_config::{
     copy_configs, get_link_to_prover, set_prover_database, traits::SaveConfigWithBasePath,
     EcosystemConfig,
 };
-use xshell::{cmd, Shell};
 use zksync_config::{configs::object_store::ObjectStoreMode, ObjectStoreConfig};
 
 use super::{

--- a/zkstack_cli/crates/zkstack/src/commands/prover/init_bellman_cuda.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/init_bellman_cuda.rs
@@ -1,7 +1,9 @@
 use anyhow::Context;
-use common::{check_prerequisites, cmd::Cmd, git, logger, spinner::Spinner, GPU_PREREQUISITES};
-use config::{traits::SaveConfigWithBasePath, EcosystemConfig};
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{
+    check_prerequisites, cmd::Cmd, git, logger, spinner::Spinner, GPU_PREREQUISITES,
+};
+use zkstack_cli_config::{traits::SaveConfigWithBasePath, EcosystemConfig};
 
 use super::args::init_bellman_cuda::InitBellmanCudaArgs;
 use crate::{

--- a/zkstack_cli/crates/zkstack/src/commands/prover/run.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/run.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context};
-use common::{check_prerequisites, cmd::Cmd, logger, GPU_PREREQUISITES};
-use config::{get_link_to_prover, ChainConfig, EcosystemConfig};
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{check_prerequisites, cmd::Cmd, logger, GPU_PREREQUISITES};
+use zkstack_cli_config::{get_link_to_prover, ChainConfig, EcosystemConfig};
 
 use super::args::run::{ProverComponent, ProverRunArgs};
 use crate::messages::{

--- a/zkstack_cli/crates/zkstack/src/commands/prover/setup_keys.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/setup_keys.rs
@@ -1,9 +1,9 @@
 use anyhow::Ok;
-use common::{
+use xshell::{cmd, Shell};
+use zkstack_cli_common::{
     check_prerequisites, cmd::Cmd, logger, spinner::Spinner, GCLOUD_PREREQUISITE, GPU_PREREQUISITES,
 };
-use config::{get_link_to_prover, EcosystemConfig};
-use xshell::{cmd, Shell};
+use zkstack_cli_config::{get_link_to_prover, EcosystemConfig};
 
 use crate::{
     commands::prover::args::setup_keys::{Mode, Region, SetupKeysArgs},

--- a/zkstack_cli/crates/zkstack/src/commands/server.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/server.rs
@@ -1,15 +1,15 @@
 use anyhow::Context;
-use common::{
+use xshell::{cmd, Shell};
+use zkstack_cli_common::{
     cmd::Cmd,
     config::global_config,
     logger,
     server::{Server, ServerMode},
 };
-use config::{
+use zkstack_cli_config::{
     traits::FileConfigWithDefaultName, ChainConfig, ContractsConfig, EcosystemConfig,
     GeneralConfig, GenesisConfig, SecretsConfig, WalletsConfig,
 };
-use xshell::{cmd, Shell};
 
 use crate::{
     commands::args::{RunServerArgs, ServerArgs, ServerCommand, WaitArgs},

--- a/zkstack_cli/crates/zkstack/src/commands/update.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/update.rs
@@ -1,17 +1,17 @@
 use std::path::Path;
 
 use anyhow::{Context, Ok};
-use common::{
+use xshell::Shell;
+use zkstack_cli_common::{
     db::migrate_db,
     git, logger,
     spinner::Spinner,
     yaml::{merge_yaml, ConfigDiff},
 };
-use config::{
+use zkstack_cli_config::{
     ChainConfig, EcosystemConfig, CONTRACTS_FILE, EN_CONFIG_FILE, ERA_OBSERBAVILITY_DIR,
     GENERAL_FILE, GENESIS_FILE, SECRETS_FILE,
 };
-use xshell::Shell;
 
 use super::args::UpdateArgs;
 use crate::{

--- a/zkstack_cli/crates/zkstack/src/defaults.rs
+++ b/zkstack_cli/crates/zkstack/src/defaults.rs
@@ -1,6 +1,6 @@
-use config::ChainConfig;
 use lazy_static::lazy_static;
 use url::Url;
+use zkstack_cli_config::ChainConfig;
 
 lazy_static! {
     pub static ref DATABASE_SERVER_URL: Url =

--- a/zkstack_cli/crates/zkstack/src/enable_evm_emulator.rs
+++ b/zkstack_cli/crates/zkstack/src/enable_evm_emulator.rs
@@ -1,11 +1,13 @@
-use common::{
+use ethers::{abi::parse_abi, contract::BaseContract, types::Address};
+use xshell::Shell;
+use zkstack_cli_common::{
     forge::{Forge, ForgeScript, ForgeScriptArgs},
     spinner::Spinner,
     wallets::Wallet,
 };
-use config::{forge_interface::script_params::ENABLE_EVM_EMULATOR_PARAMS, EcosystemConfig};
-use ethers::{abi::parse_abi, contract::BaseContract, types::Address};
-use xshell::Shell;
+use zkstack_cli_config::{
+    forge_interface::script_params::ENABLE_EVM_EMULATOR_PARAMS, EcosystemConfig,
+};
 
 use crate::{
     messages::MSG_ENABLING_EVM_EMULATOR,

--- a/zkstack_cli/crates/zkstack/src/external_node.rs
+++ b/zkstack_cli/crates/zkstack/src/external_node.rs
@@ -1,11 +1,11 @@
 use std::path::PathBuf;
 
 use anyhow::Context;
-use config::{
+use xshell::Shell;
+use zkstack_cli_config::{
     external_node::ENConfig, traits::FileConfigWithDefaultName, ChainConfig, GeneralConfig,
     SecretsConfig,
 };
-use xshell::Shell;
 use zksync_config::configs::consensus::ConsensusConfig;
 
 use crate::messages::MSG_FAILED_TO_RUN_SERVER_ERR;
@@ -63,7 +63,7 @@ impl RunExternalNode {
             consensus_args.push(format!("--consensus-path={}", consensus_config))
         }
 
-        common::external_node::run(
+        zkstack_cli_common::external_node::run(
             shell,
             code_path,
             config_general_config,

--- a/zkstack_cli/crates/zkstack/src/main.rs
+++ b/zkstack_cli/crates/zkstack/src/main.rs
@@ -4,15 +4,15 @@ use commands::{
     contract_verifier::ContractVerifierCommands,
     dev::DevCommands,
 };
-use common::{
+use xshell::Shell;
+use zkstack_cli_common::{
     check_general_prerequisites,
     config::{global_config, init_global_config, GlobalConfig},
     error::log_error,
     init_prompt_theme, logger,
     version::version_message,
 };
-use config::EcosystemConfig;
-use xshell::Shell;
+use zkstack_cli_config::EcosystemConfig;
 
 use crate::commands::{
     args::ServerArgs, chain::ChainCommands, consensus, ecosystem::EcosystemCommands,

--- a/zkstack_cli/crates/zkstack/src/utils/consensus.rs
+++ b/zkstack_cli/crates/zkstack/src/utils/consensus.rs
@@ -1,6 +1,6 @@
 use anyhow::Context as _;
-use config::ChainConfig;
 use secrecy::{ExposeSecret, Secret};
+use zkstack_cli_config::ChainConfig;
 use zksync_config::configs::consensus::{
     AttesterPublicKey, AttesterSecretKey, ConsensusSecrets, GenesisSpec, NodePublicKey,
     NodeSecretKey, ProtocolVersion, ValidatorPublicKey, ValidatorSecretKey, WeightedAttester,

--- a/zkstack_cli/crates/zkstack/src/utils/forge.rs
+++ b/zkstack_cli/crates/zkstack/src/utils/forge.rs
@@ -1,6 +1,6 @@
 use anyhow::Context as _;
-use common::{forge::ForgeScript, wallets::Wallet};
 use ethers::types::U256;
+use zkstack_cli_common::{forge::ForgeScript, wallets::Wallet};
 
 use crate::{
     consts::MINIMUM_BALANCE_FOR_WALLET,
@@ -37,7 +37,7 @@ pub async fn check_the_balance(forge: &ForgeScript) -> anyhow::Result<()> {
         if balance >= expected_balance {
             return Ok(());
         }
-        if !common::PromptConfirm::new(msg_address_doesnt_have_enough_money_prompt(
+        if !zkstack_cli_common::PromptConfirm::new(msg_address_doesnt_have_enough_money_prompt(
             &address,
             balance,
             expected_balance,

--- a/zkstack_cli/crates/zkstack/src/utils/link_to_code.rs
+++ b/zkstack_cli/crates/zkstack/src/utils/link_to_code.rs
@@ -4,10 +4,12 @@ use std::{
 };
 
 use anyhow::bail;
-use common::{cmd::Cmd, git, logger, spinner::Spinner, Prompt, PromptConfirm, PromptSelect};
-use config::ZKSYNC_ERA_GIT_REPO;
 use strum::{EnumIter, IntoEnumIterator};
 use xshell::{cmd, Shell};
+use zkstack_cli_common::{
+    cmd::Cmd, git, logger, spinner::Spinner, Prompt, PromptConfirm, PromptSelect,
+};
+use zkstack_cli_config::ZKSYNC_ERA_GIT_REPO;
 
 use crate::messages::{
     msg_path_to_zksync_does_not_exist_err, MSG_CLONING_ERA_REPO_SPINNER,

--- a/zkstack_cli/crates/zkstack/src/utils/ports.rs
+++ b/zkstack_cli/crates/zkstack/src/utils/ports.rs
@@ -1,13 +1,13 @@
 use std::{collections::HashMap, fmt, net::SocketAddr, ops::Range, path::Path};
 
 use anyhow::{bail, Context, Result};
-use config::{
-    explorer_compose::ExplorerBackendPorts, EcosystemConfig, DEFAULT_EXPLORER_API_PORT,
-    DEFAULT_EXPLORER_DATA_FETCHER_PORT, DEFAULT_EXPLORER_WORKER_PORT,
-};
 use serde_yaml::Value;
 use url::Url;
 use xshell::Shell;
+use zkstack_cli_config::{
+    explorer_compose::ExplorerBackendPorts, EcosystemConfig, DEFAULT_EXPLORER_API_PORT,
+    DEFAULT_EXPLORER_DATA_FETCHER_PORT, DEFAULT_EXPLORER_WORKER_PORT,
+};
 
 use crate::defaults::{DEFAULT_OBSERVABILITY_PORT, PORT_RANGE_END, PORT_RANGE_START};
 

--- a/zkstack_cli/crates/zkstack/src/utils/rocks_db.rs
+++ b/zkstack_cli/crates/zkstack/src/utils/rocks_db.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use config::RocksDbs;
 use xshell::Shell;
+use zkstack_cli_config::RocksDbs;
 
 use crate::defaults::{
     EN_ROCKS_DB_PREFIX, MAIN_ROCKS_DB_PREFIX, ROCKS_DB_BASIC_WITNESS_INPUT_PRODUCER,


### PR DESCRIPTION
## What ❔

* [x] Rename `zkstack_cli` crates with unique names for publishing.
* [x] Set individual versions of the `zkstack_cli` workspace crates to the common workspace version. 

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To allow publishing to crates.io.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
