### PR TITLE
fix: Allow witness_generator to use Prometheus push gateway in continuous mode

### DIFF
--- a/prover/crates/bin/witness_generator/src/main.rs
+++ b/prover/crates/bin/witness_generator/src/main.rs
@@ -134,7 +134,7 @@ async fn main() -> anyhow::Result<()> {
 
     let prometheus_config =
         if prometheus_config.is_some() && prometheus_config.unwrap().pushgateway_url.is_some() {
-            let url = prometheus_config.unwrap().gateway_endpoint();
+            let url = prometheus_config.unwrap().gateway_endpoint().unwrap();
             tracing::info!("Using Prometheus push gateway: {}", url);
             PrometheusExporterConfig::push(url, prometheus_config.unwrap().push_interval())
         } else {

--- a/prover/crates/bin/witness_generator/src/main.rs
+++ b/prover/crates/bin/witness_generator/src/main.rs
@@ -134,9 +134,9 @@ async fn main() -> anyhow::Result<()> {
 
     let prometheus_config =
         if prometheus_config.is_some() && prometheus_config.unwrap().pushgateway_url.is_some() {
-            let url = prometheus_config.gateway_endpoint();
+            let url = prometheus_config.unwrap().gateway_endpoint();
             tracing::info!("Using Prometheus push gateway: {}", url);
-            PrometheusExporterConfig::push(url, prometheus_config.push_interval())
+            PrometheusExporterConfig::push(url, prometheus_config.unwrap().push_interval())
         } else {
             tracing::info!(
                 "Exporting Prometheus metrics on port: {}",

--- a/prover/crates/bin/witness_generator/src/main.rs
+++ b/prover/crates/bin/witness_generator/src/main.rs
@@ -138,12 +138,9 @@ async fn main() -> anyhow::Result<()> {
         .is_some()
     {
         let prometheus_config = prometheus_config.unwrap();
-        let (url, push_interval) = (
-            prometheus_config.gateway_endpoint().unwrap(),
-            prometheus_config.push_interval(),
-        );
+        let url = prometheus_config.gateway_endpoint().unwrap();
         tracing::info!("Using Prometheus push gateway: {}", url);
-        PrometheusExporterConfig::push(url, push_interval)
+        PrometheusExporterConfig::push(url, prometheus_config.push_interval())
     } else {
         tracing::info!(
             "Exporting Prometheus metrics on port: {}",

--- a/prover/crates/bin/witness_generator/src/main.rs
+++ b/prover/crates/bin/witness_generator/src/main.rs
@@ -132,17 +132,18 @@ async fn main() -> anyhow::Result<()> {
             .listener_port
     };
 
-    let prometheus_config = if prometheus_config.pushgateway_url.is_some() {
-        let url = prometheus_config.gateway_endpoint();
-        tracing::info!("Using Prometheus push gateway: {}", url);
-        PrometheusExporterConfig::push(url, prometheus_config.push_interval())
-    } else {
-        tracing::info!(
-            "Exporting Prometheus metrics on port: {}",
-            prometheus_listener_port
-        );
-        PrometheusExporterConfig::pull(prometheus_listener_port)
-    };
+    let prometheus_config =
+        if prometheus_config.is_some() && prometheus_config.unwrap().pushgateway_url.is_some() {
+            let url = prometheus_config.gateway_endpoint();
+            tracing::info!("Using Prometheus push gateway: {}", url);
+            PrometheusExporterConfig::push(url, prometheus_config.push_interval())
+        } else {
+            tracing::info!(
+                "Exporting Prometheus metrics on port: {}",
+                prometheus_listener_port
+            );
+            PrometheusExporterConfig::pull(prometheus_listener_port)
+        };
 
     let connection_pool = ConnectionPool::<Prover>::singleton(database_secrets.prover_url()?)
         .build()


### PR DESCRIPTION
## What ❔

Allow witness_generator to use Prometheus push gateway in continuous mode.
Log which metrics method is used on start.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To keep receiving metrics in any running mode.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
