### PR TITLE
chore: remove unnecessary chrono import

### DIFF
--- a/prover/crates/bin/prover_cli/src/commands/stats.rs
+++ b/prover/crates/bin/prover_cli/src/commands/stats.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use chrono::{self, NaiveTime};
+use chrono::NaiveTime;
 use clap::{Args, ValueEnum};
 use zksync_basic_types::prover_dal::ProofGenerationTime;
 use zksync_db_connection::connection_pool::ConnectionPool;


### PR DESCRIPTION
## What ❔  
Removed the unnecessary `chrono` import and kept only `NaiveTime`.

## Why ❔  
To clean up the code and avoid importing more than needed.

## Is this a breaking change?  
- [ ] Yes  
- [x] No  

## Operational changes  
None

## Checklist  
- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).  
- [x] Tests for the changes have been added / updated.  
- [ ] Documentation comments have been added / updated.  
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.