### PR TITLE
feat(api): add endpoint supports_unsafe_deposit_filter

### DIFF
--- a/core/lib/web3_decl/src/namespaces/unstable.rs
+++ b/core/lib/web3_decl/src/namespaces/unstable.rs
@@ -47,4 +47,7 @@ pub trait UnstableNamespace {
         &self,
         batch: L1BatchNumber,
     ) -> RpcResult<Option<DataAvailabilityDetails>>;
+
+    #[method(name = "supportsUnsafeDepositFilter")]
+    async fn supports_unsafe_deposit_filter(&self) -> RpcResult<bool>;
 }

--- a/core/node/api_server/src/web3/backend_jsonrpsee/namespaces/unstable.rs
+++ b/core/node/api_server/src/web3/backend_jsonrpsee/namespaces/unstable.rs
@@ -55,4 +55,8 @@ impl UnstableNamespaceServer for UnstableNamespace {
             .await
             .map_err(|err| self.current_method().map_err(err))
     }
+
+    async fn supports_unsafe_deposit_filter(&self) -> RpcResult<bool> {
+        Ok(self.supports_unsafe_deposit_filter_impl())
+    }
 }

--- a/core/node/api_server/src/web3/namespaces/unstable/mod.rs
+++ b/core/node/api_server/src/web3/namespaces/unstable/mod.rs
@@ -174,4 +174,8 @@ impl UnstableNamespace {
             l2_da_validator: da_details.l2_da_validator,
         }))
     }
+
+    pub fn supports_unsafe_deposit_filter_impl(&self) -> bool {
+        true
+    }
 }


### PR DESCRIPTION
## What ❔

add endpoint supports_unsafe_deposit_filter

## Why ❔

Having this functionality for main nodes is strongly recommended for v26 upgrade. Endpoint allows to check if node is "ready" from outside.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

No changes

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
