### PR TITLE
fix: API URL for prover gateway

### DIFF
--- a/prover/crates/bin/prover_fri_gateway/src/rpc_server/mod.rs
+++ b/prover/crates/bin/prover_fri_gateway/src/rpc_server/mod.rs
@@ -24,7 +24,7 @@ impl RpcServer {
     }
 
     pub async fn run(self, mut stop_receiver: watch::Receiver<bool>) -> anyhow::Result<()> {
-        let address = format!("127.0.0.1:{}", self.ws_port);
+        let address = format!("0.0.0.0:{}", self.ws_port);
         let server = Server::builder().build(address.clone()).await?;
         let handle = server.start(self.processor.into_rpc());
         let close_handle = handle.clone();


### PR DESCRIPTION
## What ❔

Change WS server URL to 0.0.0.0 from 127.0.0.1

## Why ❔

For the server to be externally discoverable

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
