### PR TITLE
chore: bump cargo toml to 26.4.0

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1192,7 +1192,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "block_reverter"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "clap 4.5.23",
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "custom_genesis_export"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "genesis_generator"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "clap 4.5.23",
@@ -4844,7 +4844,7 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "loadnext"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5027,7 +5027,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "merkle_tree_consistency_checker"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "clap 4.5.23",
@@ -7574,7 +7574,7 @@ dependencies = [
 
 [[package]]
 name = "selector_generator"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "clap 4.5.23",
@@ -8107,7 +8107,7 @@ dependencies = [
 
 [[package]]
 name = "snapshots_creator"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -8754,7 +8754,7 @@ dependencies = [
 
 [[package]]
 name = "system-constants-generator"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "codegen",
  "once_cell",
@@ -9724,7 +9724,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "verified_sources_fetcher"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -9781,7 +9781,7 @@ dependencies = [
 
 [[package]]
 name = "vm-benchmark"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "assert_matches",
  "criterion",
@@ -10586,7 +10586,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_base_token_adjuster"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10608,7 +10608,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_basic_types"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10653,7 +10653,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_block_reverter"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -10677,7 +10677,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_circuit_breaker"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10691,7 +10691,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_commitment_generator"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "circuit_encodings",
@@ -10739,7 +10739,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_config"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -10912,7 +10912,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_consistency_checker"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -10937,7 +10937,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_contract_verification_server"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -10957,7 +10957,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_contract_verifier"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "clap 4.5.23",
@@ -10974,7 +10974,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_contract_verifier_lib"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11006,7 +11006,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_contracts"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "bincode",
  "envy",
@@ -11020,7 +11020,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_core_leftovers"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -11034,7 +11034,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_crypto_primitives"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -11062,7 +11062,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_da_client"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11071,7 +11071,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_da_clients"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11116,7 +11116,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_da_dispatcher"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11133,7 +11133,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_dal"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -11170,7 +11170,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_db_connection"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11188,7 +11188,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_env_config"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "envy",
@@ -11200,7 +11200,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_eth_client"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -11222,7 +11222,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_eth_sender"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11252,7 +11252,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_eth_signer"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "async-trait",
  "rlp",
@@ -11263,7 +11263,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_eth_watch"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -11290,7 +11290,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_external_node"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11344,7 +11344,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_external_price_api"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11365,7 +11365,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_external_proof_integration_api"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11411,7 +11411,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_health_check"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -11426,7 +11426,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_house_keeper"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11458,7 +11458,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_l1_contract_interface"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "circuit_definitions",
@@ -11479,7 +11479,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_logs_bloom_backfill"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "tokio",
@@ -11491,7 +11491,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_mempool"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "tracing",
  "zksync_types",
@@ -11499,7 +11499,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_merkle_tree"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11528,7 +11528,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_metadata_calculator"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11562,7 +11562,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_mini_merkle_tree"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "criterion",
  "once_cell",
@@ -11572,7 +11572,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_multivm"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11604,7 +11604,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_node_api_server"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11658,7 +11658,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_node_consensus"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11702,7 +11702,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_node_db_pruner"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11724,7 +11724,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_node_fee_model"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11743,7 +11743,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_node_framework"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11806,7 +11806,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_node_framework_derive"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "proc-macro2 1.0.92",
  "quote 1.0.37",
@@ -11815,7 +11815,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_node_genesis"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "bincode",
@@ -11836,7 +11836,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_node_storage_init"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11858,7 +11858,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_node_sync"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11893,7 +11893,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_node_test_utils"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "zksync_contracts",
  "zksync_dal",
@@ -11905,7 +11905,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_object_store"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11943,7 +11943,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_proof_data_handler"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -12005,7 +12005,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_protobuf_config"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "hex",
@@ -12025,7 +12025,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_prover_interface"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "bincode",
  "circuit_definitions",
@@ -12044,7 +12044,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_queued_job_processor"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12056,7 +12056,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_reorg_detector"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -12077,7 +12077,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_server"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "clap 4.5.23",
@@ -12107,7 +12107,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_shared_metrics"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "rustc_version 0.4.1",
  "serde",
@@ -12119,7 +12119,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_snapshots_applier"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -12158,7 +12158,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_state"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -12182,7 +12182,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_state_keeper"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -12222,7 +12222,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_storage"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "num_cpus",
  "once_cell",
@@ -12235,7 +12235,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_system_constants"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -12243,7 +12243,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_task_management"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -12255,7 +12255,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_tee_prover"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12280,7 +12280,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_tee_verifier"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "bincode",
@@ -12298,7 +12298,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_test_contracts"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "ethabi",
  "foundry-compilers",
@@ -12314,7 +12314,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_types"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -12345,7 +12345,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_utils"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -12356,7 +12356,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_vlog"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "chrono",
@@ -12401,7 +12401,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_vm_executor"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -12419,7 +12419,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_vm_interface"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -12437,7 +12437,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_vm_runner"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -12471,7 +12471,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_web3_decl"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -92,7 +92,7 @@ inherits = "release"
 debug = true
 
 [workspace.package]
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 edition = "2021"
 authors = ["The Matter Labs Team <hello@matterlabs.dev>"]
 homepage = "https://zksync.io/"
@@ -260,71 +260,71 @@ zksync_protobuf = "=0.8.0"
 zksync_protobuf_build = "=0.8.0"
 
 # "Local" dependencies
-zksync_multivm = { version = "26.3.0-non-semver-compat", path = "lib/multivm" }
-zksync_vlog = { version = "26.3.0-non-semver-compat", path = "lib/vlog" }
-zksync_vm_interface = { version = "26.3.0-non-semver-compat", path = "lib/vm_interface" }
-zksync_vm_executor = { version = "26.3.0-non-semver-compat", path = "lib/vm_executor" }
-zksync_basic_types = { version = "26.3.0-non-semver-compat", path = "lib/basic_types" }
-zksync_circuit_breaker = { version = "26.3.0-non-semver-compat", path = "lib/circuit_breaker" }
-zksync_config = { version = "26.3.0-non-semver-compat", path = "lib/config" }
-zksync_contract_verifier_lib = { version = "26.3.0-non-semver-compat", path = "lib/contract_verifier" }
-zksync_contracts = { version = "26.3.0-non-semver-compat", path = "lib/contracts" }
-zksync_core_leftovers = { version = "26.3.0-non-semver-compat", path = "lib/zksync_core_leftovers" }
-zksync_dal = { version = "26.3.0-non-semver-compat", path = "lib/dal" }
-zksync_db_connection = { version = "26.3.0-non-semver-compat", path = "lib/db_connection" }
-zksync_env_config = { version = "26.3.0-non-semver-compat", path = "lib/env_config" }
-zksync_eth_client = { version = "26.3.0-non-semver-compat", path = "lib/eth_client" }
-zksync_da_client = { version = "26.3.0-non-semver-compat", path = "lib/da_client" }
-zksync_eth_signer = { version = "26.3.0-non-semver-compat", path = "lib/eth_signer" }
-zksync_health_check = { version = "26.3.0-non-semver-compat", path = "lib/health_check" }
-zksync_l1_contract_interface = { version = "26.3.0-non-semver-compat", path = "lib/l1_contract_interface" }
-zksync_mempool = { version = "26.3.0-non-semver-compat", path = "lib/mempool" }
-zksync_merkle_tree = { version = "26.3.0-non-semver-compat", path = "lib/merkle_tree" }
+zksync_multivm = { version = "26.4.0-non-semver-compat", path = "lib/multivm" }
+zksync_vlog = { version = "26.4.0-non-semver-compat", path = "lib/vlog" }
+zksync_vm_interface = { version = "26.4.0-non-semver-compat", path = "lib/vm_interface" }
+zksync_vm_executor = { version = "26.4.0-non-semver-compat", path = "lib/vm_executor" }
+zksync_basic_types = { version = "26.4.0-non-semver-compat", path = "lib/basic_types" }
+zksync_circuit_breaker = { version = "26.4.0-non-semver-compat", path = "lib/circuit_breaker" }
+zksync_config = { version = "26.4.0-non-semver-compat", path = "lib/config" }
+zksync_contract_verifier_lib = { version = "26.4.0-non-semver-compat", path = "lib/contract_verifier" }
+zksync_contracts = { version = "26.4.0-non-semver-compat", path = "lib/contracts" }
+zksync_core_leftovers = { version = "26.4.0-non-semver-compat", path = "lib/zksync_core_leftovers" }
+zksync_dal = { version = "26.4.0-non-semver-compat", path = "lib/dal" }
+zksync_db_connection = { version = "26.4.0-non-semver-compat", path = "lib/db_connection" }
+zksync_env_config = { version = "26.4.0-non-semver-compat", path = "lib/env_config" }
+zksync_eth_client = { version = "26.4.0-non-semver-compat", path = "lib/eth_client" }
+zksync_da_client = { version = "26.4.0-non-semver-compat", path = "lib/da_client" }
+zksync_eth_signer = { version = "26.4.0-non-semver-compat", path = "lib/eth_signer" }
+zksync_health_check = { version = "26.4.0-non-semver-compat", path = "lib/health_check" }
+zksync_l1_contract_interface = { version = "26.4.0-non-semver-compat", path = "lib/l1_contract_interface" }
+zksync_mempool = { version = "26.4.0-non-semver-compat", path = "lib/mempool" }
+zksync_merkle_tree = { version = "26.4.0-non-semver-compat", path = "lib/merkle_tree" }
 zksync_bin_metadata = { version = "=26.1.0-non-semver-compat", path = "lib/bin_metadata" }
-zksync_mini_merkle_tree = { version = "26.3.0-non-semver-compat", path = "lib/mini_merkle_tree" }
-zksync_object_store = { version = "26.3.0-non-semver-compat", path = "lib/object_store" }
-zksync_protobuf_config = { version = "26.3.0-non-semver-compat", path = "lib/protobuf_config" }
-zksync_prover_interface = { version = "26.3.0-non-semver-compat", path = "lib/prover_interface" }
-zksync_queued_job_processor = { version = "26.3.0-non-semver-compat", path = "lib/queued_job_processor" }
-zksync_snapshots_applier = { version = "26.3.0-non-semver-compat", path = "lib/snapshots_applier" }
-zksync_state = { version = "26.3.0-non-semver-compat", path = "lib/state" }
-zksync_storage = { version = "26.3.0-non-semver-compat", path = "lib/storage" }
-zksync_system_constants = { version = "26.3.0-non-semver-compat", path = "lib/constants" }
-zksync_tee_verifier = { version = "26.3.0-non-semver-compat", path = "lib/tee_verifier" }
-zksync_test_contracts = { version = "26.3.0-non-semver-compat", path = "lib/test_contracts" }
-zksync_types = { version = "26.3.0-non-semver-compat", path = "lib/types" }
-zksync_utils = { version = "26.3.0-non-semver-compat", path = "lib/utils" }
-zksync_web3_decl = { version = "26.3.0-non-semver-compat", path = "lib/web3_decl" }
-zksync_crypto_primitives = { version = "26.3.0-non-semver-compat", path = "lib/crypto_primitives" }
-zksync_external_price_api = { version = "26.3.0-non-semver-compat", path = "lib/external_price_api" }
-zksync_task_management = { version = "26.3.0-non-semver-compat", path = "lib/task_management" }
+zksync_mini_merkle_tree = { version = "26.4.0-non-semver-compat", path = "lib/mini_merkle_tree" }
+zksync_object_store = { version = "26.4.0-non-semver-compat", path = "lib/object_store" }
+zksync_protobuf_config = { version = "26.4.0-non-semver-compat", path = "lib/protobuf_config" }
+zksync_prover_interface = { version = "26.4.0-non-semver-compat", path = "lib/prover_interface" }
+zksync_queued_job_processor = { version = "26.4.0-non-semver-compat", path = "lib/queued_job_processor" }
+zksync_snapshots_applier = { version = "26.4.0-non-semver-compat", path = "lib/snapshots_applier" }
+zksync_state = { version = "26.4.0-non-semver-compat", path = "lib/state" }
+zksync_storage = { version = "26.4.0-non-semver-compat", path = "lib/storage" }
+zksync_system_constants = { version = "26.4.0-non-semver-compat", path = "lib/constants" }
+zksync_tee_verifier = { version = "26.4.0-non-semver-compat", path = "lib/tee_verifier" }
+zksync_test_contracts = { version = "26.4.0-non-semver-compat", path = "lib/test_contracts" }
+zksync_types = { version = "26.4.0-non-semver-compat", path = "lib/types" }
+zksync_utils = { version = "26.4.0-non-semver-compat", path = "lib/utils" }
+zksync_web3_decl = { version = "26.4.0-non-semver-compat", path = "lib/web3_decl" }
+zksync_crypto_primitives = { version = "26.4.0-non-semver-compat", path = "lib/crypto_primitives" }
+zksync_external_price_api = { version = "26.4.0-non-semver-compat", path = "lib/external_price_api" }
+zksync_task_management = { version = "26.4.0-non-semver-compat", path = "lib/task_management" }
 
 # Framework and components
-zksync_node_framework = { version = "26.3.0-non-semver-compat", path = "node/node_framework" }
-zksync_node_framework_derive = { version = "26.3.0-non-semver-compat", path = "lib/node_framework_derive" }
-zksync_eth_watch = { version = "26.3.0-non-semver-compat", path = "node/eth_watch" }
-zksync_shared_metrics = { version = "26.3.0-non-semver-compat", path = "node/shared_metrics" }
-zksync_proof_data_handler = { version = "26.3.0-non-semver-compat", path = "node/proof_data_handler" }
-zksync_block_reverter = { version = "26.3.0-non-semver-compat", path = "node/block_reverter" }
-zksync_commitment_generator = { version = "26.3.0-non-semver-compat", path = "node/commitment_generator" }
-zksync_house_keeper = { version = "26.3.0-non-semver-compat", path = "node/house_keeper" }
-zksync_node_genesis = { version = "26.3.0-non-semver-compat", path = "node/genesis" }
-zksync_da_dispatcher = { version = "26.3.0-non-semver-compat", path = "node/da_dispatcher" }
-zksync_da_clients = { version = "26.3.0-non-semver-compat", path = "node/da_clients" }
-zksync_eth_sender = { version = "26.3.0-non-semver-compat", path = "node/eth_sender" }
-zksync_node_db_pruner = { version = "26.3.0-non-semver-compat", path = "node/db_pruner" }
-zksync_node_fee_model = { version = "26.3.0-non-semver-compat", path = "node/fee_model" }
-zksync_vm_runner = { version = "26.3.0-non-semver-compat", path = "node/vm_runner" }
-zksync_external_proof_integration_api = { version = "26.3.0-non-semver-compat", path = "node/external_proof_integration_api" }
-zksync_node_test_utils = { version = "26.3.0-non-semver-compat", path = "node/test_utils" }
-zksync_state_keeper = { version = "26.3.0-non-semver-compat", path = "node/state_keeper" }
-zksync_reorg_detector = { version = "26.3.0-non-semver-compat", path = "node/reorg_detector" }
-zksync_consistency_checker = { version = "26.3.0-non-semver-compat", path = "node/consistency_checker" }
-zksync_metadata_calculator = { version = "26.3.0-non-semver-compat", path = "node/metadata_calculator" }
-zksync_node_sync = { version = "26.3.0-non-semver-compat", path = "node/node_sync" }
-zksync_node_storage_init = { version = "26.3.0-non-semver-compat", path = "node/node_storage_init" }
-zksync_node_consensus = { version = "26.3.0-non-semver-compat", path = "node/consensus" }
-zksync_contract_verification_server = { version = "26.3.0-non-semver-compat", path = "node/contract_verification_server" }
-zksync_node_api_server = { version = "26.3.0-non-semver-compat", path = "node/api_server" }
-zksync_base_token_adjuster = { version = "26.3.0-non-semver-compat", path = "node/base_token_adjuster" }
-zksync_logs_bloom_backfill = { version = "26.3.0-non-semver-compat", path = "node/logs_bloom_backfill" }
+zksync_node_framework = { version = "26.4.0-non-semver-compat", path = "node/node_framework" }
+zksync_node_framework_derive = { version = "26.4.0-non-semver-compat", path = "lib/node_framework_derive" }
+zksync_eth_watch = { version = "26.4.0-non-semver-compat", path = "node/eth_watch" }
+zksync_shared_metrics = { version = "26.4.0-non-semver-compat", path = "node/shared_metrics" }
+zksync_proof_data_handler = { version = "26.4.0-non-semver-compat", path = "node/proof_data_handler" }
+zksync_block_reverter = { version = "26.4.0-non-semver-compat", path = "node/block_reverter" }
+zksync_commitment_generator = { version = "26.4.0-non-semver-compat", path = "node/commitment_generator" }
+zksync_house_keeper = { version = "26.4.0-non-semver-compat", path = "node/house_keeper" }
+zksync_node_genesis = { version = "26.4.0-non-semver-compat", path = "node/genesis" }
+zksync_da_dispatcher = { version = "26.4.0-non-semver-compat", path = "node/da_dispatcher" }
+zksync_da_clients = { version = "26.4.0-non-semver-compat", path = "node/da_clients" }
+zksync_eth_sender = { version = "26.4.0-non-semver-compat", path = "node/eth_sender" }
+zksync_node_db_pruner = { version = "26.4.0-non-semver-compat", path = "node/db_pruner" }
+zksync_node_fee_model = { version = "26.4.0-non-semver-compat", path = "node/fee_model" }
+zksync_vm_runner = { version = "26.4.0-non-semver-compat", path = "node/vm_runner" }
+zksync_external_proof_integration_api = { version = "26.4.0-non-semver-compat", path = "node/external_proof_integration_api" }
+zksync_node_test_utils = { version = "26.4.0-non-semver-compat", path = "node/test_utils" }
+zksync_state_keeper = { version = "26.4.0-non-semver-compat", path = "node/state_keeper" }
+zksync_reorg_detector = { version = "26.4.0-non-semver-compat", path = "node/reorg_detector" }
+zksync_consistency_checker = { version = "26.4.0-non-semver-compat", path = "node/consistency_checker" }
+zksync_metadata_calculator = { version = "26.4.0-non-semver-compat", path = "node/metadata_calculator" }
+zksync_node_sync = { version = "26.4.0-non-semver-compat", path = "node/node_sync" }
+zksync_node_storage_init = { version = "26.4.0-non-semver-compat", path = "node/node_storage_init" }
+zksync_node_consensus = { version = "26.4.0-non-semver-compat", path = "node/consensus" }
+zksync_contract_verification_server = { version = "26.4.0-non-semver-compat", path = "node/contract_verification_server" }
+zksync_node_api_server = { version = "26.4.0-non-semver-compat", path = "node/api_server" }
+zksync_base_token_adjuster = { version = "26.4.0-non-semver-compat", path = "node/base_token_adjuster" }
+zksync_logs_bloom_backfill = { version = "26.4.0-non-semver-compat", path = "node/logs_bloom_backfill" }

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -8179,7 +8179,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_basic_types"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8292,7 +8292,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_config"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -8383,7 +8383,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_contracts"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "envy",
  "hex",
@@ -8396,7 +8396,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_core_leftovers"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "ctrlc",
@@ -8410,7 +8410,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_crypto_primitives"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -8438,7 +8438,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_dal"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -8474,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_db_connection"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -8490,7 +8490,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_env_config"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "envy",
@@ -8501,7 +8501,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_eth_client"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -8518,7 +8518,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_eth_signer"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "async-trait",
  "rlp",
@@ -8607,7 +8607,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_l1_contract_interface"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "circuit_definitions",
@@ -8624,7 +8624,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_mini_merkle_tree"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -8633,7 +8633,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_multivm"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "circuit_sequencer_api",
@@ -8659,7 +8659,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_object_store"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8770,7 +8770,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_protobuf_config"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "hex",
@@ -8927,7 +8927,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_prover_interface"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "circuit_definitions",
  "circuit_sequencer_api",
@@ -9008,7 +9008,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_queued_job_processor"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9037,7 +9037,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_system_constants"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -9045,7 +9045,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_task_management"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "futures 0.3.31",
@@ -9057,7 +9057,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_types"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9086,7 +9086,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_utils"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -9120,7 +9120,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_vlog"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9165,7 +9165,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_vm_interface"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9181,7 +9181,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_web3_decl"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/zkstack_cli/Cargo.lock
+++ b/zkstack_cli/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_basic_types"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6641,7 +6641,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_config"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "rand",
@@ -6710,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_contracts"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "envy",
  "hex",
@@ -6723,7 +6723,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_crypto_primitives"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "blake2",
@@ -6739,7 +6739,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_eth_client"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -6756,7 +6756,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_eth_signer"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "async-trait",
  "rlp",
@@ -6767,7 +6767,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_mini_merkle_tree"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -6814,7 +6814,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_system_constants"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -6822,7 +6822,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_types"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6847,7 +6847,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_utils"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -6857,7 +6857,7 @@ dependencies = [
 
 [[package]]
 name = "zksync_web3_decl"
-version = "26.3.0-non-semver-compat"
+version = "26.4.0-non-semver-compat"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## What ❔

Bump Cargo to 26.4.0.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To correspond to the release-please config after merge without Cargo.toml and Cargo.lock updates.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
