### PR TITLE
fix(prover): Fixing shutdown time for circuit-prover

### DIFF
--- a/prover/crates/bin/circuit_prover/src/main.rs
+++ b/prover/crates/bin/circuit_prover/src/main.rs
@@ -141,14 +141,11 @@ async fn main() -> anyhow::Result<()> {
         }
     }
     let shutdown_time = Instant::now();
-    tasks.complete(GRACEFUL_SHUTDOWN_DURATION).await;
-    PROVER_BINARY_METRICS
-        .shutdown_time
-        .observe(shutdown_time.elapsed());
-    PROVER_BINARY_METRICS.run_time.observe(start_time.elapsed());
     metrics_stop_sender
         .send(true)
         .context("failed to stop metrics")?;
+    tasks.complete(GRACEFUL_SHUTDOWN_DURATION).await;
+    tracing::info!("Tasks completed in {:?}.", shutdown_time.elapsed());
     Ok(())
 }
 /// Loads configs necessary for proving.


### PR DESCRIPTION
## What ❔
Fixed shutdown time for circuit-prover. Metrics didn't allow circuit-prover to exit properly on SIGTERM
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔
Circuit-prover was waiting for GRACEFUL_SHUTDOWN_TIME timeout regardless whether it had jobs or not. Metrics didn't exit properly.
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
