### PR TITLE
fix(api): lock simultaneous tx insertsion with mutex

### DIFF
--- a/core/node/api_server/src/tx_sender/master_pool_sink.rs
+++ b/core/node/api_server/src/tx_sender/master_pool_sink.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::hash_map::HashMap,
-    sync::Arc,
-};
+use std::{collections::hash_map::HashMap, sync::Arc};
 
 use tokio::sync::Mutex;
 use zksync_dal::{transactions_dal::L2TxSubmissionResult, ConnectionPool, Core, CoreDal};

--- a/core/node/api_server/src/tx_sender/master_pool_sink.rs
+++ b/core/node/api_server/src/tx_sender/master_pool_sink.rs
@@ -22,7 +22,7 @@ impl MasterPoolSink {
     pub fn new(master_pool: ConnectionPool<Core>) -> Self {
         Self {
             master_pool,
-            inflight_requests: Mutex::new(HashMap::new()),
+            inflight_requests: Default::default(),
         }
     }
 }
@@ -67,6 +67,10 @@ impl TxSink for MasterPoolSink {
             Err(err) => Err(err.generalize().into()),
         };
 
+        self.inflight_requests
+            .lock()
+            .await
+            .remove(&address_and_nonce);
         API_METRICS.inflight_tx_submissions.dec_by(1);
 
         result

--- a/core/node/api_server/src/tx_sender/master_pool_sink.rs
+++ b/core/node/api_server/src/tx_sender/master_pool_sink.rs
@@ -1,7 +1,10 @@
-use std::{collections::hash_map::HashMap, sync::Arc};
+use std::{
+    collections::hash_map::{Entry, HashMap},
+    sync::{Arc, Weak},
+};
 
 use tokio::sync::Mutex;
-use zksync_dal::{transactions_dal::L2TxSubmissionResult, ConnectionPool, Core, CoreDal};
+use zksync_dal::{transactions_dal::L2TxSubmissionResult, ConnectionPool, Core, CoreDal, DalError};
 use zksync_multivm::interface::{tracer::ValidationTraces, TransactionExecutionMetrics};
 use zksync_shared_metrics::{TxStage, APP_METRICS};
 use zksync_types::{l2::L2Tx, Address, Nonce, H256};
@@ -9,13 +12,42 @@ use zksync_types::{l2::L2Tx, Address, Nonce, H256};
 use super::{tx_sink::TxSink, SubmitTxError};
 use crate::web3::metrics::API_METRICS;
 
