### PR TITLE
ci: Stop copying unneeded setup-data files into each gar images

### DIFF
--- a/.github/workflows/build-circuit-prover-gpu-gar.yml
+++ b/.github/workflows/build-circuit-prover-gpu-gar.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Download Setup data
         run: |
-          gsutil -m rsync -r gs://matterlabs-setup-data-us/${{ inputs.setup_keys_id }} docker/circuit-prover-gpu-gar
+          gsutil -m rsync -x "fflonk|plonk|setup_compression" -r gs://matterlabs-setup-data-us/${{ inputs.setup_keys_id }} docker/circuit-prover-gpu-gar
 
       - name: Login to us-central1 GAR
         run: |

--- a/.github/workflows/build-proof-fri-gpu-compressor-gar.yml
+++ b/.github/workflows/build-proof-fri-gpu-compressor-gar.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Download FFLONK key and setup data
         run: |
-          gsutil -m rsync -r gs://matterlabs-setup-data-us/${{ inputs.setup_keys_id }} docker/proof-fri-gpu-compressor-gar
+          gsutil -m rsync -x "setup_(basic|leaf|node|recursion_tip|scheduler)" -r gs://matterlabs-setup-data-us/${{ inputs.setup_keys_id }} docker/proof-fri-gpu-compressor-gar
           gsutil -m cp -r gs://matterlabs-setup-keys-us/setup-keys/setup_compact.key docker/proof-fri-gpu-compressor-gar
 
       - name: Login to us-central1 GAR


### PR DESCRIPTION
## What ❔

Stop copying unneeded setup-data files into each circuit-prover-gpu-gar and proof-fri-gpu-compressor-gar images.


<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To reduce docker image size and startup time.
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.

ref ZKD-2469
