### PR TITLE
ci: fix nonce reuse

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -504,7 +504,11 @@ jobs:
 
       - name: Run integration tests en
         run: |
-          ci_run ./bin/run_on_all_chains.sh "zkstack dev test integration --no-deps --ignore-prerequisites --external-node" ${{ env.CHAINS }} ${{ env.INTEGRATION_TESTS_LOGS_DIR }}
+          for i in {1..10}
+          do
+            mkdir -p ${{ env.INTEGRATION_TESTS_EN_LOGS_DIR }}/$i
+            ci_run ./bin/run_on_all_chains.sh "zkstack dev test integration --no-deps --ignore-prerequisites --external-node" ${{ env.CHAINS }} ${{ env.INTEGRATION_TESTS_EN_LOGS_DIR }}/$i
+          done
 
       - name: Fee projection tests
         run: |

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -504,11 +504,7 @@ jobs:
 
       - name: Run integration tests en
         run: |
-          for i in {1..10}
-          do
-            mkdir -p ${{ env.INTEGRATION_TESTS_EN_LOGS_DIR }}/$i
-            ci_run ./bin/run_on_all_chains.sh "zkstack dev test integration --no-deps --ignore-prerequisites --external-node" ${{ env.CHAINS }} ${{ env.INTEGRATION_TESTS_EN_LOGS_DIR }}/$i
-          done
+          ci_run ./bin/run_on_all_chains.sh "zkstack dev test integration --no-deps --ignore-prerequisites --external-node" ${{ env.CHAINS }} ${{ env.INTEGRATION_TESTS_LOGS_DIR }}
 
       - name: Fee projection tests
         run: |


### PR DESCRIPTION
## What ❔

In a very unlikely scenario timeouted tx can still succeed in the short window while we are resubmitting it with updated gas. This PR handles this gracefully + another case when nonce might have been used asynchronously by someone else.

## Why ❔

Good ol' flakiness

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
