### PR TITLE
fix: update erc20 bridge address in bridge updater as well

### DIFF
--- a/core/node/api_server/src/web3/state.rs
+++ b/core/node/api_server/src/web3/state.rs
@@ -237,8 +237,9 @@ impl BridgeAddressesHandle {
         *self.0.write().await = bridge_addresses;
     }
 
-    pub async fn update_l1_shared_bridge(&self, l1_shared_bridge: Address) {
+    pub async fn update_l1_shared_and_erc20_bridges(&self, l1_shared_bridge: Address) {
         self.0.write().await.l1_shared_default_bridge = Some(l1_shared_bridge);
+        self.0.write().await.l1_erc20_default_bridge = Some(l1_shared_bridge);
     }
 
     pub async fn update_l2_shared_bridge(&self, l2_shared_bridge: Address) {

--- a/core/node/node_framework/src/implementations/layers/web3_api/server/bridge_addresses.rs
+++ b/core/node/node_framework/src/implementations/layers/web3_api/server/bridge_addresses.rs
@@ -73,7 +73,7 @@ impl L1UpdaterInner {
         match self.get_shared_bridge_info().await {
             Ok(info) => {
                 self.bridge_address_updater
-                    .update_l1_shared_bridge(info.l1_shared_bridge_addr)
+                    .update_l1_shared_and_erc20_bridges(info.l1_shared_bridge_addr)
                     .await;
                 // We only update one way:
                 // - Once the L2 asset router should be used, there is never a need to go back


### PR DESCRIPTION
## What ❔

update erc20 bridge address in bridge updater as well as shared bridge address

## Why ❔

EN wants them to be in sync

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
