### PR TITLE
feat(zkstack): Add stuck token check

### DIFF
--- a/zkstack_cli/crates/zkstack/Cargo.toml
+++ b/zkstack_cli/crates/zkstack/Cargo.toml
@@ -65,3 +65,4 @@ xshell.workspace = true
 # Features that allows gateway-chain related actions.
 # These should be available for outside users until stabilized.
 gateway = []
+default = ["gateway"]

--- a/zkstack_cli/crates/zkstack/Cargo.toml
+++ b/zkstack_cli/crates/zkstack/Cargo.toml
@@ -65,4 +65,3 @@ xshell.workspace = true
 # Features that allows gateway-chain related actions.
 # These should be available for outside users until stabilized.
 gateway = []
-default = ["gateway"]

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/gateway.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/gateway.rs
@@ -185,7 +185,6 @@ pub(crate) async fn check_l2_ntv_existence(l2_client: &Box<DynClient<L2>>) -> an
     Ok(())
 }
 
-const L2_TOKENS_CACHE: &'static str = "l2-tokens-cache.json";
 const CONTRACT_DEPLOYED_EVENT: &'static str = "ContractDeployed(address,bytes32,address)";
 
 /// Returns a list of tokens that can be deployed via the L2 legacy shared bridge.
@@ -194,15 +193,17 @@ const CONTRACT_DEPLOYED_EVENT: &'static str = "ContractDeployed(address,bytes32,
 pub async fn get_deployed_by_bridge(
     l2_rpc_url: &str,
     l2_shared_bridge_address: Address,
+    l2_chain_id: u64,
     block_range: u64,
 ) -> anyhow::Result<Vec<Address>> {
     println!(
         "Retrieving L2 bridged tokens... If done for the first time, it may take a few minutes"
     );
+    let l2_tokens_cache = &format!("l2-tokens-cache-{l2_chain_id}.json");
     // Each legacy bridged token is deployed via the legacy shared bridge.
     let total_logs_for_bridged_tokens = get_logs_for_events(
         0,
-        &L2_TOKENS_CACHE,
+        l2_tokens_cache,
         l2_rpc_url,
         block_range,
         &[(
@@ -265,6 +266,7 @@ pub async fn check_token_readiness(
     let all_tokens = get_deployed_by_bridge(
         &l2_rpc_url,
         l2_legacy_shared_bridge_addr,
+        l2_chain_id,
         l2_tokens_indexing_block_range.unwrap_or(DEFAULT_BLOCK_RANGE),
     )
     .await?;

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/gateway_register_l2_tokens.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/gateway_register_l2_tokens.rs
@@ -42,6 +42,7 @@ abigen!(
     function assetId(address)(bytes32)
     function setLegacyTokenAssetId(address _l2TokenAddress) public
     function L2_LEGACY_SHARED_BRIDGE()(address)
+    function originChainId(bytes32)(uint256)
 ]"
 );
 
@@ -81,9 +82,15 @@ pub async fn migrate_l2_tokens(
     let all_tokens = get_deployed_by_bridge(
         &l2_rpc_url,
         l2_legacy_shared_bridge_addr,
+        l2_chain_id,
         l2_tokens_indexing_block_range.unwrap_or(DEFAULT_BLOCK_RANGE),
     )
     .await?;
+
+    let mut total_tokens_registered = 0;
+    let mut total_tokens_stuck = 0;
+
+    let mut stuck_tokens = vec![];
 
     for token in all_tokens {
         let current_asset_id = l2_native_token_vault.asset_id(token).await?;
@@ -107,8 +114,25 @@ pub async fn migrate_l2_tokens(
             } else {
                 anyhow::bail!("Transaction failed or was dropped.");
             }
+            total_tokens_registered += 1;
+        } else if l1_address != Address::zero() {
+            let origin_chain_id = l2_native_token_vault
+                .origin_chain_id(current_asset_id)
+                .await?;
+
+            if origin_chain_id == U256::zero() {
+                stuck_tokens.push(token);
+                total_tokens_stuck += 1;
+            }
         }
     }
+
+    println!(
+        "Overall {} tokens were registered and {} were found temporarily stuck until v27",
+        total_tokens_registered,
+        stuck_tokens.len()
+    );
+    println!("Stuck tokens: {:#?}", stuck_tokens);
 
     Ok(())
 }

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/gateway_register_l2_tokens.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/gateway_register_l2_tokens.rs
@@ -89,6 +89,7 @@ pub async fn migrate_l2_tokens(
 
     let mut total_tokens_registered = 0;
     let mut total_tokens_stuck = 0;
+    let mut total_legacy_tokens = 0;
 
     let mut stuck_tokens = vec![];
 
@@ -115,6 +116,7 @@ pub async fn migrate_l2_tokens(
                 anyhow::bail!("Transaction failed or was dropped.");
             }
             total_tokens_registered += 1;
+            total_legacy_tokens += 1;
         } else if l1_address != Address::zero() {
             let origin_chain_id = l2_native_token_vault
                 .origin_chain_id(current_asset_id)
@@ -124,11 +126,15 @@ pub async fn migrate_l2_tokens(
                 stuck_tokens.push(token);
                 total_tokens_stuck += 1;
             }
+
+            total_legacy_tokens += 1;
         }
     }
 
     println!(
-        "Overall {} tokens were registered and {} were found temporarily stuck until v27",
+        "Chain contains {} legacy tokens in total. Out of those: {} tokens were migrated before, {} tokens have just been migrated and {} were found temporarily stuck until v27",
+        total_legacy_tokens,
+        total_legacy_tokens - total_tokens_registered - stuck_tokens.len(),
         total_tokens_registered,
         stuck_tokens.len()
     );


### PR DESCRIPTION
## What ❔

Add a check to output the tokens that are temporarily not withdrawable before v27 upgrade.

It is helpful to double check that there was no impact on mainnet and help to finalize the registration on testnets

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
