### PR TITLE
fix(api): Improve estimation for gas_per_pubdata_limit

### DIFF
--- a/core/node/api_server/src/tx_sender/gas_estimation.rs
+++ b/core/node/api_server/src/tx_sender/gas_estimation.rs
@@ -530,11 +530,18 @@ impl<'a> GasEstimator<'a> {
             gas_per_pubdata_byte = self.gas_per_pubdata_byte
         );
 
+        // Given that we scale overall fee, we should also scale the limit for gas per pubdata price that user agrees to.
+        // However, we should not exceed the limit that was provided by the user in the initial request.
+        let gas_per_pubdata_limit = std::cmp::min(
+            ((self.gas_per_pubdata_byte as f64 * estimated_fee_scale_factor) as u64).into(),
+            self.transaction.gas_per_pubdata_byte_limit(),
+        );
+
         Ok(Fee {
             max_fee_per_gas: self.base_fee.into(),
             max_priority_fee_per_gas: 0u32.into(),
             gas_limit: full_gas_limit.into(),
-            gas_per_pubdata_limit: self.gas_per_pubdata_byte.into(),
+            gas_per_pubdata_limit,
         })
     }
 }


### PR DESCRIPTION
Fixes the `gas_per_pubdata_limit` field calculation. Right now, we provide the value we get from deriving the existing batch input, which is most likely lower than limit provided in fee estimation request.
Given that we scale the overall fee, it should be safe to scale the limit as well, as long as we don't go beyond the limit supplied in the tx.

Providing the limit as-is without scaling can be very flaky: transaction risks to be left in the mempool over minor `gas_per_pubdata` changes.