### PR TITLE
fix(zk_toolbox): Fix path to prover data handler port

### DIFF
--- a/zkstack_cli/crates/zkstack/src/commands/chain/init/configs.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/init/configs.rs
@@ -63,7 +63,7 @@ pub async fn init_configs(
     let mut general_config = chain_config.get_general_config().await?.patched();
     let prover_data_handler_port = general_config
         .base()
-        .get_opt::<u16>("proof_data_handler.http_port")?;
+        .get_opt::<u16>("data_handler.http_port")?;
     if let Some(port) = prover_data_handler_port {
         general_config.insert("prover_gateway.api_url", format!("http://127.0.0.1:{port}"))?;
     }


### PR DESCRIPTION
## What ❔

Fixes a path to the prover data handler port.

## Why ❔

Without this fix, the prover gateway config is set up incorrectly.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.