-type LockedTxnMap = Mutex<HashMap<(Address, Nonce), (H256, Arc<Mutex<()>>)>>;
+/// Guard for `address_and_nonce` keyed tx insertion.
+struct Guard {
+    inflight_requests: Weak<Mutex<HashMap<(Address, Nonce), H256>>>,
+    address_and_nonce: (Address, Nonce),
+}
+
+impl Guard {
+    pub fn new(
+        inflight_requests: Weak<Mutex<HashMap<(Address, Nonce), H256>>>,
+        address_and_nonce: (Address, Nonce),
+    ) -> Self {
+        Self {
+            inflight_requests,
+            address_and_nonce,
+        }
+    }
+}
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let inflight_requests = self.inflight_requests.upgrade();
+        let address_and_nonce = self.address_and_nonce;
+        tokio::spawn(async move {
+            if let Some(inflight_requests) = inflight_requests {
+                inflight_requests.lock().await.remove(&address_and_nonce);
+                API_METRICS.inflight_tx_submissions.dec_by(1);
+            }
+        });
+    }
+}
 
 /// Wrapper for the master DB pool that allows to submit transactions to the mempool.
 #[derive(Debug)]
 pub struct MasterPoolSink {
     master_pool: ConnectionPool<Core>,
-    inflight_requests: LockedTxnMap,
+    inflight_requests: Arc<Mutex<HashMap<(Address, Nonce), H256>>>,
 }
 
 impl MasterPoolSink {
@@ -39,40 +71,39 @@ impl TxSink for MasterPoolSink {
         let tx_hash = tx.hash();
 
         let mut lock = self.inflight_requests.lock().await;
-        let (hash_in_progress, mutex) = lock.entry(address_and_nonce).or_default();
-        let mutex_clone = mutex.clone();
-        // `_internal_lock` prevents simultaneous insertion of multiple txs with the same `address_and_nonce`.
-        let Ok(_internal_lock) = mutex_clone.try_lock() else {
-            let submission_res_handle = if *hash_in_progress == tx_hash {
-                L2TxSubmissionResult::Duplicate
-            } else {
-                L2TxSubmissionResult::InsertionInProgress
-            };
-            APP_METRICS.processed_txs[&TxStage::Mempool(submission_res_handle)].inc();
-            return Ok(submission_res_handle);
+        let _guard = match lock.entry(address_and_nonce) {
+            Entry::Occupied(entry) => {
+                let submission_res_handle = if entry.get() == &tx_hash {
+                    L2TxSubmissionResult::Duplicate
+                } else {
+                    L2TxSubmissionResult::InsertionInProgress
+                };
+                APP_METRICS.processed_txs[&TxStage::Mempool(submission_res_handle)].inc();
+                return Ok(submission_res_handle);
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(tx.hash());
+                API_METRICS.inflight_tx_submissions.inc_by(1);
+
+                Guard::new(Arc::downgrade(&self.inflight_requests), address_and_nonce)
+            }
         };
-        *hash_in_progress = tx_hash;
         drop(lock);
-        API_METRICS.inflight_tx_submissions.inc_by(1);
 
-        let result = match self.master_pool.connection_tagged("api").await {
-            Ok(mut connection) => connection
-                .transactions_dal()
-                .insert_transaction_l2(tx, execution_metrics, validation_traces)
-                .await
-                .inspect(|submission_res_handle| {
-                    APP_METRICS.processed_txs[&TxStage::Mempool(*submission_res_handle)].inc();
-                })
-                .map_err(|err| err.generalize().into()),
-            Err(err) => Err(err.generalize().into()),
-        };
-
-        self.inflight_requests
-            .lock()
+        let mut connection = self
+            .master_pool
+            .connection_tagged("api")
             .await
-            .remove(&address_and_nonce);
-        API_METRICS.inflight_tx_submissions.dec_by(1);
+            .map_err(DalError::generalize)?;
+        let result = connection
+            .transactions_dal()
+            .insert_transaction_l2(tx, execution_metrics, validation_traces)
+            .await
+            .inspect(|submission_res_handle| {
+                APP_METRICS.processed_txs[&TxStage::Mempool(*submission_res_handle)].inc();
+            })
+            .map_err(DalError::generalize)?;
 
-        result
+        Ok(result)
     }
 }

--- a/core/node/api_server/src/tx_sender/master_pool_sink.rs
+++ b/core/node/api_server/src/tx_sender/master_pool_sink.rs
@@ -68,12 +68,11 @@ impl TxSink for MasterPoolSink {
         validation_traces: ValidationTraces,
     ) -> Result<L2TxSubmissionResult, SubmitTxError> {
         let address_and_nonce = (tx.initiator_account(), tx.nonce());
-        let tx_hash = tx.hash();
 
         let mut lock = self.inflight_requests.lock().await;
         let _guard = match lock.entry(address_and_nonce) {
             Entry::Occupied(entry) => {
-                let submission_res_handle = if entry.get() == &tx_hash {
+                let submission_res_handle = if entry.get() == &tx.hash() {
                     L2TxSubmissionResult::Duplicate
                 } else {
                     L2TxSubmissionResult::InsertionInProgress


### PR DESCRIPTION
## What ❔

Fixes the lock for simultaneous tx insertion with mutex.

## Why ❔

The previous approach could lead to a "stuck" state if the task panics/get canceled before hashmap entry is cleaned.
This shouldn't happen now with guard removing entry on drop.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

No changes

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
