### PR TITLE
fix(data-availability-fetcher): prevent EN database from being populated with unnecessary inclusion data

### DIFF
--- a/core/node/node_sync/src/data_availability_fetcher/mod.rs
+++ b/core/node/node_sync/src/data_availability_fetcher/mod.rs
@@ -178,21 +178,21 @@ impl DataAvailabilityFetcher {
             return Ok(StepOutcome::NoInclusionDataFromMainNode);
         };
 
-        let inclusion_data = match pubdata_type {
-            PubdataType::NoDA => InclusionData::default(), // to handle Stage 0 -> Stage 1 Validium migration
-            _ => {
-                let inclusion_data_from_rpc = self
-                    .da_client
-                    .get_inclusion_data(da_details.blob_id.as_str())
-                    .await
-                    .map_err(|err| {
-                        to_retriable_error(anyhow::anyhow!("Error fetching inclusion data: {err}"))
-                    })?;
+        // to handle Stage 0 -> Stage 1 Validium migration
+        let inclusion_data = if expected_inclusion_data.is_empty() {
+            InclusionData::default()
+        } else {
+            let inclusion_data_from_rpc = self
+                .da_client
+                .get_inclusion_data(da_details.blob_id.as_str())
+                .await
+                .map_err(|err| {
+                    to_retriable_error(anyhow::anyhow!("Error fetching inclusion data: {err}"))
+                })?;
 
-                match inclusion_data_from_rpc {
-                    Some(data) => data,
-                    None => return Ok(StepOutcome::UnableToFetchInclusionData),
-                }
+            match inclusion_data_from_rpc {
+                Some(data) => data,
+                None => return Ok(StepOutcome::UnableToFetchInclusionData),
             }
         };
 
@@ -222,7 +222,7 @@ impl DataAvailabilityFetcher {
                 da_details.blob_id.as_str(),
                 da_details.sent_at.naive_utc(),
                 pubdata_type,
-                Some(inclusion_data.data.as_slice()),
+                Some(expected_inclusion_data.as_slice()),
                 da_details.l2_da_validator,
             )
             .await

--- a/core/node/node_sync/src/data_availability_fetcher/mod.rs
+++ b/core/node/node_sync/src/data_availability_fetcher/mod.rs
@@ -178,7 +178,7 @@ impl DataAvailabilityFetcher {
             return Ok(StepOutcome::NoInclusionDataFromMainNode);
         };
 
-        // to handle Stage 0 -> Stage 1 Validium migration
+        // to handle Validiums that doesn't have inclusion verification
         let inclusion_data = if expected_inclusion_data.is_empty() {
             InclusionData::default()
         } else {


### PR DESCRIPTION
## What ❔

The EN database is populated with the `inclusion_data` received from the DA layer, not from the main node.
In case the main node has no inclusion data, but the DA layer returns some - it is being stored in the DB. Later on it is used in `consistency_checker` which will lead to it failing.

## Why ❔

To prevent inconsistency in `inclusion_data` field that will lead to `consistency_checker` failing.

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
