### PR TITLE
fix(contract-verifier): handle errors when the contract code is unavailable in Etherscan

### DIFF
--- a/core/lib/contract_verifier/src/etherscan/errors.rs
+++ b/core/lib/contract_verifier/src/etherscan/errors.rs
@@ -2,13 +2,15 @@ use zksync_dal::DalError;
 
 #[derive(Debug, thiserror::Error)]
 pub(super) enum EtherscanError {
-    #[error(transparent)]
+    #[error("Error while sending an HTTP request")]
     Reqwest(#[from] reqwest::Error),
     #[error("Failed to deserialize content: {error}\n{content}")]
     Serde {
         error: serde_json::Error,
         content: String,
     },
+    #[error("Contract bytecode is not available")]
+    ContractBytecodeNotAvailable,
     #[error("Contract source code not verified")]
     ContractNotVerified,
     #[error("Contract source code already verified")]

--- a/core/lib/contract_verifier/src/etherscan/mod.rs
+++ b/core/lib/contract_verifier/src/etherscan/mod.rs
@@ -76,6 +76,12 @@ fn get_api_error_retry_policy(api_error: &EtherscanError) -> ApiErrorRetryPolicy
                 pause_duration: Duration::from_secs(5),
             }
         }
+        EtherscanError::ContractBytecodeNotAvailable => {
+            // This error happens when the contract is not yet indexed by Etherscan.
+            ApiErrorRetryPolicy::Retryable {
+                pause_duration: Duration::from_secs(60), // 1 min
+            }
+        }
         EtherscanError::Reqwest(_) => {
             // Most likely the error is caused by the network issue of some sort. But if the request error is caused by
             // the constructed payload, we can't afford to retry indefinitely, so we number of attempts is limited.

--- a/core/lib/contract_verifier/src/etherscan/types.rs
+++ b/core/lib/contract_verifier/src/etherscan/types.rs
@@ -171,6 +171,9 @@ impl RawEtherscanResponse {
                 if result_lower.contains("pending") {
                     return EtherscanError::VerificationPending;
                 }
+                if result_lower.contains("unable to locate contractcode") {
+                    return EtherscanError::ContractBytecodeNotAvailable;
+                }
                 // There is a number of daily limit in between the checked values. I don't want to rely on the exact
                 // number as it is a subject to change.
                 if result_lower.starts_with("daily limit")
@@ -462,7 +465,7 @@ mod tests {
             (
                 RawEtherscanResponse {
                     status: "0".to_string(),
-                    message: "Error".to_string(),
+                    message: "NOTOK".to_string(),
                     result: serde_json::Value::String(
                         "Contract source code not verified".to_string(),
                     ),
@@ -472,7 +475,7 @@ mod tests {
             (
                 RawEtherscanResponse {
                     status: "0".to_string(),
-                    message: "Error".to_string(),
+                    message: "NOTOK".to_string(),
                     result: serde_json::Value::String(
                         "Contract source code already verified".to_string(),
                     ),
@@ -482,7 +485,7 @@ mod tests {
             (
                 RawEtherscanResponse {
                     status: "0".to_string(),
-                    message: "Error".to_string(),
+                    message: "NOTOK".to_string(),
                     result: serde_json::Value::String("Already Verified".to_string()),
                 },
                 EtherscanError::ContractAlreadyVerified,
@@ -490,7 +493,7 @@ mod tests {
             (
                 RawEtherscanResponse {
                     status: "0".to_string(),
-                    message: "Error".to_string(),
+                    message: "NOTOK".to_string(),
                     result: serde_json::Value::String("Pending in queue".to_string()),
                 },
                 EtherscanError::VerificationPending,
@@ -498,7 +501,15 @@ mod tests {
             (
                 RawEtherscanResponse {
                     status: "0".to_string(),
-                    message: "Error".to_string(),
+                    message: "NOTOK".to_string(),
+                    result: serde_json::Value::String("Unable to locate ContractCode at 0x0000000000000000000000000000000000000000".to_string()),
+                },
+                EtherscanError::ContractBytecodeNotAvailable,
+            ),
+            (
+                RawEtherscanResponse {
+                    status: "0".to_string(),
+                    message: "NOTOK".to_string(),
                     result: serde_json::Value::String(
                         "Daily limit of 100 source code submissions reached".to_string(),
                     ),
@@ -508,7 +519,7 @@ mod tests {
             (
                 RawEtherscanResponse {
                     status: "0".to_string(),
-                    message: "Error".to_string(),
+                    message: "NOTOK".to_string(),
                     result: serde_json::Value::String("Max rate limit reached".to_string()),
                 },
                 EtherscanError::RateLimitExceeded,
@@ -516,7 +527,7 @@ mod tests {
             (
                 RawEtherscanResponse {
                     status: "0".to_string(),
-                    message: "Error".to_string(),
+                    message: "NOTOK".to_string(),
                     result: serde_json::Value::String("Invalid API Key".to_string()),
                 },
                 EtherscanError::InvalidApiKey,
@@ -524,7 +535,7 @@ mod tests {
             (
                 RawEtherscanResponse {
                     status: "0".to_string(),
-                    message: "Error".to_string(),
+                    message: "NOTOK".to_string(),
                     result: serde_json::Value::String("Missing/Invalid API Key".to_string()),
                 },
                 EtherscanError::InvalidApiKey,
@@ -532,11 +543,11 @@ mod tests {
             (
                 RawEtherscanResponse {
                     status: "0".to_string(),
-                    message: "Error".to_string(),
+                    message: "NOTOK".to_string(),
                     result: serde_json::Value::String("Unknown error".to_string()),
                 },
                 EtherscanError::ErrorResponse {
-                    message: "Error".to_string(),
+                    message: "NOTOK".to_string(),
                     result: "Unknown error".to_string(),
                 },
             ),
@@ -553,6 +564,10 @@ mod tests {
                 (
                     EtherscanError::DailyVerificationRequestsLimitExceeded,
                     EtherscanError::DailyVerificationRequestsLimitExceeded,
+                ) => {}
+                (
+                    EtherscanError::ContractBytecodeNotAvailable,
+                    EtherscanError::ContractBytecodeNotAvailable,
                 ) => {}
                 (EtherscanError::RateLimitExceeded, EtherscanError::RateLimitExceeded) => {}
                 (EtherscanError::InvalidApiKey, EtherscanError::InvalidApiKey) => {}

--- a/core/lib/dal/migrations/20250321121118_requeue_failed_etherscan_verifications.down.sql
+++ b/core/lib/dal/migrations/20250321121118_requeue_failed_etherscan_verifications.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/core/lib/dal/migrations/20250321121118_requeue_failed_etherscan_verifications.up.sql
+++ b/core/lib/dal/migrations/20250321121118_requeue_failed_etherscan_verifications.up.sql
@@ -1,0 +1,15 @@
+-- These requests were not supposed to be added to the DB in the first place.
+-- It's been fixed, and now we can safely remove them.
+DELETE FROM etherscan_verification_requests
+WHERE status = 'failed' AND error = 'Unsupported source code data format';
+
+-- We didn't process such errors properly, so we need to requeue these requests.
+-- We have just a few failed requests, so the performance of the query is not a concern.
+UPDATE etherscan_verification_requests
+SET 
+	status = 'queued',
+	etherscan_verification_id = NULL,
+	processing_started_at = NULL,
+	error = NULL,
+	attempts = 1
+WHERE status = 'failed' AND error LIKE '%Unable to locate ContractCode%';


### PR DESCRIPTION
## What ❔

When a contract is not yet indexed by Etherscan and we try to verify it, the following error is returned:
`Unable to locate ContractCode at <address>`. This PR adds proper processing for such errors to give Etherscan time to index the contract.

## Why ❔

Currently, `Unable to locate ContractCode` errors are not properly processed, and as a result, the verification requests fail.

## Is this a breaking change?
- [ ] Yes
- [X] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [X] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
