### PR TITLE
fix typo README.md

### DIFF
--- a/zkstack_cli/crates/zkstack/README.md
+++ b/zkstack_cli/crates/zkstack/README.md
@@ -545,7 +545,7 @@ Setup keys
 
 - `--mode`
 
-  Possible valuess: `download`, `generate`
+  Possible values: `download`, `generate`
 
 - `--region`
 


### PR DESCRIPTION
### Title
`fix typo README.md`

### Description
This pull request fixes a typo in the `zkstack_cli/crates/zkstack/README.md` file:
- Corrected "valuess" to "values" in the options description for the `--mode` argument.

### Details of Changes
- Replaced the incorrect spelling "valuess" with the correct "values" in the `--mode` section of the README.

### Checklist
- [x] The typo has been corrected.
- [x] Changes reviewed for accuracy.
- [x] Documentation remains consistent with the repository's standards.

### Additional Notes
This is an editorial change and does not affect functionality. The fix ensures the options are described clearly and correctly.
