### PR TITLE
perf(api): Use watch channel in values cache updates

### DIFF
--- a/core/lib/state/src/postgres/metrics.rs
+++ b/core/lib/state/src/postgres/metrics.rs
@@ -2,7 +2,9 @@
 
 use std::time::Duration;
 
-use vise::{Buckets, Counter, EncodeLabelSet, EncodeLabelValue, Family, Gauge, Histogram, Metrics};
+use vise::{
+    Buckets, Counter, EncodeLabelSet, EncodeLabelValue, Family, Gauge, Histogram, Metrics, Unit,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelSet, EncodeLabelValue)]
 #[metrics(label = "stage", rename_all = "snake_case")]
@@ -18,6 +20,12 @@ pub(super) struct ValuesCacheMetrics {
     pub stale_values: Counter,
     /// Number of times the values cache was emptied because it was too far back.
     pub values_emptied: Counter,
+    /// Interval between queueing sequential update commands for the values cache.
+    #[metrics(buckets = Buckets::LATENCIES, unit = Unit::Seconds)]
+    pub values_command_interval: Histogram<Duration>,
+    /// Latency of receiving a values cache update command.
+    #[metrics(buckets = Buckets::LATENCIES, unit = Unit::Seconds)]
+    pub values_receive_latency: Histogram<Duration>,
     /// Latency of values cache update stages.
     #[metrics(buckets = Buckets::LATENCIES)]
     pub values_update: Family<ValuesUpdateStage, Histogram<Duration>>,

--- a/core/lib/state/src/postgres/mod.rs
+++ b/core/lib/state/src/postgres/mod.rs
@@ -192,9 +192,13 @@ impl ValuesCache {
         to_l2_block: L2BlockNumber,
         connection: &mut Connection<'_, Core>,
     ) -> anyhow::Result<()> {
-        tracing::debug!(
-            "Updating storage values cache from L2 block {from_l2_block} to {to_l2_block}"
-        );
+        if from_l2_block == L2BlockNumber(0) {
+            tracing::debug!("Initializing storage values cache at L2 block {to_l2_block}");
+        } else {
+            tracing::debug!(
+                "Updating storage values cache from L2 block {from_l2_block} to {to_l2_block}"
+            );
+        }
 
         let update_latency = CACHE_METRICS.values_update[&ValuesUpdateStage::LoadKeys].start();
         let l2_blocks = (from_l2_block + 1)..=to_l2_block;

--- a/core/lib/state/src/postgres/tests.rs
+++ b/core/lib/state/src/postgres/tests.rs
@@ -624,6 +624,7 @@ fn mini_fuzz_values_cache_inner(
                     .block_on(values_cache.update(
                         cache_valid_for,
                         L2BlockNumber(latest_block_number),
+                        Duration::ZERO,
                         &mut connection,
                     ))
                     .unwrap();


### PR DESCRIPTION
## What ❔

Switches `PostgresStorageCachesTask` to use a watch channel for update commands instead of an unbounded MPSC one.

## Why ❔

Under load, update commands can be queued faster than they are processed, and the existing logic to drop the cache if it's too far behind the current L2 block is never triggered (while it should).

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.