### PR TITLE
Update interopmessages.md

### DIFF
--- a/docs/src/specs/interop/interopmessages.md
+++ b/docs/src/specs/interop/interopmessages.md
@@ -39,7 +39,7 @@ contract InteropCenter {
    uint256 messageNum; // a 'nonce' to guarantee different hashes.
  }
 
- // Verifies if such interop message was ever producted.
+ // Verifies if such interop message was ever produced.
  function verifyInteropMessage(bytes32 interopHash, Proof merkleProof) return bool;
 }
 ```


### PR DESCRIPTION
Corrected a typo in interopmessages.md: "producted" → "produced" in a comment. This improves clarity and documentation accuracy. No functional changes were made.