### PR TITLE
feat(da-clients): raise Avail blob size to 1mb

### DIFF
--- a/core/node/da_clients/src/avail/sdk.rs
+++ b/core/node/da_clients/src/avail/sdk.rs
@@ -41,7 +41,7 @@ struct SubmitData {
 struct BoundedVec<_0>(pub Vec<_0>);
 
 impl RawAvailClient {
-    pub(crate) const MAX_BLOB_SIZE: usize = 512 * 1024; // 512kb
+    pub(crate) const MAX_BLOB_SIZE: usize = 1024 * 1024; // 1mb
 
     pub(crate) async fn new(
         app_id: u32,


### PR DESCRIPTION
## What ❔

Increase Avail max blob size to 1 MB.

## Why ❔

Avail now supports larger blobs, we can adjust our constants now.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
