### PR TITLE
fix(prover): Replace Histogram with Gauge for startup_time/run_time/shutdown_time metrics

### DIFF
--- a/prover/crates/bin/circuit_prover/src/main.rs
+++ b/prover/crates/bin/circuit_prover/src/main.rs
@@ -77,9 +77,7 @@ async fn main() -> anyhow::Result<()> {
     .await
     .context("failed to load configs")?;
 
-    PROVER_BINARY_METRICS
-        .startup_time
-        .observe(start_time.elapsed());
+    PROVER_BINARY_METRICS.startup_time.set(start_time.elapsed());
 
     let cancellation_token = CancellationToken::new();
 

--- a/prover/crates/bin/circuit_prover/src/metrics.rs
+++ b/prover/crates/bin/circuit_prover/src/metrics.rs
@@ -1,20 +1,17 @@
 use std::time::Duration;
 
-use vise::{Buckets, Histogram, Metrics};
+use vise::{Gauge, Metrics};
 
 /// Instrument prover binary lifecycle
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "prover_binary")]
 pub struct ProverBinaryMetrics {
     /// How long does it take for prover to load data before it can produce proofs?
-    #[metrics(buckets = Buckets::LATENCIES)]
-    pub startup_time: Histogram<Duration>,
+    pub startup_time: Gauge<Duration>,
     /// How long did the prover binary run for?
-    #[metrics(buckets = Buckets::LATENCIES)]
-    pub run_time: Histogram<Duration>,
+    pub run_time: Gauge<Duration>,
     /// How long does it take prover to gracefully shutdown?
-    #[metrics(buckets = Buckets::LATENCIES)]
-    pub shutdown_time: Histogram<Duration>,
+    pub shutdown_time: Gauge<Duration>,
 }
 
 #[vise::register]


### PR DESCRIPTION
## What ❔

Replace Histogram with Gauge for startup_time/run_time/shutdown_time metrics.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Histogram metric is excessive to report single number from binary and loses  precision. 
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
