### PR TITLE
fix(da):  use correct pubdata params on existing batch after switching da

### DIFF
--- a/core/lib/vm_executor/src/batch/factory.rs
+++ b/core/lib/vm_executor/src/batch/factory.rs
@@ -320,7 +320,7 @@ impl<S: ReadStorage + 'static, Tr: BatchTracer> CommandReceiver<S, Tr> {
         storage: S,
         l1_batch_params: L1BatchEnv,
         system_env: SystemEnv,
-        pubdata_builder: Rc<dyn PubdataBuilder>,
+        _: Rc<dyn PubdataBuilder>,
     ) -> anyhow::Result<StorageView<S>> {
         tracing::info!("Starting executing L1 batch #{}", &l1_batch_params.number);
 
@@ -376,8 +376,9 @@ impl<S: ReadStorage + 'static, Tr: BatchTracer> CommandReceiver<S, Tr> {
                         break;
                     }
                 }
-                Command::FinishBatch(resp) => {
-                    let vm_block_result = self.finish_batch(&mut vm, pubdata_builder)?;
+                Command::FinishBatch(pubdata_params, resp) => {
+                    let vm_block_result =
+                        self.finish_batch(&mut vm, pubdata_params_to_builder(pubdata_params))?;
                     if resp.send(vm_block_result).is_err() {
                         break;
                     }

--- a/core/lib/vm_interface/src/executor.rs
+++ b/core/lib/vm_interface/src/executor.rs
@@ -43,7 +43,10 @@ pub trait BatchExecutor<S>: 'static + Send + fmt::Debug {
     async fn start_next_l2_block(&mut self, env: L2BlockEnv) -> anyhow::Result<()>;
 
     /// Finished the current L1 batch.
-    async fn finish_batch(self: Box<Self>) -> anyhow::Result<(FinishedL1Batch, StorageView<S>)>;
+    async fn finish_batch(
+        self: Box<Self>,
+        pubdata_params: PubdataParams,
+    ) -> anyhow::Result<(FinishedL1Batch, StorageView<S>)>;
 }
 
 /// VM executor capable of executing isolated transactions / calls (as opposed to [batch execution](BatchExecutor)).

--- a/core/node/node_sync/src/external_io.rs
+++ b/core/node/node_sync/src/external_io.rs
@@ -16,6 +16,7 @@ use zksync_state_keeper::{
 };
 use zksync_types::{
     block::UnsealedL1BatchHeader,
+    commitment::PubdataParams,
     protocol_upgrade::ProtocolUpgradeTx,
     protocol_version::{ProtocolSemanticVersion, VersionPatch},
     L1BatchNumber, L2BlockNumber, L2ChainId, ProtocolVersionId, Transaction, H256,
@@ -476,6 +477,10 @@ impl StateKeeperIO for ExternalIO {
             .with_context(|| format!("error waiting for params for L1 batch #{l1_batch_number}"))?;
         wait_latency.observe();
         Ok(hash)
+    }
+
+    async fn get_pubdata_params(&mut self, _: ProtocolVersionId) -> anyhow::Result<PubdataParams> {
+        Ok(Default::default())
     }
 }
 

--- a/core/node/state_keeper/src/executor/tests/mod.rs
+++ b/core/node/state_keeper/src/executor/tests/mod.rs
@@ -9,7 +9,9 @@ use zksync_multivm::interface::{
 use zksync_system_constants::{COMPRESSOR_ADDRESS, L1_MESSENGER_ADDRESS};
 use zksync_test_contracts::{Account, TestContract};
 use zksync_types::{
-    address_to_h256, get_nonce_key,
+    address_to_h256,
+    commitment::PubdataParams,
+    get_nonce_key,
     utils::{deployed_address_create, storage_key_for_eth_balance},
     vm::FastVmMode,
     web3, Execute, PriorityOpId, H256, L2_MESSAGE_ROOT_ADDRESS, U256,
@@ -95,7 +97,10 @@ async fn execute_l2_tx(storage_type: StorageType, vm_mode: FastVmMode) {
 
     let res = executor.execute_tx(alice.execute()).await.unwrap();
     assert_executed(&res);
-    executor.finish_batch().await.unwrap();
+    executor
+        .finish_batch(PubdataParams::default())
+        .await
+        .unwrap();
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -167,7 +172,10 @@ async fn execute_l2_tx_after_snapshot_recovery(
     let res = executor.execute_tx(alice.execute()).await.unwrap();
     if mutation.is_none() {
         assert_executed(&res);
-        executor.finish_batch().await.unwrap();
+        executor
+            .finish_batch(PubdataParams::default())
+            .await
+            .unwrap();
     } else {
         assert_rejected(&res);
     }
@@ -214,7 +222,10 @@ async fn execute_l1_tx(vm_mode: FastVmMode) {
         .await
         .unwrap();
     assert_executed(&res);
-    executor.finish_batch().await.unwrap();
+    executor
+        .finish_batch(PubdataParams::default())
+        .await
+        .unwrap();
 }
 
 /// Checks that we can successfully execute a single L2 tx and a single L1 tx in batch executor.
@@ -261,7 +272,10 @@ async fn execute_l2_and_l1_txs(vm_mode: FastVmMode) {
         .unwrap();
     assert_executed(&res);
 
-    executor.finish_batch().await.unwrap();
+    executor
+        .finish_batch(PubdataParams::default())
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -289,7 +303,10 @@ async fn working_with_transient_storage() {
     let res = executor.execute_tx(test_tx).await.unwrap();
     assert_succeeded(&res);
 
-    executor.finish_batch().await.unwrap();
+    executor
+        .finish_batch(PubdataParams::default())
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -317,7 +334,10 @@ async fn decommitting_contract() {
     let res = executor.execute_tx(test_tx).await.unwrap();
     assert_succeeded(&res);
 
-    executor.finish_batch().await.unwrap();
+    executor
+        .finish_batch(PubdataParams::default())
+        .await
+        .unwrap();
 }
 
 /// Checks that we can successfully rollback the transaction and execute it once again.
@@ -373,7 +393,10 @@ async fn rollback(vm_mode: FastVmMode) {
         "Execution results must be the same"
     );
 
-    executor.finish_batch().await.unwrap();
+    executor
+        .finish_batch(PubdataParams::default())
+        .await
+        .unwrap();
 }
 
 /// Checks that incorrect transactions are marked as rejected.
@@ -435,7 +458,10 @@ async fn too_big_gas_limit(vm_mode: FastVmMode) {
 
     let res = executor.execute_tx(big_gas_limit_tx).await.unwrap();
     assert_executed(&res);
-    executor.finish_batch().await.unwrap();
+    executor
+        .finish_batch(PubdataParams::default())
+        .await
+        .unwrap();
 }
 
 /// Checks that we can't execute the same transaction twice.
@@ -510,7 +536,10 @@ async fn deploy_and_call_loadtest(vm_mode: FastVmMode) {
             .await
             .unwrap(),
     );
-    executor.finish_batch().await.unwrap();
+    executor
+        .finish_batch(PubdataParams::default())
+        .await
+        .unwrap();
 }
 
 #[test_casing(3, FAST_VM_MODES)]
@@ -531,7 +560,10 @@ async fn deploy_failedcall(vm_mode: FastVmMode) {
     let execute_tx = executor.execute_tx(tx.tx).await.unwrap();
     assert_executed(&execute_tx);
 
-    executor.finish_batch().await.unwrap();
+    executor
+        .finish_batch(PubdataParams::default())
+        .await
+        .unwrap();
 }
 
 /// Checks that a tx that is reverted by the VM still can be included into a batch.
@@ -583,7 +615,10 @@ async fn execute_reverted_tx(vm_mode: FastVmMode) {
             .await
             .unwrap(),
     );
-    executor.finish_batch().await.unwrap();
+    executor
+        .finish_batch(PubdataParams::default())
+        .await
+        .unwrap();
 }
 
 /// Runs the batch executor through a semi-realistic basic scenario:
@@ -667,7 +702,10 @@ async fn execute_realistic_scenario(vm_mode: FastVmMode) {
         .unwrap();
     assert_executed(&res);
 
-    executor.finish_batch().await.unwrap();
+    executor
+        .finish_batch(PubdataParams::default())
+        .await
+        .unwrap();
 }
 
 /// Checks that we handle the bootloader out of gas error on execution phase.
@@ -720,7 +758,10 @@ async fn bootloader_tip_out_of_gas() {
     let res = executor.execute_tx(alice.execute()).await.unwrap();
     assert_executed(&res);
 
-    let (finished_batch, _) = executor.finish_batch().await.unwrap();
+    let (finished_batch, _) = executor
+        .finish_batch(PubdataParams::default())
+        .await
+        .unwrap();
 
     // Just a bit below the gas used for the previous batch execution should be fine to execute the tx
     // but not enough to execute the block tip.
@@ -794,7 +835,10 @@ async fn catchup_rocksdb_cache() {
     let tx = alice.execute();
     let res = executor.execute_tx(tx.clone()).await.unwrap();
     assert_executed(&res);
-    executor.finish_batch().await.unwrap();
+    executor
+        .finish_batch(PubdataParams::default())
+        .await
+        .unwrap();
 
     // Async RocksDB cache should be aware of the tx and should reject it
     let mut executor = tester
@@ -809,7 +853,10 @@ async fn catchup_rocksdb_cache() {
     executor.rollback_last_tx().await.unwrap(); // Roll back the vm to the pre-rejected-tx state.
     let res = executor.execute_tx(bob.execute()).await.unwrap();
     assert_executed(&res);
-    executor.finish_batch().await.unwrap();
+    executor
+        .finish_batch(PubdataParams::default())
+        .await
+        .unwrap();
     // Wait for all background tasks to exit, otherwise we might still be holding a RocksDB lock
     tester.wait_for_tasks().await;
 
@@ -867,7 +914,10 @@ async fn execute_tx_with_large_packable_bytecode(vm_mode: FastVmMode) {
     assert_eq!(compressed_bytecodes.len(), 1);
     assert!(compressed_bytecodes[0].len() < BYTECODE_LEN / 2);
 
-    executor.finish_batch().await.unwrap();
+    executor
+        .finish_batch(PubdataParams::default())
+        .await
+        .unwrap();
 }
 
 #[test_casing(3, FAST_VM_MODES)]

--- a/core/node/state_keeper/src/executor/tests/tester.rs
+++ b/core/node/state_keeper/src/executor/tests/tester.rs
@@ -692,7 +692,10 @@ impl StorageSnapshot {
             executor.start_next_l2_block(l2_block_env).await.unwrap();
         }
 
-        let (finished_batch, _) = executor.finish_batch().await.unwrap();
+        let (finished_batch, _) = executor
+            .finish_batch(PubdataParams::default())
+            .await
+            .unwrap();
         let storage_logs = &finished_batch.block_tip_execution_result.logs.storage_logs;
         storage_writes_deduplicator.apply(storage_logs.iter().filter(|log| log.log.is_write()));
         let modified_entries = storage_writes_deduplicator.into_modified_key_values();

--- a/core/node/state_keeper/src/io/mempool.rs
+++ b/core/node/state_keeper/src/io/mempool.rs
@@ -447,6 +447,25 @@ impl StateKeeperIO for MempoolIO {
         );
         Ok(batch_state_hash)
     }
+
+    async fn get_pubdata_params(
+        &mut self,
+        protocol_version: ProtocolVersionId,
+    ) -> anyhow::Result<PubdataParams> {
+        let pubdata_params = match (
+            protocol_version.is_pre_gateway(),
+            self.l2_da_validator_address,
+        ) {
+            (true, _) => PubdataParams::default(),
+            (false, Some(l2_da_validator_address)) => PubdataParams {
+                l2_da_validator_address,
+                pubdata_type: self.pubdata_type,
+            },
+            (false, None) => anyhow::bail!("L2 DA validator address not found"),
+        };
+
+        Ok(pubdata_params)
+    }
 }
 
 /// Sleeps until the current timestamp is larger than the provided `timestamp`.

--- a/core/node/state_keeper/src/io/mod.rs
+++ b/core/node/state_keeper/src/io/mod.rs
@@ -169,4 +169,10 @@ pub trait StateKeeperIO: 'static + Send + Sync + fmt::Debug + IoSealCriteria {
     /// Loads state hash for the L1 batch with the specified number. The batch is guaranteed to be present
     /// in the storage.
     async fn load_batch_state_hash(&self, number: L1BatchNumber) -> anyhow::Result<H256>;
+
+    /// Get the latest pubdata params
+    async fn get_pubdata_params(
+        &mut self,
+        protocol_version_id: ProtocolVersionId,
+    ) -> anyhow::Result<PubdataParams>;
 }

--- a/core/node/state_keeper/src/keeper.rs
+++ b/core/node/state_keeper/src/keeper.rs
@@ -198,8 +198,12 @@ impl ZkSyncStateKeeper {
                 Self::start_next_l2_block(&mut updates_manager, &mut *batch_executor).await?;
             }
 
-            let (finished_batch, _) = batch_executor.finish_batch().await?;
             let sealed_batch_protocol_version = updates_manager.protocol_version();
+            let pubdata_params_io = self
+                .io
+                .get_pubdata_params(sealed_batch_protocol_version)
+                .await?;
+            let (finished_batch, _) = batch_executor.finish_batch(pubdata_params_io).await?;
             updates_manager.finish_batch(finished_batch);
             let mut next_cursor = updates_manager.io_cursor();
             self.output_handler

--- a/core/node/state_keeper/src/testonly/mod.rs
+++ b/core/node/state_keeper/src/testonly/mod.rs
@@ -70,6 +70,7 @@ impl BatchExecutor<OwnedStorage> for MockBatchExecutor {
 
     async fn finish_batch(
         self: Box<Self>,
+        _: PubdataParams,
     ) -> anyhow::Result<(FinishedL1Batch, StorageView<OwnedStorage>)> {
         let storage = OwnedStorage::boxed(InMemoryStorage::default());
         Ok((FinishedL1Batch::mock(), StorageView::new(storage)))

--- a/core/node/state_keeper/src/testonly/test_batch_executor.rs
+++ b/core/node/state_keeper/src/testonly/test_batch_executor.rs
@@ -514,6 +514,7 @@ impl BatchExecutor<OwnedStorage> for TestBatchExecutor {
 
     async fn finish_batch(
         self: Box<Self>,
+        _: PubdataParams,
     ) -> anyhow::Result<(FinishedL1Batch, StorageView<OwnedStorage>)> {
         let storage = OwnedStorage::boxed(InMemoryStorage::default());
         Ok((FinishedL1Batch::mock(), StorageView::new(storage)))
@@ -826,6 +827,10 @@ impl StateKeeperIO for TestIO {
 
     async fn load_batch_state_hash(&self, _l1_batch_number: L1BatchNumber) -> anyhow::Result<H256> {
         Ok(H256::zero())
+    }
+
+    async fn get_pubdata_params(&mut self, _: ProtocolVersionId) -> anyhow::Result<PubdataParams> {
+        Ok(Default::default())
     }
 }
 

--- a/core/node/vm_runner/src/process.rs
+++ b/core/node/vm_runner/src/process.rs
@@ -127,7 +127,7 @@ impl VmRunner {
         }
 
         let (batch, storage_view) = batch_executor
-            .finish_batch()
+            .finish_batch(Default::default())
             .await
             .context("VM runner failed to execute batch tip")?;
         let output = L1BatchOutput {


### PR DESCRIPTION
## What ❔

Currently, the pubdata params is defined when we are opening a new batch (it is returned by `wait_for_new_batch_env`) and tied to the `FinishBatch` command. 

This can create concurrent issue in case we are switching da with an existing opened batch.

To solve this, we are updating the logic to fetch the pubdata params ONLY before closing the batch introducing a new method `get_pubdata_params` in `StateKeeperIO` and pass it to the `FinishBatch` command.

With this new flow, the concurrent problem does not exist.




## Why ❔

In case there is an existing non-empty batch when switching DA, the batch will still be using old pubdata parameters and won't be able to be committed to L1.

The system will break

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
None

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
