### PR TITLE
chore: Add logging to witness generator db save

### DIFF
--- a/prover/crates/bin/witness_generator/src/rounds/mod.rs
+++ b/prover/crates/bin/witness_generator/src/rounds/mod.rs
@@ -173,6 +173,9 @@ where
             artifacts,
         )
         .await?;
+
+        tracing::info!("Saved {:?} to database for job {:?}", R::ROUND, job_id);
+
         Ok(())
     }
 


### PR DESCRIPTION
A lot of prover infra relies on tracing. Tracing is not available on all environments. As such, troubleshooting issues covered by tracing is not possible. A recent service degradation could not be troubleshot due to lack of tracing. This line enables troubleshooting even when tracing is not available.

## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
