### PR TITLE
chore: make `IntoOldVmTracer` public

### DIFF
--- a/core/lib/multivm/src/lib.rs
+++ b/core/lib/multivm/src/lib.rs
@@ -10,7 +10,7 @@ pub use zksync_vm_interface as interface;
 pub use crate::{
     glue::{
         history_mode::HistoryMode,
-        tracers::{MultiVmTracer, MultiVmTracerPointer},
+        tracers::{IntoOldVmTracer, MultiVmTracer, MultiVmTracerPointer},
     },
     versions::{
         vm_1_3_2, vm_1_4_1, vm_1_4_2, vm_boojum_integration, vm_fast, vm_latest, vm_m5, vm_m6,


### PR DESCRIPTION
## What ❔

Exposes `IntoOldVmTracer`

## Why ❔

Currently it is impossible to create new multivm tracers outside of this crate

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
