### PR TITLE
Add tracing info to every function under compressor.rs

### DIFF
--- a/prover/crates/lib/keystore/src/compressor.rs
+++ b/prover/crates/lib/keystore/src/compressor.rs
@@ -18,7 +18,7 @@ impl proof_compression_gpu::BlobStorage for Keystore {
             ),
             ProverServiceDataType::VerificationKey,
         );
-
+        tracing::info!("Reading filepath {:?}", filepath);
         Box::new(File::open(filepath).unwrap())
     }
 
@@ -27,7 +27,7 @@ impl proof_compression_gpu::BlobStorage for Keystore {
             ProverServiceDataKey::new_compression(circuit_id),
             ProverServiceDataType::FinalizationHints,
         );
-
+        tracing::info!("Reading filepath {:?}", filepath);
         Box::new(File::open(filepath).unwrap())
     }
 
@@ -36,7 +36,7 @@ impl proof_compression_gpu::BlobStorage for Keystore {
             ProverServiceDataKey::new_compression(circuit_id),
             ProverServiceDataType::VerificationKey,
         );
-
+        tracing::info!("Reading filepath {:?}", filepath);
         Box::new(File::open(filepath).unwrap())
     }
 
@@ -45,7 +45,7 @@ impl proof_compression_gpu::BlobStorage for Keystore {
             ProverServiceDataKey::new_compression(circuit_id),
             ProverServiceDataType::SetupData,
         );
-
+        tracing::info!("Reading filepath {:?}", filepath);
         Box::new(File::open(filepath).unwrap())
     }
 
@@ -54,7 +54,7 @@ impl proof_compression_gpu::BlobStorage for Keystore {
             ProverServiceDataKey::new_compression_wrapper(circuit_id),
             ProverServiceDataType::FinalizationHints,
         );
-
+        tracing::info!("Reading filepath {:?}", filepath);
         Box::new(File::open(filepath).unwrap())
     }
 
@@ -63,7 +63,7 @@ impl proof_compression_gpu::BlobStorage for Keystore {
             ProverServiceDataKey::new_compression_wrapper(circuit_id),
             ProverServiceDataType::VerificationKey,
         );
-
+        tracing::info!("Reading filepath {:?}", filepath);
         Box::new(File::open(filepath).unwrap())
     }
 
@@ -75,7 +75,7 @@ impl proof_compression_gpu::BlobStorage for Keystore {
             ProverServiceDataKey::new_compression_wrapper(circuit_id),
             ProverServiceDataType::SetupData,
         );
-
+        tracing::info!("Reading filepath {:?}", filepath);
         Box::new(File::open(filepath).unwrap())
     }
 
@@ -84,7 +84,7 @@ impl proof_compression_gpu::BlobStorage for Keystore {
             ProverServiceDataKey::snark(),
             ProverServiceDataType::FflonkSnarkVerificationKey,
         );
-
+        tracing::info!("Reading filepath {:?}", filepath);
         Box::new(File::open(filepath).unwrap())
     }
 
@@ -93,7 +93,7 @@ impl proof_compression_gpu::BlobStorage for Keystore {
             ProverServiceDataKey::snark(),
             ProverServiceDataType::FflonkSetupData,
         );
-
+        tracing::info!("Reading filepath {:?}", filepath);
         Box::new(File::open(filepath).unwrap())
     }
 
@@ -102,7 +102,7 @@ impl proof_compression_gpu::BlobStorage for Keystore {
             ProverServiceDataKey::snark(),
             ProverServiceDataType::SnarkVerificationKey,
         );
-
+        tracing::info!("Reading filepath {:?}", filepath);
         Box::new(File::open(filepath).unwrap())
     }
 
@@ -111,13 +111,14 @@ impl proof_compression_gpu::BlobStorage for Keystore {
             ProverServiceDataKey::snark(),
             ProverServiceDataType::PlonkSetupData,
         );
-
+        tracing::info!("Reading filepath {:?}", filepath);
         Box::new(File::open(filepath).unwrap())
     }
 
     fn read_compact_raw_crs(&self) -> Box<dyn Read + Send + Sync> {
         let filepath =
             std::env::var(COMPACT_CRS_ENV_VAR).expect("No compact CRS file path provided");
+        tracing::info!("Reading filepath {:?}", filepath);
         Box::new(File::open(filepath).unwrap())
     }
 }
@@ -128,7 +129,7 @@ impl proof_compression_gpu::BlobStorageExt for Keystore {
             ProverServiceDataKey::new_compression(circuit_id),
             ProverServiceDataType::FinalizationHints,
         );
-
+        tracing::info!("Writing filepath {:?}", filepath);
         Box::new(File::create(filepath).unwrap())
     }
 
@@ -137,7 +138,7 @@ impl proof_compression_gpu::BlobStorageExt for Keystore {
             ProverServiceDataKey::new_compression(circuit_id),
             ProverServiceDataType::VerificationKey,
         );
