### PR TITLE
fix(en): Fix race condition in EN storage initialization

### DIFF
--- a/core/node/node_storage_init/src/external_node/revert.rs
+++ b/core/node/node_storage_init/src/external_node/revert.rs
@@ -34,6 +34,12 @@ impl RevertStorage for ExternalNodeReverter {
         Ok(())
     }
 
+    async fn is_reorg_needed(&self, stop_receiver: watch::Receiver<bool>) -> anyhow::Result<bool> {
+        ReorgDetector::new(self.client.clone(), self.pool.clone())
+            .check_reorg_presence(stop_receiver)
+            .await
+    }
+
     async fn last_correct_batch_for_reorg(
         &self,
         stop_receiver: watch::Receiver<bool>,

--- a/core/node/node_storage_init/src/lib.rs
+++ b/core/node/node_storage_init/src/lib.rs
@@ -182,10 +182,7 @@ impl NodeStorageInitializer {
     ) -> anyhow::Result<bool> {
         // May be `true` if stop signal is received, but the node will shut down without launching any tasks anyway.
         let initialized = if let Some(reverter) = &self.strategy.block_reverter {
-            reverter
-                .last_correct_batch_for_reorg(stop_receiver)
-                .await?
-                .is_none()
+            !reverter.is_reorg_needed(stop_receiver).await?
         } else {
             true
         };

--- a/core/node/node_storage_init/src/traits.rs
+++ b/core/node/node_storage_init/src/traits.rs
@@ -18,6 +18,9 @@ pub trait InitializeStorage: fmt::Debug + Send + Sync + 'static {
 /// This trait assumes that for any invalid state there exists a batch number to which the storage can be rolled back.
 #[async_trait::async_trait]
 pub trait RevertStorage: fmt::Debug + Send + Sync + 'static {
+    /// Checks whether a reorg is needed for the storage.
+    async fn is_reorg_needed(&self, stop_receiver: watch::Receiver<bool>) -> anyhow::Result<bool>;
+
     /// Checks if the storage is invalid state and has to be rolled back.
     async fn last_correct_batch_for_reorg(
         &self,


### PR DESCRIPTION
## What ❔

Reworks `NodeStorageInitializer::is_chain_tip_correct()` so that it performs the minimum amount of work possible, i.e. detects whether the latest L1 batch / L2 block diverge or not.

## Why ❔

EN storage initialization is prone to a data race: the "is storage initialized" check calls `NodeStorageInitializer::is_chain_tip_correct()`, which internally performs the entire iteration of the reorg detector (in particular, binary search for the first diverged block). This can lead to a data race with block revert logic, which may be executed concurrently. This data race was observed on the revert integration tests.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.