### PR TITLE
fix: make eigenda_eth_rpc in Eigen config optional in file-based configs

### DIFF
--- a/core/lib/protobuf_config/src/da_client.rs
+++ b/core/lib/protobuf_config/src/da_client.rs
@@ -69,9 +69,12 @@ impl ProtoRepr for proto::DataAvailabilityClient {
                     &conf.settlement_layer_confirmation_depth,
                 )
                 .context("settlement_layer_confirmation_depth")?,
-                eigenda_eth_rpc: Some(SensitiveUrl::from_str(
-                    required(&conf.eigenda_eth_rpc).context("eigenda_eth_rpc")?,
-                )?),
+                eigenda_eth_rpc: conf
+                    .eigenda_eth_rpc
+                    .clone()
+                    .map(|x| SensitiveUrl::from_str(&x).context("eigenda_eth_rpc"))
+                    .transpose()
+                    .context("eigenda_eth_rpc")?,
                 eigenda_svc_manager_address: required(&conf.eigenda_svc_manager_address)
                     .and_then(|x| parse_h160(x))
                     .context("eigenda_svc_manager_address")?,


### PR DESCRIPTION
## What ❔

Make `eigenda_eth_rpc` in Eigen config optional in proto configs

## Why ❔

This was incorrectly forced to be "required" despite the actual config field being optional

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
