### PR TITLE
ci: release zkstack binary with zkstack_cli releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,3 +31,12 @@ jobs:
       upgrade-dependencies: true                            # Upgrade cross-workspace dependencies
       version-suffix: 'non-semver-compat'                   # Version suffix for the crates.io release
       workspace-dirs: 'core prover zkstack_cli'             # List of additional workspace directories to update Cargo.lock
+
+  # Trigger workflow to publish zkstack binaries
+  release-zkstack-cli-bins:
+    if: ${{ fromJSON(needs.release-please.outputs.all).zkstack_cli--release_created == 'true' }}
+    needs: release-please
+    uses: ./.github/workflows/release-zkstack-bins.yml
+    with:
+      tag: ${{ fromJSON(needs.release-please.outputs.all).zkstack_cli--tag_name }}
+    secrets: inherit

--- a/.github/workflows/release-zkstack-bins.yml
+++ b/.github/workflows/release-zkstack-bins.yml
@@ -1,0 +1,125 @@
+name: Release zkstack bins
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        description: 'The tag to use for the Docker image.'
+        required: true
+  workflow_dispatch:
+    inputs:
+      prerelease_name:
+        description: "Suffix to use for manual pre-release."
+        required: false
+        type: string
+        default: "prerelease-test"
+
+defaults:
+  run:
+    shell: 'bash -ex {0}'
+    working-directory: zkstack_cli
+
+jobs:
+
+  build:
+    name: Build binaries
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64-unknown-linux-gnu
+            platform: matterlabs-ci-runner-highmem-long
+          - arch: aarch64-unknown-linux-gnu
+            platform: matterlabs-ci-runner-arm
+          - arch: x86_64-apple-darwin
+            platform: macos-latest-large
+          - arch: aarch64-apple-darwin
+            platform: macos-latest-xlarge
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || '' }}
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly-2024-08-01
+          rustflags: ""
+
+      - name: Install target
+        run: rustup target add ${{ matrix.arch }}
+
+      - name: Build zkstack
+        run: |
+          if [[ "${{ matrix.arch }}" == *"linux"* ]]; then
+            export RUSTFLAGS='-C target-feature=+crt-static'
+            export OPENSSL_STATIC=1
+          fi
+          cargo build --bin zkstack --target ${{ matrix.arch }} --release
+
+      - name: Pack zkstack
+        run: |
+          tar -C ./target/${{ matrix.arch }}/release -czf \
+            zkstack-${{ inputs.tag || inputs.prerelease_name }}-${{ matrix.arch }}.tar.gz \
+            zkstack
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zkstack-${{ matrix.arch }}
+          path: |
+            ./zkstack_cli/zkstack-${{ inputs.tag || inputs.prerelease_name }}-${{ matrix.arch }}.tar.gz
+            ./zkstack_cli/target/${{ matrix.arch }}/release/zkstack
+
+
+  upload-binaries:
+    name: Upload binaries
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || '' }}
+
+      - name: Define release name
+        id: release_tag
+        shell: 'bash -ex {0}'
+        run: |
+          [ ! -z "${{ inputs.tag }}" ] && TAG="${{ inputs.tag }}" \
+            || TAG="$(git rev-parse --short HEAD)"
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "zkstack-*"
+          path: artifacts
+
+      - name: Binaries attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'artifacts/**/zkstack'
+
+      - name: Update release artifacts
+        if: ${{ inputs.tag != '' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: 'artifacts/**/zkstack*.tar.gz'
+
+      - name: Create release
+        if: ${{ inputs.prerelease_name != '' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          name: 'zkstack ${{ inputs.prerelease_name }} ${{ steps.release_tag.outputs.tag }}'
+          tag_name: ${{ steps.release_tag.outputs.tag }}
+          prerelease: true
+          files: 'artifacts/**/zkstack*.tar.gz'

--- a/zkstack_cli/Cargo.toml
+++ b/zkstack_cli/Cargo.toml
@@ -75,3 +75,6 @@ secrecy = "0.8.0"
 async-trait = "0.1.68"
 sqruff-lib = "0.19.0"
 reqwest = { version = "0.12.8", features = ["blocking"] }
+
+[profile.release]
+strip = true


### PR DESCRIPTION
## What ❔

Release `zkstack` binary with each `zkstack_cli` release.

When `zkstack_cli` release PR is merged, an additional job will be triggered to build and publish `zkstack` executables for Linux and MacOS platforms to the release artifacts.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

* [x] Allows users and developers to use prebuilt binary instead of always building `zkstack`.
* [x] Allows CI jobs that do not need to rebuild `zkstack_cli` to reuse the latest stable `zkstack` binary saving valuable CI and runners time.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Testing

* [x] Build binaries workflow: https://github.com/matter-labs/zksync-era/actions/runs/13286808848
* [x] Release-please triggers check: https://github.com/antonbaliasnikov/release-please-multiple/actions/runs/13288930605

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
