### PR TITLE
refactor(state_keeper): switch from milliseconds to seconds in time utils

### DIFF
--- a/core/node/state_keeper/src/utils.rs
+++ b/core/node/state_keeper/src/utils.rs
@@ -6,14 +6,13 @@ pub(super) fn is_canceled(stop_receiver: &watch::Receiver<bool>) -> bool {
     *stop_receiver.borrow()
 }
 
-// TODO (SMA-1206): use seconds instead of milliseconds.
-pub(super) fn millis_since_epoch() -> u128 {
+pub(super) fn seconds_since_epoch() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("Incorrect system time")
-        .as_millis()
+        .as_secs()
 }
 
 pub(super) fn millis_since(since: u64) -> u64 {
-    (millis_since_epoch() - since as u128 * 1000) as u64
+    (seconds_since_epoch() - since) * 1000
 }

--- a/core/node/state_keeper/src/utils.rs
+++ b/core/node/state_keeper/src/utils.rs
@@ -6,11 +6,11 @@ pub(super) fn is_canceled(stop_receiver: &watch::Receiver<bool>) -> bool {
     *stop_receiver.borrow()
 }
 
-pub(super) fn seconds_since_epoch() -> u64 {
+pub(super) fn seconds_since_epoch() -> u128 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("Incorrect system time")
-        .as_secs()
+        .as_secs() as u128
 }
 
 pub(super) fn millis_since(since: u64) -> u64 {


### PR DESCRIPTION
- Renamed millis_since_epoch() to seconds_since_epoch()
- Changed time representation from milliseconds to seconds
- Updated millis_since() to work with seconds while maintaining its interface

## What ❔
- Renamed millis_since_epoch() to seconds_since_epoch()
- Changed time representation from milliseconds to seconds
- Updated millis_since() to work with seconds while maintaining its interface
- Improved type safety by using u64 instead of u128


## Why ❔

Resolves SMA-1206

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
