### PR TITLE
test: Test that the wrapped base token has correct metadata

### DIFF
--- a/core/tests/ts-integration/tests/base-token.test.ts
+++ b/core/tests/ts-integration/tests/base-token.test.ts
@@ -8,6 +8,7 @@ import { Token } from '../src/types';
 import * as zksync from 'zksync-ethers';
 import * as ethers from 'ethers';
 import { scaledGasPrice, waitForL2ToL1LogProof } from '../src/helpers';
+import { IL2NativeTokenVault__factory } from 'zksync-ethers/build/typechain';
 
 const SECONDS = 2000;
 jest.setTimeout(100 * SECONDS);
@@ -179,6 +180,39 @@ describe('base ERC20 contract checks', () => {
 
         expect(finalL1Balance).toEqual(initialL1Balance + amount);
         expect(finalL2Balance + amount + fee).toEqual(initialL2Balance);
+    });
+
+    test('Wrapped base token metadata', async () => {
+        // This test is intended only to be run against newly created chains.
+        if (!testMaster.isLocalHost()) {
+            return;
+        }
+
+        let name;
+        let symbol;
+
+        if (isETHBasedChain) {
+            name = 'Ether';
+            symbol = 'ETH';
+        } else {
+            const contract = new ethers.Contract(baseTokenDetails.l1Address, zksync.utils.IERC20, alice.ethWallet());
+            name = await contract.name();
+            symbol = await contract.symbol();
+        }
+
+        const expectedWrappedBaseTokenName = `Wrapped ${name}`;
+        const expectedWrappedBaseTokenSymbol = `W${symbol}`;
+
+        const l2NativeTokenVault = IL2NativeTokenVault__factory.connect(
+            zksync.utils.L2_NATIVE_TOKEN_VAULT_ADDRESS,
+            alice
+        );
+        const wethToken = await l2NativeTokenVault.WETH_TOKEN();
+
+        const wrappedBaseToken = new ethers.Contract(wethToken, zksync.utils.IERC20, alice);
+
+        expect(expectedWrappedBaseTokenName).toEqual(await wrappedBaseToken.name());
+        expect(expectedWrappedBaseTokenSymbol).toEqual(await wrappedBaseToken.symbol());
     });
 
     afterAll(async () => {


### PR DESCRIPTION
## What ❔

This was not the case until the chain creation params patch. We already have unit tests for similar behavior in `era-contracts` repo, but it is better to have one here as well, especially considering that it is lightweight

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
