### PR TITLE
feat(zksync_tee_prover): add TDX support for containerized TEE prover

### DIFF
--- a/.github/workflows/build-tee-prover-template.yml
+++ b/.github/workflows/build-tee-prover-template.yml
@@ -27,6 +27,15 @@ jobs:
     env:
       IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
     runs-on: [matterlabs-ci-runner-high-performance]
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.nixcontainer }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { nixcontainer: 'container-tee-prover-azure' }
+          - { nixcontainer: 'container-tee-prover-tdx' }
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
         if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -54,7 +63,7 @@ jobs:
       - name: Build Docker images
         id: build
         run: |
-          nix build -L .#container-tee-prover-azure
+          nix build -L .#${{ matrix.config.nixcontainer }}
           export IMAGE_TAG=$(docker load -i result | grep -Po 'Loaded image.*: \K.*')
           echo "IMAGE_TAG=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           echo "IMAGE_NAME=${IMAGE_TAG%:*}" >> "$GITHUB_OUTPUT"

--- a/etc/nix/container-tee-prover-tdx.nix
+++ b/etc/nix/container-tee-prover-tdx.nix
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025 Matter Labs
+{ buildEnv
+, curl
+, dockerTools
+, nixsgx
+, openssl
+, strace
+, tee_prover
+, teepot
+, ...
+}:
+dockerTools.buildLayeredImage {
+  name = "zksync-tee-prover-tdx";
+
+  config = {
+    Entrypoint = [ "/bin/sh" "-c" ];
+    Cmd = [
+      ''
+        ${teepot.teepot.tee_key_preexec}/bin/tee-key-preexec \
+          --env-prefix TEE_PROVER_ -- \
+          ${tee_prover}/bin/zksync_tee_prover
+      ''
+    ];
+    Env = [
+      "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+    ];
+  };
+
+  contents = buildEnv {
+    name = "image-root";
+
+    paths = with dockerTools;[
+      strace
+      openssl.out
+      curl.out
+      nixsgx.sgx-dcap.quote_verify
+      nixsgx.sgx-dcap.default_qpl
+      usrBinEnv
+      binSh
+      caCertificates
+      fakeNss
+    ];
+    pathsToLink = [ "/bin" "/lib" "/etc" "/share" "/tmp" ];
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
             inherit (appliedOverlay.zksync-era) zksync tee_prover zkstack foundry-zksync;
             default = appliedOverlay.zksync-era.tee_prover;
           } // (pkgs.lib.optionalAttrs (pkgs.stdenv.hostPlatform.isx86_64 && pkgs.stdenv.hostPlatform.isLinux) {
-            inherit (appliedOverlay.zksync-era) container-tee-prover-azure container-tee-prover-dcap;
+            inherit (appliedOverlay.zksync-era) container-tee-prover-azure container-tee-prover-dcap container-tee-prover-tdx;
           });
 
           devShells = {


### PR DESCRIPTION
## What ❔

- Added `container-tee-prover-tdx` to supported TEE prover containers.
- Introduced a new Nix derivation for the TDX container image, including dependencies and configuration. This enhances compatibility with Intel TDX environments.

## Why ❔

This will enable us to run the `zksync_tee_prover` in the TDX VM.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
