### PR TITLE
fix: insert tokens without PG copy

### DIFF
--- a/core/lib/dal/src/tokens_dal.rs
+++ b/core/lib/dal/src/tokens_dal.rs
@@ -11,6 +11,10 @@ pub struct TokensDal<'a, 'c> {
 
 impl TokensDal<'_, '_> {
     pub async fn add_tokens(&mut self, tokens: &[TokenInfo]) -> DalResult<()> {
+        if tokens.is_empty() {
+            // sqlx query builder produces invalid SQL request when no values are provided
+            return Ok(());
+        }
         let tokens_len = tokens.len();
         let mut builder = QueryBuilder::new(
             r#"

--- a/core/lib/dal/src/tokens_dal.rs
+++ b/core/lib/dal/src/tokens_dal.rs
@@ -378,4 +378,30 @@ mod tests {
             []
         );
     }
+
+    fn problematic_token_info() -> TokenInfo {
+        TokenInfo {
+            l1_address: Address::repeat_byte(1),
+            l2_address: Address::repeat_byte(2),
+            metadata: TokenMetadata {
+                name: "T|est".to_string(),
+                symbol: "T|ST".to_string(),
+                decimals: 10,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn adding_problematic_tokens() {
+        let pool = ConnectionPool::<Core>::test_pool().await;
+        let mut storage = pool.connection().await.unwrap();
+        storage
+            .protocol_versions_dal()
+            .save_protocol_version_with_tx(&ProtocolVersion::default())
+            .await
+            .unwrap();
+
+        let tokens = [problematic_token_info()];
+        storage.tokens_dal().add_tokens(&tokens).await.unwrap();
+    }
 }

--- a/core/lib/dal/src/tokens_dal.rs
+++ b/core/lib/dal/src/tokens_dal.rs
@@ -32,7 +32,7 @@ impl TokensDal<'_, '_> {
                 .push_bind(token.l2_address.as_bytes())
                 .push_bind(&token.metadata.name)
                 .push_bind(&token.metadata.symbol)
-                .push_bind(token.metadata.decimals as i32)
+                .push_bind(i32::from(token.metadata.decimals))
                 .push("FALSE")
                 .push("NOW()")
                 .push("NOW()");

--- a/core/lib/dal/src/tokens_dal.rs
+++ b/core/lib/dal/src/tokens_dal.rs
@@ -1,4 +1,4 @@
-use sqlx::{types::chrono::Utc, QueryBuilder};
+use sqlx::QueryBuilder;
 use zksync_db_connection::{connection::Connection, error::DalResult, instrument::InstrumentExt};
 use zksync_types::{tokens::TokenInfo, Address, L2BlockNumber};
 
@@ -12,7 +12,6 @@ pub struct TokensDal<'a, 'c> {
 impl TokensDal<'_, '_> {
     pub async fn add_tokens(&mut self, tokens: &[TokenInfo]) -> DalResult<()> {
         let tokens_len = tokens.len();
-        let now = Utc::now().naive_utc().to_string();
         let mut builder = QueryBuilder::new(
             r#"
             INSERT INTO
@@ -35,8 +34,8 @@ impl TokensDal<'_, '_> {
                 .push_bind(&token.metadata.symbol)
                 .push_bind(token.metadata.decimals as i32)
                 .push("FALSE")
-                .push_bind(&now)
-                .push_bind(&now);
+                .push("NOW()")
+                .push("NOW()");
         });
         builder
             .build()


### PR DESCRIPTION
## What ❔

Migrates `add_tokens` from COPY to INSERT to avoid globbing user data into the query. Additionally replaces `\x00` (aka NULL) character with whitespace as Postgres can't handle them in `TEXT` fields.

## Why ❔

Robustness

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
None

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
