### PR TITLE
Update LICENSE-MIT

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Matter Labs
+Copyright (c) 2019-2025 Matter Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated the copyright year from 2019 to 2025 in the LICENSE file