### PR TITLE
chore: fix zkstack completion for zsh

### DIFF
--- a/zkstack_cli/crates/zkstack/build.rs
+++ b/zkstack_cli/crates/zkstack/build.rs
@@ -112,15 +112,22 @@ impl ShellAutocomplete for clap_complete::Shell {
                         .context(format!("could not read .{}rc", shell))?;
 
                     if !shell_rc_content.contains("# zkstack completion") {
-                        std::fs::write(
-                            shell_rc,
+                        let completion_snippet = if shell == "zsh" {
+                            format!(
+                                "{}\n# zkstack completion\nautoload -Uz compinit\ncompinit\nsource \"{}\"\n",
+                                shell_rc_content,
+                                completion_file.to_str().unwrap()
+                            )
+                        } else {
                             format!(
                                 "{}\n# zkstack completion\nsource \"{}\"\n",
                                 shell_rc_content,
                                 completion_file.to_str().unwrap()
-                            ),
-                        )
-                        .context(format!("could not write .{}rc", shell))?;
+                            )
+                        };
+
+                        std::fs::write(shell_rc, completion_snippet)
+                            .context(format!("could not write .{}rc", shell))?;
                     }
                 } else {
                     println!(


### PR DESCRIPTION
## What ❔

Fixes `zkstack` completion for `zsh` shell.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

For `zsh` shell default completion will fail with the following error:
`command not found: compdef`
because autocompletion is not activated by default.

This PR adds the following to activate it on `zsh` in addition to `source` of the autocompletion script:
```
autoload -Uz compinit
compinit
```

*[Related thread](https://unix.stackexchange.com/questions/339954/zsh-command-not-found-compinstall-compinit-compdef)

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
