### PR TITLE
fix: Add autoscaler_queue metric back

### DIFF
--- a/prover/crates/bin/prover_autoscaler/src/global/manager.rs
+++ b/prover/crates/bin/prover_autoscaler/src/global/manager.rs
@@ -118,6 +118,7 @@ impl Task for Manager {
                         .get(&(ppv.to_string(), scaler.queue_report_field()))
                         .cloned()
                         .unwrap_or(0);
+                    AUTOSCALER_METRICS.queue[&(ns.clone(), scaler.deployment())].set(q);
                     tracing::debug!(
                         "Running eval for namespace {ns}, PPV {ppv}, scaler {} found queue {q}",
                         scaler.deployment()


### PR DESCRIPTION


## What ❔
Add `autoscaler_queue` metric back.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

`autoscaler_queue` metric is used in dashboard to show current queue per scaler target.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.

ref ZKD-2229
