### PR TITLE
fix: Install needed rust toolchain

### DIFF
--- a/.github/workflows/cargo-license.yaml
+++ b/.github/workflows/cargo-license.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-    - uses: EmbarkStudios/cargo-deny-action@8371184bd11e21dcf8ac82ebf8c9c9f74ebf7268 # v2.0.1
+    - uses: EmbarkStudios/cargo-deny-action@8d73959fce1cdc8989f23fdf03bec6ae6a6576ef # v2.0.7
       with:
         manifest-path: "./core/Cargo.toml"
         command: check

--- a/docker/zk-environment/Dockerfile
+++ b/docker/zk-environment/Dockerfile
@@ -170,9 +170,11 @@ ENV RUSTC_WRAPPER=/usr/local/cargo/bin/sccache
 
 # If target is 'main' - then install default rust.
 FROM rust-lightweight-base as rust-lightweight
-RUN wget -c -O - https://sh.rustup.rs | bash -s -- -y
+RUN wget -c -O - https://sh.rustup.rs | bash -s -- -y && \
+    rustup show active-toolchain || rustup toolchain install
 
 
 # If target is nightly - then install only nightly rust.
 FROM rust-lightweight-base as rust-lightweight-nightly
-RUN wget -c -O - https://sh.rustup.rs | bash -s -- -y --default-toolchain nightly-2024-08-01
+RUN wget -c -O - https://sh.rustup.rs | bash -s -- -y --default-toolchain nightly-2024-08-01 && \
+    rustup show active-toolchain || rustup toolchain install


### PR DESCRIPTION
## What ❔

rustup broke installation of default toolchain in v1.28.0, it has to be installed manually now.

See https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To fix zk-environment-publish.yml and Cargo licence check CIs.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
