### PR TITLE
chore: fix crates.io publishing

### DIFF
--- a/.github/workflows/cargo-license.yaml
+++ b/.github/workflows/cargo-license.yaml
@@ -9,4 +9,4 @@ jobs:
       with:
         manifest-path: "./core/Cargo.toml"
         command: check
-        command-arguments: "--hide-inclusion-graph"
+        command-arguments: "--allow unmaintained --hide-inclusion-graph"

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -28,7 +28,9 @@ jobs:
 
   publish-crates:
     name: Publish to crates.io
-    runs-on: matterlabs-ci-runner-high-performance
+    runs-on: matterlabs-ci-runner-highdisk
+    env:
+      ZKSYNC_USE_CUDA_STUBS: true
     steps:
       - name: Publish crates
         uses: matter-labs/zksync-ci-common/.github/actions/publish-crates@v1
@@ -40,3 +42,4 @@ jobs:
           run_build: ${{ inputs.run-build }}
           run_tests: ${{ inputs.run-tests }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}
+          dependencies: 'clang libclang-dev'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,6 +31,7 @@ jobs:
       upgrade-dependencies: true                            # Upgrade cross-workspace dependencies
       version-suffix: 'non-semver-compat'                   # Version suffix for the crates.io release
       workspace-dirs: 'core prover zkstack_cli'             # List of additional workspace directories to update Cargo.lock
+      dependencies: 'clang libclang-dev'                    # Additional Linux dependencies to install
 
   # Trigger workflow to publish zkstack binaries
   release-zkstack-cli-bins:

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1907,9 +1907,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -5314,7 +5314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7576,15 +7576,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]

--- a/core/bin/custom_genesis_export/Cargo.toml
+++ b/core/bin/custom_genesis_export/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
+publish = false
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }

--- a/core/lib/queued_job_processor/Cargo.toml
+++ b/core/lib/queued_job_processor/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-tokio = { workspace = true, features = ["time"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 tracing.workspace = true
 
 zksync_utils.workspace = true

--- a/core/lib/test_contracts/Cargo.toml
+++ b/core/lib/test_contracts/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
+publish = false
 
 [dependencies]
 zksync_types.workspace = true


### PR DESCRIPTION
## What ❔

Fix crates.io publishing.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To unblock `core` crates.io publishing in CI.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
