### PR TITLE
feat(zkstack_cli): support calls for DA mode switching

### DIFF
--- a/zkstack_cli/crates/zkstack/src/commands/chain/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/mod.rs
@@ -29,6 +29,8 @@ mod migrate_from_gateway;
 #[cfg(feature = "gateway")]
 mod migrate_to_gateway;
 pub mod register_chain;
+mod set_da_validator_pair;
+mod set_pubdata_pricing_mode;
 mod set_token_multiplier_setter;
 mod setup_legacy_bridge;
 mod utils;
@@ -88,6 +90,10 @@ pub enum ChainCommands {
     GatewayUpgrade(gateway_upgrade::GatewayUpgradeArgs),
     /// Enable EVM emulation on chain (Not supported yet)
     EnableEvmEmulator(ForgeScriptArgs),
+    /// Set the pubdata pricing mode on L1
+    SetPubdataPricingMode(ForgeScriptArgs),
+    /// Set the DA validator pair on L1
+    SetDAValidatorPair(ForgeScriptArgs),
 }
 
 pub(crate) async fn run(shell: &Shell, args: ChainCommands) -> anyhow::Result<()> {
@@ -117,6 +123,10 @@ pub(crate) async fn run(shell: &Shell, args: ChainCommands) -> anyhow::Result<()
         ChainCommands::UpdateTokenMultiplierSetter(args) => {
             set_token_multiplier_setter::run(args, shell).await
         }
+        ChainCommands::SetPubdataPricingMode(args) => {
+            set_pubdata_pricing_mode::run(args, shell).await
+        }
+        ChainCommands::SetDAValidatorPair(args) => set_da_validator_pair::run(args, shell).await,
         #[cfg(feature = "gateway")]
         ChainCommands::ConvertToGateway(args) => convert_to_gateway::run(args, shell).await,
         #[cfg(feature = "gateway")]

--- a/zkstack_cli/crates/zkstack/src/commands/chain/set_da_validator_pair.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/set_da_validator_pair.rs
@@ -48,7 +48,11 @@ pub async fn run(args: ForgeScriptArgs, shell: &Shell) -> anyhow::Result<()> {
         MSG_DA_VALIDATOR_PAIR_SET_TO,
         format!(
             "l1_da_validator: {:?}, l2_da_validator: {:?}",
-            l1_da_validator_addr, contracts_config.l2.da_validator_addr
+            l1_da_validator_addr,
+            contracts_config
+                .l2
+                .da_validator_addr
+                .context("da_validator_addr")?
         ),
     );
 

--- a/zkstack_cli/crates/zkstack/src/commands/chain/set_da_validator_pair.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/set_da_validator_pair.rs
@@ -1,0 +1,56 @@
+use anyhow::Context;
+use xshell::Shell;
+use zkstack_cli_common::{forge::ForgeScriptArgs, logger, spinner::Spinner};
+use zkstack_cli_config::EcosystemConfig;
+
+use crate::{
+    accept_ownership::set_da_validator_pair,
+    commands::chain::init::get_l1_da_validator,
+    messages::{
+        MSG_CHAIN_NOT_INITIALIZED, MSG_DA_VALIDATOR_PAIR_SET_TO, MSG_SETTING_DA_VALIDATOR_PAIR,
+    },
+};
+
+pub async fn run(args: ForgeScriptArgs, shell: &Shell) -> anyhow::Result<()> {
+    let ecosystem_config = EcosystemConfig::from_file(shell)?;
+    let chain_config = ecosystem_config
+        .load_current_chain()
+        .context(MSG_CHAIN_NOT_INITIALIZED)?;
+    let contracts_config = chain_config.get_contracts_config()?;
+    let l1_url = chain_config
+        .get_secrets_config()
+        .await?
+        .get("l1.l1_rpc_url")?;
+
+    let l1_da_validator_addr = get_l1_da_validator(&chain_config)
+        .await
+        .context("l1_da_validator_addr")?;
+
+    let spinner = Spinner::new(MSG_SETTING_DA_VALIDATOR_PAIR);
+    set_da_validator_pair(
+        shell,
+        &ecosystem_config,
+        contracts_config.l1.chain_admin_addr,
+        &chain_config.get_wallets_config()?.governor,
+        contracts_config.l1.diamond_proxy_addr,
+        l1_da_validator_addr,
+        contracts_config
+            .l2
+            .da_validator_addr
+            .context("da_validator_addr")?,
+        &args.clone(),
+        l1_url,
+    )
+    .await?;
+    spinner.finish();
+
+    logger::note(
+        MSG_DA_VALIDATOR_PAIR_SET_TO,
+        format!(
+            "l1_da_validator: {:?}, l2_da_validator: {:?}",
+            l1_da_validator_addr, contracts_config.l2.da_validator_addr
+        ),
+    );
+
+    Ok(())
+}

--- a/zkstack_cli/crates/zkstack/src/commands/chain/set_pubdata_pricing_mode.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/set_pubdata_pricing_mode.rs
@@ -1,0 +1,47 @@
+use anyhow::Context;
+use xshell::Shell;
+use zkstack_cli_common::{forge::ForgeScriptArgs, logger, spinner::Spinner};
+use zkstack_cli_config::EcosystemConfig;
+
+use crate::{
+    accept_ownership::set_pubdata_pricing_mode,
+    messages::{
+        MSG_CHAIN_NOT_INITIALIZED, MSG_PUBDATA_PRICING_MODE_SET_TO,
+        MSG_SETTING_PUBDATA_PRICING_MODE,
+    },
+};
+
+pub async fn run(args: ForgeScriptArgs, shell: &Shell) -> anyhow::Result<()> {
+    let ecosystem_config = EcosystemConfig::from_file(shell)?;
+    let chain_config = ecosystem_config
+        .load_current_chain()
+        .context(MSG_CHAIN_NOT_INITIALIZED)?;
+    let contracts_config = chain_config.get_contracts_config()?;
+    let l1_url = chain_config
+        .get_secrets_config()
+        .await?
+        .get("l1.l1_rpc_url")?;
+
+    let pubdata_pricing_mode = chain_config
+        .get_genesis_config()
+        .await?
+        .get("l1_batch_commit_data_generator_mode")?;
+
+    let spinner = Spinner::new(MSG_SETTING_PUBDATA_PRICING_MODE);
+    set_pubdata_pricing_mode(
+        shell,
+        &ecosystem_config,
+        pubdata_pricing_mode,
+        contracts_config.l1.chain_admin_addr,
+        contracts_config.l1.diamond_proxy_addr,
+        &chain_config.get_wallets_config()?.governor,
+        &args.clone(),
+        l1_url,
+    )
+    .await?;
+    spinner.finish();
+
+    logger::note(MSG_PUBDATA_PRICING_MODE_SET_TO, pubdata_pricing_mode);
+
+    Ok(())
+}

--- a/zkstack_cli/crates/zkstack/src/messages.rs
+++ b/zkstack_cli/crates/zkstack/src/messages.rs
@@ -107,7 +107,10 @@ pub(super) const MSG_RECREATE_ROCKS_DB_ERRROR: &str = "Failed to create rocks db
 pub(super) const MSG_ERA_OBSERVABILITY_ALREADY_SETUP: &str = "Era observability already setup";
 pub(super) const MSG_DOWNLOADING_ERA_OBSERVABILITY_SPINNER: &str =
     "Downloading era observability...";
-
+pub(super) const MSG_SETTING_PUBDATA_PRICING_MODE: &str = "Setting pubdata pricing mode...";
+pub(super) const MSG_PUBDATA_PRICING_MODE_SET_TO: &str = "Pubdata pricing mode set to";
+pub(super) const MSG_SETTING_DA_VALIDATOR_PAIR: &str = "Setting da validator pair...";
+pub(super) const MSG_DA_VALIDATOR_PAIR_SET_TO: &str = "DA validator pair set to";
 pub(super) fn msg_ecosystem_no_found_preexisting_contract(chains: &str) -> String {
     format!("Not found preexisting ecosystem Contracts with chains {chains}")
 }


### PR DESCRIPTION
## What ❔

Add **set-pubdata-pricing-mode** and **set-da-validator-pair** commands in the zkstack chain cli.

## Why ❔

Helper for switching the chain DA mode

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
requires https://github.com/matter-labs/era-contracts/pull/1322 to be merged first to be able to call **set-pubdata-pricing-mode**

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