-
+        tracing::info!("Writing filepath {:?}", filepath);
         Box::new(File::create(filepath).unwrap())
     }
 
@@ -146,7 +147,7 @@ impl proof_compression_gpu::BlobStorageExt for Keystore {
             ProverServiceDataKey::new_compression(circuit_id),
             ProverServiceDataType::SetupData,
         );
-
+        tracing::info!("Writing filepath {:?}", filepath);
         Box::new(File::create(filepath).unwrap())
     }
 
@@ -155,7 +156,7 @@ impl proof_compression_gpu::BlobStorageExt for Keystore {
             ProverServiceDataKey::new_compression_wrapper(circuit_id),
             ProverServiceDataType::FinalizationHints,
         );
-
+        tracing::info!("Writing filepath {:?}", filepath);
         Box::new(File::create(filepath).unwrap())
     }
 
@@ -164,7 +165,7 @@ impl proof_compression_gpu::BlobStorageExt for Keystore {
             ProverServiceDataKey::new_compression_wrapper(circuit_id),
             ProverServiceDataType::VerificationKey,
         );
-
+        tracing::info!("Writing filepath {:?}", filepath);
         Box::new(File::create(filepath).unwrap())
     }
 
@@ -173,7 +174,7 @@ impl proof_compression_gpu::BlobStorageExt for Keystore {
             ProverServiceDataKey::new_compression_wrapper(circuit_id),
             ProverServiceDataType::SetupData,
         );
-
+        tracing::info!("Writing filepath {:?}", filepath);
         Box::new(File::create(filepath).unwrap())
     }
 
@@ -182,7 +183,7 @@ impl proof_compression_gpu::BlobStorageExt for Keystore {
             ProverServiceDataKey::snark(),
             ProverServiceDataType::FflonkSnarkVerificationKey,
         );
-
+        tracing::info!("Writing filepath {:?}", filepath);
         Box::new(File::create(filepath).unwrap())
     }
 
@@ -191,7 +192,7 @@ impl proof_compression_gpu::BlobStorageExt for Keystore {
             ProverServiceDataKey::snark(),
             ProverServiceDataType::FflonkSetupData,
         );
-
+        tracing::info!("Writing filepath {:?}", filepath);
         Box::new(File::create(filepath).unwrap())
     }
 
@@ -200,7 +201,7 @@ impl proof_compression_gpu::BlobStorageExt for Keystore {
             ProverServiceDataKey::snark(),
             ProverServiceDataType::SnarkVerificationKey,
         );
-
+        tracing::info!("Writing filepath {:?}", filepath);
         Box::new(File::create(filepath).unwrap())
     }
 
@@ -209,13 +210,14 @@ impl proof_compression_gpu::BlobStorageExt for Keystore {
             ProverServiceDataKey::snark(),
             ProverServiceDataType::PlonkSetupData,
         );
-
+        tracing::info!("Writing filepath {:?}", filepath);
         Box::new(File::create(filepath).unwrap())
     }
 
     fn write_compact_raw_crs(&self) -> Box<dyn Write> {
         let filepath =
             std::env::var(COMPACT_CRS_ENV_VAR).expect("No compact CRS file path provided");
+        tracing::info!("Writing filepath {:?}", filepath);
         Box::new(File::create(filepath).unwrap())
     }
 }


### PR DESCRIPTION
## What ❔

Simple change adding more logs to:
`prover/crates/lib/keystore/src/compressor.rs`

## Why ❔

We ran into an error and all we got from the logs was this:

> 2025-02-01T08:31:54.644781Z  INFO zksync_proof_fri_compressor::compressor: Started proof compression for L1 batch: L1BatchNumber(7)
thread 'tokio-runtime-worker' panicked at crates/lib/keystore/src/compressor.rs:115:39:
called Result::unwrap() on an Err value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
2025-02-01T08:31:54.760894Z ERROR zksync_queued_job_processor: Error occurred while processing ProofCompressor job L1BatchNumber(7): "called Result::unwrap() on an Err value: Os { code: 2, kind: NotFound, message: \"No such file or directory\" }"
Compact raw CRS loading takes 0s

Clearly a file was missing `message: "No such file or directory" ` but no hint at what file was missing `

____

After adding this we get a  bit more in the logs enough to figure what file was missing:

> 2025-02-02T17:55:45.316365Z  INFO zksync_proof_fri_compressor::compressor: Started proof compression for L1 batch: L1BatchNumber(7)
2025-02-02T17:55:45.350429Z  INFO zksync_prover_keystore::compressor: Reading filepath "keys/setup/setup_compact.key"
2025-02-02T17:55:45.350552Z  INFO zksync_prover_keystore::compressor: Reading filepath "/data/keys/plonk_setup_snark_data.bin"
thread 'tokio-runtime-worker' panicked at crates/lib/keystore/src/compressor.rs:115:39:
called Result::unwrap() on an Err value: Os { code: 2, kind: NotFound, message: "No such file or directory" }


Hopefully this change helps someone else save many hours of troubleshooting

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
