### PR TITLE
fix(contract-verifier): Correctly process partial verification for EVM contracts

### DIFF
--- a/core/lib/contract_verifier/src/tests/real.rs
+++ b/core/lib/contract_verifier/src/tests/real.rs
@@ -748,12 +748,18 @@ async fn using_zksolc_partial_match(use_cbor: bool) {
     );
 
     assert_eq!(
-        identifier_for_request.matches(output_for_storage.deployed_bytecode()),
+        identifier_for_request.matches(&ContractIdentifier::from_bytecode(
+            BytecodeMarker::EraVm,
+            output_for_storage.deployed_bytecode()
+        )),
         Match::Partial,
         "must be a partial match (1)"
     );
     assert_eq!(
-        identifier_for_storage.matches(output_for_request.deployed_bytecode()),
+        identifier_for_storage.matches(&ContractIdentifier::from_bytecode(
+            BytecodeMarker::EraVm,
+            output_for_request.deployed_bytecode()
+        )),
         Match::Partial,
         "must be a partial match (2)"
     );

--- a/core/lib/contract_verifier/src/tests/real.rs
+++ b/core/lib/contract_verifier/src/tests/real.rs
@@ -604,7 +604,7 @@ async fn using_real_compiler_in_verifier(bytecode_kind: BytecodeMarker, toolchai
         (BytecodeMarker::Evm, Toolchain::Solidity) => {
             assert_matches!(
                 identifier.detected_metadata,
-                Some(DetectedMetadata::Cbor),
+                Some(DetectedMetadata::Cbor { .. }),
                 "Cbor metadata for EVM Solidity by default"
             );
         }
@@ -760,11 +760,11 @@ async fn using_zksolc_partial_match(use_cbor: bool) {
     if use_cbor {
         assert_matches!(
             identifier_for_request.detected_metadata,
-            Some(DetectedMetadata::Cbor)
+            Some(DetectedMetadata::Cbor { .. })
         );
         assert_matches!(
             identifier_for_storage.detected_metadata,
-            Some(DetectedMetadata::Cbor)
+            Some(DetectedMetadata::Cbor { .. })
         );
     } else {
         assert_matches!(

--- a/core/lib/types/src/contract_verification/contract_identifier.rs
+++ b/core/lib/types/src/contract_verification/contract_identifier.rs
@@ -193,10 +193,8 @@ impl ContractIdentifier {
     }
 
     /// Checks the kind of match between identifier and other bytecode.
-    pub fn matches(&self, other: &[u8]) -> Match {
-        let other_identifier = Self::from_bytecode(self.bytecode_marker, other);
-
-        if self.bytecode_keccak256 == other_identifier.bytecode_keccak256 {
+    pub fn matches(&self, other: &Self) -> Match {
+        if self.bytecode_keccak256 == other.bytecode_keccak256 {
             return Match::Full;
         }
 
@@ -205,9 +203,7 @@ impl ContractIdentifier {
         // and presence in another, or different kinds of metadata. This is OK: partial
         // match is needed mostly when you cannot reproduce the original metadata, but one always
         // can submit the contract with the same metadata kind.
-        if self.bytecode_without_metadata_keccak256
-            == other_identifier.bytecode_without_metadata_keccak256
-        {
+        if self.bytecode_without_metadata_keccak256 == other.bytecode_without_metadata_keccak256 {
             return Match::Partial;
         }
 


### PR DESCRIPTION
I've discovered that partial verification doesn't work correctly for EVM contracts, because we expect creation bytecode to be equal for compiled and deployed contracts. This is too strict, because it's OK for them to be different in metadata hash only.

I didn't add any tests for this (it was somewhat tricky), but checked manually that the issue was resolved after that.