### PR TITLE
fix: block.timestamp is not accurate

### DIFF
--- a/core/node/node_sync/src/external_io.rs
+++ b/core/node/node_sync/src/external_io.rs
@@ -408,6 +408,7 @@ impl StateKeeperIO for ExternalIO {
         match action {
             SyncAction::Tx(tx) => {
                 self.actions.pop_action().unwrap();
+                //reset the flag because a l2 block is generated after receiving the tx
                 self.current_l2_block_params = None;
                 return Ok(Some(Transaction::from(*tx)));
             }

--- a/core/node/node_sync/src/tests.rs
+++ b/core/node/node_sync/src/tests.rs
@@ -222,7 +222,7 @@ async fn external_io_basics(snapshot_recovery: bool) {
     let tx = create_l2_transaction(10, 100);
     let tx_hash = tx.hash();
     let tx = FetchedTransaction::new(tx.into());
-    let actions = vec![open_l1_batch, tx.into(), SyncAction::SealL2Block];
+    let actions = vec![open_l1_batch, tx.into(), SyncAction::SealBatch];
 
     let (actions_sender, action_queue) = ActionQueue::new();
     let client = MockMainNodeClient::default();
@@ -299,7 +299,7 @@ async fn external_io_works_without_local_protocol_version(snapshot_recovery: boo
 
     let tx = create_l2_transaction(10, 100);
     let tx = FetchedTransaction::new(tx.into());
-    let actions = vec![open_l1_batch, tx.into(), SyncAction::SealL2Block];
+    let actions = vec![open_l1_batch, tx.into(), SyncAction::SealBatch];
 
     let (actions_sender, action_queue) = ActionQueue::new();
     let mut client = MockMainNodeClient::default();
@@ -407,7 +407,7 @@ pub(super) async fn run_state_keeper_with_multiple_l2_blocks(
     });
     let second_l2_block_actions: Vec<_> = iter::once(open_l2_block)
         .chain(more_txs)
-        .chain([SyncAction::SealL2Block])
+        .chain([SyncAction::SealBatch])
         .collect();
 
     let tx_hashes = extract_tx_hashes(
@@ -506,7 +506,7 @@ async fn test_external_io_recovery(
         },
         number: snapshot.l2_block_number + 3,
     };
-    let actions = vec![open_l2_block, new_tx.into(), SyncAction::SealL2Block];
+    let actions = vec![open_l2_block, new_tx.into(), SyncAction::SealBatch];
     actions_sender.push_actions(actions).await.unwrap();
     state_keeper
         .wait_for_local_block(snapshot.l2_block_number + 3)
@@ -587,7 +587,7 @@ pub(super) async fn run_state_keeper_with_multiple_l1_batches(
     let second_tx = create_l2_transaction(10, 100);
     let second_tx_hash = second_tx.hash();
     let second_tx = FetchedTransaction::new(second_tx.into());
-    let second_l1_batch_actions = vec![l1_batch, second_tx.into(), SyncAction::SealL2Block];
+    let second_l1_batch_actions = vec![l1_batch, second_tx.into(), SyncAction::SealBatch];
 
     let (actions_sender, action_queue) = ActionQueue::new();
     let state_keeper = StateKeeperHandles::new(

--- a/core/node/state_keeper/src/io/mempool.rs
+++ b/core/node/state_keeper/src/io/mempool.rs
@@ -295,22 +295,7 @@ impl StateKeeperIO for MempoolIO {
         cursor: &IoCursor,
         max_wait: Duration,
     ) -> anyhow::Result<Option<L2BlockParams>> {
-        // We must provide different timestamps for each L2 block.
-        // If L2 block sealing interval is greater than 1 second then `sleep_past` won't actually sleep.
-        let timeout_result = tokio::time::timeout(
-            max_wait,
-            sleep_past(cursor.prev_l2_block_timestamp, cursor.next_l2_block),
-        )
-        .await;
-        let Ok(timestamp) = timeout_result else {
-            return Ok(None);
-        };
-
-        Ok(Some(L2BlockParams {
-            timestamp,
-            // This value is effectively ignored by the protocol.
-            virtual_blocks: 1,
-        }))
+        self.wait_for_new_l2_block_params(cursor, max_wait).await
     }
 
     async fn wait_for_next_tx(

--- a/core/node/state_keeper/src/io/mempool.rs
+++ b/core/node/state_keeper/src/io/mempool.rs
@@ -290,6 +290,29 @@ impl StateKeeperIO for MempoolIO {
         }))
     }
 
+    async fn wait_for_l2_block_params_when_closing_batch(
+        &mut self,
+        cursor: &IoCursor,
+        max_wait: Duration,
+    ) -> anyhow::Result<Option<L2BlockParams>> {
+        // We must provide different timestamps for each L2 block.
+        // If L2 block sealing interval is greater than 1 second then `sleep_past` won't actually sleep.
+        let timeout_result = tokio::time::timeout(
+            max_wait,
+            sleep_past(cursor.prev_l2_block_timestamp, cursor.next_l2_block),
+        )
+        .await;
+        let Ok(timestamp) = timeout_result else {
+            return Ok(None);
+        };
+
+        Ok(Some(L2BlockParams {
+            timestamp,
+            // This value is effectively ignored by the protocol.
+            virtual_blocks: 1,
+        }))
+    }
+
     async fn wait_for_next_tx(
         &mut self,
         max_wait: Duration,

--- a/core/node/state_keeper/src/io/mod.rs
+++ b/core/node/state_keeper/src/io/mod.rs
@@ -135,6 +135,13 @@ pub trait StateKeeperIO: 'static + Send + Sync + fmt::Debug + IoSealCriteria {
         max_wait: Duration,
     ) -> anyhow::Result<Option<L2BlockParams>>;
 
+    /// Blocks for up to `max_wait` until the parameters for the final L2 block are available.
+    async fn wait_for_l2_block_params_when_closing_batch(
+        &mut self,
+        cursor: &IoCursor,
+        max_wait: Duration,
+    ) -> anyhow::Result<Option<L2BlockParams>>;
+
     /// Blocks for up to `max_wait` until the next transaction is available for execution.
     /// Returns `None` if no transaction became available until the timeout.
     async fn wait_for_next_tx(

--- a/core/node/state_keeper/src/io/mod.rs
+++ b/core/node/state_keeper/src/io/mod.rs
@@ -133,10 +133,10 @@ pub trait StateKeeperIO: 'static + Send + Sync + fmt::Debug + IoSealCriteria {
         &mut self,
         cursor: &IoCursor,
         max_wait: Duration,
-    ) -> anyhow::Result<Option<L2BlockParams>>;
+    ) -> anyhow::Result<Option<(L2BlockParams, Option<Transaction>)>>;
 
     /// Blocks for up to `max_wait` until the parameters for the final L2 block are available.
-    async fn wait_for_l2_block_params_when_closing_batch(
+    async fn wait_for_empty_l2_block_params(
         &mut self,
         cursor: &IoCursor,
         max_wait: Duration,

--- a/core/node/state_keeper/src/io/tests/mod.rs
+++ b/core/node/state_keeper/src/io/tests/mod.rs
@@ -658,7 +658,7 @@ async fn different_timestamp_for_l2_blocks_in_same_batch(commitment_mode: L1Batc
     let current_timestamp = seconds_since_epoch();
     io_cursor.prev_l2_block_timestamp = current_timestamp;
 
-    let l2_block_params = mempool
+    let (l2_block_params, _) = mempool
         .wait_for_new_l2_block_params(&io_cursor, Duration::from_secs(10))
         .await
         .unwrap()

--- a/core/node/state_keeper/src/keeper.rs
+++ b/core/node/state_keeper/src/keeper.rs
@@ -459,7 +459,7 @@ impl ZkSyncStateKeeper {
             l2_block = %updates.l2_block.number,
         )
     )]
-    async fn wait_for_closing_l2_block_params_when_closing_batch(
+    async fn wait_for_l2_block_params_when_closing_batch(
         &mut self,
         updates: &mut UpdatesManager,
         stop_receiver: &watch::Receiver<bool>,
@@ -471,7 +471,7 @@ impl ZkSyncStateKeeper {
                 .io
                 .wait_for_l2_block_params_when_closing_batch(&cursor, POLL_WAIT_DURATION)
                 .await
-                .context("error waiting for new L2 block params in wait_for_closing_l2_block_params_when_closing_batch")?
+                .context("error waiting for new L2 block params in wait_for_l2_block_params_when_closing_batch")?
             {
                 self.health_updater
                     .update(StateKeeperHealthDetails::from(&cursor).into());
@@ -655,12 +655,14 @@ impl ZkSyncStateKeeper {
                 // Push the current block if it has not been done yet
                 if is_last_block_sealed {
                     let new_l2_block_params = self
-                        .wait_for_closing_l2_block_params_when_closing_batch(
+                        .wait_for_l2_block_params_when_closing_batch(
                             updates_manager,
                             stop_receiver,
                         )
                         .await
-                        .map_err(|e| e.context("wait_for_new_l2_block_params"))?;
+                        .map_err(|e| {
+                            e.context("wait_for_l2_block_params_when_closing_batch")
+                        })?;
                     Self::start_next_l2_block(new_l2_block_params, updates_manager, batch_executor)
                         .await?;
                 }

--- a/core/node/state_keeper/src/testonly/test_batch_executor.rs
+++ b/core/node/state_keeper/src/testonly/test_batch_executor.rs
@@ -725,15 +725,7 @@ impl StateKeeperIO for TestIO {
         cursor: &IoCursor,
         _max_wait: Duration,
     ) -> anyhow::Result<Option<L2BlockParams>> {
-        assert_eq!(cursor.next_l2_block, self.l2_block_number);
-        let params = L2BlockParams {
-            timestamp: self.timestamp,
-            // 1 is just a constant used for tests.
-            virtual_blocks: 1,
-        };
-        self.l2_block_number += 1;
-        self.timestamp += 1;
-        Ok(Some(params))
+        self.wait_for_new_l2_block_params(cursor, _max_wait).await
     }
 
     async fn wait_for_next_tx(

--- a/core/node/state_keeper/src/testonly/test_batch_executor.rs
+++ b/core/node/state_keeper/src/testonly/test_batch_executor.rs
@@ -720,6 +720,22 @@ impl StateKeeperIO for TestIO {
         Ok(Some(params))
     }
 
+    async fn wait_for_l2_block_params_when_closing_batch(
+        &mut self,
+        cursor: &IoCursor,
+        _max_wait: Duration,
+    ) -> anyhow::Result<Option<L2BlockParams>> {
+        assert_eq!(cursor.next_l2_block, self.l2_block_number);
+        let params = L2BlockParams {
+            timestamp: self.timestamp,
+            // 1 is just a constant used for tests.
+            virtual_blocks: 1,
+        };
+        self.l2_block_number += 1;
+        self.timestamp += 1;
+        Ok(Some(params))
+    }
+
     async fn wait_for_next_tx(
         &mut self,
         max_wait: Duration,


### PR DESCRIPTION
## What ❔

Related to https://github.com/zkSync-Community-Hub/zksync-developers/discussions/820

Change the l2 block creation logic to start a new l2 block only when a transaction is ready to be executed.

## Why ❔

Current logic start a new l2 block as soon as the previous one is sealed.

A contract that relies on `block.timestamp` would be able to predict the time correctly because if the l2 block goes stale (no transaction), then it will be open indefinitely and the timestamp will not be accurate anymore

Solution has been tested locally but any feedbacks would be appreciated

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.

