### PR TITLE
test: make fee tests robust

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -516,12 +516,8 @@ jobs:
             ci_run zkstack server wait --ignore-prerequisites --verbose --chain gateway
           fi
 
-          for i in {1..10}
-          do
-            mkdir -p ${{ env.FEES_LOGS_DIR }}/$i
-            # Always run the chain-specific fee tests
-            ci_run ./bin/run_on_all_chains.sh "zkstack dev test fees --no-deps --no-kill" ${{ env.CHAINS }} ${{ env.FEES_LOGS_DIR }}/$i
-          done
+          # Always run the chain-specific fee tests
+          ci_run ./bin/run_on_all_chains.sh "zkstack dev test fees --no-deps --no-kill" ${{ env.CHAINS }} ${{ env.FEES_LOGS_DIR }}
 
       - name: Run revert tests
         run: |

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -516,8 +516,12 @@ jobs:
             ci_run zkstack server wait --ignore-prerequisites --verbose --chain gateway
           fi
 
-          # Always run the chain-specific fee tests
-          ci_run ./bin/run_on_all_chains.sh "zkstack dev test fees --no-deps --no-kill" ${{ env.CHAINS }} ${{ env.FEES_LOGS_DIR }}
+          for i in {1..10}
+          do
+            mkdir -p ${{ env.FEES_LOGS_DIR }}/$i
+            # Always run the chain-specific fee tests
+            ci_run ./bin/run_on_all_chains.sh "zkstack dev test fees --no-deps --no-kill" ${{ env.CHAINS }} ${{ env.FEES_LOGS_DIR }}/$i
+          done
 
       - name: Run revert tests
         run: |

--- a/core/tests/recovery-test/package.json
+++ b/core/tests/recovery-test/package.json
@@ -23,7 +23,7 @@
     "@types/node": "^18.19.15",
     "@types/node-fetch": "^2.5.7",
     "chai": "^4.3.4",
-    "ethers": "^6.7.1",
+    "ethers": "^6.13.5",
     "mocha": "^9.0.2",
     "mocha-steps": "^1.3.0",
     "node-fetch": "^2.6.1",

--- a/core/tests/revert-test/package.json
+++ b/core/tests/revert-test/package.json
@@ -24,7 +24,7 @@
     "@types/node-fetch": "^2.5.7",
     "chai": "^4.3.4",
     "ethereumjs-abi": "^0.6.8",
-    "ethers": "^6.7.1",
+    "ethers": "^6.13.5",
     "mocha": "^9.0.2",
     "mocha-steps": "^1.3.0",
     "node-fetch": "^2.6.1",

--- a/core/tests/ts-integration/package.json
+++ b/core/tests/ts-integration/package.json
@@ -24,7 +24,7 @@
     "chalk": "^4.0.0",
     "elliptic": "^6.5.5",
     "ethereumjs-abi": "^0.6.8",
-    "ethers": "^6.7.1",
+    "ethers": "^6.13.5",
     "hardhat": "=2.22.2",
     "jest": "^29.0.3",
     "jest-environment-node": "^29.0.3",

--- a/core/tests/ts-integration/src/context-owner.ts
+++ b/core/tests/ts-integration/src/context-owner.ts
@@ -612,8 +612,24 @@ export class TestContextOwner {
                 await this.waitForVmPlayground();
                 this.reporter.finishAction();
             }
-            this.reporter.startAction(`Tearing down the context`);
+            this.reporter.startAction(`Collecting funds`);
             await this.collectFunds();
