### PR TITLE
feat(zkstack-cli): Adding support for v27 upgrade

### DIFF
--- a/ZkStack.yaml
+++ b/ZkStack.yaml
@@ -4,6 +4,6 @@ link_to_code: .
 chains: ./chains
 config: ./configs/
 default_chain: era
-era_chain_id: 270
+era_chain_id: 271
 prover_version: NoProofs
 wallet_creation: Localhost

--- a/zkstack_cli/crates/config/src/forge_interface/gateway_ecosystem_upgrade/README.md
+++ b/zkstack_cli/crates/config/src/forge_interface/gateway_ecosystem_upgrade/README.md
@@ -1,0 +1,9 @@
+# Input and outputs from the Ecosystem.s.sol script.
+
+This script is responsible for creating the protocol upgrade.
+
+Inputs are matching l1-contracts/upgrade-envs and outputs are matching l1-contracts/upgrade-envs/outputs format.
+
+Warning: the contents might change between protocol versions, so make sure that you use correct one.
+
+This code is for v26 (Gateway) release.

--- a/zkstack_cli/crates/config/src/forge_interface/gateway_ecosystem_upgrade/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/gateway_ecosystem_upgrade/input.rs
@@ -51,6 +51,9 @@ impl GatewayEcosystemUpgradeInput {
                     .diamond_init_minimal_l2_gas_price,
                 bootloader_hash: new_genesis_input.bootloader_hash,
                 default_aa_hash: new_genesis_input.default_aa_hash,
+                evm_emulator_hash: new_genesis_input
+                    .evm_emulator_hash
+                    .expect("EVM emulator hash is required"),
                 diamond_init_priority_tx_max_pubdata: initial_deployment_config
                     .diamond_init_priority_tx_max_pubdata,
                 diamond_init_pubdata_pricing_mode: initial_deployment_config
@@ -112,6 +115,7 @@ pub struct GatewayUpgradeContractsConfig {
     pub diamond_init_minimal_l2_gas_price: u64,
     pub bootloader_hash: H256,
     pub default_aa_hash: H256,
+    pub evm_emulator_hash: H256,
 
     pub bridgehub_proxy_address: Address,
     pub old_shared_bridge_proxy_address: Address,

--- a/zkstack_cli/crates/config/src/forge_interface/gateway_ecosystem_upgrade/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/gateway_ecosystem_upgrade/output.rs
@@ -37,6 +37,7 @@ pub struct GatewayEcosystemUpgradeContractsOutput {
     pub diamond_init_max_pubdata_per_batch: u64,
     pub diamond_init_minimal_l2_gas_price: u64,
     pub diamond_init_priority_tx_max_pubdata: u64,
+    pub diamond_init_pubdata_pricing_mode: u64,
     pub expected_rollup_l2_da_validator: Address,
     pub expected_validium_l2_da_validator: Address,
 
@@ -65,6 +66,11 @@ pub struct GatewayEcosystemUpgradeDeployedAddresses {
     pub l1_bytecodes_supplier_addr: Address,
     pub l2_wrapped_base_token_store_addr: Address,
 
+    pub l1_transitionary_owner: Address,
+    pub l1_rollup_da_manager: Address,
+    pub l1_gateway_upgrade: Address,
+    pub l1_governance_upgrade_timer: Address,
+
     pub bridgehub: GatewayEcosystemUpgradeBridgehub,
     pub bridges: GatewayEcosystemUpgradeBridges,
     pub state_transition: GatewayEcosystemUpgradeStateTransition,
@@ -85,6 +91,8 @@ pub struct GatewayEcosystemUpgradeBridges {
     pub l1_nullifier_implementation_addr: Address,
     pub shared_bridge_implementation_addr: Address,
     pub shared_bridge_proxy_addr: Address,
+    pub bridged_standard_erc20_impl: Address,
+    pub bridged_token_beacon: Address,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/zkstack_cli/crates/config/src/forge_interface/mod.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/mod.rs
@@ -9,3 +9,4 @@ pub mod paymaster;
 pub mod register_chain;
 pub mod script_params;
 pub mod setup_legacy_bridge;
+pub mod v27_ecosystem_upgrade;

--- a/zkstack_cli/crates/config/src/forge_interface/script_params.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/script_params.rs
@@ -89,6 +89,7 @@ pub const GATEWAY_PREPARATION: ForgeScriptParams = ForgeScriptParams {
 pub const GATEWAY_GOVERNANCE_TX_PATH1: &str =
     "contracts/l1-contracts/script-out/gateway-deploy-governance-txs-1.json";
 
+// For this to work, you have to be in v26 branch of the era-contracts.
 pub const GATEWAY_UPGRADE_ECOSYSTEM_PARAMS: ForgeScriptParams = ForgeScriptParams {
     input: "script-config/gateway-upgrade-ecosystem.toml",
     output: "script-out/gateway-upgrade-ecosystem.toml",
@@ -105,4 +106,11 @@ pub const FINALIZE_UPGRADE_SCRIPT_PARAMS: ForgeScriptParams = ForgeScriptParams 
     input: "script-config/gateway-finalize-upgrade.toml",
     output: "script-out/gateway-finalize-upgrade.toml",
     script_path: "deploy-scripts/upgrade/FinalizeUpgrade.s.sol",
+};
+
+// For branch v27 .
+pub const V27_UPGRADE_ECOSYSTEM_PARAMS: ForgeScriptParams = ForgeScriptParams {
+    input: "script-config/upgrade-ecosystem.toml",
+    output: "script-out/upgrade-ecosystem.toml",
+    script_path: "deploy-scripts/upgrade/EcosystemUpgrade.s.sol",
 };

--- a/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/README.md
+++ b/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/README.md
@@ -1,0 +1,9 @@
+# Input and outputs from the Ecosystem.s.sol script.
+
+This script is responsible for creating the protocol upgrade.
+
+Inputs are matching l1-contracts/upgrade-envs and outputs are matching l1-contracts/upgrade-envs/outputs format.
+
+Warning: the contents might change between protocol versions, so make sure that you use correct one.
+
+This code is for v27 (EVM) release.

--- a/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/input.rs
@@ -19,8 +19,6 @@ pub struct V27EcosystemUpgradeInput {
     pub contracts: V27UpgradeContractsConfig,
     pub tokens: V27UpgradeTokensConfig,
     pub governance_upgrade_timer_initial_delay: u64,
-
-    pub gateway: V27GatewayConfig,
 }
 
 impl ZkStackConfig for V27EcosystemUpgradeInput {}
@@ -101,11 +99,6 @@ impl V27EcosystemUpgradeInput {
             tokens: V27UpgradeTokensConfig {
                 token_weth_address: initial_deployment_config.token_weth_address,
             },
-            // For now, gateway is disabled.
-            gateway: V27GatewayConfig {
-                chain_id: 0,
-                gateway_state_transition: V27GatewayStateTransition {},
-            },
         }
     }
 }
@@ -149,12 +142,3 @@ pub struct V27UpgradeContractsConfig {
 pub struct V27UpgradeTokensConfig {
     pub token_weth_address: Address,
 }
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct V27GatewayConfig {
-    pub chain_id: u64,
-    pub gateway_state_transition: V27GatewayStateTransition,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct V27GatewayStateTransition {}

--- a/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/input.rs
@@ -25,8 +25,8 @@ pub struct V27EcosystemUpgradeInput {
 
 impl ZkStackConfig for V27EcosystemUpgradeInput {}
 
-const PREVIOUS_PROTOCOL_VERSION: u64 = 26;
-const LATEST_PROTOCOL_VERSION: u64 = 27;
+const PREVIOUS_PROTOCOL_VERSION: u64 = 26 << 32;
+const LATEST_PROTOCOL_VERSION: u64 = 27 << 32;
 
 impl V27EcosystemUpgradeInput {
     pub fn new(
@@ -47,8 +47,8 @@ impl V27EcosystemUpgradeInput {
             // TODO: for local testing, even 0 is fine - but before prod, we should load it from some configuration.
             governance_upgrade_timer_initial_delay: 0,
             contracts: V27UpgradeContractsConfig {
-                create2_factory_addr: initial_deployment_config.create2_factory_addr,
-                create2_factory_salt: initial_deployment_config.create2_factory_salt,
+                create2_factory_addr: current_contracts_config.create2_factory_addr,
+                create2_factory_salt: current_contracts_config.create2_factory_salt,
                 governance_min_delay: initial_deployment_config.governance_min_delay,
                 max_number_of_chains: initial_deployment_config.max_number_of_chains,
                 diamond_init_batch_overhead_l1_gas: initial_deployment_config
@@ -89,9 +89,11 @@ impl V27EcosystemUpgradeInput {
                     .ecosystem_contracts
                     .l1_bytecodes_supplier_addr
                     .unwrap(),
+                // For local setup - the governance addr is the 'upgrade handler / owner'
+                protocol_upgrade_handler_proxy_address: current_contracts_config.l1.governance_addr,
                 // FIXME
                 governance_security_council_address: Address::zero(),
-                protocol_upgrade_handler_proxy_address: Address::zero(),
+
                 protocol_upgrade_handler_impl_address: Address::zero(),
 
                 latest_protocol_version: LATEST_PROTOCOL_VERSION,
@@ -113,8 +115,7 @@ pub struct V27UpgradeContractsConfig {
     pub governance_min_delay: u64,
     pub max_number_of_chains: u64,
     pub create2_factory_salt: H256,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub create2_factory_addr: Option<Address>,
+    pub create2_factory_addr: Address,
     pub validator_timelock_execution_delay: u64,
     pub genesis_root: H256,
     pub genesis_rollup_leaf_index: u64,

--- a/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/input.rs
@@ -1,0 +1,145 @@
+use ethers::types::{Address, H256};
+use serde::{Deserialize, Serialize};
+use zksync_basic_types::L2ChainId;
+
+use crate::{
+    forge_interface::deploy_ecosystem::input::{GenesisInput, InitialDeploymentConfig},
+    traits::ZkStackConfig,
+    ContractsConfig,
+};
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct V27EcosystemUpgradeInput {
+    pub era_chain_id: L2ChainId,
+    pub owner_address: Address,
+    pub testnet_verifier: bool,
+    pub support_l2_legacy_shared_bridge_test: bool,
+    pub contracts: V27UpgradeContractsConfig,
+    pub tokens: V27UpgradeTokensConfig,
+    pub governance_upgrade_timer_initial_delay: u64,
+    pub old_protocol_version: u64,
+}
+
+impl ZkStackConfig for V27EcosystemUpgradeInput {}
+
+impl V27EcosystemUpgradeInput {
+    pub fn new(
+        new_genesis_input: &GenesisInput,
+        current_contracts_config: &ContractsConfig,
+        // It is expected to not change between the versions
+        initial_deployment_config: &InitialDeploymentConfig,
+        era_chain_id: L2ChainId,
+        era_diamond_proxy: Address,
+        testnet_verifier: bool,
+    ) -> Self {
+        Self {
+            era_chain_id,
+            testnet_verifier,
+            owner_address: current_contracts_config.l1.governance_addr,
+            // FIXME
+            support_l2_legacy_shared_bridge_test: false,
+            old_protocol_version: 0,
+            // TODO: for local testing, even 0 is fine - but before prod, we should load it from some configuration.
+            governance_upgrade_timer_initial_delay: 0,
+            contracts: V27UpgradeContractsConfig {
+                create2_factory_addr: initial_deployment_config.create2_factory_addr,
+                create2_factory_salt: initial_deployment_config.create2_factory_salt,
+                governance_min_delay: initial_deployment_config.governance_min_delay,
+                max_number_of_chains: initial_deployment_config.max_number_of_chains,
+                diamond_init_batch_overhead_l1_gas: initial_deployment_config
+                    .diamond_init_batch_overhead_l1_gas,
+                diamond_init_max_l2_gas_per_batch: initial_deployment_config
+                    .diamond_init_max_l2_gas_per_batch,
+                diamond_init_max_pubdata_per_batch: initial_deployment_config
+                    .diamond_init_max_pubdata_per_batch,
+                diamond_init_minimal_l2_gas_price: initial_deployment_config
+                    .diamond_init_minimal_l2_gas_price,
+                bootloader_hash: new_genesis_input.bootloader_hash,
+                default_aa_hash: new_genesis_input.default_aa_hash,
+                evm_emulator_hash: new_genesis_input
+                    .evm_emulator_hash
+                    .expect("EVM emulator hash is required"),
+                diamond_init_priority_tx_max_pubdata: initial_deployment_config
+                    .diamond_init_priority_tx_max_pubdata,
+                diamond_init_pubdata_pricing_mode: initial_deployment_config
+                    .diamond_init_pubdata_pricing_mode,
+                // These values are not optional in genesis config with file based configuration
+                genesis_batch_commitment: new_genesis_input.genesis_commitment,
+                genesis_rollup_leaf_index: new_genesis_input.rollup_last_leaf_index,
+                genesis_root: new_genesis_input.genesis_root_hash,
+                recursion_circuits_set_vks_hash: H256::zero(),
+                recursion_leaf_level_vk_hash: H256::zero(),
+                recursion_node_level_vk_hash: H256::zero(),
+                priority_tx_max_gas_limit: initial_deployment_config.priority_tx_max_gas_limit,
+                validator_timelock_execution_delay: initial_deployment_config
+                    .validator_timelock_execution_delay,
+
+                bridgehub_proxy_address: current_contracts_config
+                    .ecosystem_contracts
+                    .bridgehub_proxy_addr,
+                old_shared_bridge_proxy_address: current_contracts_config.bridges.shared.l1_address,
+                state_transition_manager_address: current_contracts_config
+                    .ecosystem_contracts
+                    .state_transition_proxy_addr,
+                transparent_proxy_admin: current_contracts_config
+                    .ecosystem_contracts
+                    .transparent_proxy_admin_addr,
+                era_diamond_proxy,
+                legacy_erc20_bridge_address: current_contracts_config.bridges.erc20.l1_address,
+                old_validator_timelock: current_contracts_config
+                    .ecosystem_contracts
+                    .validator_timelock_addr,
+                // FIXME
+                governance_security_council_address: Address::zero(),
+                latest_protocol_version: 0,
+                l1_bytecodes_supplier_addr: Address::zero(),
+            },
+            tokens: V27UpgradeTokensConfig {
+                token_weth_address: initial_deployment_config.token_weth_address,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct V27UpgradeContractsConfig {
+    pub governance_min_delay: u64,
+    pub max_number_of_chains: u64,
+    pub create2_factory_salt: H256,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub create2_factory_addr: Option<Address>,
+    pub validator_timelock_execution_delay: u64,
+    pub genesis_root: H256,
+    pub genesis_rollup_leaf_index: u64,
+    pub genesis_batch_commitment: H256,
+    pub recursion_node_level_vk_hash: H256,
+    pub recursion_leaf_level_vk_hash: H256,
+    pub recursion_circuits_set_vks_hash: H256,
+    pub priority_tx_max_gas_limit: u64,
+    pub diamond_init_pubdata_pricing_mode: u64,
+    pub diamond_init_batch_overhead_l1_gas: u64,
+    pub diamond_init_max_pubdata_per_batch: u64,
+    pub diamond_init_max_l2_gas_per_batch: u64,
+    pub diamond_init_priority_tx_max_pubdata: u64,
+    pub diamond_init_minimal_l2_gas_price: u64,
+    pub bootloader_hash: H256,
+    pub default_aa_hash: H256,
+    pub evm_emulator_hash: H256,
+
+    pub bridgehub_proxy_address: Address,
+    pub old_shared_bridge_proxy_address: Address,
+    pub state_transition_manager_address: Address,
+    pub transparent_proxy_admin: Address,
+    pub era_diamond_proxy: Address,
+    pub legacy_erc20_bridge_address: Address,
+    pub old_validator_timelock: Address,
+
+    pub governance_security_council_address: Address,
+    pub latest_protocol_version: u64,
+    pub l1_bytecodes_supplier_addr: Address,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct V27UpgradeTokensConfig {
+    pub token_weth_address: Address,
+}

--- a/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/mod.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/mod.rs
@@ -1,0 +1,2 @@
+pub mod input;
+pub mod output;

--- a/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/output.rs
@@ -69,6 +69,7 @@ pub struct V27EcosystemUpgradeContractsOutput {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct V27EcosystemUpgradeDeployedAddresses {
     pub native_token_vault_addr: Address,
+    pub native_token_vault_implementation_addr: Address,
     pub rollup_l1_da_validator_addr: Address,
     pub validator_timelock_addr: Address,
     pub validium_l1_da_validator_addr: Address,
@@ -77,7 +78,6 @@ pub struct V27EcosystemUpgradeDeployedAddresses {
 
     pub l1_transitionary_owner: Address,
     pub l1_rollup_da_manager: Address,
-    pub l1_gateway_upgrade: Address,
     pub l1_governance_upgrade_timer: Address,
 
     pub bridgehub: V27EcosystemUpgradeBridgehub,
@@ -98,6 +98,7 @@ pub struct V27EcosystemUpgradeBridgehub {
 pub struct V27EcosystemUpgradeBridges {
     pub erc20_bridge_implementation_addr: Address,
     pub l1_nullifier_implementation_addr: Address,
+    pub l1_nullifier_proxy_addr: Address,
     // in the past known as 'shared bridge'
     pub l1_asset_router_implementation_addr: Address,
     pub l1_asset_router_proxy_addr: Address,

--- a/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/output.rs
@@ -117,6 +117,8 @@ pub struct V27EcosystemUpgradeStateTransition {
     pub mailbox_facet_addr: Address,
     pub state_transition_implementation_addr: Address,
     pub verifier_addr: Address,
+    pub verifier_fflonk_addr: Address,
+    pub verifier_plonk_addr: Address,
 }
 
 impl ZkStackConfig for V27EcosystemUpgradeOutput {}

--- a/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/output.rs
@@ -13,15 +13,24 @@ pub struct V27EcosystemUpgradeOutput {
     pub l1_chain_id: u32,
     pub owner_address: Address,
     pub chain_upgrade_diamond_cut: Bytes,
-    pub governance_stage1_calls: Bytes,
-    pub governance_stage2_calls: Bytes,
+    pub protocol_upgrade_handler_proxy_address: Address,
+    pub protocol_upgrade_handler_impl_address: Address,
+    pub governance_calls: V27GovernanceCalls,
 
+    #[serde(rename = "contracts_newConfig")]
     pub contracts_config: V27EcosystemUpgradeContractsOutput,
+
     pub deployed_addresses: V27EcosystemUpgradeDeployedAddresses,
     /// List of transactions that were executed during the upgrade.
     /// This is added later by the zkstack and not present in the toml file that solidity creates.
     #[serde(default)]
     pub transactions: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct V27GovernanceCalls {
+    pub governance_stage1_calls: Bytes,
+    pub governance_stage2_calls: Bytes,
 }
 
 impl FileConfigWithDefaultName for V27EcosystemUpgradeOutput {
@@ -50,7 +59,7 @@ pub struct V27EcosystemUpgradeContractsOutput {
     pub recursion_leaf_level_vk_hash: H256,
     pub recursion_node_level_vk_hash: H256,
 
-    pub new_protocol_version: u64,
+    pub new_protocol_version: u64, // broken
     pub old_protocol_version: u64,
 
     pub old_validator_timelock: Address,
@@ -89,8 +98,9 @@ pub struct V27EcosystemUpgradeBridgehub {
 pub struct V27EcosystemUpgradeBridges {
     pub erc20_bridge_implementation_addr: Address,
     pub l1_nullifier_implementation_addr: Address,
-    pub shared_bridge_implementation_addr: Address,
-    pub shared_bridge_proxy_addr: Address,
+    // in the past known as 'shared bridge'
+    pub l1_asset_router_implementation_addr: Address,
+    pub l1_asset_router_proxy_addr: Address,
     pub bridged_standard_erc20_impl: Address,
     pub bridged_token_beacon: Address,
 }

--- a/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/v27_ecosystem_upgrade/output.rs
@@ -1,0 +1,111 @@
+use ethers::types::{Address, H256};
+use serde::{Deserialize, Serialize};
+use zksync_basic_types::web3::Bytes;
+
+use crate::traits::{FileConfigWithDefaultName, ZkStackConfig};
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct V27EcosystemUpgradeOutput {
+    pub create2_factory_addr: Address,
+    pub create2_factory_salt: H256,
+    pub deployer_addr: Address,
+    pub era_chain_id: u32,
+    pub l1_chain_id: u32,
+    pub owner_address: Address,
+    pub chain_upgrade_diamond_cut: Bytes,
+    pub governance_stage1_calls: Bytes,
+    pub governance_stage2_calls: Bytes,
+
+    pub contracts_config: V27EcosystemUpgradeContractsOutput,
+    pub deployed_addresses: V27EcosystemUpgradeDeployedAddresses,
+    /// List of transactions that were executed during the upgrade.
+    /// This is added later by the zkstack and not present in the toml file that solidity creates.
+    #[serde(default)]
+    pub transactions: Vec<String>,
+}
+
+impl FileConfigWithDefaultName for V27EcosystemUpgradeOutput {
+    const FILE_NAME: &'static str = "ecosystem_upgrade_output.yaml";
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct V27EcosystemUpgradeContractsOutput {
+    pub diamond_cut_data: Bytes,
+
+    pub diamond_init_batch_overhead_l1_gas: u64,
+    pub diamond_init_max_l2_gas_per_batch: u64,
+    pub diamond_init_max_pubdata_per_batch: u64,
+    pub diamond_init_minimal_l2_gas_price: u64,
+    pub diamond_init_priority_tx_max_pubdata: u64,
+    pub diamond_init_pubdata_pricing_mode: u64,
+    pub expected_rollup_l2_da_validator: Address,
+    pub expected_validium_l2_da_validator: Address,
+
+    // Probably gonna need it to add new chains
+    pub force_deployments_data: Bytes,
+
+    pub priority_tx_max_gas_limit: u64,
+
+    pub recursion_circuits_set_vks_hash: H256,
+    pub recursion_leaf_level_vk_hash: H256,
+    pub recursion_node_level_vk_hash: H256,
+
+    pub new_protocol_version: u64,
+    pub old_protocol_version: u64,
+
+    pub old_validator_timelock: Address,
+    pub l1_legacy_shared_bridge: Address,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct V27EcosystemUpgradeDeployedAddresses {
+    pub native_token_vault_addr: Address,
+    pub rollup_l1_da_validator_addr: Address,
+    pub validator_timelock_addr: Address,
+    pub validium_l1_da_validator_addr: Address,
+    pub l1_bytecodes_supplier_addr: Address,
+    pub l2_wrapped_base_token_store_addr: Address,
+
+    pub l1_transitionary_owner: Address,
+    pub l1_rollup_da_manager: Address,
+    pub l1_gateway_upgrade: Address,
+    pub l1_governance_upgrade_timer: Address,
+
+    pub bridgehub: V27EcosystemUpgradeBridgehub,
+    pub bridges: V27EcosystemUpgradeBridges,
+    pub state_transition: V27EcosystemUpgradeStateTransition,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct V27EcosystemUpgradeBridgehub {
+    pub bridgehub_implementation_addr: Address,
+    pub ctm_deployment_tracker_implementation_addr: Address,
+    pub ctm_deployment_tracker_proxy_addr: Address,
+    pub message_root_implementation_addr: Address,
+    pub message_root_proxy_addr: Address,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct V27EcosystemUpgradeBridges {
+    pub erc20_bridge_implementation_addr: Address,
+    pub l1_nullifier_implementation_addr: Address,
+    pub shared_bridge_implementation_addr: Address,
+    pub shared_bridge_proxy_addr: Address,
+    pub bridged_standard_erc20_impl: Address,
+    pub bridged_token_beacon: Address,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct V27EcosystemUpgradeStateTransition {
+    pub admin_facet_addr: Address,
+    pub default_upgrade_addr: Address,
+    pub diamond_init_addr: Address,
+    pub executor_facet_addr: Address,
+    pub genesis_upgrade_addr: Address,
+    pub getters_facet_addr: Address,
+    pub mailbox_facet_addr: Address,
+    pub state_transition_implementation_addr: Address,
+    pub verifier_addr: Address,
+}
+
+impl ZkStackConfig for V27EcosystemUpgradeOutput {}

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/mod.rs
@@ -3,3 +3,4 @@ pub mod change_default;
 pub mod create;
 pub mod gateway_upgrade;
 pub mod init;
+pub mod v27_upgrade;

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/v27_upgrade.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/v27_upgrade.rs
@@ -1,0 +1,76 @@
+use std::path::PathBuf;
+
+use clap::{Parser, ValueEnum};
+use serde::{Deserialize, Serialize};
+use strum::EnumIter;
+use url::Url;
+use zkstack_cli_common::{forge::ForgeScriptArgs, Prompt};
+use zkstack_cli_types::L1Network;
+
+use crate::{
+    defaults::LOCAL_RPC_URL,
+    messages::{MSG_L1_RPC_URL_HELP, MSG_L1_RPC_URL_INVALID_ERR, MSG_L1_RPC_URL_PROMPT},
+};
+
+#[derive(
+    Debug, Serialize, Deserialize, Clone, Copy, ValueEnum, EnumIter, strum::Display, PartialEq, Eq,
+)]
+pub enum V27UpgradeStage {
+    // Deploy contracts + init everything the governance will need to approve the upgrade
+    NoGovernancePrepare,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Parser)]
+pub struct V27UpgradeArgs {
+    #[clap(flatten)]
+    #[serde(flatten)]
+    pub forge_args: ForgeScriptArgs,
+    #[clap(long, value_enum)]
+    ecosystem_upgrade_stage: V27UpgradeStage,
+    /// Path to ecosystem contracts
+    #[clap(long)]
+    pub ecosystem_contracts_path: Option<PathBuf>,
+    #[clap(long, help = MSG_L1_RPC_URL_HELP)]
+    pub l1_rpc_url: Option<String>,
+}
+
+impl V27UpgradeArgs {
+    pub fn fill_values_with_prompt(self, l1_network: L1Network, dev: bool) -> V27UpgradeArgsFinal {
+        let l1_rpc_url = self.l1_rpc_url.unwrap_or_else(|| {
+            let mut prompt = Prompt::new(MSG_L1_RPC_URL_PROMPT);
+            if dev {
+                return LOCAL_RPC_URL.to_string();
+            }
+            if l1_network == L1Network::Localhost {
+                prompt = prompt.default(LOCAL_RPC_URL);
+            }
+            prompt
+                .validate_with(|val: &String| -> Result<(), String> {
+                    Url::parse(val)
+                        .map(|_| ())
+                        .map_err(|_| MSG_L1_RPC_URL_INVALID_ERR.to_string())
+                })
+                .ask()
+        });
+        V27UpgradeArgsFinal {
+            forge_args: self.forge_args,
+            ecosystem_upgrade_stage: self.ecosystem_upgrade_stage,
+            ecosystem_contracts_path: self.ecosystem_contracts_path,
+            l1_rpc_url,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Parser)]
+pub struct V27UpgradeArgsFinal {
+    #[clap(flatten)]
+    #[serde(flatten)]
+    pub forge_args: ForgeScriptArgs,
+    #[clap(long, value_enum)]
+    pub ecosystem_upgrade_stage: V27UpgradeStage,
+    /// Path to ecosystem contracts
+    #[clap(long)]
+    pub ecosystem_contracts_path: Option<PathBuf>,
+    #[clap(long, help = MSG_L1_RPC_URL_HELP)]
+    pub l1_rpc_url: String,
+}

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/mod.rs
@@ -17,6 +17,7 @@ mod gateway_upgrade;
 pub(crate) mod init;
 pub(crate) mod setup_observability;
 mod utils;
+mod v27_upgrade;
 
 #[derive(Subcommand, Debug)]
 #[allow(clippy::large_enum_variant)]
@@ -39,6 +40,7 @@ pub enum EcosystemCommands {
     /// Gateway version upgrade
     #[cfg(feature = "gateway")]
     GatewayUpgrade(crate::commands::ecosystem::args::gateway_upgrade::GatewayUpgradeArgs),
+    V27Upgrade(crate::commands::ecosystem::args::v27_upgrade::V27UpgradeArgs),
 }
 
 pub(crate) async fn run(shell: &Shell, args: EcosystemCommands) -> anyhow::Result<()> {
@@ -50,5 +52,6 @@ pub(crate) async fn run(shell: &Shell, args: EcosystemCommands) -> anyhow::Resul
         EcosystemCommands::SetupObservability => setup_observability::run(shell),
         #[cfg(feature = "gateway")]
         EcosystemCommands::GatewayUpgrade(args) => gateway_upgrade::run(args, shell).await,
+        EcosystemCommands::V27Upgrade(args) => v27_upgrade::run(args, shell).await,
     }
 }

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/v27_upgrade.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/v27_upgrade.rs
@@ -78,15 +78,14 @@ async fn no_governance_prepare(
     // FIXME: we will have to force this in production environment
     // assert_eq!(era_config.chain_id, ecosystem_config.era_chain_id);
 
-    let gateway_upgrade_input = V27EcosystemUpgradeInput::new(
+    let upgrade_input = V27EcosystemUpgradeInput::new(
         &default_genesis_input,
         &current_contracts_config,
         &initial_deployment_config,
         ecosystem_config.era_chain_id,
-        era_config.get_contracts_config()?.l1.diamond_proxy_addr,
         ecosystem_config.prover_version == ProverMode::NoProofs,
     );
-    gateway_upgrade_input.save(shell, ecosystem_upgrade_config_path.clone())?;
+    upgrade_input.save(shell, ecosystem_upgrade_config_path.clone())?;
 
     let mut forge = Forge::new(&ecosystem_config.path_to_l1_foundry())
         .script(&V27_UPGRADE_ECOSYSTEM_PARAMS.script(), forge_args.clone())

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/v27_upgrade.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/v27_upgrade.rs
@@ -1,0 +1,140 @@
+use anyhow::Context;
+use serde::Deserialize;
+use xshell::Shell;
+use zkstack_cli_common::{forge::Forge, git, spinner::Spinner};
+use zkstack_cli_config::{
+    forge_interface::{
+        deploy_ecosystem::input::GenesisInput,
+        script_params::V27_UPGRADE_ECOSYSTEM_PARAMS,
+        v27_ecosystem_upgrade::{
+            input::V27EcosystemUpgradeInput, output::V27EcosystemUpgradeOutput,
+        },
+    },
+    raw::RawConfig,
+    traits::{ReadConfig, SaveConfig, SaveConfigWithBasePath},
+    EcosystemConfig, GENESIS_FILE,
+};
+use zkstack_cli_types::ProverMode;
+
+use super::args::v27_upgrade::{V27UpgradeArgs, V27UpgradeArgsFinal};
+use crate::{
+    commands::ecosystem::args::v27_upgrade::V27UpgradeStage,
+    messages::MSG_INTALLING_DEPS_SPINNER,
+    utils::forge::{fill_forge_private_key, WalletOwner},
+};
+
+pub async fn run(args: V27UpgradeArgs, shell: &Shell) -> anyhow::Result<()> {
+    println!("Running ecosystem v27 upgrade args");
+
+    let ecosystem_config = EcosystemConfig::from_file(shell)?;
+    git::submodule_update(shell, ecosystem_config.link_to_code.clone())?;
+
+    let mut final_ecosystem_args = args.fill_values_with_prompt(ecosystem_config.l1_network, true);
+
+    match final_ecosystem_args.ecosystem_upgrade_stage {
+        V27UpgradeStage::NoGovernancePrepare => {
+            no_governance_prepare(&mut final_ecosystem_args, shell, &ecosystem_config).await?;
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct BroadcastFile {
+    pub transactions: Vec<BroadcastFileTransactions>,
+}
+#[derive(Debug, Deserialize)]
+struct BroadcastFileTransactions {
+    pub hash: String,
+}
+
+async fn no_governance_prepare(
+    init_args: &mut V27UpgradeArgsFinal,
+    shell: &Shell,
+    ecosystem_config: &EcosystemConfig,
+) -> anyhow::Result<()> {
+    let spinner = Spinner::new(MSG_INTALLING_DEPS_SPINNER);
+    spinner.finish();
+
+    let forge_args = init_args.forge_args.clone();
+    let l1_rpc_url = init_args.l1_rpc_url.clone();
+
+    let genesis_config_path = ecosystem_config
+        .get_default_configs_path()
+        .join(GENESIS_FILE);
+    let default_genesis_config = RawConfig::read(shell, genesis_config_path).await?;
+    let default_genesis_input = GenesisInput::new(&default_genesis_config)?;
+    let current_contracts_config = ecosystem_config.get_contracts_config()?;
+    let initial_deployment_config = ecosystem_config.get_initial_deployment_config()?;
+
+    let ecosystem_upgrade_config_path =
+        V27_UPGRADE_ECOSYSTEM_PARAMS.input(&ecosystem_config.link_to_code);
+
+    let era_config = ecosystem_config
+        .load_chain(Some("era".to_string()))
+        .context("No era")?;
+
+    // FIXME: we will have to force this in production environment
+    // assert_eq!(era_config.chain_id, ecosystem_config.era_chain_id);
+
+    let gateway_upgrade_input = V27EcosystemUpgradeInput::new(
+        &default_genesis_input,
+        &current_contracts_config,
+        &initial_deployment_config,
+        ecosystem_config.era_chain_id,
+        era_config.get_contracts_config()?.l1.diamond_proxy_addr,
+        ecosystem_config.prover_version == ProverMode::NoProofs,
+    );
+    gateway_upgrade_input.save(shell, ecosystem_upgrade_config_path.clone())?;
+
+    let mut forge = Forge::new(&ecosystem_config.path_to_l1_foundry())
+        .script(&V27_UPGRADE_ECOSYSTEM_PARAMS.script(), forge_args.clone())
+        .with_ffi()
+        .with_rpc_url(l1_rpc_url)
+        .with_slow()
+        .with_gas_limit(1_000_000_000_000)
+        .with_broadcast();
+
+    forge = fill_forge_private_key(
+        forge,
+        ecosystem_config.get_wallets()?.deployer.as_ref(),
+        WalletOwner::Deployer,
+    )?;
+
+    println!("Preparing the ecosystem for the upgrade!");
+
+    forge.run(shell)?;
+
+    println!("done!");
+
+    let l1_chain_id = era_config.l1_network.chain_id();
+
+    let broadcast_file: BroadcastFile = {
+        let file_content = std::fs::read_to_string(
+            ecosystem_config
+                .link_to_code
+                .join("contracts/l1-contracts")
+                .join(format!(
+                    "broadcast/EcosystemUpgrade.s.sol/{}/run-latest.json",
+                    l1_chain_id
+                )),
+        )
+        .context("Failed to read broadcast file")?;
+        serde_json::from_str(&file_content).context("Failed to parse broadcast file")?
+    };
+
+    let mut output = V27EcosystemUpgradeOutput::read(
+        shell,
+        V27_UPGRADE_ECOSYSTEM_PARAMS.output(&ecosystem_config.link_to_code),
+    )?;
+
+    // Add all the transaction hashes.
+    for tx in broadcast_file.transactions {
+        output.transactions.push(tx.hash);
+    }
+
+    output.save_with_base_path(shell, &ecosystem_config.config)?;
+
+    Ok(())
+}


### PR DESCRIPTION
## What ❔

Adding the ability do execute v27 upgrade using zkstack cli.

## Why ❔



## Is this a breaking change?
- [ ] Yes
- [X] No

## Operational changes
To run:

```
zkstack e v27-upgrade --ecosystem-upgrade-stage no-governance-prepare
```

