### PR TITLE
feat(eth-watch): split heavy get logs requests if 503

### DIFF
--- a/core/node/eth_watch/src/client.rs
+++ b/core/node/eth_watch/src/client.rs
@@ -90,7 +90,7 @@ const TOO_MANY_RESULTS_ALCHEMY: &str = "response size exceeded";
 const TOO_MANY_RESULTS_RETH: &str = "length limit exceeded";
 const TOO_BIG_RANGE_RETH: &str = "query exceeds max block range";
 const TOO_MANY_RESULTS_CHAINSTACK: &str = "range limit exceeded";
-const REQUEST_REJECTED_503: &str = "Request rejected `503`";
+const REQUEST_REJECTED_503: &str = "503";
 
 /// Implementation of [`EthClient`] based on HTTP JSON-RPC.
 #[derive(Debug, Clone)]

--- a/core/node/eth_watch/src/client.rs
+++ b/core/node/eth_watch/src/client.rs
@@ -90,6 +90,7 @@ const TOO_MANY_RESULTS_ALCHEMY: &str = "response size exceeded";
 const TOO_MANY_RESULTS_RETH: &str = "length limit exceeded";
 const TOO_BIG_RANGE_RETH: &str = "query exceeds max block range";
 const TOO_MANY_RESULTS_CHAINSTACK: &str = "range limit exceeded";
+const REQUEST_REJECTED_503: &str = "Request rejected `503`";
 
 /// Implementation of [`EthClient`] based on HTTP JSON-RPC.
 #[derive(Debug, Clone)]
@@ -222,6 +223,7 @@ where
                 || err_message.contains(TOO_MANY_RESULTS_RETH)
                 || err_message.contains(TOO_BIG_RANGE_RETH)
                 || err_message.contains(TOO_MANY_RESULTS_CHAINSTACK)
+                || err_message.contains(REQUEST_REJECTED_503)
             {
                 // get the numeric block ids
                 let from_number = match from {

--- a/core/node/eth_watch/src/client.rs
+++ b/core/node/eth_watch/src/client.rs
@@ -90,7 +90,7 @@ const TOO_MANY_RESULTS_ALCHEMY: &str = "response size exceeded";
 const TOO_MANY_RESULTS_RETH: &str = "length limit exceeded";
 const TOO_BIG_RANGE_RETH: &str = "query exceeds max block range";
 const TOO_MANY_RESULTS_CHAINSTACK: &str = "range limit exceeded";
-const REQUEST_REJECTED_503: &str = "503";
+const REQUEST_REJECTED_503: &str = "Request rejected `503`";
 
 /// Implementation of [`EthClient`] based on HTTP JSON-RPC.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## What ❔

split heavy get logs requests if got error 503

## Why ❔

We use proxyd that proxies mostly vanila reth nodes in our setup, some get_logs requests with big block range take a lot of time so they can rejected in proxyd by timeout, in this case 503 is returned. We should split such requests into smaller so they can be processed.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
