### PR TITLE
fix: EVM emulation integration – upgrade workflow fixes

### DIFF
--- a/core/lib/basic_types/src/protocol_version.rs
+++ b/core/lib/basic_types/src/protocol_version.rs
@@ -75,11 +75,11 @@ pub enum ProtocolVersionId {
 
 impl ProtocolVersionId {
     pub const fn latest() -> Self {
-        Self::Version26 // FIXME: change to `Version27`
+        Self::Version27
     }
 
     pub const fn next() -> Self {
-        Self::Version27
+        Self::Version28
     }
 
     pub fn try_from_packed_semver(packed_semver: U256) -> Result<Self, String> {

--- a/core/lib/basic_types/src/protocol_version.rs
+++ b/core/lib/basic_types/src/protocol_version.rs
@@ -75,7 +75,7 @@ pub enum ProtocolVersionId {
 
 impl ProtocolVersionId {
     pub const fn latest() -> Self {
-        Self::Version26
+        Self::Version26 // FIXME: change to `Version27`
     }
 
     pub const fn next() -> Self {
@@ -125,7 +125,10 @@ impl ProtocolVersionId {
             ProtocolVersionId::Version25 => VmVersion::Vm1_5_0IncreasedBootloaderMemory,
             ProtocolVersionId::Version26 => VmVersion::VmGateway,
             ProtocolVersionId::Version27 => VmVersion::VmGateway,
-            ProtocolVersionId::Version28 => unreachable!("Version 28 is not yet supported"),
+
+            // Speculative VM version for the next protocol version to be used in the upgrade integration test etc.
+            // TODO: Must be changed when the protocol version is actually implemented!
+            ProtocolVersionId::Version28 => VmVersion::VmGateway,
         }
     }
 
@@ -304,7 +307,10 @@ impl From<ProtocolVersionId> for VmVersion {
             ProtocolVersionId::Version25 => VmVersion::Vm1_5_0IncreasedBootloaderMemory,
             ProtocolVersionId::Version26 => VmVersion::VmGateway,
             ProtocolVersionId::Version27 => VmVersion::VmGateway,
-            ProtocolVersionId::Version28 => unreachable!("Version 28 is not yet supported"),
+
+            // Speculative VM version for the next protocol version to be used in the upgrade integration test etc.
+            // TODO: Must be changed when the protocol version is actually implemented!
+            ProtocolVersionId::Version28 => VmVersion::VmGateway,
         }
     }
 }

--- a/core/lib/basic_types/src/protocol_version.rs
+++ b/core/lib/basic_types/src/protocol_version.rs
@@ -155,6 +155,10 @@ impl ProtocolVersionId {
         self < &Self::Version27
     }
 
+    pub fn is_post_fflonk(&self) -> bool {
+        self >= &Self::Version27
+    }
+
     pub fn is_1_4_0(&self) -> bool {
         self >= &ProtocolVersionId::Version18 && self < &ProtocolVersionId::Version20
     }

--- a/core/lib/vm_executor/src/oneshot/contracts.rs
+++ b/core/lib/vm_executor/src/oneshot/contracts.rs
@@ -107,7 +107,10 @@ impl<C: ContractsKind> MultiVmBaseSystemContracts<C> {
             ProtocolVersionId::Version25 => &self.vm_protocol_defense,
             ProtocolVersionId::Version26 => &self.gateway,
             ProtocolVersionId::Version27 => &self.vm_evm_emulator,
-            ProtocolVersionId::Version28 => unreachable!("Version 28 is not supported yet"),
+
+            // Speculative base system contracts for the next protocol version to be used in the upgrade integration test etc.
+            // TODO: Must be changed when the protocol version is actually implemented!
+            ProtocolVersionId::Version28 => &self.vm_evm_emulator,
         };
         base.clone()
     }

--- a/core/node/eth_watch/src/tests/client.rs
+++ b/core/node/eth_watch/src/tests/client.rs
@@ -501,6 +501,7 @@ fn upgrade_into_diamond_cut(upgrade: ProtocolUpgrade) -> Token {
         factory_deps,
         bootloader_hash: upgrade.bootloader_code_hash.unwrap_or_default().into(),
         default_account_hash: upgrade.default_account_code_hash.unwrap_or_default().into(),
+        evm_emulator_hash: upgrade.evm_emulator_code_hash.unwrap_or_default().into(),
         verifier: upgrade.verifier_address.unwrap_or_default(),
         verifier_params: upgrade.verifier_params.unwrap_or_default().into(),
         l1_contracts_upgrade_calldata: vec![],

--- a/core/node/genesis/src/utils.rs
+++ b/core/node/genesis/src/utils.rs
@@ -120,12 +120,11 @@ pub fn get_deduped_log_queries(storage_logs: &[StorageLog]) -> Vec<LogQuery> {
     deduped_log_queries
 }
 
-// Default account and bootloader are not a regular system contracts
-// they have never been actually deployed anywhere,
-// They are the initial code that is fed into the VM upon its start.
-// Both are rather parameters of a block and not system contracts.
-// The code of the bootloader should not be deployed anywhere anywhere in the kernel space (i.e. addresses below 2^16)
-// because in this case we will have to worry about protecting it.
+/// Default account, bootloader and EVM emulator are not regular system contracts.
+/// They have never been actually deployed anywhere, rather, they are the initial code that is fed into the VM upon its start.
+/// Hence, they are rather parameters of a block and not *real* system contracts.
+/// The code of the bootloader should not be deployed anywhere in the kernel space (i.e. addresses below 2^16)
+/// because in this case we will have to worry about protecting it.
 pub(super) async fn insert_base_system_contracts_to_factory_deps(
     storage: &mut Connection<'_, Core>,
     contracts: &BaseSystemContracts,

--- a/core/tests/upgrade-test/tests/upgrade.test.ts
+++ b/core/tests/upgrade-test/tests/upgrade.test.ts
@@ -267,7 +267,7 @@ describe('Upgrade test', function () {
         );
 
         const evmEmulatorCode = readCode(
-          'contracts/system-contracts/zkout/EvmEmulator.yul/contracts-preprocessed/EvmEmulator.yul.json',
+            'contracts/system-contracts/zkout/EvmEmulator.yul/contracts-preprocessed/EvmEmulator.yul.json'
         );
 
         bootloaderHash = ethers.hexlify(zksync.utils.hashBytecode(bootloaderCode));


### PR DESCRIPTION
## What ❔

Fixes the upgrade workflow with new L1 contracts.

## Why ❔

The existing workflow doesn't work because of changes in `ProposedUpgrade` (+ some stubs in the codebase).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.