### PR TITLE
chore: Make prover DAL test to use transaction for jobs insert

### DIFF
--- a/prover/crates/lib/prover_dal/src/fri_prover_dal.rs
+++ b/prover/crates/lib/prover_dal/src/fri_prover_dal.rs
@@ -1078,7 +1078,6 @@ mod tests {
                 L1VerifierConfig::default(),
             )
             .await;
-
         tx.fri_prover_jobs_dal()
             .insert_prover_jobs(
                 L1BatchNumber(1),
@@ -1088,5 +1087,7 @@ mod tests {
                 ProtocolSemanticVersion::default(),
             )
             .await;
+
+        tx.commit().await.unwrap();
     }
 }

--- a/prover/crates/lib/prover_dal/src/fri_prover_dal.rs
+++ b/prover/crates/lib/prover_dal/src/fri_prover_dal.rs
@@ -1070,15 +1070,16 @@ mod tests {
     async fn test_insert_prover_jobs() {
         let pool = ConnectionPool::<Prover>::prover_test_pool().await;
         let mut conn = pool.connection().await.unwrap();
+        let mut tx = conn.start_transaction().await.unwrap();
 
-        conn.fri_protocol_versions_dal()
+        tx.fri_protocol_versions_dal()
             .save_prover_protocol_version(
                 ProtocolSemanticVersion::default(),
                 L1VerifierConfig::default(),
             )
             .await;
 
-        conn.fri_prover_jobs_dal()
+        tx.fri_prover_jobs_dal()
             .insert_prover_jobs(
                 L1BatchNumber(1),
                 mock_circuit_ids_and_urls(10000),


### PR DESCRIPTION
## What ❔
Modified insert jobs test to use transaction to be consistent with logic 

## Why ❔
To catch potential issues that can be introduced if transaction/commit logic is used vs inserting rows in each conn separately.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
No changes required

## Checklist

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
