### PR TITLE
chore: fix typo in initialization message

### DIFF
--- a/docker/local-node/entrypoint.sh
+++ b/docker/local-node/entrypoint.sh
@@ -106,7 +106,7 @@ INIT_FILE="/var/lib/zksync/data/INIT_COMPLETED.remove_to_reset"
 if [ -f "$INIT_FILE" ]; then
   echo "Initialization was done in the past - simply starting server"
 else
-  echo "Initialing local environment"
+  echo "Initializing local environment"
 
   mkdir -p /var/lib/zksync/data
 


### PR DESCRIPTION
## What ❔

I corrected a typo in the script. The message "Initialing local environment" has been updated to the correct form: "Initializing local environment". This ensures proper spelling and clarity in the output.

For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
