### PR TITLE
feat(zkos): Merkle tree follow-ups

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -10781,6 +10781,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",
+ "vise",
  "zksync_basic_types",
  "zksync_crypto_primitives",
  "zksync_storage",

--- a/core/lib/zk_os_merkle_tree/Cargo.toml
+++ b/core/lib/zk_os_merkle_tree/Cargo.toml
@@ -21,6 +21,7 @@ once_cell.workspace = true
 rayon.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+vise.workspace = true
 
 [dev-dependencies]
 clap = { workspace = true, features = ["derive"] }

--- a/core/lib/zk_os_merkle_tree/examples/loadtest.rs
+++ b/core/lib/zk_os_merkle_tree/examples/loadtest.rs
@@ -136,7 +136,7 @@ impl Cli {
             let start = Instant::now();
             let output = if self.proofs {
                 let (output, proof) = tree
-                    .extend_with_proof(&kvs)
+                    .extend_with_proof(&kvs, &[])
                     .context("failed extending tree")?;
                 black_box(proof); // Ensure that proof creation isn't optimized away
                 output

--- a/core/lib/zk_os_merkle_tree/src/lib.rs
+++ b/core/lib/zk_os_merkle_tree/src/lib.rs
@@ -9,7 +9,7 @@ pub use zksync_crypto_primitives::hasher::blake2::Blake2Hasher;
 pub use self::{
     errors::DeserializeError,
     hasher::HashTree,
-    storage::{Database, MerkleTreeColumnFamily, PatchSet, RocksDBWrapper},
+    storage::{Database, MerkleTreeColumnFamily, PatchSet, Patched, RocksDBWrapper},
     types::{BatchOutput, TreeEntry},
 };
 use crate::{
@@ -27,6 +27,14 @@ mod storage;
 #[cfg(test)]
 mod tests;
 mod types;
+
+/// Unstable types that should not be used unless you know what you're doing (e.g., implementing
+/// `Database` trait for a custom type). There are no guarantees whatsoever that APIs / structure of
+/// these types will remain stable.
+#[doc(hidden)]
+pub mod unstable {
+    pub use crate::types::{KeyLookup, Manifest, Node, NodeKey, Root};
+}
 
 /// Marker trait for tree parameters.
 pub trait TreeParams: fmt::Debug + Send + Sync {

--- a/core/lib/zk_os_merkle_tree/src/lib.rs
+++ b/core/lib/zk_os_merkle_tree/src/lib.rs
@@ -127,6 +127,17 @@ impl<DB: Database, P: TreeParams> MerkleTree<DB, P> {
         self.root_hash(version)
     }
 
+    /// Creates a batch proof for `keys` at the specified tree version.
+    ///
+    /// # Errors
+    ///
+    /// - Returns an error if the version doesn't exist.
+    /// - Proxies database errors.
+    pub fn prove(&self, version: u64, keys: &[H256]) -> anyhow::Result<BatchTreeProof> {
+        let (patch, mut update) = self.create_patch(version, &[], keys)?;
+        Ok(patch.create_batch_proof(&self.hasher, vec![], update.take_read_operations()))
+    }
+
     /// Extends this tree by creating its new version.
     ///
     /// All keys in the provided entries must be distinct.

--- a/core/lib/zk_os_merkle_tree/src/metrics.rs
+++ b/core/lib/zk_os_merkle_tree/src/metrics.rs
@@ -1,0 +1,74 @@
+//! Merkle tree metrics.
+
+use std::time::Duration;
+
+use vise::{Buckets, EncodeLabelSet, EncodeLabelValue, Family, Gauge, Histogram, Metrics, Unit};
+
+const NODE_COUNT_BUCKETS: Buckets = Buckets::values(&[
+    100.0, 200.0, 500.0, 1_000.0, 2_000.0, 5_000.0, 10_000.0, 20_000.0, 50_000.0, 100_000.0,
+]);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, EncodeLabelSet)]
+#[metrics(rename_all = "snake_case", label = "stage")]
+pub(crate) enum LoadStage {
+    Total,
+    KeyLookup,
+    TreeNodes,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue, EncodeLabelSet)]
+#[metrics(rename_all = "snake_case", label = "stage")]
+pub(crate) enum BatchProofStage {
+    Total,
+    Hashing,
+    Traversal,
+}
+
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "zk_os_merkle_tree")]
+pub(crate) struct MerkleTreeMetrics {
+    /// Current number of leaves in the tree.
+    pub leaf_count: Gauge<u64>,
+
+    // Latencies of different operations
+    /// Time spent loading tree nodes from DB per batch.
+    #[metrics(buckets = Buckets::LATENCIES, unit = Unit::Seconds)]
+    pub load_nodes_latency: Family<LoadStage, Histogram<Duration>>,
+    #[metrics(buckets = Buckets::LATENCIES, unit = Unit::Seconds)]
+    pub batch_proof_latency: Family<BatchProofStage, Histogram<Duration>>,
+    /// Time spent traversing the tree and creating new nodes per batch.
+    #[metrics(buckets = Buckets::LATENCIES, unit = Unit::Seconds)]
+    pub extend_patch_latency: Histogram<Duration>,
+    /// Time spent finalizing a batch (mainly hash computations).
+    #[metrics(buckets = Buckets::LATENCIES, unit = Unit::Seconds)]
+    pub finalize_patch_latency: Histogram<Duration>,
+    /// Time spent applying a batch to the database.
+    #[metrics(buckets = Buckets::LATENCIES, unit = Unit::Seconds)]
+    pub apply_patch_latency: Histogram<Duration>,
+
+    /// Number of updated leaves in a batch.
+    #[metrics(buckets = NODE_COUNT_BUCKETS)]
+    pub batch_updates_count: Histogram<usize>,
+    /// Number of newly inserted leaves in a batch.
+    #[metrics(buckets = NODE_COUNT_BUCKETS)]
+    pub batch_inserts_count: Histogram<usize>,
+    /// Number of keys read in a batch. Only set in the proof generation mode.
+    #[metrics(buckets = NODE_COUNT_BUCKETS)]
+    pub batch_reads_count: Histogram<usize>,
+    /// Number of missing keys read in a batch. Only set in the proof generation mode.
+    #[metrics(buckets = NODE_COUNT_BUCKETS)]
+    pub batch_missing_reads_count: Histogram<usize>,
+    /// Number of leaves loaded for a batch update.
+    #[metrics(buckets = NODE_COUNT_BUCKETS)]
+    pub loaded_leaves: Histogram<usize>,
+    /// Number of internal nodes loaded for a batch update.
+    #[metrics(buckets = NODE_COUNT_BUCKETS)]
+    pub loaded_internal_nodes: Histogram<usize>,
+
+    /// Number of hashes included in a generated proof.
+    #[metrics(buckets = NODE_COUNT_BUCKETS)]
+    pub proof_hashes_count: Histogram<usize>,
+}
+
+#[vise::register]
+pub(crate) static METRICS: vise::Global<MerkleTreeMetrics> = vise::Global::new();

