### PR TITLE
fix(en): handling of old batches in consistency checker on SL change

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2550,9 +2550,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/core/lib/dal/.sqlx/query-cf8aaa95e3e8c376b6083c7015753e30af54675ce58273cbb29312e6e88cbdf5.json
+++ b/core/lib/dal/.sqlx/query-cf8aaa95e3e8c376b6083c7015753e30af54675ce58273cbb29312e6e88cbdf5.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT eth_txs.chain_id\n            FROM l1_batches\n            JOIN eth_txs ON eth_txs.id = l1_batches.eth_commit_tx_id\n            WHERE\n                number = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "chain_id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "cf8aaa95e3e8c376b6083c7015753e30af54675ce58273cbb29312e6e88cbdf5"
+}

--- a/core/lib/dal/src/eth_sender_dal.rs
+++ b/core/lib/dal/src/eth_sender_dal.rs
@@ -470,6 +470,27 @@ impl EthSenderDal<'_, '_> {
         Ok(())
     }
 
+    pub async fn get_batch_commit_chain_id(
+        &mut self,
+        batch_number: L1BatchNumber,
+    ) -> DalResult<Option<SLChainId>> {
+        let row = sqlx::query!(
+            r#"
+            SELECT eth_txs.chain_id
+            FROM l1_batches
+            JOIN eth_txs ON eth_txs.id = l1_batches.eth_commit_tx_id
+            WHERE
+                number = $1
+            "#,
+            i64::from(batch_number.0),
+        )
+        .instrument("get_batch_commit_chain_id")
+        .with_arg("batch_number", &batch_number)
+        .fetch_optional(self.storage)
+        .await?;
+        Ok(row.and_then(|r| r.chain_id).map(|id| SLChainId(id as u64)))
+    }
+
     pub async fn get_batch_execute_chain_id(
         &mut self,
         batch_number: L1BatchNumber,

--- a/core/node/consistency_checker/src/lib.rs
+++ b/core/node/consistency_checker/src/lib.rs
@@ -135,6 +135,7 @@ impl HandleConsistencyCheckerEvent for ConsistencyCheckerHealthUpdater {
 struct LocalL1BatchCommitData {
     l1_batch: L1BatchWithMetadata,
     commit_tx_hash: H256,
+    commit_chain_id: Option<SLChainId>,
     commitment_mode: L1BatchCommitmentMode,
 }
 
@@ -170,10 +171,16 @@ impl LocalL1BatchCommitData {
             return Ok(None);
         };
 
+        let commit_chain_id = storage
+            .eth_sender_dal()
+            .get_batch_commit_chain_id(batch_number)
+            .await?;
+
         let this = Self {
             l1_batch,
             commit_tx_hash,
             commitment_mode,
+            commit_chain_id,
         };
         let metadata = &this.l1_batch.metadata;
 
@@ -391,7 +398,7 @@ impl ConsistencyChecker {
         })
     }
 
-    pub fn with_l1_diamond_proxy_addr(mut self, address: Address) -> Self {
+    pub fn with_sl_diamond_proxy_addr(mut self, address: Address) -> Self {
         self.chain_data.diamond_proxy_addr = Some(address);
         self
     }
@@ -709,6 +716,27 @@ impl ConsistencyChecker {
                 continue;
             };
             drop(storage);
+
+            if let Some(commit_chain_id) = local.commit_chain_id {
+                if commit_chain_id != self.chain_data.chain_id {
+                    if batch_number < last_committed_batch {
+                        // It's ok to skip check for old batches.
+                        tracing::info!(
+                            "Skip checking batch #{batch_number}, it was committed to chain with id {commit_chain_id} \
+                            while node is configured to check on chain with id {}",
+                            self.chain_data.chain_id
+                        );
+                    } else {
+                        // Chain migrated to different SL, throw error so it can restart and reload SL data.
+                        anyhow::bail!(
+                            "Batch #{batch_number} was committed to chain with id {commit_chain_id} \
+                            while node is configured to check chain with id {}. Error is thrown so node can restart and reload SL data. \
+                            If node doesn't make any progress after restart, then it's bug, please contact developers.",
+                            self.chain_data.chain_id
+                        );
+                    }
+                }
+            }
 
             match self.check_commitments(batch_number, &local).await {
                 Ok(()) => {

--- a/core/node/node_framework/src/implementations/layers/consistency_checker.rs
+++ b/core/node/node_framework/src/implementations/layers/consistency_checker.rs
@@ -74,7 +74,7 @@ impl WiringLayer for ConsistencyCheckerLayer {
         )
         .await
         .map_err(WiringError::Internal)?
-        .with_l1_diamond_proxy_addr(
+        .with_sl_diamond_proxy_addr(
             input
                 .sl_chain_contracts
                 .0


### PR DESCRIPTION
## What ❔

Fixes handling of old batches in consistency checker on SL change. Consistency checker will skip old batches if they were committed on a different SL.

## Why ❔

Old batches could be sent to different SL, it's ok to skip them, otherwise node will be in crashloop until some amount of new batches are commited.
By design EN should panic and restart on SL change, with this change restart should happen only once per SL change.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
