### PR TITLE
fix(zkstack_cli): default core_object_store path

### DIFF
--- a/zkstack_cli/crates/config/src/general.rs
+++ b/zkstack_cli/crates/config/src/general.rs
@@ -72,6 +72,11 @@ pub fn set_file_artifacts(
         "snapshot_recovery.object_store",
         &file_artifacts.snapshot,
     )?;
+    set_file_backed_path_if_selected(
+        config,
+        "core_object_store",
+        &file_artifacts.core_object_store,
+    )?;
     Ok(())
 }
 


### PR DESCRIPTION
## What ❔

Set correct default core_object_store path i.e. `chains/<CHAIN_NAME>/artifacts`, currently it's just `artifacts`

## Why ❔

If >1 chain is initted they should store artifacts in different folders

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

Nothing

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
