### PR TITLE
feat(zkstack): Clarify prompt for funds check

### DIFF
--- a/zkstack_cli/crates/zkstack/src/messages.rs
+++ b/zkstack_cli/crates/zkstack/src/messages.rs
@@ -359,7 +359,7 @@ pub(super) fn msg_address_doesnt_have_enough_money_prompt(
     let actual = format_ether(actual);
     let expected = format_ether(expected);
     format!(
-        "Address {address:?} doesn't have enough money to deploy contracts only {actual} ETH but expected: {expected} ETH do you want to try again?"
+        "It is recommended to have {expected} ETH on the address {address:?} to deploy contracts. Current balance is {actual} ETH. How do you want to proceed?",
     )
 }
 

--- a/zkstack_cli/crates/zkstack/src/utils/forge.rs
+++ b/zkstack_cli/crates/zkstack/src/utils/forge.rs
@@ -28,6 +28,10 @@ pub fn fill_forge_private_key(
 }
 
 pub async fn check_the_balance(forge: &ForgeScript) -> anyhow::Result<()> {
+    const MSG_CONTINUE: &str = "Proceed with the deployment anyway";
+    const MSG_CHECK_BALANCE: &str = "Check the balance again";
+    const MSG_EXIT: &str = "Exit";
+
     let Some(address) = forge.address() else {
         return Ok(());
     };
@@ -37,14 +41,19 @@ pub async fn check_the_balance(forge: &ForgeScript) -> anyhow::Result<()> {
         if balance >= expected_balance {
             return Ok(());
         }
-        if !zkstack_cli_common::PromptConfirm::new(msg_address_doesnt_have_enough_money_prompt(
-            &address,
-            balance,
-            expected_balance,
-        ))
+
+        let prompt_msg =
+            msg_address_doesnt_have_enough_money_prompt(&address, balance, expected_balance);
+        match zkstack_cli_common::PromptSelect::new(
+            &prompt_msg,
+            [MSG_CONTINUE, MSG_CHECK_BALANCE, MSG_EXIT],
+        )
         .ask()
         {
-            break;
+            MSG_CONTINUE => return Ok(()),
+            MSG_CHECK_BALANCE => continue,
+            MSG_EXIT => anyhow::bail!("Exiting the deployment process"),
+            _ => unreachable!(),
         }
     }
     Ok(())


### PR DESCRIPTION
Current prompt for balance check is not clear (it implies that you need 5 ETH in order to proceed; which isn't what it does).
This PR makes it more clear and gives user a choice to exit.

![image](https://github.com/user-attachments/assets/71edf22f-2321-4704-a992-cb487eaea264)

![image](https://github.com/user-attachments/assets/e3053668-af29-46f8-950b-065bb86e256e)
