### PR TITLE
fix: add mainnet address for Avail L1 DA Validator

### DIFF
--- a/zkstack_cli/crates/types/src/l1_network.rs
+++ b/zkstack_cli/crates/types/src/l1_network.rs
@@ -45,7 +45,7 @@ impl L1Network {
             L1Network::Sepolia | L1Network::Holesky => {
                 Some(Address::from_str("0x73d59fe232fce421d1365d6a5beec49acde3d0d9").unwrap())
             }
-            L1Network::Mainnet => None, // TODO: add mainnet address after it is known
+            L1Network::Mainnet => Some(Address::from_str("0x73d59fe232fce421d1365d6a5beec49acde3d0d9").unwrap()),
         }
     }
 }


### PR DESCRIPTION
## What ❔

This PR adds the mainnet address for the Avail L1 DA Validator in the L1Network enum.
The same address that is used for testnet networks (Sepolia and Holesky) is now also used for mainnet.
This resolves the TODO comment in the code.

## Why ❔

Ensuring the mainnet uses the correct Avail L1 DA Validator address aligns with the existing testnet configuration.
This change removes the TODO comment, improving code clarity and completeness.

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes

No additional configuration changes, flags, or scripts are affected.
Non-Matter Labs entities running their own ZK Chain do not need to take any action.

## Checklist


- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
