### PR TITLE
fix: allow configuring NoDA client via ENV

### DIFF
--- a/core/lib/env_config/src/da_client.rs
+++ b/core/lib/env_config/src/da_client.rs
@@ -8,7 +8,7 @@ use zksync_config::configs::{
         celestia::CelestiaSecrets,
         eigen::EigenSecrets,
         DAClientConfig, AVAIL_CLIENT_CONFIG_NAME, CELESTIA_CLIENT_CONFIG_NAME,
-        EIGEN_CLIENT_CONFIG_NAME, OBJECT_STORE_CLIENT_CONFIG_NAME,
+        EIGEN_CLIENT_CONFIG_NAME, NO_DA_CLIENT_CONFIG_NAME, OBJECT_STORE_CLIENT_CONFIG_NAME,
     },
     secrets::DataAvailabilitySecrets,
     AvailConfig,
@@ -38,6 +38,7 @@ impl FromEnv for DAClientConfig {
             OBJECT_STORE_CLIENT_CONFIG_NAME => {
                 Self::ObjectStore(envy_load("da_object_store", "DA_")?)
             }
+            NO_DA_CLIENT_CONFIG_NAME => Self::NoDA,
             _ => anyhow::bail!("Unknown DA client name: {}", client_tag),
         };
 


### PR DESCRIPTION
## What ❔

Allow configuring NoDA client via environment variables.

## Why ❔

This is required by the partners running chains using ENV-based configuration.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
