### PR TITLE
Fix JoinHandle import issue by enabling 'rt' feature in Tokio

### DIFF
--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -57,7 +57,7 @@ structopt = "0.3.26"
 strum = { version = "0.26" }
 strum_macros = "0.26"
 tempfile = "3"
-tokio = "1"
+tokio = { version = "1", features = ["rt"] }
 tokio-util = "0.7.11"
 tokio-stream = "0.1.16"
 toml_edit = "0.14.4"
@@ -71,13 +71,13 @@ vise = "0.2.0"
 circuit_definitions = "=0.150.19"
 circuit_sequencer_api = "=0.150.19"
 zkevm_test_harness = "=0.150.19"
-proof-compression-gpu = { package = "proof-compression", version = "=0.152.10"}
-fflonk-gpu = { package = "fflonk-cuda", version = "=0.152.10"}
+proof-compression-gpu = { package = "proof-compression", version = "=0.152.10" }
+fflonk-gpu = { package = "fflonk-cuda", version = "=0.152.10" }
 fflonk = "=0.30.12"
 franklin-crypto = "=0.30.12"
 
 # GPU proving dependencies
-wrapper_prover = { package = "zksync-wrapper-prover", version = "=0.152.10"}
+wrapper_prover = { package = "zksync-wrapper-prover", version = "=0.152.10" }
 shivini = "=0.152.10"
 boojum-cuda = "=0.152.10"
 


### PR DESCRIPTION
### Description
This PR resolves the build failure in [`zksync_prover_job_processor`](https://github.com/matter-labs/zksync-era/tree/main/prover/crates/lib/prover_job_processor) caused by the following error:
```
error[E0432]: unresolved import tokio::task::JoinHandle
   --> crates/lib/prover_job_processor/src/job_runner.rs:1:5
    |
1   | use tokio::task::JoinHandle;
    |     ^^^^^^^^^^^^^^^^^^^^^^^ no JoinHandle in task
```
The error occurred because `JoinHandle` was gated behind the `rt` feature in Tokio, which was disabled. Enabling the feature resolves the import and fixes the build.