--- a/core/lib/zk_os_merkle_tree/src/metrics.rs
+++ b/core/lib/zk_os_merkle_tree/src/metrics.rs
@@ -2,7 +2,9 @@
 
 use std::time::Duration;
 
-use vise::{Buckets, EncodeLabelSet, EncodeLabelValue, Family, Gauge, Histogram, Metrics, Unit};
+use vise::{
+    Buckets, EncodeLabelSet, EncodeLabelValue, Family, Gauge, Histogram, Info, Metrics, Unit,
+};
 
 const NODE_COUNT_BUCKETS: Buckets = Buckets::values(&[
     100.0, 200.0, 500.0, 1_000.0, 2_000.0, 5_000.0, 10_000.0, 20_000.0, 50_000.0, 100_000.0,
@@ -24,9 +26,18 @@ pub(crate) enum BatchProofStage {
     Traversal,
 }
 
+#[derive(Debug, EncodeLabelSet)]
+pub(crate) struct MerkleTreeInfo {
+    pub hasher: &'static str,
+    pub depth: u64,
+    pub internal_node_depth: u64,
+}
+
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "zk_os_merkle_tree")]
 pub(crate) struct MerkleTreeMetrics {
+    /// Merkle tree information. Only set on the first tree initialization.
+    pub info: Info<MerkleTreeInfo>,
     /// Current number of leaves in the tree.
     pub leaf_count: Gauge<u64>,
 
@@ -46,6 +57,7 @@ pub(crate) struct MerkleTreeMetrics {
     #[metrics(buckets = Buckets::LATENCIES, unit = Unit::Seconds)]
     pub apply_patch_latency: Histogram<Duration>,
 
+    // Node statistics
     /// Number of updated leaves in a batch.
     #[metrics(buckets = NODE_COUNT_BUCKETS)]
     pub batch_updates_count: Histogram<usize>,
@@ -64,6 +76,26 @@ pub(crate) struct MerkleTreeMetrics {
     /// Number of internal nodes loaded for a batch update.
     #[metrics(buckets = NODE_COUNT_BUCKETS)]
     pub loaded_internal_nodes: Histogram<usize>,
+    /// Number of readonly leaves. Only set in the proof generation mode.
+    #[metrics(buckets = NODE_COUNT_BUCKETS)]
+    pub readonly_leaves: Histogram<usize>,
+    /// Number of readonly internal nodes. Only set in the proof generation mode.
+    #[metrics(buckets = NODE_COUNT_BUCKETS)]
+    pub readonly_internal_nodes: Histogram<usize>,
+
+    /// Total number of key lookup entries persisted to RocksDB in a single patch.
+    #[metrics(buckets = NODE_COUNT_BUCKETS)]
+    pub apply_patch_key_lookup_entries_count: Histogram<usize>,
+    /// Total number of leaves persisted to RocksDB in a single patch.
+    #[metrics(buckets = NODE_COUNT_BUCKETS)]
+    pub apply_patch_leaves_count: Histogram<usize>,
+    /// Total number of internal nodes persisted to RocksDB in a single patch.
+    #[metrics(buckets = NODE_COUNT_BUCKETS)]
+    pub apply_patch_internal_nodes_count: Histogram<usize>,
+    /// Number of hashes in child references copied from previous tree versions. Allows to estimate
+    /// the level of redundancy of the tree.
+    #[metrics(buckets = NODE_COUNT_BUCKETS)]
+    pub apply_patch_copied_hashes: Histogram<usize>,
 
     /// Number of hashes included in a generated proof.
     #[metrics(buckets = NODE_COUNT_BUCKETS)]

--- a/core/lib/zk_os_merkle_tree/src/storage/mod.rs
+++ b/core/lib/zk_os_merkle_tree/src/storage/mod.rs
@@ -162,6 +162,18 @@ impl PatchSet {
         }
     }
 
+    fn copied_hashes_count(&self) -> usize {
+        let copied_hashes = self.patches_by_version.iter().map(|(&version, patch)| {
+            let copied_hashes = patch
+                .internal
+                .iter()
+                .flat_map(HashMap::values)
+                .map(|node| node.children.iter().filter(|r| r.version < version).count());
+            copied_hashes.sum::<usize>()
+        });
+        copied_hashes.sum()
+    }
+
     #[cfg(test)]
     pub(crate) fn manifest_mut(&mut self) -> &mut Manifest {
         &mut self.manifest

--- a/core/lib/zk_os_merkle_tree/src/storage/mod.rs
+++ b/core/lib/zk_os_merkle_tree/src/storage/mod.rs
@@ -1,7 +1,7 @@
 use std::{
     cmp,
     collections::{BTreeMap, HashMap},
-    ops,
+    ops, slice,
 };
 
 use zksync_basic_types::H256;
@@ -140,25 +140,34 @@ pub struct PatchSet {
 }
 
 impl PatchSet {
+    fn is_new_version(&self, version: u64) -> bool {
+        version >= self.manifest.version_count // this patch truncates `version`
+            || self.patches_by_version.contains_key(&version)
+    }
+
     fn index(&self, version: u64, key: &H256) -> KeyLookup {
-        let (next_key, next_entry) = self
+        let (next_key, next_idx) = self
             .sorted_new_leaves
             .range(key..)
             .find(|(_, entry)| entry.inserted_at <= version)
-            .expect("guards must be inserted into a tree on initialization");
-        if next_key == key {
-            return KeyLookup::Existing(next_entry.index);
+            .map(|(key, entry)| (*key, entry.index))
+            // Default to the max guard even if it's not present in the patch set. This is important
+            // for using `PatchSet` inside `Patched`.
+            .unwrap_or_else(|| (H256::repeat_byte(0xff), 1));
+        if next_key == *key {
+            return KeyLookup::Existing(next_idx);
         }
 
-        let (prev_key, prev_entry) = self
+        let (prev_key, prev_idx) = self
             .sorted_new_leaves
             .range(..key)
             .rev()
             .find(|(_, entry)| entry.inserted_at <= version)
-            .expect("guards must be inserted into a tree on initialization");
+            .map(|(key, entry)| (*key, entry.index))
+            .unwrap_or_else(|| (H256::zero(), 0));
         KeyLookup::Missing {
-            prev_key_and_index: (*prev_key, prev_entry.index),
-            next_key_and_index: (*next_key, next_entry.index),
+            prev_key_and_index: (prev_key, prev_idx),
+            next_key_and_index: (next_key, next_idx),
         }
     }
 
@@ -250,5 +259,176 @@ impl Database for PatchSet {
 
         self.manifest = manifest;
         Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct Patched<DB> {
+    inner: DB,
+    patch: Option<PatchSet>,
+}
+
+impl<DB: Database> Patched<DB> {
+    pub fn new(inner: DB) -> Self {
+        Self { inner, patch: None }
+    }
+
+    /// Returns `Ok(None)` if the patch is not responsible for the requested version.
+    fn lookup_patch(&self, key: &NodeKey) -> Result<Option<Node>, DeserializeError> {
+        let Some(patch) = &self.patch else {
+            return Ok(None);
+        };
+
+        Ok(if patch.is_new_version(key.version) {
+            patch.try_nodes(slice::from_ref(key))?.into_iter().next()
+        } else {
+            None
+        })
+    }
+
+    /// Flushes changes from RAM to the wrapped database.
+    ///
+    /// # Errors
+    ///
+    /// Proxies database I/O errors.
+    pub fn flush(&mut self) -> anyhow::Result<()> {
+        if let Some(patch) = self.patch.take() {
+            self.inner.apply_patch(patch)?;
+        }
+        Ok(())
+    }
+
+    /// Forgets about changes held in RAM.
+    pub fn reset(&mut self) {
+        self.patch = None;
+    }
+
+    /// Returns the wrapped database.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the database contains uncommitted changes. Call [`Self::flush()`]
+    /// or [`Self::reset()`] beforehand to avoid this panic.
+    pub fn into_inner(self) -> DB {
+        assert!(
+            self.patch.is_none(),
+            "The `Patched` database contains uncommitted changes"
+        );
+        self.inner
+    }
+}
+
+impl<DB: Database> Database for Patched<DB> {
+    fn indices(&self, version: u64, keys: &[H256]) -> Result<Vec<KeyLookup>, DeserializeError> {
+        let Some(patch) = &self.patch else {
+            return self.inner.indices(version, keys);
+        };
+        if !patch.is_new_version(version) {
+            return self.inner.indices(version, keys);
+        }
+
+        let patch_lookup = patch.indices(version, keys)?;
+        let db_keys = keys.iter().zip(&patch_lookup).filter_map(|(key, lookup)| {
+            if matches!(lookup, KeyLookup::Existing(_)) {
+                // The key is present in the patch; not necessary to request it from the DB.
+                None
+            } else {
+                Some(*key)
+            }
+        });
+        let db_keys: Vec<_> = db_keys.collect();
+        let mut db_lookup = self.inner.indices(version, &db_keys)?.into_iter();
+
+        let merged = patch_lookup.into_iter().map(|from_patch| match from_patch {
+            lookup @ KeyLookup::Existing(_) => lookup,
+            KeyLookup::Missing {
+                prev_key_and_index: patch_prev,
+                next_key_and_index: patch_next,
+            } => {
+                match db_lookup.next().unwrap() {
+                    // Exact match in the database, no need to merge
+                    lookup @ KeyLookup::Existing(_) => lookup,
+                    KeyLookup::Missing {
+                        prev_key_and_index: db_prev,
+                        next_key_and_index: db_next,
+                    } => KeyLookup::Missing {
+                        // Using `min` / `max` work because `(prev|next)_key_and_index` have key as the first element.
+                        prev_key_and_index: patch_prev.max(db_prev),
+                        next_key_and_index: patch_next.min(db_next),
+                    },
+                }
+            }
+        });
+        Ok(merged.collect())
+    }
+
+    fn try_manifest(&self) -> Result<Option<Manifest>, DeserializeError> {
+        if let Some(patch) = &self.patch {
+            Ok(Some(patch.manifest.clone()))
+        } else {
+            self.inner.try_manifest()
+        }
+    }
+
+    fn try_root(&self, version: u64) -> Result<Option<Root>, DeserializeError> {
+        if let Some(patch) = &self.patch {
+            if patch.is_new_version(version) {
+                return patch.try_root(version);
+            }
+        }
+        self.inner.try_root(version)
+    }
+
+    fn try_nodes(&self, keys: &[NodeKey]) -> Result<Vec<Node>, DeserializeError> {
+        if self.patch.is_none() {
+            return self.inner.try_nodes(keys);
+        }
+
+        let mut is_in_patch = vec![false; keys.len()];
+        let mut patch_nodes = vec![];
+        for (key, is_in_patch) in keys.iter().zip(&mut is_in_patch) {
+            if let Some(patch_node) = self.lookup_patch(key)? {
+                *is_in_patch = true;
+                patch_nodes.push(patch_node);
+            }
+        }
+
+        let db_keys: Vec<_> = keys
+            .iter()
+            .zip(&is_in_patch)
+            .filter_map(|(key, is_in_patch)| (!is_in_patch).then_some(*key))
+            .collect();
+        let mut db_nodes = self.inner.try_nodes(&db_keys)?.into_iter();
+        let mut patch_nodes = patch_nodes.into_iter();
+
+        let all_nodes = is_in_patch.into_iter().map(|is_in_patch| {
+            if is_in_patch {
+                patch_nodes.next().unwrap()
+            } else {
+                db_nodes.next().unwrap()
+            }
+        });
+        Ok(all_nodes.collect())
+    }
+
+    fn apply_patch(&mut self, patch: PatchSet) -> anyhow::Result<()> {
+        if let Some(existing_patch) = &mut self.patch {
+            existing_patch.apply_patch(patch)?;
+        } else {
+            self.patch = Some(patch);
+        }
+        Ok(())
+    }
+
+    fn truncate(
+        &mut self,
+        manifest: Manifest,
+        truncated_versions: ops::RangeTo<u64>,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.patch.is_none(),
+            "Cannot truncate `Patched` database with non-flushed changes"
+        );
+        self.inner.truncate(manifest, truncated_versions)
     }
 }

--- a/core/lib/zk_os_merkle_tree/src/storage/patch.rs
+++ b/core/lib/zk_os_merkle_tree/src/storage/patch.rs
@@ -405,6 +405,8 @@ impl<P: TreeParams> WorkingPatchSet<P> {
         if readonly_leaf_indices_len > 0 {
             // Filter out all internal nodes that were not updated (= don't have updated child refs).
             let removed_node_count = this.remove_readonly_nodes(version);
+            METRICS.readonly_leaves.observe(readonly_leaf_indices_len);
+            METRICS.readonly_internal_nodes.observe(removed_node_count);
             tracing::debug!(
                 leaves = readonly_leaf_indices_len,
                 internal_nodes = removed_node_count,

--- a/core/lib/zk_os_merkle_tree/src/storage/patch.rs
+++ b/core/lib/zk_os_merkle_tree/src/storage/patch.rs
@@ -611,7 +611,7 @@ impl<DB: Database, P: TreeParams> MerkleTree<DB, P> {
                     if distinct_indices.insert(*idx) {
                         readonly_leaf_indices.push(*idx);
                     }
-                    TreeOperation::Update { index: *idx }
+                    TreeOperation::Hit { index: *idx }
                 }
                 KeyLookup::Missing {
                     prev_key_and_index: (_, prev_idx),
@@ -625,7 +625,7 @@ impl<DB: Database, P: TreeParams> MerkleTree<DB, P> {
                         readonly_leaf_indices.push(*next_idx);
                     }
 
-                    TreeOperation::Insert {
+                    TreeOperation::Miss {
                         prev_index: *prev_idx,
                     }
                 }
@@ -650,7 +650,7 @@ impl<DB: Database, P: TreeParams> MerkleTree<DB, P> {
             match lookup {
                 &KeyLookup::Existing(idx) => {
                     updates.push((idx, entry.value));
-                    operations.push(TreeOperation::Update { index: idx });
+                    operations.push(TreeOperation::Hit { index: idx });
                 }
 
                 KeyLookup::Missing {
@@ -659,7 +659,7 @@ impl<DB: Database, P: TreeParams> MerkleTree<DB, P> {
                 } => {
                     // Adjust previous / next indices according to the data inserted in the same batch.
                     let mut prev_index = prev_key_and_index.1;
-                    operations.push(TreeOperation::Insert { prev_index });
+                    operations.push(TreeOperation::Miss { prev_index });
 
                     if let Some((&local_prev_key, inserted)) =
                         sorted_new_leaves.range(..entry.key).next_back()

--- a/core/lib/zk_os_merkle_tree/src/storage/patch.rs
+++ b/core/lib/zk_os_merkle_tree/src/storage/patch.rs
@@ -509,7 +509,7 @@ impl<DB: Database, P: TreeParams> MerkleTree<DB, P> {
         let started_at = Instant::now();
         let lookup = self
             .db
-            .indices(u64::MAX, &touched_keys)
+            .indices(latest_version, &touched_keys)
             .context("failed loading indices")?;
         tracing::debug!(elapsed = ?started_at.elapsed(), "loaded lookup info");
 

--- a/core/lib/zk_os_merkle_tree/src/storage/patch.rs
+++ b/core/lib/zk_os_merkle_tree/src/storage/patch.rs
@@ -520,6 +520,12 @@ impl<P: TreeParams> WorkingPatchSet<P> {
             root_hash,
         };
 
+        // Release excessive capacity occupied by the partial patch set. We'll never modify it inside a `PatchSet`.
+        this.leaves.shrink_to_fit();
+        for internal_level in &mut this.internal {
+            internal_level.shrink_to_fit();
+        }
+
         let patch = PatchSet {
             manifest: Manifest {
                 version_count: update.version + 1,

--- a/core/lib/zk_os_merkle_tree/src/storage/rocksdb.rs
+++ b/core/lib/zk_os_merkle_tree/src/storage/rocksdb.rs
@@ -9,6 +9,7 @@ use zksync_storage::{db::NamedColumnFamily, rocksdb, rocksdb::DBPinnableSlice, R
 
 use crate::{
     errors::{DeserializeContext, DeserializeErrorKind},
+    metrics::METRICS,
     storage::{InsertedKeyEntry, PartialPatchSet, PatchSet},
     types::{InternalNode, KeyLookup, Leaf, Manifest, Node, NodeKey, Root},
     Database, DeserializeError,
@@ -246,6 +247,7 @@ impl Database for RocksDBWrapper {
         let mut node_bytes = Vec::with_capacity(128);
         // ^ 128 looks somewhat reasonable as node capacity
 
+        let copied_hashes = patch.copied_hashes_count();
         let new_leaves = patch.sorted_new_leaves.len();
         let total_leaves: usize = patch
             .patches_by_version
@@ -310,11 +312,20 @@ impl Database for RocksDBWrapper {
             }
         }
 
+        METRICS
+            .apply_patch_key_lookup_entries_count
+            .observe(new_leaves);
+        METRICS.apply_patch_leaves_count.observe(total_leaves);
+        METRICS
+            .apply_patch_internal_nodes_count
+            .observe(total_internal_nodes);
+        METRICS.apply_patch_copied_hashes.observe(copied_hashes);
         tracing::debug!(
             total_size = write_batch.size_in_bytes(),
             new_leaves,
             total_leaves,
             total_internal_nodes,
+            copied_hashes,
             "writing to RocksDB"
         );
 

--- a/core/lib/zk_os_merkle_tree/src/storage/tests.rs
+++ b/core/lib/zk_os_merkle_tree/src/storage/tests.rs
@@ -220,7 +220,7 @@ where
         key: H256::repeat_byte(0x01),
         value: H256::repeat_byte(0x10),
     };
-    let (mut patch, update) = merkle_tree.create_patch(0, &[new_entry]).unwrap();
+    let (mut patch, update) = merkle_tree.create_patch(0, &[new_entry], &[]).unwrap();
 
     assert_eq!(patch.inner().leaf_count, 2);
     assert_eq!(
@@ -314,7 +314,7 @@ where
         value: H256::repeat_byte(0x20),
     };
     let (mut patch, update) = merkle_tree
-        .create_patch(0, &[first_entry, second_entry])
+        .create_patch(0, &[first_entry, second_entry], &[])
         .unwrap();
 
     let final_update = patch.update(update);
@@ -332,7 +332,7 @@ where
         key: first_entry.key,
         value: H256::repeat_byte(0x33),
     };
-    let (mut patch, update) = merkle_tree.create_patch(1, &[updated_entry]).unwrap();
+    let (mut patch, update) = merkle_tree.create_patch(1, &[updated_entry], &[]).unwrap();
 
     assert!(update.inserts.is_empty());
     assert_eq!(update.updates, [(2, updated_entry.value)]);
@@ -393,7 +393,7 @@ where
         value: H256::repeat_byte(0x20),
     };
     let (mut patch, update) = merkle_tree
-        .create_patch(0, &[updated_entry, second_entry])
+        .create_patch(0, &[updated_entry, second_entry], &[])
         .unwrap();
 
     assert_eq!(

--- a/core/lib/zk_os_merkle_tree/src/tests.rs
+++ b/core/lib/zk_os_merkle_tree/src/tests.rs
@@ -181,8 +181,10 @@ fn test_extending_tree_with_proof(db: impl Database, inserts_count: usize, updat
     let inserts: Vec<_> = nodes.collect();
 
     let mut tree = MerkleTree::new(db).unwrap();
-    let (inserts_output, proof) = tree.extend_with_proof(&inserts).unwrap();
-    let root_hash_from_proof = proof.verify(&Blake2Hasher, 64, None, &inserts).unwrap();
+    let (inserts_output, proof) = tree.extend_with_proof(&inserts, &[]).unwrap();
+    let root_hash_from_proof = proof
+        .verify(&Blake2Hasher, 64, None, &inserts, &[])
+        .unwrap();
     assert_eq!(root_hash_from_proof, inserts_output.root_hash);
 
     // Test a proof with only updates.
@@ -194,7 +196,7 @@ fn test_extending_tree_with_proof(db: impl Database, inserts_count: usize, updat
         })
         .collect();
 
-    let (output, proof) = tree.extend_with_proof(&updates).unwrap();
+    let (output, proof) = tree.extend_with_proof(&updates, &[]).unwrap();
     let updates_tree_hash = output.root_hash;
 
     assert_eq!(proof.operations.len(), updates.len());
@@ -214,7 +216,7 @@ fn test_extending_tree_with_proof(db: impl Database, inserts_count: usize, updat
     );
 
     let root_hash_from_proof = proof
-        .verify(&Blake2Hasher, 64, Some(inserts_output), &updates)
+        .verify(&Blake2Hasher, 64, Some(inserts_output), &updates, &[])
         .unwrap();
     assert_eq!(root_hash_from_proof, updates_tree_hash);
 }
@@ -261,9 +263,9 @@ fn test_incrementally_extending_tree_with_proofs(db: impl Database, update_count
             let mut entries = chunk.to_vec();
             entries.extend(updates);
 
-            let (new_output, proof) = tree.extend_with_proof(&entries).unwrap();
+            let (new_output, proof) = tree.extend_with_proof(&entries, &[]).unwrap();
             let proof_hash = proof
-                .verify(&Blake2Hasher, 64, Some(tree_output), &entries)
+                .verify(&Blake2Hasher, 64, Some(tree_output), &entries, &[])
                 .unwrap();
             assert_eq!(proof_hash, new_output.root_hash);
             tree_output = new_output;

--- a/core/lib/zk_os_merkle_tree/src/tests.rs
+++ b/core/lib/zk_os_merkle_tree/src/tests.rs
@@ -209,8 +209,8 @@ fn test_extending_tree_with_proof(db: impl Database, inserts_count: usize, updat
     let mut updated_indices = vec![];
     for op in &proof.operations {
         match *op {
-            TreeOperation::Update { index } => updated_indices.push(index),
-            TreeOperation::Insert { .. } => panic!("unexpected operation: {op:?}"),
+            TreeOperation::Hit { index } => updated_indices.push(index),
+            TreeOperation::Miss { .. } => panic!("unexpected operation: {op:?}"),
         }
     }
     updated_indices.sort_unstable();

--- a/core/lib/zk_os_merkle_tree/src/types/mod.rs
+++ b/core/lib/zk_os_merkle_tree/src/types/mod.rs
@@ -89,6 +89,7 @@ impl InternalNode {
 
 /// Arbitrary tree node.
 #[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum Node {
     Internal(InternalNode),
     Leaf(Leaf),


### PR DESCRIPTION
## What ❔

- Implements proofs for read operations in the ZK OS Merkle tree. Adds tree API to get such proofs asynchronously.
- Adds metrics for the tree.
- Allows batches writes / in-memory buffering for the tree.

## Why ❔

- Read proofs are necessary for ZK OS integration.
- Metrics are necessary for observability.
- In-memory buffering improves performance.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.