### PR TITLE
Fix typo in test function name: "baxtch" to "batch"

### DIFF
--- a/core/lib/types/src/fee_model.rs
+++ b/core/lib/types/src/fee_model.rs
@@ -581,7 +581,7 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_baxtch_fee_model_input_v2_only_compute_overhead() {
+    fn test_compute_batch_fee_model_input_v2_only_compute_overhead() {
         // Here we use sensible config, but when only compute is used to close the batch
         let config = FeeModelConfigV2 {
             minimal_l2_gas_price: 100_000_000_000,


### PR DESCRIPTION
Fixed a typo in the test function name in core/lib/types/src/fee_model.rs where "batch" was incorrectly spelled as "baxtch" in the function name test_compute_baxtch_fee_model_input_v2_only_compute_overhead.