### PR TITLE
fix: Compressor setup data

### DIFF
--- a/prover/crates/lib/keystore/src/keystore.rs
+++ b/prover/crates/lib/keystore/src/keystore.rs
@@ -132,12 +132,12 @@ impl Keystore {
             ProverServiceDataType::FinalizationHints => self
                 .basedir
                 .join(format!("finalization_hints_{}.bin", name)),
-            ProverServiceDataType::PlonkSetupData => {
-                self.setup_data_path.join(format!("plonk_setup_{}_data.bin", name))
-            }
-            ProverServiceDataType::FflonkSetupData => {
-                self.setup_data_path.join(format!("fflonk_setup_{}_data.bin", name))
-            }
+            ProverServiceDataType::PlonkSetupData => self
+                .setup_data_path
+                .join(format!("plonk_setup_{}_data.bin", name)),
+            ProverServiceDataType::FflonkSetupData => self
+                .setup_data_path
+                .join(format!("fflonk_setup_{}_data.bin", name)),
             ProverServiceDataType::SnarkVerificationKey => {
                 self.basedir.join(format!("verification_{}_key.json", name))
             }

--- a/prover/crates/lib/keystore/src/keystore.rs
+++ b/prover/crates/lib/keystore/src/keystore.rs
@@ -133,10 +133,10 @@ impl Keystore {
                 .basedir
                 .join(format!("finalization_hints_{}.bin", name)),
             ProverServiceDataType::PlonkSetupData => {
-                self.basedir.join(format!("plonk_setup_{}_data.bin", name))
+                self.setup_data_path.join(format!("plonk_setup_{}_data.bin", name))
             }
             ProverServiceDataType::FflonkSetupData => {
-                self.basedir.join(format!("fflonk_setup_{}_data.bin", name))
+                self.setup_data_path.join(format!("fflonk_setup_{}_data.bin", name))
             }
             ProverServiceDataType::SnarkVerificationKey => {
                 self.basedir.join(format!("verification_{}_key.json", name))


### PR DESCRIPTION
## What ❔

Load compressor setup data from the right dir

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
