### PR TITLE
fix(zksync_tee_prover): refine retriable HTTP error handling

### DIFF
--- a/core/bin/zksync_tee_prover/src/error.rs
+++ b/core/bin/zksync_tee_prover/src/error.rs
@@ -21,13 +21,20 @@ impl TeeProverError {
 
 fn is_retriable_http_error(err: &reqwest::Error) -> bool {
     err.is_timeout()
-            || err.is_connect()
-            // Not all request errors are logically transient, but a significant part of them are (e.g.,
-            // `hyper` protocol-level errors), and it's safer to consider an error retriable.
-            || err.is_request()
-            || has_transient_io_source(err)
-            || err.status() == Some(StatusCode::BAD_GATEWAY)
-            || err.status() == Some(StatusCode::SERVICE_UNAVAILABLE)
+        || err.is_connect()
+        // Not all request errors are logically transient, but a significant part of them are (e.g.,
+        // `hyper` protocol-level errors), and it's safer to consider an error retriable.
+        || err.is_request()
+        || has_transient_io_source(err)
+        || matches!(
+            err.status(),
+            Some(
+                StatusCode::INTERNAL_SERVER_ERROR // 500
+              | StatusCode::BAD_GATEWAY // 502
+              | StatusCode::SERVICE_UNAVAILABLE // 503
+              | StatusCode::GATEWAY_TIMEOUT // 504
+            )
+        )
 }
 
 fn has_transient_io_source(err: &(dyn StdError + 'static)) -> bool {


### PR DESCRIPTION
## What ❔

- Added `GATEWAY_TIMEOUT` and `INTERNAL_SERVER_ERROR` to retriable errors.
- Enhances resilience by accounting for more transient HTTP errors.
- Ensures better alignment with standard HTTP error handling practices.

## Why ❔

Prevents failing the service on retriable errors

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
