### PR TITLE
fix(zkstack): shouldn't attempt to create db on migrate command

### DIFF
--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/migrate.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/migrate.rs
@@ -42,11 +42,6 @@ fn migrate_database(shell: &Shell, link_to_code: impl AsRef<Path>, dal: Dal) -> 
         MSG_DATABASE_MIGRATE_GERUND,
         &dal.path,
     ));
-    Cmd::new(cmd!(
-        shell,
-        "cargo sqlx database create --database-url {url}"
-    ))
-    .run()?;
     Cmd::new(cmd!(shell, "cargo sqlx migrate run --database-url {url}")).run()?;
     spinner.finish();
 


### PR DESCRIPTION
## What ❔
`zkstack dev migrate` attempts to create a database first before performing the migration. It should instead only try to perform the migration, and fail if the database does not exist.

## Why ❔
Keeping the create database command may potentially drop and recreate the database - the current behaviour of `cargo sqlx database create` doesn't do this, but it may change in the future. Furthermore, even if the database doesn't exist, it doesn't make sense for a migrate command to perform database creation.

## Checklist
- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