+            this.reporter.finishAction();
+            this.reporter.startAction(`Destroying providers`);
+            // Destroy providers so that they drop potentially active connections to the node. Not doing so might cause
+            // unexpected network errors to propagate during node termination.
+            try {
+                this.l1Provider.destroy();
+            } catch (err: any) {
+                // Catch any request cancellation errors that propagate here after destroying L1 provider
+                console.log(`Caught error while destroying L1 provider: ${err}`);
+            }
+            try {
+                this.l2Provider.destroy();
+            } catch (err: any) {
+                // Catch any request cancellation errors that propagate here after destroying L2 provider
+                console.log(`Caught error while destroying L2 provider: ${err}`);
+            }
             this.reporter.finishAction();
         } catch (error: any) {
             // Report the issue to the console and mark the last action as failed.

--- a/core/tests/ts-integration/src/helpers.ts
+++ b/core/tests/ts-integration/src/helpers.ts
@@ -3,7 +3,6 @@ import * as zksync from 'zksync-ethers';
 import * as ethers from 'ethers';
 import * as hre from 'hardhat';
 import { ZkSyncArtifact } from '@matterlabs/hardhat-zksync-solc/dist/src/types';
-import { TransactionReceipt } from 'ethers';
 
 export const SYSTEM_CONTEXT_ADDRESS = '0x000000000000000000000000000000000000800b';
 
@@ -78,8 +77,8 @@ export async function anyTransaction(wallet: zksync.Wallet): Promise<ethers.Tran
 export async function waitForNewL1Batch(wallet: zksync.Wallet): Promise<zksync.types.TransactionReceipt> {
     const MAX_ATTEMPTS = 3;
 
-    let txResponse = null;
-    let txReceipt: TransactionReceipt | null = null;
+    let txResponse: ethers.TransactionResponse | null = null;
+    let txReceipt: ethers.TransactionReceipt | null = null;
     let nonce = Number(await wallet.getNonce());
     for (let i = 0; i < MAX_ATTEMPTS; i++) {
         // Send a dummy transaction and wait for it to execute. We override `maxFeePerGas` as the default ethers behavior
@@ -87,11 +86,31 @@ export async function waitForNewL1Batch(wallet: zksync.Wallet): Promise<zksync.t
         // extreme gas price fluctuations.
         let gasPrice = await wallet.provider.getGasPrice();
         if (!txResponse || !txResponse.maxFeePerGas || txResponse.maxFeePerGas < gasPrice) {
-            txResponse = await wallet.transfer({
-                to: wallet.address,
-                amount: 0,
-                overrides: { maxFeePerGas: gasPrice, nonce: nonce, maxPriorityFeePerGas: 0, type: 2 }
-            });
+            txResponse = await wallet
+                .transfer({
+                    to: wallet.address,
+                    amount: 0,
+                    overrides: { maxFeePerGas: gasPrice, nonce: nonce, maxPriorityFeePerGas: 0, type: 2 }
+                })
+                .catch((e) => {
+                    // Unlike `waitForTransaction` below, these errors are not wrapped as `EthersError` for some reason
+                    if (<Error>e.message.match(/Not enough gas/)) {
+                        console.log(
+                            `Transaction did not have enough gas, likely gas price went up (attempt ${i + 1}/${MAX_ATTEMPTS})`
+                        );
+                        return null;
+                    } else if (<Error>e.message.match(/max fee per gas less than block base fee/)) {
+                        console.log(
+                            `Transaction's max fee per gas was lower than block base fee, likely gas price went up (attempt ${i + 1}/${MAX_ATTEMPTS})`
+                        );
+                        return null;
+                    } else {
+                        return Promise.reject(e);
+                    }
+                });
+            if (!txResponse) {
+                continue;
+            }
         } else {
             console.log('Gas price has not gone up, waiting longer');
         }

--- a/core/tests/ts-integration/tests/fees.test.ts
+++ b/core/tests/ts-integration/tests/fees.test.ts
@@ -410,9 +410,13 @@ testFees('Test fees', function () {
     });
 
     afterAll(async () => {
-        await mainNodeSpawner.killAndSpawnMainNode();
         // Returning the pubdata price to the default one
         // Spawning with no options restores defaults.
+        await mainNodeSpawner.killAndSpawnMainNode();
+
+        // Wait for current batch to close so gas price returns to normal.
+        await waitForNewL1Batch(alice);
+
         await testMaster.deinitialize();
         __ZKSYNC_TEST_CONTEXT_OWNER__.setL2NodePid(mainNodeSpawner.mainNode!.proc.pid!);
     });

--- a/core/tests/upgrade-test/package.json
+++ b/core/tests/upgrade-test/package.json
@@ -23,7 +23,7 @@
     "@types/node-fetch": "^2.5.7",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
-    "ethers": "^6.7.1",
+    "ethers": "^6.13.5",
     "mocha": "^9.0.2",
     "mocha-steps": "^1.3.0",
     "node-fetch": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2943,10 +2943,12 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
   integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
 
-"@types/node@18.15.13":
-  version "18.15.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.13.tgz#f64277c341150c979e42b00e4ac289290c9df469"
-  integrity sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==
+"@types/node@22.7.5":
+  version "22.7.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.5.tgz#cfde981727a7ab3611a481510b473ae54442b92b"
+  integrity sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==
+  dependencies:
+    undici-types "~6.19.2"
 
 "@types/node@^10.0.3":
   version "10.17.60"
@@ -5487,18 +5489,18 @@ ethers@^5.0.2, ethers@^5.7.0, ethers@^5.7.2, ethers@~5.7.0, ethers@~5.7.2:
     "@ethersproject/web" "5.7.1"
     "@ethersproject/wordlists" "5.7.0"
 
-ethers@^6.7.1:
-  version "6.12.1"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.12.1.tgz#517ff6d66d4fd5433e38e903051da3e57c87ff37"
-  integrity sha512-j6wcVoZf06nqEcBbDWkKg8Fp895SS96dSnTCjiXT+8vt2o02raTn4Lo9ERUuIVU5bAjoPYeA+7ytQFexFmLuVw==
+ethers@^6.13.5:
+  version "6.13.5"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.13.5.tgz#8c1d6ac988ac08abc3c1d8fabbd4b8b602851ac4"
+  integrity sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==
   dependencies:
     "@adraffy/ens-normalize" "1.10.1"
     "@noble/curves" "1.2.0"
     "@noble/hashes" "1.3.2"
-    "@types/node" "18.15.13"
+    "@types/node" "22.7.5"
     aes-js "4.0.0-beta.5"
-    tslib "2.4.0"
-    ws "8.5.0"
+    tslib "2.7.0"
+    ws "8.17.1"
 
 ethers@~5.5.0:
   version "5.5.4"
@@ -10791,10 +10793,10 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
-  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+tslib@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
+  integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
 
 tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
@@ -11006,6 +11008,11 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+undici-types@~6.19.2:
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
+  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
 undici@^5.14.0:
   version "5.28.4"
@@ -11287,10 +11294,10 @@ ws@7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
-ws@8.5.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
-  integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
+ws@8.17.1:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
+  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
 
 ws@^7.4.6:
   version "7.5.9"


### PR DESCRIPTION
## What ❔

A bunch of small improvements to make fee tests robust:
* Upgrade ethers
* Catch retryable networking issues in `ethers.FetchRequest`
* Destroy providers on context teardown to avoid econnreset
* Retry fee-related issues that can arise when transaction is rejected by mempool

## Why ❔

Fee tests are disruptively flaky right now

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
