### PR TITLE
chore(validium): improve error handling, update AvailL1DAValidator address

### DIFF
--- a/core/node/da_clients/src/avail/sdk.rs
+++ b/core/node/da_clients/src/avail/sdk.rs
@@ -353,11 +353,11 @@ impl RawAvailClient {
 
         let balance = resp
             .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Invalid balance"))?;
-
-        Ok(balance
+            .ok_or_else(|| anyhow::anyhow!("Invalid balance"))?
             .parse()
-            .context("Unable to parse the account balance")?)
+            .context("Unable to parse the account balance")?;
+
+        Ok(balance)
     }
 }
 

--- a/core/node/da_clients/src/avail/sdk.rs
+++ b/core/node/da_clients/src/avail/sdk.rs
@@ -355,9 +355,9 @@ impl RawAvailClient {
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("Invalid balance"))?;
 
-        balance
+        Ok(balance
             .parse()
-            .context("Unable to parse the account balance")
+            .context("Unable to parse the account balance")?)
     }
 }
 

--- a/core/node/da_dispatcher/src/da_dispatcher.rs
+++ b/core/node/da_dispatcher/src/da_dispatcher.rs
@@ -174,7 +174,7 @@ impl DataAvailabilityDispatcher {
                 let balance = client_arc
                     .balance()
                     .await
-                    .with_context(|| "Unable to retrieve DA operator balance");
+                    .context("Unable to retrieve DA operator balance");
 
                 match balance {
                     Ok(balance) => {

--- a/zkstack_cli/crates/types/src/l1_network.rs
+++ b/zkstack_cli/crates/types/src/l1_network.rs
@@ -43,7 +43,7 @@ impl L1Network {
         match self {
             L1Network::Localhost => None,
             L1Network::Sepolia | L1Network::Holesky => {
-                Some(Address::from_str("0xd99d6569785547ac72150d0309aeDb30C7871b51").unwrap())
+                Some(Address::from_str("0x73d59fe232fce421d1365d6a5beec49acde3d0d9").unwrap())
             }
             L1Network::Mainnet => None, // TODO: add mainnet address after it is known
         }


### PR DESCRIPTION
## What ❔

- Fix `balance` in Avail client
- Improve error handling in `da_dispatcher`'s `poll_for_inclusion` function
- Update the AvailL1DAValidator for Sepolia

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
