### PR TITLE
fix(api): Fix panic applying nonce override

### DIFF
--- a/core/lib/state/src/postgres/mod.rs
+++ b/core/lib/state/src/postgres/mod.rs
@@ -493,7 +493,7 @@ impl<'a> PostgresStorage<'a> {
         mut connection: Connection<'a, Core>,
         block_number: L2BlockNumber,
         consider_new_l1_batch: bool,
-    ) -> anyhow::Result<PostgresStorage<'a>> {
+    ) -> anyhow::Result<Self> {
         let resolved = connection
             .storage_web3_dal()
             .resolve_l1_batch_number_of_l2_block(block_number)
@@ -535,6 +535,11 @@ impl<'a> PostgresStorage<'a> {
 
     fn values_cache(&self) -> Option<&ValuesCache> {
         Some(&self.caches.as_ref()?.values.as_ref()?.cache)
+    }
+
+    /// Returns the wrapped connection.
+    pub fn into_inner(self) -> Connection<'a, Core> {
+        self.connection
     }
 }
 

--- a/core/lib/types/src/api/state_override.rs
+++ b/core/lib/types/src/api/state_override.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{hash_map, HashMap};
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use zksync_basic_types::{bytecode::BytecodeHash, web3::Bytes, H256, U256};
@@ -31,6 +31,15 @@ impl StateOverride {
     /// Iterates over all account overrides.
     pub fn iter(&self) -> impl Iterator<Item = (&Address, &OverrideAccount)> + '_ {
         self.0.iter()
+    }
+}
+
+impl IntoIterator for StateOverride {
+    type Item = (Address, OverrideAccount);
+    type IntoIter = hash_map::IntoIter<Address, OverrideAccount>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 

--- a/core/lib/vm_interface/src/storage/overrides.rs
+++ b/core/lib/vm_interface/src/storage/overrides.rs
@@ -9,13 +9,19 @@ use zksync_types::{AccountTreeId, StorageKey, StorageValue, H256};
 
 use super::ReadStorage;
 
+/// Storage overrides.
+#[derive(Debug, Default)]
+pub struct StorageOverrides {
+    pub overridden_slots: HashMap<StorageKey, H256>,
+    pub overridden_factory_deps: HashMap<H256, Vec<u8>>,
+    pub empty_accounts: HashSet<AccountTreeId>,
+}
+
 /// A storage view that allows to override some of the storage values.
 #[derive(Debug)]
 pub struct StorageWithOverrides<S> {
     storage_handle: S,
-    overridden_slots: HashMap<StorageKey, H256>,
-    overridden_factory_deps: HashMap<H256, Vec<u8>>,
-    empty_accounts: HashSet<AccountTreeId>,
+    overrides: StorageOverrides,
 }
 
 impl<S: ReadStorage> StorageWithOverrides<S> {
@@ -23,31 +29,33 @@ impl<S: ReadStorage> StorageWithOverrides<S> {
     pub fn new(storage: S) -> Self {
         Self {
             storage_handle: storage,
-            overridden_slots: HashMap::new(),
-            overridden_factory_deps: HashMap::new(),
-            empty_accounts: HashSet::new(),
+            overrides: StorageOverrides::default(),
         }
     }
 
     pub fn set_value(&mut self, key: StorageKey, value: StorageValue) {
-        self.overridden_slots.insert(key, value);
+        self.overrides.overridden_slots.insert(key, value);
     }
 
     pub fn store_factory_dep(&mut self, hash: H256, code: Vec<u8>) {
-        self.overridden_factory_deps.insert(hash, code);
+        self.overrides.overridden_factory_deps.insert(hash, code);
     }
 
     pub fn insert_erased_account(&mut self, account: AccountTreeId) {
-        self.empty_accounts.insert(account);
+        self.overrides.empty_accounts.insert(account);
+    }
+
+    pub fn into_parts(self) -> (S, StorageOverrides) {
+        (self.storage_handle, self.overrides)
     }
 }
 
 impl<S: ReadStorage + fmt::Debug> ReadStorage for StorageWithOverrides<S> {
     fn read_value(&mut self, key: &StorageKey) -> StorageValue {
-        if let Some(value) = self.overridden_slots.get(key) {
+        if let Some(value) = self.overrides.overridden_slots.get(key) {
             return *value;
         }
-        if self.empty_accounts.contains(key.account()) {
+        if self.overrides.empty_accounts.contains(key.account()) {
             return H256::zero();
         }
         self.storage_handle.read_value(key)
@@ -58,7 +66,8 @@ impl<S: ReadStorage + fmt::Debug> ReadStorage for StorageWithOverrides<S> {
     }
 
     fn load_factory_dep(&mut self, hash: H256) -> Option<Vec<u8>> {
-        self.overridden_factory_deps
+        self.overrides
+            .overridden_factory_deps
             .get(&hash)
             .cloned()
             .or_else(|| self.storage_handle.load_factory_dep(hash))

--- a/core/node/api_server/src/execution_sandbox/execute.rs
+++ b/core/node/api_server/src/execution_sandbox/execute.rs
@@ -205,7 +205,7 @@ impl SandboxExecutor {
             .await?;
 
         let storage = if let Some(state_override) = state_override {
-            tokio::task::spawn_blocking(move || apply_state_override(storage, &state_override))
+            tokio::task::spawn_blocking(|| apply_state_override(storage, state_override))
                 .await
                 .context("applying state override failed")?
         } else {

--- a/core/node/api_server/src/execution_sandbox/execute.rs
+++ b/core/node/api_server/src/execution_sandbox/execute.rs
@@ -204,8 +204,15 @@ impl SandboxExecutor {
             .prepare_env_and_storage(connection, block_args, &action)
             .await?;
 
-        let state_override = state_override.unwrap_or_default();
-        let storage = apply_state_override(storage, &state_override);
+        let storage = if let Some(state_override) = state_override {
+            tokio::task::spawn_blocking(move || apply_state_override(storage, &state_override))
+                .await
+                .context("applying state override failed")?
+        } else {
+            // Do not spawn a new thread in the most frequent case.
+            StorageWithOverrides::new(storage)
+        };
+
         let (execution_args, tracing_params) = action.into_parts();
         self.engine
             .execute_in_sandbox(storage, env, execution_args, tracing_params)

--- a/core/node/api_server/src/execution_sandbox/mod.rs
+++ b/core/node/api_server/src/execution_sandbox/mod.rs
@@ -25,6 +25,8 @@ mod error;
 mod execute;
 mod storage;
 #[cfg(test)]
+pub(crate) mod testonly;
+#[cfg(test)]
 mod tests;
 mod validate;
 mod vm_metrics;

--- a/core/node/api_server/src/execution_sandbox/testonly.rs
+++ b/core/node/api_server/src/execution_sandbox/testonly.rs
@@ -1,0 +1,64 @@
+use tokio::runtime::Handle;
+use zksync_dal::{Connection, Core, CoreDal};
+use zksync_state::PostgresStorage;
+use zksync_types::{
+    api::state_override::StateOverride, AccountTreeId, L2BlockNumber, StorageKey, StorageLog, H256,
+};
+
+use super::storage::apply_state_override;
+
+/// Applies overrides to the Postgres storage by inserting the necessary storage logs / factory deps into the genesis block.
+pub(crate) async fn apply_state_overrides(
+    mut connection: Connection<'static, Core>,
+    state_override: StateOverride,
+) {
+    let latest_block = connection
+        .blocks_dal()
+        .get_sealed_l2_block_number()
+        .await
+        .unwrap()
+        .expect("no blocks in Postgres");
+    let state = PostgresStorage::new_async(Handle::current(), connection, latest_block, false)
+        .await
+        .unwrap();
+    let state_with_overrides =
+        tokio::task::spawn_blocking(move || apply_state_override(state, &state_override))
+            .await
+            .unwrap();
+    let (state, overrides) = state_with_overrides.into_parts();
+
+    let mut connection = state.into_inner();
+    let mut storage_logs = vec![];
+    // Old logs must be erased before inserting `overridden_slots`.
+    let all_existing_logs = connection
+        .storage_logs_dal()
+        .dump_all_storage_logs_for_tests()
+        .await;
+    for log in all_existing_logs {
+        if let (Some(addr), Some(key)) = (log.address, log.key) {
+            let account = AccountTreeId::new(addr);
+            if overrides.empty_accounts.contains(&account) {
+                let key = StorageKey::new(account, key);
+                storage_logs.push(StorageLog::new_write_log(key, H256::zero()));
+            }
+        }
+    }
+
+    storage_logs.extend(
+        overrides
+            .overridden_slots
+            .into_iter()
+            .map(|(key, value)| StorageLog::new_write_log(key, value)),
+    );
+
+    connection
+        .storage_logs_dal()
+        .append_storage_logs(L2BlockNumber(0), &storage_logs)
+        .await
+        .unwrap();
+    connection
+        .factory_deps_dal()
+        .insert_factory_deps(L2BlockNumber(0), &overrides.overridden_factory_deps)
+        .await
+        .unwrap();
+}

--- a/core/node/api_server/src/execution_sandbox/testonly.rs
+++ b/core/node/api_server/src/execution_sandbox/testonly.rs
@@ -22,7 +22,7 @@ pub(crate) async fn apply_state_overrides(
         .await
         .unwrap();
     let state_with_overrides =
-        tokio::task::spawn_blocking(move || apply_state_override(state, &state_override))
+        tokio::task::spawn_blocking(|| apply_state_override(state, state_override))
             .await
             .unwrap();
     let (state, overrides) = state_with_overrides.into_parts();

--- a/core/node/api_server/src/execution_sandbox/vm_metrics.rs
+++ b/core/node/api_server/src/execution_sandbox/vm_metrics.rs
@@ -1,9 +1,13 @@
 use std::time::Duration;
 
 use vise::{
-    Buckets, EncodeLabelSet, EncodeLabelValue, Family, Gauge, Histogram, LatencyObserver, Metrics,
+    Buckets, Counter, EncodeLabelSet, EncodeLabelValue, Family, Gauge, Histogram, LatencyObserver,
+    Metrics,
 };
-use zksync_types::H256;
+use zksync_types::{
+    api::state_override::{OverrideState, StateOverride},
+    H256,
+};
 
 use crate::utils::ReportFilter;
 
@@ -75,6 +79,27 @@ impl Drop for SubmitTxLatencyObserver<'_> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue)]
+#[metrics(rename_all = "snake_case")]
+enum OverrideKind {
+    Code,
+    Nonce,
+    Balance,
+    StorageSlot,
+}
+
+impl OverrideKind {
+    fn for_method(self, method: &'static str) -> StateOverrideLabels {
+        StateOverrideLabels { method, kind: self }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelSet)]
+struct StateOverrideLabels {
+    method: &'static str,
+    kind: OverrideKind,
+}
+
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "api_web3")]
 pub(crate) struct SandboxMetrics {
@@ -96,6 +121,8 @@ pub(crate) struct SandboxMetrics {
     /// is (as expected) greater than the final gas estimate.
     #[metrics(buckets = Buckets::linear(-0.05..=0.15, 0.01))]
     pub estimate_gas_optimistic_gas_limit_relative_diff: Histogram<f64>,
+    /// Statistics on state overrides.
+    state_overrides: Family<StateOverrideLabels, Counter>,
 }
 
 impl SandboxMetrics {
@@ -108,6 +135,27 @@ impl SandboxMetrics {
             inner: Some(self.submit_tx[&stage].start()),
             tx_hash,
             stage,
+        }
+    }
+
+    pub fn observe_override_metrics(&self, method: &'static str, state_overrides: &StateOverride) {
+        for (_, account_override) in state_overrides.iter() {
+            if account_override.code.is_some() {
+                self.state_overrides[&OverrideKind::Code.for_method(method)].inc();
+            }
+            if account_override.nonce.is_some() {
+                self.state_overrides[&OverrideKind::Nonce.for_method(method)].inc();
+            }
+            if account_override.balance.is_some() {
+                self.state_overrides[&OverrideKind::Balance.for_method(method)].inc();
+            }
+            if let Some(state) = &account_override.state {
+                let slot_count = match state {
+                    OverrideState::State(slots) | OverrideState::StateDiff(slots) => slots.len(),
+                };
+                self.state_overrides[&OverrideKind::StorageSlot.for_method(method)]
+                    .inc_by(slot_count as u64);
+            }
         }
     }
 }

--- a/core/node/api_server/src/tx_sender/tests/send_tx.rs
+++ b/core/node/api_server/src/tx_sender/tests/send_tx.rs
@@ -33,9 +33,8 @@ async fn submitting_tx_requires_one_connection() {
     // Manually set sufficient balance for the tx initiator.
     StateBuilder::default()
         .with_balance(tx.initiator_account(), u64::MAX.into())
-        .apply(&mut storage)
+        .apply(storage)
         .await;
-    drop(storage);
 
     let mut tx_executor = MockOneshotExecutor::default();
     tx_executor.set_tx_responses(move |received_tx, _| {
@@ -137,9 +136,8 @@ async fn fee_validation_errors() {
 
     StateBuilder::default()
         .with_balance(tx.initiator_account(), u64::MAX.into())
-        .apply(&mut storage)
+        .apply(storage)
         .await;
-    drop(storage);
 
     // Sanity check: validation should succeed with reasonable fee params.
     tx_sender
@@ -193,12 +191,11 @@ async fn sending_transfer() {
     let mut alice = Account::random();
 
     // Manually set sufficient balance for the tx initiator.
-    let mut storage = tx_sender.acquire_replica_connection().await.unwrap();
+    let storage = tx_sender.acquire_replica_connection().await.unwrap();
     StateBuilder::default()
         .with_balance(alice.address(), u64::MAX.into())
-        .apply(&mut storage)
+        .apply(storage)
         .await;
-    drop(storage);
 
     let transfer = alice.create_transfer(1_000_000_000.into());
     let vm_result = tx_sender.submit_tx(transfer, block_args).await.unwrap();
@@ -230,12 +227,11 @@ async fn sending_transfer_with_incorrect_signature() {
     let mut alice = Account::random();
     let transfer_value = 1_000_000_000.into();
 
-    let mut storage = tx_sender.acquire_replica_connection().await.unwrap();
+    let storage = tx_sender.acquire_replica_connection().await.unwrap();
     StateBuilder::default()
         .with_balance(alice.address(), u64::MAX.into())
-        .apply(&mut storage)
+        .apply(storage)
         .await;
-    drop(storage);
 
     let mut transfer = alice.create_transfer(transfer_value);
     transfer.execute.value = transfer_value / 2; // This should invalidate tx signature
@@ -251,13 +247,12 @@ async fn sending_load_test_transaction(tx_params: LoadnextContractExecutionParam
     let block_args = pending_block_args(&tx_sender).await;
     let mut alice = Account::random();
 
-    let mut storage = tx_sender.acquire_replica_connection().await.unwrap();
+    let storage = tx_sender.acquire_replica_connection().await.unwrap();
     StateBuilder::default()
         .with_load_test_contract()
         .with_balance(alice.address(), u64::MAX.into())
-        .apply(&mut storage)
+        .apply(storage)
         .await;
-    drop(storage);
 
     let tx = alice.create_load_test_tx(tx_params);
     let vm_result = tx_sender.submit_tx(tx, block_args).await.unwrap();
@@ -271,13 +266,12 @@ async fn sending_reverting_transaction() {
     let block_args = pending_block_args(&tx_sender).await;
     let mut alice = Account::random();
 
-    let mut storage = tx_sender.acquire_replica_connection().await.unwrap();
+    let storage = tx_sender.acquire_replica_connection().await.unwrap();
     StateBuilder::default()
         .with_counter_contract(0)
         .with_balance(alice.address(), u64::MAX.into())
-        .apply(&mut storage)
+        .apply(storage)
         .await;
-    drop(storage);
 
     let tx = alice.create_counter_tx(1.into(), true);
     let vm_result = tx_sender.submit_tx(tx, block_args).await.unwrap();
@@ -294,13 +288,12 @@ async fn sending_transaction_out_of_gas() {
     let block_args = pending_block_args(&tx_sender).await;
     let mut alice = Account::random();
 
-    let mut storage = tx_sender.acquire_replica_connection().await.unwrap();
+    let storage = tx_sender.acquire_replica_connection().await.unwrap();
     StateBuilder::default()
         .with_infinite_loop_contract()
         .with_balance(alice.address(), u64::MAX.into())
-        .apply(&mut storage)
+        .apply(storage)
         .await;
-    drop(storage);
 
     let tx = alice.create_infinite_loop_tx();
     let vm_result = tx_sender.submit_tx(tx, block_args).await.unwrap();
@@ -328,9 +321,8 @@ async fn submit_tx_with_validation_traces(actual_range: Range<u64>, expected_ran
     // Manually set sufficient balance for the tx initiator.
     StateBuilder::default()
         .with_balance(tx.initiator_account(), u64::MAX.into())
-        .apply(&mut storage)
+        .apply(storage)
         .await;
-    drop(storage);
 
     let mut tx_executor = MockOneshotExecutor::default();
     tx_executor.set_tx_responses(move |received_tx, _| {

--- a/core/node/api_server/src/utils.rs
+++ b/core/node/api_server/src/utils.rs
@@ -466,7 +466,7 @@ mod tests {
             .unwrap();
         StateBuilder::default()
             .with_balance(alice.address(), u64::MAX.into())
-            .apply(&mut storage)
+            .apply(storage)
             .await;
 
         let deploy_execute = Execute {
@@ -508,6 +508,7 @@ mod tests {
         persist_block_with_transactions(&pool, txs).await;
 
         // Check the account type helper.
+        let mut storage = pool.connection().await.unwrap();
         let account_types = get_account_types(
             &mut storage,
             [alice.address, account_addr].into_iter(),

--- a/core/node/api_server/src/web3/namespaces/eth.rs
+++ b/core/node/api_server/src/web3/namespaces/eth.rs
@@ -62,6 +62,8 @@ impl EthNamespace {
     ) -> Result<Bytes, Web3Error> {
         let block_id = block_id.unwrap_or(BlockId::Number(BlockNumber::Pending));
         self.current_method().set_block_id(block_id);
+        self.current_method()
+            .observe_state_override(state_override.as_ref());
 
         let mut connection = self.state.acquire_connection().await?;
         let block_args = self
@@ -100,6 +102,9 @@ impl EthNamespace {
         _block: Option<BlockNumber>,
         state_override: Option<StateOverride>,
     ) -> Result<U256, Web3Error> {
+        self.current_method()
+            .observe_state_override(state_override.as_ref());
+
         let mut request_with_gas_per_pubdata_overridden = request;
         self.state
             .set_nonce_for_call_request(&mut request_with_gas_per_pubdata_overridden)

--- a/core/node/api_server/src/web3/namespaces/zks.rs
+++ b/core/node/api_server/src/web3/namespaces/zks.rs
@@ -60,6 +60,9 @@ impl ZksNamespace {
         request: CallRequest,
         state_override: Option<StateOverride>,
     ) -> Result<Fee, Web3Error> {
+        self.current_method()
+            .observe_state_override(state_override.as_ref());
+
         let mut request_with_gas_per_pubdata_overridden = request;
         self.state
             .set_nonce_for_call_request(&mut request_with_gas_per_pubdata_overridden)
@@ -91,6 +94,9 @@ impl ZksNamespace {
         request: CallRequest,
         state_override: Option<StateOverride>,
     ) -> Result<U256, Web3Error> {
+        self.current_method()
+            .observe_state_override(state_override.as_ref());
+
         let mut request_with_gas_per_pubdata_overridden = request;
         // When we're estimating fee, we are trying to deduce values related to fee, so we should
         // not consider provided ones.
@@ -121,6 +127,9 @@ impl ZksNamespace {
         block_args: BlockArgs,
         state_override: Option<StateOverride>,
     ) -> Result<Fee, Web3Error> {
+        self.current_method()
+            .observe_state_override(state_override.as_ref());
+
         let scale_factor = self.state.api_config.estimate_gas_scale_factor;
         let acceptable_overestimation =
             self.state.api_config.estimate_gas_acceptable_overestimation;


### PR DESCRIPTION
## What ❔

- Refactors state override application in the API server.
- Adds metrics related to state overrides.

## Why ❔

Currently, `eth_call` / `eth_estimateGas` will panic if a nonce override is supplied. This is because in this case, storage is read using blocking `ReadStorage` trait in the non-blocking context.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.