### PR TITLE
fix: JSON proof serialization

### DIFF
--- a/core/lib/prover_interface/src/outputs.rs
+++ b/core/lib/prover_interface/src/outputs.rs
@@ -13,6 +13,7 @@ use zksync_types::{protocol_version::ProtocolSemanticVersion, tee_types::TeeType
 
 /// A "final" ZK proof that can be sent to the L1 contract.
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(untagged)]
 #[allow(clippy::large_enum_variant)]
 pub enum L1BatchProofForL1 {
     Fflonk(FflonkL1BatchProofForL1),

--- a/core/lib/prover_interface/tests/job_serialization.rs
+++ b/core/lib/prover_interface/tests/job_serialization.rs
@@ -102,8 +102,7 @@ fn test_proof_request_serialization() {
     let encoded_obj = serde_json::to_string(&proof).unwrap();
     let encoded_json = r#"{
         "Proof": {
-            "Plonk": {
-                "aggregation_result_coords": [
+            "aggregation_result_coords": [
                     [
                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
                     ],
@@ -159,7 +158,6 @@ fn test_proof_request_serialization() {
                 },
                 "protocol_version": "0.25.10"
             }
-        }
     }"#;
     let decoded_obj: SubmitProofRequest = serde_json::from_str(&encoded_obj).unwrap();
     let decoded_json: SubmitProofRequest = serde_json::from_str(encoded_json).unwrap();


### PR DESCRIPTION
## What ❔

Add `#[serde(untagged)]` for L1BatchProofForL1 to ensure backwards compatibility.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
