### PR TITLE
fix: Add debug information to object store retries

### DIFF
--- a/core/lib/object_store/src/retries.rs
+++ b/core/lib/object_store/src/retries.rs
@@ -41,10 +41,10 @@ impl Request<'_> {
                 Ok(result) => break Ok(result),
                 Err(err) if err.is_retriable() => {
                     if retries > max_retries {
-                        tracing::warn!(%err, "Exhausted {max_retries} retries performing request; returning last error");
+                        tracing::warn!(?err, "Exhausted {max_retries} retries performing request; returning last error");
                         break Err(err);
                     }
-                    tracing::info!(%err, "Failed request, retries: {retries}/{max_retries}");
+                    tracing::info!(?err, "Failed request, retries: {retries}/{max_retries}");
                     retries += 1;
                     // Randomize sleep duration to prevent stampeding the server if multiple requests are initiated at the same time.
                     let sleep_duration = Duration::from_secs(backoff_secs)


### PR DESCRIPTION
Currently, data is in format mode, which strips away a lot of the troubleshooting capabilities. This change marks error as Debug, instead of Display.

It will turn entries like:
```
error sending request for url (http://example.invalid/)
```
into:
```
reqwest::Error { kind: Request, url: "http://example.invalid/", source: hyper_util::client::legacy::Error(Connect, ConnectError("dns error", Custom { kind: Uncategorized, error: "failed to lookup address information: Name or service not known" })) }
```