### PR TITLE
perf(zkos): Choose optimal amortization radix for ZK OS Merkle tree

### DIFF
--- a/core/lib/storage/src/db.rs
+++ b/core/lib/storage/src/db.rs
@@ -628,6 +628,11 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
         // ^ unwrap() is safe for the same reasons as in `prefix_iterator_cf()`.
     }
 
+    pub fn raw_iterator(&self, cf: CF) -> rocksdb::DBIterator<'_> {
+        let cf = self.column_family(cf);
+        self.inner.db.iterator_cf(cf, IteratorMode::Start)
+    }
+
     /// Creates a new profiled operation.
     pub fn new_profiled_operation(&self, name: &'static str) -> ProfiledOperation {
         ProfiledOperation {

--- a/core/lib/storage/src/db.rs
+++ b/core/lib/storage/src/db.rs
@@ -103,6 +103,17 @@ impl RocksDBCaches {
     }
 }
 
+/// Size statistics for a column family. All sizes are measured in bytes.
+#[derive(Debug)]
+pub struct SizeStats {
+    pub live_data_size: u64,
+    pub total_sst_size: u64,
+    pub total_mem_table_size: u64,
+    pub block_cache_size: u64,
+    pub index_and_filters_size: u64,
+    pub files_at_level: Vec<u64>,
+}
+
 #[derive(Debug)]
 pub(crate) struct RocksDBInner {
     db: DB,
@@ -116,8 +127,6 @@ pub(crate) struct RocksDBInner {
 
 impl RocksDBInner {
     pub(crate) fn collect_metrics(&self, metrics: &RocksdbSizeMetrics) {
-        const MAX_LEVEL: usize = 6;
-
         for &cf_name in &self.cf_names {
             let cf = self.db.cf_handle(cf_name).unwrap();
             // ^ `unwrap()` is safe (CF existence is checked during DB initialization)
@@ -150,33 +159,15 @@ impl RocksDBInner {
                 metrics.pending_compactions[&labels].set(pending_compactions);
             }
 
-            let live_data_size = self.int_property(cf, properties::ESTIMATE_LIVE_DATA_SIZE);
-            if let Some(size) = live_data_size {
-                metrics.live_data_size[&labels].set(size);
-            }
-            let total_sst_file_size = self.int_property(cf, properties::TOTAL_SST_FILES_SIZE);
-            if let Some(size) = total_sst_file_size {
-                metrics.total_sst_size[&labels].set(size);
-            }
-            let total_mem_table_size = self.int_property(cf, properties::SIZE_ALL_MEM_TABLES);
-            if let Some(size) = total_mem_table_size {
-                metrics.total_mem_table_size[&labels].set(size);
-            }
-            let block_cache_size = self.int_property(cf, properties::BLOCK_CACHE_USAGE);
-            if let Some(size) = block_cache_size {
-                metrics.block_cache_size[&labels].set(size);
-            }
-            let index_and_filters_size =
-                self.int_property(cf, properties::ESTIMATE_TABLE_READERS_MEM);
-            if let Some(size) = index_and_filters_size {
-                metrics.index_and_filters_size[&labels].set(size);
-            }
+            let size_stats = self.size_stats(cf);
+            metrics.live_data_size[&labels].set(size_stats.live_data_size);
+            metrics.total_sst_size[&labels].set(size_stats.total_sst_size);
+            metrics.total_mem_table_size[&labels].set(size_stats.total_mem_table_size);
+            metrics.block_cache_size[&labels].set(size_stats.block_cache_size);
+            metrics.index_and_filters_size[&labels].set(size_stats.index_and_filters_size);
 
-            for level in 0..=MAX_LEVEL {
-                let files_at_level = self.int_property(cf, &properties::num_files_at_level(level));
-                if let Some(files_at_level) = files_at_level {
-                    metrics.files_at_level[&labels.for_level(level)].set(files_at_level);
-                }
+            for (level, files_at_level) in size_stats.files_at_level.into_iter().enumerate() {
+                metrics.files_at_level[&labels.for_level(level)].set(files_at_level);
             }
         }
     }
@@ -193,6 +184,39 @@ impl RocksDBInner {
             tracing::warn!("Property `{name_str}` is not defined");
         }
         property
+    }
+
+    fn size_stats(&self, cf: &ColumnFamily) -> SizeStats {
+        const MAX_LEVEL: usize = 6;
+
+        let live_data_size = self
+            .int_property(cf, properties::ESTIMATE_LIVE_DATA_SIZE)
+            .unwrap_or(0);
+        let total_sst_size = self
+            .int_property(cf, properties::TOTAL_SST_FILES_SIZE)
+            .unwrap_or(0);
+        let total_mem_table_size = self
+            .int_property(cf, properties::SIZE_ALL_MEM_TABLES)
+            .unwrap_or(0);
+        let block_cache_size = self
+            .int_property(cf, properties::BLOCK_CACHE_USAGE)
+            .unwrap_or(0);
+        let index_and_filters_size = self
+            .int_property(cf, properties::ESTIMATE_TABLE_READERS_MEM)
+            .unwrap_or(0);
+        let files_at_level = (0..=MAX_LEVEL).map(|level| {
+            self.int_property(cf, &properties::num_files_at_level(level))
+                .unwrap_or(0)
+        });
+
+        SizeStats {
+            live_data_size,
+            total_sst_size,
+            total_mem_table_size,
+            block_cache_size,
+            index_and_filters_size,
+            files_at_level: files_at_level.collect(),
+        }
     }
 
     /// Waits until writes are not stopped for any of the CFs. Writes can stop immediately on DB initialization
@@ -568,6 +592,12 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
             .db
             .cf_handle(cf.name())
             .unwrap_or_else(|| panic!("Column family `{}` doesn't exist", cf.name()))
+    }
+
+    /// Returns size stats for the specified column family.
+    pub fn size_stats(&self, cf: CF) -> SizeStats {
+        let cf = self.column_family(cf);
+        self.inner.size_stats(cf)
     }
 
     pub fn get_cf(&self, cf: CF, key: &[u8]) -> Result<Option<Vec<u8>>, rocksdb::Error> {

--- a/core/lib/storage/src/db.rs
+++ b/core/lib/storage/src/db.rs
@@ -628,9 +628,9 @@ impl<CF: NamedColumnFamily> RocksDB<CF> {
         // ^ unwrap() is safe for the same reasons as in `prefix_iterator_cf()`.
     }
 
-    pub fn raw_iterator(&self, cf: CF) -> rocksdb::DBIterator<'_> {
+    pub fn raw_iterator(&self, cf: CF, options: ReadOptions) -> rocksdb::DBRawIterator<'_> {
         let cf = self.column_family(cf);
-        self.inner.db.iterator_cf(cf, IteratorMode::Start)
+        self.inner.db.raw_iterator_cf_opt(cf, options)
     }
 
     /// Creates a new profiled operation.

--- a/core/lib/zk_os_merkle_tree/README.md
+++ b/core/lib/zk_os_merkle_tree/README.md
@@ -42,11 +42,11 @@ with additional data (for now, it's just the number of leaves).
 - A **leaf** consists of a key, value and prev / next indices as expected.
 - **Internal nodes** consist of refs to children; each ref is a version + hash. To reduce the amount of I/O ops (at the
   cost of read / write volume overhead), an internal node contains >2 child refs; that's what the radix mentioned above
-  means (e.g., in a radix-16 tree each internal node _usually_ contains 16 child refs, with the only possible exception
+  means (e.g., in a radix-8 tree each internal node _usually_ contains 8 child refs, with the only possible exception
   being the rightmost node on each tree level).
 
-E.g., here's a radix-16 amortized tree with 2 versions and toy depth 8 (i.e., 1 internal node level excluding the root,
-and 1 leaf level). The first version inserts 17 leaves, and the second version updates the last leaf.
+E.g., here's a radix-8 amortized tree with 2 versions and toy depth 8 (i.e., 1 internal node level excluding the root,
+and 1 leaf level). The first version inserts 9 leaves, and the second version updates the last leaf.
 
 ```mermaid
 ---
@@ -60,15 +60,15 @@ flowchart TD
     Internal1_1[Internal 1']
     Leaf0[Leaf 0]
     Leaf1[Leaf 1]
-    Leaf15[Leaf 15]
-    Leaf16[Leaf 16]
-    Leaf16_1[Leaf 16']
+    Leaf7[Leaf 7]
+    Leaf8[Leaf 8]
+    Leaf8_1[Leaf 8']
     Root0-->Internal0 & Internal1
-    Internal0-->Leaf0 & Leaf1 & Leaf15
-    Internal1-->Leaf16
+    Internal0-->Leaf0 & Leaf1 & Leaf7
+    Internal1-->Leaf8
 
     Root1-->Internal0 & Internal1_1
-    Internal1_1-->Leaf16_1
+    Internal1_1-->Leaf8_1
 ```
 
 Tree nodes are mapped to the RocksDB column family (CF) using _node keys_ consisting of a version, the number of
@@ -98,21 +98,65 @@ The order of timings should be as follows (measured on MacBook Pro with 12-core 
 using the command line above):
 
 ```text
-2025-02-19T11:06:24.736870Z  INFO loadtest: Processing block #999
-2025-02-19T11:06:24.813829Z DEBUG zk_os_merkle_tree::storage::patch: loaded lookup info, elapsed: 76.89375ms
-2025-02-19T11:06:24.908340Z DEBUG zk_os_merkle_tree::storage::patch: loaded nodes, elapsed: 93.501125ms, distinct_indices.len: 23967
-2025-02-19T11:06:24.908994Z DEBUG zk_os_merkle_tree: loaded tree data, elapsed: 172.085ms, inserts: 4000, updates: 16000, loaded_internal_nodes: 36294
-2025-02-19T11:06:24.936667Z DEBUG zk_os_merkle_tree::storage::patch: collected hashes for batch proof, hash_latency: 15.131706ms, traverse_latency: 10.213624ms
-2025-02-19T11:06:24.936756Z DEBUG zk_os_merkle_tree: created batch proof, elapsed: 27.751333ms, proof.leaves.len: 23967, proof.hashes.len: 156210
-2025-02-19T11:06:24.944054Z DEBUG zk_os_merkle_tree: updated tree structure, elapsed: 7.285209ms
-2025-02-19T11:06:24.954820Z DEBUG zk_os_merkle_tree: hashed tree, elapsed: 10.747417ms
-2025-02-19T11:06:25.017817Z DEBUG zk_os_merkle_tree: persisted tree, elapsed: 62.967083ms
-2025-02-19T11:06:25.018655Z  INFO loadtest: Processed block #999 in 281.765541ms, root hash = 0x12fa11d7742d67509c9a980e0fb62a1b64a478c9ff4d7596555e1f0d5cb2043f
-2025-02-19T11:06:25.018669Z  INFO loadtest: Verifying tree consistency...
-2025-02-19T11:07:06.144174Z  INFO loadtest: Verified tree consistency in 41.126574667s
+2025-03-06T13:22:11.424921Z  INFO loadtest: Processing block #999
+2025-03-06T13:22:11.446972Z DEBUG zk_os_merkle_tree::storage::rocksdb: completed looking up keys in RocksDB, get_latency: 13.920959ms, iterators_latency: 8.026958ms
+2025-03-06T13:22:11.447005Z DEBUG zk_os_merkle_tree::storage::patch: loaded lookup info, elapsed: 21.989917ms
+2025-03-06T13:22:11.520249Z DEBUG zk_os_merkle_tree::storage::patch: loaded tree nodes, elapsed: 71.171667ms, distinct_indices.len: 23957
+2025-03-06T13:22:11.520980Z DEBUG zk_os_merkle_tree: loaded tree data, elapsed: 95.991375ms, inserts: 4000, updates: 16000, reads: 0, missing_reads: 0, loaded_internal_nodes: 52014
+2025-03-06T13:22:11.544711Z DEBUG zk_os_merkle_tree::storage::patch: collected hashes for batch proof, hash_latency: 8.357416ms, traverse_latency: 13.081128ms
+2025-03-06T13:22:11.544736Z DEBUG zk_os_merkle_tree: created batch proof, elapsed: 23.742333ms, proof.leaves.len: 23957, proof.hashes.len: 156163
+2025-03-06T13:22:11.548526Z DEBUG zk_os_merkle_tree: updated tree structure, elapsed: 3.782583ms
+2025-03-06T13:22:11.555859Z DEBUG zk_os_merkle_tree: hashed tree, elapsed: 7.317958ms
+2025-03-06T13:22:11.573310Z DEBUG zk_os_merkle_tree::storage::rocksdb: writing to RocksDB, total_size: 18170664, new_leaves: 4000, total_leaves: 27957, total_internal_nodes: 52587, copied_hashes: 340018
+2025-03-06T13:22:11.619629Z DEBUG zk_os_merkle_tree: persisted tree, elapsed: 63.751166ms
+2025-03-06T13:22:11.620027Z  INFO loadtest: Processed block #999 in 195.059833ms, root hash = 0xad654212e304280b5110ca6b7135e9c24e0a0adb9ba02ea19e47a661a7461bd3
+2025-03-06T13:22:11.620035Z  INFO loadtest: Verifying tree consistency...
+2025-03-06T13:22:34.016518Z  INFO loadtest: Verified tree consistency in 22.396118375s
+2025-03-06T13:22:34.016931Z  INFO loadtest: estimated DB size, cf: Tree, size: SizeStats { live_data_size: 13507730612, total_sst_size: 13643167327, total_mem_table_size: 19924992, block_cache_size: 8361730, index_and_filters_size: 188981940, files_at_level: [2, 2, 19, 81, 0, 0, 0] }
+2025-03-06T13:22:34.016961Z  INFO loadtest: estimated DB size, cf: KeyIndices, size: SizeStats { live_data_size: 172022529, total_sst_size: 189695030, total_mem_table_size: 4196352, block_cache_size: 8272884, index_and_filters_size: 5607953, files_at_level: [1, 3, 0, 0, 0, 0, 0] }
 ```
 
-I.e., latency is dominated by I/O (~30% for key–index lookup, ~30% for loading tree nodes, and ~20% for tree
+I.e., latency is dominated by I/O (~10% for key–index lookup, ~35% for loading tree nodes, and ~30% for tree
 persistence).
+
+### Optimal internal node depth
+
+Internal node depth (= amortization radix of the tree) is the only tree param not set externally. It influences the I/O
+and compute overhead:
+
+- Higher amortization radix generally means more data duplication, i.e. more data loaded before tree update and more
+  data written on update.
+- OTOH, the number of distinct RocksDB keys loaded / written decreases with the amortization radix.
+- Higher radix means more hash computations to create proofs.
+
+On local benchmarks, it looks like a radix-8 tree is preferable to radix-16 or radix-4, providing comparable or better
+performance, and having lower I/O overhead than the radix-16 tree. This is in contrast with the Era tree / original
+Jellyfish tree, in which radix-16 amortization is preferable. This can be explained by the fact that as a dense tree,
+internal nodes are almost always full; in the sparse Era tree, internal nodes deep in the tree (i.e., the vast majority
+of all internal nodes) are statistically half-full.
+
+<details>
+<summary>Benchmark details</summary>
+
+Two workloads were used: **small** (1,000 blocks x 4k reads + 16k updates / block) and **large** (100 blocks x 40k
+reads + 160k updates / block), each with and without generating batch update proofs for each block.
+
+Total block processing latency at the end of the run:
+
+| Setup            | Radix-4 | Radix-8 | Radix-16 |
+| :--------------- | ------: | ------: | -------: |
+| Small, proofs    |   240ms |   200ms |    230ms |
+| Small, no proofs |   220ms |   180ms |    200ms |
+| Large, proofs    |   1.61s |   1.35s |    1.41s |
+| Large, no proofs |   1.44s |   1.21s |    1.19s |
+
+Size of the nodes CF at the end of the run:
+
+| Setup | Radix-4 | Radix-8 | Radix-16 |
+| :---- | ------: | ------: | -------: |
+| Small | 12.0 GB | 13.5 GB |  17.4 GB |
+| Large |  6.2 GB |  6.4 GB |   7.1 GB |
+
+</details>
 
 [jellyfish merkle tree]: https://developers.diem.com/papers/jellyfish-merkle-tree/2021-01-14.pdf

--- a/core/lib/zk_os_merkle_tree/src/consistency.rs
+++ b/core/lib/zk_os_merkle_tree/src/consistency.rs
@@ -200,7 +200,7 @@ impl<DB: Database, P: TreeParams> MerkleTree<DB, P> {
                 assert_eq!(children.len(), 1);
                 let child = children.into_iter().next().unwrap();
 
-                // Recursion here is OK; the tree isn't that deep (16 nibbles max, with upper levels most likely having a single child).
+                // Recursion here is OK; the tree isn't that deep.
                 let child_hash = match &child {
                     Node::Internal(node) => {
                         assert!(child_key.nibble_count <= max_nibbles_for_internal_node::<P>());

--- a/core/lib/zk_os_merkle_tree/src/errors.rs
+++ b/core/lib/zk_os_merkle_tree/src/errors.rs
@@ -36,6 +36,8 @@ pub(crate) enum DeserializeErrorKind {
         #[source]
         err: Box<dyn error::Error + Send + Sync>,
     },
+    #[error("storage backend error: {0}")]
+    Backend(#[source] anyhow::Error),
 }
 
 #[derive(Debug)]

--- a/core/lib/zk_os_merkle_tree/src/hasher/nodes.rs
+++ b/core/lib/zk_os_merkle_tree/src/hasher/nodes.rs
@@ -73,7 +73,6 @@ impl InternalNode {
                 .extend(iter::repeat(H256::zero()).take(full_level_len - level_hashes.len()));
             full_level_len /= 2;
         });
-        assert_eq!(hashes.0.len(), capacity);
         hashes
     }
 }
@@ -154,7 +153,8 @@ mod tests {
     #[test]
     fn constructing_internal_hashes() {
         let nodes = HashMap::from([(0, InternalNode::new(16, 0)), (1, InternalNode::new(7, 0))]);
-        let internal_hashes = InternalHashes::new::<DefaultTreeParams>(&nodes, &Blake2Hasher, 0);
+        let internal_hashes =
+            InternalHashes::new::<DefaultTreeParams<64, 4>>(&nodes, &Blake2Hasher, 0);
 
         assert_eq!(internal_hashes.level_offsets, [0, 8, 12]);
 

--- a/core/lib/zk_os_merkle_tree/src/lib.rs
+++ b/core/lib/zk_os_merkle_tree/src/lib.rs
@@ -38,17 +38,24 @@ pub mod unstable {
 
 /// Marker trait for tree parameters.
 pub trait TreeParams: fmt::Debug + Send + Sync {
+    /// Hasher used by the tree.
     type Hasher: HashTree;
 
+    /// Total tree depth. E.g., 64 means that a tree can accommodate up to `1 << 64` leaves (including guards).
     const TREE_DEPTH: u8;
+    /// Depth of internal nodes in the tree. E.g., 3 means that an internal node has up to `1 << 3 = 8` children
+    /// (i.e., radix-8 amortization). This parameter is an implementation detail; for an outside observer (e.g., for proofs),
+    /// the tree is always binary.
     const INTERNAL_NODE_DEPTH: u8;
 }
 
+/// Returns the number of nibbles in [`NodeKey`](types::NodeKey)s for leaves.
 #[inline(always)]
-pub(crate) fn leaf_nibbles<P: TreeParams>() -> u8 {
+pub(crate) const fn leaf_nibbles<P: TreeParams>() -> u8 {
     P::TREE_DEPTH.div_ceil(P::INTERNAL_NODE_DEPTH)
 }
 
+/// Returns the max number of nibbles  in [`NodeKey`](types::NodeKey)s for internal nodes.
 #[inline(always)]
 pub(crate) const fn max_nibbles_for_internal_node<P: TreeParams>() -> u8 {
     P::TREE_DEPTH.div_ceil(P::INTERNAL_NODE_DEPTH) - 1
@@ -59,9 +66,9 @@ pub(crate) const fn max_node_children<P: TreeParams>() -> u8 {
     1 << P::INTERNAL_NODE_DEPTH
 }
 
-// TODO: internal node depth 3 looks slightly better from the I/O overhead & performance perspective
+/// Default Merkle tree parameters that should balance its performance and I/O requirements.
 #[derive(Debug)]
-pub struct DefaultTreeParams<const TREE_DEPTH: u8 = 64, const INTERNAL_NODE_DEPTH: u8 = 4>(());
+pub struct DefaultTreeParams<const TREE_DEPTH: u8 = 64, const INTERNAL_NODE_DEPTH: u8 = 3>(());
 
 impl<const TREE_DEPTH: u8, const INTERNAL_NODE_DEPTH: u8> TreeParams
     for DefaultTreeParams<TREE_DEPTH, INTERNAL_NODE_DEPTH>

--- a/core/lib/zk_os_merkle_tree/src/metrics.rs
+++ b/core/lib/zk_os_merkle_tree/src/metrics.rs
@@ -15,6 +15,8 @@ const NODE_COUNT_BUCKETS: Buckets = Buckets::values(&[
 pub(crate) enum LoadStage {
     Total,
     KeyLookup,
+    KeyLookupGets,
+    KeyLookupIteration,
     TreeNodes,
 }
 

--- a/core/lib/zk_os_merkle_tree/src/tests.rs
+++ b/core/lib/zk_os_merkle_tree/src/tests.rs
@@ -32,13 +32,13 @@ fn tree_internal_node_depth_mismatch() {
     let mut db = PatchSet::default();
     db.manifest_mut().version_count = 1;
     db.manifest_mut().tags = TreeTags {
-        internal_node_depth: 3,
+        internal_node_depth: 2,
         ..TreeTags::for_params::<DefaultTreeParams>(&Blake2Hasher)
     };
 
     let err = MerkleTree::new(db).unwrap_err().to_string();
     assert!(
-        err.contains("Unexpected internal node depth: expected 4, got 3"),
+        err.contains("Unexpected internal node depth: expected 3, got 2"),
         "{err}"
     );
 }


### PR DESCRIPTION
## What ❔

- Changes the default amortization radix to 8.
- Uses RocksDB multi-gets for key–index lookup.

## Why ❔

- Changing amortization radix to 8 yields ~10–20% performance improvement compared to previously used radix-16 on local benches (see the updated readme). It also reduces storage overhead.
- Multi-gets for key–index lookup reduce lookup latency ~2x on the local benches (= ~20% total block processing latency improvement).

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.