### PR TITLE
fix: add permissions to fix failing VM perf CI runs

### DIFF
--- a/.github/workflows/vm-perf-comparison.yml
+++ b/.github/workflows/vm-perf-comparison.yml
@@ -9,6 +9,8 @@ jobs:
   vm-benchmarks:
     name: Run VM benchmarks
     runs-on: [ matterlabs-ci-runner-highmem-long ]
+    permissions:
+      pull-requests: write
 
     steps:
       - name: checkout base branch


### PR DESCRIPTION
## What ❔

Fix permissions in VM perf tests

## Why ❔

In external contributions we have all the VM perf test runs failing with the `Error: Resource not accessible by integration` error like [here](https://github.com/matter-labs/zksync-era/actions/runs/13282215771/job/37083063381?pr=3584).

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
