### PR TITLE
feat: Starting from v26 version, always fetch the address of the validator timelock from CTM

### DIFF
--- a/core/node/eth_sender/src/eth_tx_aggregator.rs
+++ b/core/node/eth_sender/src/eth_tx_aggregator.rs
@@ -449,7 +449,10 @@ impl EthTxAggregator {
         if chain_protocol_version_id < ProtocolVersionId::gateway_upgrade() {
             self.config_timelock_contract_address
         } else {
-            assert!(chain_protocol_version_id <= stm_protocol_version_id, "Chain upgraded before STM");
+            assert!(
+                chain_protocol_version_id <= stm_protocol_version_id,
+                "Chain upgraded before STM"
+            );
 
             stm_validator_timelock_address
         }

--- a/core/node/eth_sender/src/eth_tx_aggregator.rs
+++ b/core/node/eth_sender/src/eth_tx_aggregator.rs
@@ -443,10 +443,15 @@ impl EthTxAggregator {
         stm_protocol_version_id: ProtocolVersionId,
         stm_validator_timelock_address: Address,
     ) -> Address {
-        if chain_protocol_version_id == stm_protocol_version_id {
-            stm_validator_timelock_address
-        } else {
+        // For chains before v26 (gateway) we use the timelock address from config.
+        // After that, the timelock address can be fetched from STM as it is the valid one
+        // for versions starting from v26 and is not expected to change in the near future.
+        if chain_protocol_version_id < ProtocolVersionId::gateway_upgrade() {
             self.config_timelock_contract_address
+        } else {
+            assert!(chain_protocol_version_id <= stm_protocol_version_id, "Chain upgraded before STM");
+
+            stm_validator_timelock_address
         }
     }
 


### PR DESCRIPTION
## What ❔

If a chain has a protocol version greater than v26 (gateway), then the validator timelock will be fetched from L1.

This is needed to ensure smooth upgrade to v27 for chains.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
