### PR TITLE
test(vm): Test EVM emulator in `multivm` crate (pt. 2)

### DIFF
--- a/core/lib/multivm/src/versions/shadow/tests.rs
+++ b/core/lib/multivm/src/versions/shadow/tests.rs
@@ -356,7 +356,17 @@ mod evm {
 
     #[test]
     fn real_emulator_create2_deployment() {
-        test_create2_deployment::<super::ShadowedFastVm>();
+        test_create2_deployment_in_evm::<super::ShadowedFastVm>();
+    }
+
+    #[test]
+    fn reusing_create_address() {
+        test_reusing_create_address_in_evm::<super::ShadowedFastVm>();
+    }
+
+    #[test]
+    fn reusing_create2_salt() {
+        test_reusing_create2_salt_in_evm::<super::ShadowedFastVm>();
     }
 
     #[test]
@@ -642,6 +652,16 @@ mod simple_execution {
     #[test]
     fn create2_deployment_address() {
         test_create2_deployment_address::<super::ShadowedFastVm>();
+    }
+
+    #[test]
+    fn reusing_create_address() {
+        test_reusing_create_address::<super::ShadowedFastVm>();
+    }
+
+    #[test]
+    fn reusing_create2_salt() {
+        test_reusing_create2_salt::<super::ShadowedFastVm>();
     }
 }
 

--- a/core/lib/multivm/src/versions/shadow/tests.rs
+++ b/core/lib/multivm/src/versions/shadow/tests.rs
@@ -355,6 +355,11 @@ mod evm {
     }
 
     #[test]
+    fn real_emulator_create2_deployment() {
+        test_create2_deployment::<super::ShadowedFastVm>();
+    }
+
+    #[test]
     fn deployment_with_partial_reverts() {
         test_deployment_with_partial_reverts::<super::ShadowedFastVm>();
     }

--- a/core/lib/multivm/src/versions/testonly/evm.rs
+++ b/core/lib/multivm/src/versions/testonly/evm.rs
@@ -476,15 +476,6 @@ pub(crate) fn test_era_vm_deployment_after_evm_deployment<VM: TestedVm>() {
     deploy_eravm_counter(&mut vm, proxy_counter_bytecode, counter_address);
 }
 
-/// Also checks `CREATE2` address computation.
-pub(crate) fn test_deployment_with_partial_reverts<VM: TestedVm>() {
-    for seed in [1, 10, 100, 1_000] {
-        println!("Testing with RNG seed {seed}");
-        let mut rng = StdRng::seed_from_u64(seed);
-        test_deployment_with_partial_reverts_and_rng::<VM>(&mut rng);
-    }
-}
-
 fn evm_create2_address(
     sender: Address,
     salt: H256,
@@ -500,6 +491,53 @@ fn evm_create2_address(
     buffer.extend_from_slice(&web3::keccak256(&creation_bytecode_and_args));
     let hash_digest = web3::keccak256(&buffer);
     Address::from_slice(&hash_digest[12..])
+}
+
+pub(crate) fn test_create2_deployment<VM: TestedVm>() {
+    let mut vm: VmTester<VM> = prepare_tester_with_real_emulator().0.build::<VM>();
+    let account = &mut vm.rich_accounts[0];
+    let test_fn = TestEvmContract::evm_tester().function("testCreate2Deployment");
+
+    let mut rng = StdRng::seed_from_u64(123);
+    for _ in 0..10 {
+        let salt = H256(rng.gen());
+        let constructor_arg = U256(rng.gen());
+        let expected_address = evm_create2_address(
+            EVM_ADDRESS,
+            salt,
+            TestEvmContract::counter().init_bytecode,
+            &[Token::Uint(constructor_arg)],
+        );
+
+        let test_tx = account.get_l2_tx_for_execute(
+            Execute {
+                contract_address: Some(EVM_ADDRESS),
+                calldata: test_fn
+                    .encode_input(&[
+                        Token::FixedBytes(salt.as_bytes().to_vec()),
+                        Token::Uint(constructor_arg),
+                        Token::Address(expected_address),
+                    ])
+                    .unwrap(),
+                value: 0.into(),
+                factory_deps: vec![],
+            },
+            None,
+        );
+
+        let (_, vm_result) = vm
+            .vm
+            .execute_transaction_with_bytecode_compression(test_tx, true);
+        assert!(!vm_result.result.is_failed(), "{vm_result:?}");
+    }
+}
+
+pub(crate) fn test_deployment_with_partial_reverts<VM: TestedVm>() {
+    for seed in [1, 10, 100, 1_000] {
+        println!("Testing with RNG seed {seed}");
+        let mut rng = StdRng::seed_from_u64(seed);
+        test_deployment_with_partial_reverts_and_rng::<VM>(&mut rng);
+    }
 }
 
 fn test_deployment_with_partial_reverts_and_rng<VM: TestedVm>(rng: &mut impl Rng) {

--- a/core/lib/multivm/src/versions/testonly/simple_execution.rs
+++ b/core/lib/multivm/src/versions/testonly/simple_execution.rs
@@ -71,7 +71,6 @@ pub(crate) fn test_simple_execute<VM: TestedVm>() {
     assert_matches!(block_tip.result, ExecutionResult::Success { .. });
 }
 
-// TODO: also test EVM contract addresses once EVM emulator is implemented
 pub(crate) fn test_create2_deployment_address<VM: TestedVm>() {
     let mut vm_tester = VmTesterBuilder::new().with_rich_accounts(1).build::<VM>();
     let account = &mut vm_tester.rich_accounts[0];

--- a/core/lib/multivm/src/versions/testonly/simple_execution.rs
+++ b/core/lib/multivm/src/versions/testonly/simple_execution.rs
@@ -1,8 +1,12 @@
 use assert_matches::assert_matches;
+use ethabi::Token;
 use zksync_test_contracts::{TestContract, TxType};
-use zksync_types::{Execute, H256};
+use zksync_types::{utils::deployed_address_create, Address, Execute, H256};
 
-use super::{default_pubdata_builder, extract_deploy_events, tester::VmTesterBuilder, TestedVm};
+use super::{
+    default_pubdata_builder, extract_deploy_events, tester::VmTesterBuilder, ContractToDeploy,
+    TestedVm,
+};
 use crate::interface::{ExecutionResult, InspectExecutionMode, VmInterfaceExt};
 
 pub(crate) fn test_estimate_fee<VM: TestedVm>() {
@@ -104,4 +108,63 @@ pub(crate) fn test_create2_deployment_address<VM: TestedVm>() {
     let deploy_events = extract_deploy_events(&res.logs.events);
     assert_eq!(deploy_events.len(), 1);
     assert_eq!(deploy_events[0], (account.address, expected_address));
+}
+
+pub(crate) fn test_reusing_create_address<VM: TestedVm>() {
+    let factory_bytecode = TestContract::counter_factory().bytecode.to_vec();
+    let factory_address = Address::repeat_byte(1);
+    let mut vm_tester = VmTesterBuilder::new()
+        .with_rich_accounts(1)
+        .with_custom_contracts(vec![ContractToDeploy::new(
+            factory_bytecode,
+            factory_address,
+        )])
+        .build::<VM>();
+    let account = &mut vm_tester.rich_accounts[0];
+
+    let test_fn = TestContract::counter_factory().function("testReusingCreateAddress");
+    let expected_address = deployed_address_create(factory_address, 0.into());
+    let test_tx = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: Some(factory_address),
+            calldata: test_fn
+                .encode_input(&[Token::Address(expected_address)])
+                .unwrap(),
+            value: 0.into(),
+            factory_deps: TestContract::counter_factory().factory_deps(),
+        },
+        None,
+    );
+
+    vm_tester.vm.push_transaction(test_tx);
+    let res = vm_tester.vm.execute(InspectExecutionMode::OneTx);
+    assert_matches!(res.result, ExecutionResult::Success { .. });
+}
+
+pub(crate) fn test_reusing_create2_salt<VM: TestedVm>() {
+    let factory_bytecode = TestContract::counter_factory().bytecode.to_vec();
+    let factory_address = Address::repeat_byte(1);
+    let mut vm_tester = VmTesterBuilder::new()
+        .with_rich_accounts(1)
+        .with_custom_contracts(vec![ContractToDeploy::new(
+            factory_bytecode,
+            factory_address,
+        )])
+        .build::<VM>();
+    let account = &mut vm_tester.rich_accounts[0];
+
+    let test_fn = TestContract::counter_factory().function("testReusingCreate2Salt");
+    let test_tx = account.get_l2_tx_for_execute(
+        Execute {
+            contract_address: Some(factory_address),
+            calldata: test_fn.encode_input(&[]).unwrap(),
+            value: 0.into(),
+            factory_deps: TestContract::counter_factory().factory_deps(),
+        },
+        None,
+    );
+
+    vm_tester.vm.push_transaction(test_tx);
+    let res = vm_tester.vm.execute(InspectExecutionMode::OneTx);
+    assert_matches!(res.result, ExecutionResult::Success { .. });
 }

--- a/core/lib/multivm/src/versions/vm_fast/tests/evm.rs
+++ b/core/lib/multivm/src/versions/vm_fast/tests/evm.rs
@@ -1,12 +1,13 @@
 use crate::{
     versions::testonly::evm::{
         test_calling_ecrecover_precompile, test_calling_era_contract_from_evm,
-        test_calling_sha256_precompile, test_deployment_with_partial_reverts,
-        test_era_vm_deployment_after_evm_deployment, test_era_vm_deployment_after_evm_execution,
-        test_evm_bytecode_decommit, test_evm_deployment_tx, test_far_calls_from_evm_contract,
-        test_real_emulator_basics, test_real_emulator_block_info, test_real_emulator_code_hash,
-        test_real_emulator_deployment, test_real_emulator_gas_management,
-        test_real_emulator_msg_info, test_real_emulator_recursion,
+        test_calling_sha256_precompile, test_create2_deployment,
+        test_deployment_with_partial_reverts, test_era_vm_deployment_after_evm_deployment,
+        test_era_vm_deployment_after_evm_execution, test_evm_bytecode_decommit,
+        test_evm_deployment_tx, test_far_calls_from_evm_contract, test_real_emulator_basics,
+        test_real_emulator_block_info, test_real_emulator_code_hash, test_real_emulator_deployment,
+        test_real_emulator_gas_management, test_real_emulator_msg_info,
+        test_real_emulator_recursion,
     },
     vm_fast::Vm,
 };
@@ -54,6 +55,11 @@ fn real_emulator_recursion() {
 #[test]
 fn real_emulator_deployment() {
     test_real_emulator_deployment::<Vm<_>>();
+}
+
+#[test]
+fn real_emulator_create2_deployment() {
+    test_create2_deployment::<Vm<_>>();
 }
 
 #[test]

--- a/core/lib/multivm/src/versions/vm_fast/tests/evm.rs
+++ b/core/lib/multivm/src/versions/vm_fast/tests/evm.rs
@@ -1,13 +1,14 @@
 use crate::{
     versions::testonly::evm::{
         test_calling_ecrecover_precompile, test_calling_era_contract_from_evm,
-        test_calling_sha256_precompile, test_create2_deployment,
+        test_calling_sha256_precompile, test_create2_deployment_in_evm,
         test_deployment_with_partial_reverts, test_era_vm_deployment_after_evm_deployment,
         test_era_vm_deployment_after_evm_execution, test_evm_bytecode_decommit,
         test_evm_deployment_tx, test_far_calls_from_evm_contract, test_real_emulator_basics,
         test_real_emulator_block_info, test_real_emulator_code_hash, test_real_emulator_deployment,
         test_real_emulator_gas_management, test_real_emulator_msg_info,
-        test_real_emulator_recursion,
+        test_real_emulator_recursion, test_reusing_create2_salt_in_evm,
+        test_reusing_create_address_in_evm,
     },
     vm_fast::Vm,
 };
@@ -59,7 +60,17 @@ fn real_emulator_deployment() {
 
 #[test]
 fn real_emulator_create2_deployment() {
-    test_create2_deployment::<Vm<_>>();
+    test_create2_deployment_in_evm::<Vm<_>>();
+}
+
+#[test]
+fn reusing_create_address() {
+    test_reusing_create_address_in_evm::<Vm<_>>();
+}
+
+#[test]
+fn reusing_create2_salt() {
+    test_reusing_create2_salt_in_evm::<Vm<_>>();
 }
 
 #[test]

--- a/core/lib/multivm/src/versions/vm_fast/tests/simple_execution.rs
+++ b/core/lib/multivm/src/versions/vm_fast/tests/simple_execution.rs
@@ -1,6 +1,7 @@
 use crate::{
     versions::testonly::simple_execution::{
-        test_create2_deployment_address, test_estimate_fee, test_simple_execute,
+        test_create2_deployment_address, test_estimate_fee, test_reusing_create2_salt,
+        test_reusing_create_address, test_simple_execute,
     },
     vm_fast::Vm,
 };
@@ -18,4 +19,14 @@ fn simple_execute() {
 #[test]
 fn create2_deployment_address() {
     test_create2_deployment_address::<Vm<_>>();
+}
+
+#[test]
+fn reusing_create_address() {
+    test_reusing_create_address::<Vm<_>>();
+}
+
+#[test]
+fn reusing_create2_salt() {
+    test_reusing_create2_salt::<Vm<_>>();
 }

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm.rs
@@ -1,7 +1,8 @@
 use crate::{
     versions::testonly::evm::{
         test_calling_ecrecover_precompile, test_calling_era_contract_from_evm,
-        test_calling_sha256_precompile, test_deployment_with_partial_reverts, test_emitted_events,
+        test_calling_sha256_precompile, test_create2_deployment,
+        test_deployment_with_partial_reverts, test_emitted_events,
         test_era_vm_deployment_after_evm_deployment, test_era_vm_deployment_after_evm_execution,
         test_evm_bytecode_decommit, test_evm_deployment_tx, test_far_calls_from_evm_contract,
         test_real_emulator_basics, test_real_emulator_block_info, test_real_emulator_code_hash,
@@ -54,6 +55,11 @@ fn real_emulator_recursion() {
 #[test]
 fn real_emulator_deployment() {
     test_real_emulator_deployment::<Vm<_, HistoryEnabled>>();
+}
+
+#[test]
+fn real_emulator_create2_deployment() {
+    test_create2_deployment::<Vm<_, HistoryEnabled>>();
 }
 
 #[test]

--- a/core/lib/multivm/src/versions/vm_latest/tests/evm.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/evm.rs
@@ -1,13 +1,14 @@
 use crate::{
     versions::testonly::evm::{
         test_calling_ecrecover_precompile, test_calling_era_contract_from_evm,
-        test_calling_sha256_precompile, test_create2_deployment,
+        test_calling_sha256_precompile, test_create2_deployment_in_evm,
         test_deployment_with_partial_reverts, test_emitted_events,
         test_era_vm_deployment_after_evm_deployment, test_era_vm_deployment_after_evm_execution,
         test_evm_bytecode_decommit, test_evm_deployment_tx, test_far_calls_from_evm_contract,
         test_real_emulator_basics, test_real_emulator_block_info, test_real_emulator_code_hash,
         test_real_emulator_deployment, test_real_emulator_gas_management,
         test_real_emulator_msg_info, test_real_emulator_recursion,
+        test_reusing_create2_salt_in_evm, test_reusing_create_address_in_evm,
     },
     vm_latest::{HistoryEnabled, Vm},
 };
@@ -59,7 +60,17 @@ fn real_emulator_deployment() {
 
 #[test]
 fn real_emulator_create2_deployment() {
-    test_create2_deployment::<Vm<_, HistoryEnabled>>();
+    test_create2_deployment_in_evm::<Vm<_, HistoryEnabled>>();
+}
+
+#[test]
+fn reusing_create_address() {
+    test_reusing_create_address_in_evm::<Vm<_, HistoryEnabled>>();
+}
+
+#[test]
+fn reusing_create2_salt() {
+    test_reusing_create2_salt_in_evm::<Vm<_, HistoryEnabled>>();
 }
 
 #[test]

--- a/core/lib/multivm/src/versions/vm_latest/tests/simple_execution.rs
+++ b/core/lib/multivm/src/versions/vm_latest/tests/simple_execution.rs
@@ -1,6 +1,7 @@
 use crate::{
     versions::testonly::simple_execution::{
-        test_create2_deployment_address, test_estimate_fee, test_simple_execute,
+        test_create2_deployment_address, test_estimate_fee, test_reusing_create2_salt,
+        test_reusing_create_address, test_simple_execute,
     },
     vm_latest::{HistoryEnabled, Vm},
 };
@@ -18,4 +19,14 @@ fn simple_execute() {
 #[test]
 fn create2_deployment_address() {
     test_create2_deployment_address::<Vm<_, HistoryEnabled>>();
+}
+
+#[test]
+fn reusing_create_address() {
+    test_reusing_create_address::<Vm<_, HistoryEnabled>>();
+}
+
+#[test]
+fn reusing_create2_salt() {
+    test_reusing_create2_salt::<Vm<_, HistoryEnabled>>();
 }

--- a/core/lib/test_contracts/contracts/counter/counter.sol
+++ b/core/lib/test_contracts/contracts/counter/counter.sol
@@ -25,3 +25,42 @@ contract Counter {
         return value;
     }
 }
+
+contract CounterFactory {
+    function testReusingCreateAddress(address _expectedAddress) external {
+        try this.deployThenRevert(true) {
+            revert("expected revert");
+        } catch Error(string memory reason) {
+            require(keccak256(bytes(reason)) == keccak256("requested revert"), "unexpected error");
+        }
+        address deployedAddress = this.deployThenRevert(false);
+        require(deployedAddress == _expectedAddress, "deployedAddress");
+    }
+
+    function deployThenRevert(bool _shouldRevert) external returns (address newAddress) {
+        newAddress = address(new Counter());
+        require(!_shouldRevert, "requested revert");
+    }
+
+    function testReusingCreate2Salt() external {
+        this.deploy2ThenRevert(bytes32(0), false);
+        try this.deploy2ThenRevert(bytes32(0), false) {
+            revert("expected create2 to fail");
+        } catch {
+            // failed as expected
+        }
+
+        try this.deploy2ThenRevert(hex"01", true) {
+            revert("expected revert");
+        } catch {
+            // failed as expected
+        }
+        // This should succeed because the previous deployment was reverted
+        this.deploy2ThenRevert(hex"01", false);
+    }
+
+    function deploy2ThenRevert(bytes32 _salt, bool _shouldRevert) external {
+        new Counter{salt: _salt}();
+        require(!_shouldRevert, "requested revert");
+    }
+}

--- a/core/lib/test_contracts/evm-contracts/evm.sol
+++ b/core/lib/test_contracts/evm-contracts/evm.sol
@@ -234,7 +234,14 @@ contract EvmEmulationTest is IGasTester {
         require(address(newCounter) == _expectedAddress, "address");
     }
 
-    // TODO: similarly test create2
+    function testCreate2Deployment(
+        bytes32 _salt,
+        uint256 _constructorArg,
+        address _expectedAddress
+    ) external validEvmCall {
+        Counter newCounter = new Counter{salt: _salt}(_constructorArg);
+        require(address(newCounter) == _expectedAddress, "address");
+    }
 
     ICounter counter;
 
@@ -272,7 +279,6 @@ contract EvmEmulationTest is IGasTester {
         uint gasMultiplier = _isEvmTester ? 1 : 5;
         uint currentGas = gasleft();
         if (_isEvmTester) {
-            // TODO: doesn't work for EraVM tester (~115k less gas is passed)
             _tester.testGas((currentGas * 63 / 64) * gasMultiplier, false);
         }
 
@@ -283,7 +289,6 @@ contract EvmEmulationTest is IGasTester {
         // Attempt to send "infinite" gas from the stipend (shouldn't work)
         currentGas = gasleft();
         if (_isEvmTester) {
-            // TODO: doesn't work for EraVM tester (~115k less gas is passed)
             _tester.testGas{gas: 1 << 30}((currentGas * 63 / 64) * gasMultiplier, false);
         }
 

--- a/core/lib/test_contracts/src/contracts.rs
+++ b/core/lib/test_contracts/src/contracts.rs
@@ -94,6 +94,16 @@ impl TestContract {
         &CONTRACT
     }
 
+    /// Returns a counter factory contract.
+    pub fn counter_factory() -> &'static Self {
+        static CONTRACT: Lazy<TestContract> = Lazy::new(|| {
+            let mut contract = TestContract::new(raw::counter::CounterFactory);
+            contract.dependencies = vec![TestContract::new(raw::counter::Counter)];
+            contract
+        });
+        &CONTRACT
+    }
+
     /// Returns a contract used in load testing that emulates various kinds of expensive operations
     /// (storage reads / writes, hashing, recursion via far calls etc.).
     pub fn load_test() -> &'static Self {


### PR DESCRIPTION
## What ❔

Adds some more unit tests for the EVM emulator, closing some TODOs.

## Why ❔

More test coverage is better.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.