### PR TITLE
fix: eth aggregator restriction

### DIFF
--- a/core/node/eth_sender/src/aggregator.rs
+++ b/core/node/eth_sender/src/aggregator.rs
@@ -69,8 +69,7 @@ impl OperationSkippingRestrictions {
     ) -> bool {
         if let Some(reason) = reason {
             tracing::info!(
-                "Skipping sending commit operation of type {} for batches {}-{} \
-            since {}",
+                "Skipping sending operation of type {} for batches {}-{} since {}",
                 agg_op.get_action_type(),
                 agg_op.l1_batch_range().start(),
                 agg_op.l1_batch_range().end(),
@@ -95,13 +94,13 @@ impl OperationSkippingRestrictions {
 
     fn filter_prove_op(&self, prove_op: Option<ProveBatches>) -> Option<AggregatedOperation> {
         let op = AggregatedOperation::PublishProofOnchain(prove_op?);
-        self.check_for_continuation(&op, self.commit_restriction)
+        self.check_for_continuation(&op, self.prove_restriction)
             .then_some(op)
     }
 
     fn filter_execute_op(&self, execute_op: Option<ExecuteBatches>) -> Option<AggregatedOperation> {
         let op = AggregatedOperation::Execute(execute_op?);
-        self.check_for_continuation(&op, self.commit_restriction)
+        self.check_for_continuation(&op, self.execute_restriction)
             .then_some(op)
     }
 }


### PR DESCRIPTION
## What ❔

fixes eth aggregator restrictions

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
