### PR TITLE
fix: Hack to make compressor works with setup-data in a different place vs provers

### DIFF
--- a/docker/proof-fri-gpu-compressor-gar/Dockerfile
+++ b/docker/proof-fri-gpu-compressor-gar/Dockerfile
@@ -14,5 +14,7 @@ COPY --from=proof_fri_gpu /usr/bin/zksync_proof_fri_compressor /usr/bin/
 
 ENV COMPACT_CRS_FILE=/setup_compact.key
 
+# Hack to make compressor work because it for very unknown reason shares config with prover which has setup-data in /setup-data directory now.
+RUN ln -s / /setup-data
 
 ENTRYPOINT ["zksync_proof_fri_compressor"]


### PR DESCRIPTION
## What ❔

Hack to make compressor works with setup-data in a different place vs provers.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.

ref ZKD-2456