### PR TITLE
refactor: mark unused setup_sigint_handler function as deprecated

### DIFF
--- a/core/lib/zksync_core_leftovers/src/lib.rs
+++ b/core/lib/zksync_core_leftovers/src/lib.rs
@@ -7,6 +7,7 @@ pub mod temp_config_store;
 
 /// Sets up an interrupt handler and returns a future that resolves once an interrupt signal
 /// is received.
+#[deprecated(since = "28.0.0", note = "Use SigintHandlerLayer from zksync_node_framework instead")]
 pub fn setup_sigint_handler() -> oneshot::Receiver<()> {
     let (sigint_sender, sigint_receiver) = oneshot::channel();
     let mut sigint_sender = Some(sigint_sender);


### PR DESCRIPTION
The function has been replaced by SigintHandlerLayer from the 
zksync_node_framework, which provides a more integrated approach to handling
interrupt signals within the node framework.

Instead of immediately removing the function, I've marked it as deprecated
to allow for a smoother transition and maintain backward compatibility for any
potential external users of this library. The deprecation notice provides clear
guidance to use SigintHandlerLayer instead.