### PR TITLE
feat(state-keeper): protocol upgrade sealer

### DIFF
--- a/core/node/node_sync/src/external_io.rs
+++ b/core/node/node_sync/src/external_io.rs
@@ -163,13 +163,17 @@ impl ExternalIO {
     }
 }
 
+#[async_trait]
 impl IoSealCriteria for ExternalIO {
-    fn should_seal_l1_batch_unconditionally(&mut self, _manager: &UpdatesManager) -> bool {
+    async fn should_seal_l1_batch_unconditionally(
+        &mut self,
+        _manager: &UpdatesManager,
+    ) -> anyhow::Result<bool> {
         if !matches!(self.actions.peek_action(), Some(SyncAction::SealBatch)) {
-            return false;
+            return Ok(false);
         }
         self.actions.pop_action();
-        true
+        Ok(true)
     }
 
     fn should_seal_l2_block(&mut self, _manager: &UpdatesManager) -> bool {

--- a/core/node/state_keeper/src/io/mempool.rs
+++ b/core/node/state_keeper/src/io/mempool.rs
@@ -78,9 +78,16 @@ impl IoSealCriteria for MempoolIO {
             return Ok(true);
         }
 
+        let previous_batch_protocol_version = self
+            .load_batch_version_id(manager.l1_batch.number - 1)
+            .await?;
         if self
             .protocol_upgrade_sealer
-            .should_seal_l1_batch_unconditionally(manager, &self.pool)
+            .should_seal_l1_batch_unconditionally(
+                manager,
+                &self.pool,
+                previous_batch_protocol_version,
+            )
             .await?
         {
             return Ok(true);

--- a/core/node/state_keeper/src/io/mempool.rs
+++ b/core/node/state_keeper/src/io/mempool.rs
@@ -83,11 +83,7 @@ impl IoSealCriteria for MempoolIO {
             .await?;
         if self
             .protocol_upgrade_sealer
-            .should_seal_l1_batch_unconditionally(
-                manager,
-                &self.pool,
-                previous_batch_protocol_version,
-            )
+            .should_seal_l1_batch_unconditionally(manager, previous_batch_protocol_version)
             .await?
         {
             return Ok(true);
@@ -540,10 +536,10 @@ impl MempoolIO {
     ) -> anyhow::Result<Self> {
         Ok(Self {
             mempool,
-            pool,
+            pool: pool.clone(),
             timeout_sealer: TimeoutSealer::new(config),
             l2_block_max_payload_size_sealer: L2BlockMaxPayloadSizeSealer::new(config),
-            protocol_upgrade_sealer: ProtocolUpgradeSealer::new(),
+            protocol_upgrade_sealer: ProtocolUpgradeSealer::new(pool),
             filter: L2TxFilter::default(),
             // ^ Will be initialized properly on the first newly opened batch
             l1_batch_params_provider: L1BatchParamsProvider::uninitialized(),

--- a/core/node/state_keeper/src/io/mempool.rs
+++ b/core/node/state_keeper/src/io/mempool.rs
@@ -31,7 +31,8 @@ use crate::{
     mempool_actor::l2_tx_filter,
     metrics::{L2BlockSealReason, AGGREGATION_METRICS, KEEPER_METRICS},
     seal_criteria::{
-        IoSealCriteria, L2BlockMaxPayloadSizeSealer, TimeoutSealer, UnexecutableReason,
+        io_criteria::{L2BlockMaxPayloadSizeSealer, ProtocolUpgradeSealer, TimeoutSealer},
+        IoSealCriteria, UnexecutableReason,
     },
     updates::UpdatesManager,
     utils::millis_since_epoch,
@@ -49,6 +50,7 @@ pub struct MempoolIO {
     pool: ConnectionPool<Core>,
     timeout_sealer: TimeoutSealer,
     l2_block_max_payload_size_sealer: L2BlockMaxPayloadSizeSealer,
+    protocol_upgrade_sealer: ProtocolUpgradeSealer,
     filter: L2TxFilter,
     l1_batch_params_provider: L1BatchParamsProvider,
     fee_account: Address,
@@ -62,10 +64,29 @@ pub struct MempoolIO {
     pubdata_type: PubdataType,
 }
 
+#[async_trait]
 impl IoSealCriteria for MempoolIO {
-    fn should_seal_l1_batch_unconditionally(&mut self, manager: &UpdatesManager) -> bool {
-        self.timeout_sealer
+    async fn should_seal_l1_batch_unconditionally(
+        &mut self,
+        manager: &UpdatesManager,
+    ) -> anyhow::Result<bool> {
+        if self
+            .timeout_sealer
             .should_seal_l1_batch_unconditionally(manager)
+            .await?
+        {
+            return Ok(true);
+        }
+
+        if self
+            .protocol_upgrade_sealer
+            .should_seal_l1_batch_unconditionally(manager, &self.pool)
+            .await?
+        {
+            return Ok(true);
+        }
+
+        Ok(false)
     }
 
     fn should_seal_l2_block(&mut self, manager: &UpdatesManager) -> bool {
@@ -515,6 +536,7 @@ impl MempoolIO {
             pool,
             timeout_sealer: TimeoutSealer::new(config),
             l2_block_max_payload_size_sealer: L2BlockMaxPayloadSizeSealer::new(config),
+            protocol_upgrade_sealer: ProtocolUpgradeSealer::new(),
             filter: L2TxFilter::default(),
             // ^ Will be initialized properly on the first newly opened batch
             l1_batch_params_provider: L1BatchParamsProvider::uninitialized(),

--- a/core/node/state_keeper/src/io/mempool.rs
+++ b/core/node/state_keeper/src/io/mempool.rs
@@ -78,12 +78,9 @@ impl IoSealCriteria for MempoolIO {
             return Ok(true);
         }
 
-        let previous_batch_protocol_version = self
-            .load_batch_version_id(manager.l1_batch.number - 1)
-            .await?;
         if self
             .protocol_upgrade_sealer
-            .should_seal_l1_batch_unconditionally(manager, previous_batch_protocol_version)
+            .should_seal_l1_batch_unconditionally(manager)
             .await?
         {
             return Ok(true);

--- a/core/node/state_keeper/src/io/persistence.rs
+++ b/core/node/state_keeper/src/io/persistence.rs
@@ -484,8 +484,12 @@ mod tests {
         pool: &ConnectionPool<Core>,
     ) -> H256 {
         let l1_batch_env = default_l1_batch_env(1, 1, Address::random());
-        let mut updates =
-            UpdatesManager::new(&l1_batch_env, &default_system_env(), Default::default());
+        let mut updates = UpdatesManager::new(
+            &l1_batch_env,
+            &default_system_env(),
+            Default::default(),
+            Default::default(),
+        );
         pool.connection()
             .await
             .unwrap()

--- a/core/node/state_keeper/src/io/tests/mod.rs
+++ b/core/node/state_keeper/src/io/tests/mod.rs
@@ -558,7 +558,12 @@ async fn l2_block_processing_after_snapshot_recovery(commitment_mode: L1BatchCom
         &cursor,
         previous_batch_hash,
     );
-    let mut updates = UpdatesManager::new(&l1_batch_env, &system_env, pubdata_params);
+    let mut updates = UpdatesManager::new(
+        &l1_batch_env,
+        &system_env,
+        pubdata_params,
+        system_env.version,
+    );
 
     let tx_hash = tx.hash();
     updates.extend_from_executed_transaction(

--- a/core/node/state_keeper/src/keeper.rs
+++ b/core/node/state_keeper/src/keeper.rs
@@ -587,6 +587,7 @@ impl ZkSyncStateKeeper {
             if self
                 .io
                 .should_seal_l1_batch_unconditionally(updates_manager)
+                .await?
             {
                 tracing::debug!(
                     "L1 batch #{} should be sealed unconditionally as per sealing rules",

--- a/core/node/state_keeper/src/seal_criteria/io_criteria.rs
+++ b/core/node/state_keeper/src/seal_criteria/io_criteria.rs
@@ -124,9 +124,11 @@ impl ProtocolUpgradeSealer {
         &mut self,
         manager: &UpdatesManager,
     ) -> anyhow::Result<bool> {
-        if manager.pending_executed_transactions_len() > 0
-            && manager.protocol_version() != manager.previous_batch_protocol_version()
-        {
+        if manager.pending_executed_transactions_len() == 0 {
+            return Ok(false);
+        }
+
+        if manager.protocol_version() != manager.previous_batch_protocol_version() {
             AGGREGATION_METRICS.l1_batch_reason_inc_criterion("first_batch_after_upgrade");
             return Ok(true);
         }
@@ -148,8 +150,7 @@ impl ProtocolUpgradeSealer {
             .protocol_version_id_by_timestamp(current_timestamp)
             .await
             .context("Failed loading protocol version")?;
-        let should_seal = manager.pending_executed_transactions_len() > 0
-            && protocol_version != manager.protocol_version();
+        let should_seal = protocol_version != manager.protocol_version();
         if should_seal {
             AGGREGATION_METRICS.l1_batch_reason_inc_criterion("last_batch_before_upgrade");
         }

--- a/core/node/state_keeper/src/seal_criteria/io_criteria.rs
+++ b/core/node/state_keeper/src/seal_criteria/io_criteria.rs
@@ -1,0 +1,285 @@
+use std::time::Duration;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use tokio::time::Instant;
+use zksync_config::configs::chain::StateKeeperConfig;
+use zksync_dal::{ConnectionPool, Core, CoreDal};
+use zksync_types::utils::display_timestamp;
+
+use crate::{
+    metrics::AGGREGATION_METRICS,
+    utils::{millis_since, millis_since_epoch},
+    UpdatesManager,
+};
+
+/// I/O-dependent seal criteria.
+#[async_trait]
+pub trait IoSealCriteria {
+    /// Checks whether an L1 batch should be sealed unconditionally (i.e., regardless of metrics
+    /// related to transaction execution) given the provided `manager` state.
+    async fn should_seal_l1_batch_unconditionally(
+        &mut self,
+        manager: &UpdatesManager,
+    ) -> anyhow::Result<bool>;
+    /// Checks whether an L2 block should be sealed given the provided `manager` state.
+    fn should_seal_l2_block(&mut self, manager: &UpdatesManager) -> bool;
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TimeoutSealer {
+    block_commit_deadline_ms: u64,
+    l2_block_commit_deadline_ms: u64,
+}
+
+impl TimeoutSealer {
+    pub fn new(config: &StateKeeperConfig) -> Self {
+        Self {
+            block_commit_deadline_ms: config.block_commit_deadline_ms,
+            l2_block_commit_deadline_ms: config.l2_block_commit_deadline_ms,
+        }
+    }
+}
+
+#[async_trait]
+impl IoSealCriteria for TimeoutSealer {
+    async fn should_seal_l1_batch_unconditionally(
+        &mut self,
+        manager: &UpdatesManager,
+    ) -> anyhow::Result<bool> {
+        const RULE_NAME: &str = "no_txs_timeout";
+
+        if manager.pending_executed_transactions_len() == 0 {
+            // Regardless of which sealers are provided, we never want to seal an empty batch.
+            return Ok(false);
+        }
+
+        let block_commit_deadline_ms = self.block_commit_deadline_ms;
+        // Verify timestamp
+        let should_seal_timeout =
+            millis_since(manager.batch_timestamp()) > block_commit_deadline_ms;
+
+        if should_seal_timeout {
+            AGGREGATION_METRICS.l1_batch_reason_inc_criterion(RULE_NAME);
+            tracing::debug!(
+                "Decided to seal L1 batch using rule `{RULE_NAME}`; batch timestamp: {}, \
+                 commit deadline: {block_commit_deadline_ms}ms",
+                display_timestamp(manager.batch_timestamp())
+            );
+        }
+        Ok(should_seal_timeout)
+    }
+
+    fn should_seal_l2_block(&mut self, manager: &UpdatesManager) -> bool {
+        !manager.l2_block.executed_transactions.is_empty()
+            && millis_since(manager.l2_block.timestamp) > self.l2_block_commit_deadline_ms
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct L2BlockMaxPayloadSizeSealer {
+    max_payload_size: usize,
+}
+
+impl L2BlockMaxPayloadSizeSealer {
+    pub fn new(config: &StateKeeperConfig) -> Self {
+        Self {
+            max_payload_size: config.l2_block_max_payload_size,
+        }
+    }
+
+    pub fn should_seal_l2_block(&mut self, manager: &UpdatesManager) -> bool {
+        manager.l2_block.payload_encoding_size >= self.max_payload_size
+    }
+}
+
+/// Seals L1 batch if protocol upgrade is ready to happen.
+#[derive(Debug)]
+pub(crate) struct ProtocolUpgradeSealer {
+    last_checked_at: Option<Instant>,
+    check_interval: Duration,
+}
+
+impl ProtocolUpgradeSealer {
+    pub fn new() -> Self {
+        const DEFAULT_CHECK_INTERVAL: Duration = Duration::from_secs(10);
+
+        Self {
+            last_checked_at: None,
+            check_interval: DEFAULT_CHECK_INTERVAL,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_check_interval(mut self, check_interval: Duration) -> Self {
+        self.check_interval = check_interval;
+        self
+    }
+
+    pub async fn should_seal_l1_batch_unconditionally(
+        &mut self,
+        manager: &UpdatesManager,
+        pool: &ConnectionPool<Core>,
+    ) -> anyhow::Result<bool> {
+        if self
+            .last_checked_at
+            .is_some_and(|last_check_at| last_check_at.elapsed() < self.check_interval)
+        {
+            return Ok(false);
+        }
+
+        let mut conn = pool.connection_tagged("protocol_upgrade_sealer").await?;
+        let current_timestamp = (millis_since_epoch() / 1_000) as u64;
+        let protocol_version = conn
+            .protocol_versions_dal()
+            .protocol_version_id_by_timestamp(current_timestamp)
+            .await
+            .context("Failed loading protocol version")?;
+
+        self.last_checked_at = Some(Instant::now());
+
+        Ok(protocol_version > manager.protocol_version())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zksync_multivm::interface::VmExecutionMetrics;
+    use zksync_types::{
+        protocol_version::ProtocolSemanticVersion, ProtocolVersion, ProtocolVersionId, Transaction,
+    };
+
+    use super::*;
+    use crate::tests::{
+        create_execution_result, create_transaction, create_updates_manager, seconds_since_epoch,
+    };
+
+    fn apply_tx_to_manager(tx: Transaction, manager: &mut UpdatesManager) {
+        manager.extend_from_executed_transaction(
+            tx,
+            create_execution_result([]),
+            VmExecutionMetrics::default(),
+            vec![],
+        );
+    }
+
+    /// This test mostly exists to make sure that we can't seal empty L2 blocks on the main node.
+    #[test]
+    fn timeout_l2_block_sealer() {
+        let mut timeout_l2_block_sealer = TimeoutSealer {
+            block_commit_deadline_ms: 10_000,
+            l2_block_commit_deadline_ms: 10_000,
+        };
+
+        let mut manager = create_updates_manager();
+        // Empty L2 block should not trigger.
+        manager.l2_block.timestamp = seconds_since_epoch() - 10;
+        assert!(
+            !timeout_l2_block_sealer.should_seal_l2_block(&manager),
+            "Empty L2 block shouldn't be sealed"
+        );
+
+        // Non-empty L2 block should trigger.
+        apply_tx_to_manager(create_transaction(10, 100), &mut manager);
+        assert!(
+            timeout_l2_block_sealer.should_seal_l2_block(&manager),
+            "Non-empty L2 block with old timestamp should be sealed"
+        );
+
+        // Check the timestamp logic. This relies on the fact that the test shouldn't run
+        // for more than 10 seconds (while the test itself is trivial, it may be preempted
+        // by other tests).
+        manager.l2_block.timestamp = seconds_since_epoch();
+        assert!(
+            !timeout_l2_block_sealer.should_seal_l2_block(&manager),
+            "Non-empty L2 block with too recent timestamp shouldn't be sealed"
+        );
+    }
+
+    #[test]
+    fn max_size_l2_block_sealer() {
+        let tx = create_transaction(10, 100);
+        let tx_encoding_size =
+            zksync_protobuf::repr::encode::<zksync_dal::consensus::proto::Transaction>(&tx).len();
+
+        let mut max_payload_sealer = L2BlockMaxPayloadSizeSealer {
+            max_payload_size: tx_encoding_size,
+        };
+
+        let mut manager = create_updates_manager();
+        assert!(
+            !max_payload_sealer.should_seal_l2_block(&manager),
+            "Empty L2 block shouldn't be sealed"
+        );
+
+        apply_tx_to_manager(tx, &mut manager);
+        assert!(
+            max_payload_sealer.should_seal_l2_block(&manager),
+            "L2 block with payload encoding size equal or greater than max payload size should be sealed"
+        );
+    }
+
+    #[tokio::test]
+    async fn protocol_upgrade_sealer() {
+        const CHECK_INTERVAL: Duration = Duration::from_millis(100);
+
+        let pool = ConnectionPool::<Core>::test_pool().await;
+        let mut sealer = ProtocolUpgradeSealer::new().with_check_interval(CHECK_INTERVAL);
+
+        let mut conn = pool.connection().await.unwrap();
+
+        conn.protocol_versions_dal()
+            .save_protocol_version_with_tx(&ProtocolVersion {
+                version: ProtocolSemanticVersion {
+                    minor: ProtocolVersionId::latest(),
+                    patch: 0.into(),
+                },
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let manager = create_updates_manager();
+
+        // No new version, shouldn't seal.
+        let should_seal = sealer
+            .should_seal_l1_batch_unconditionally(&manager, &pool)
+            .await
+            .unwrap();
+        assert!(!should_seal);
+
+        // Insert new protocol version.
+        conn.protocol_versions_dal()
+            .save_protocol_version_with_tx(&ProtocolVersion {
+                version: ProtocolSemanticVersion {
+                    minor: ProtocolVersionId::next(),
+                    patch: 0.into(),
+                },
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let first_checked_at = sealer.last_checked_at.unwrap();
+        let should_seal = sealer
+            .should_seal_l1_batch_unconditionally(&manager, &pool)
+            .await
+            .unwrap();
+        if first_checked_at == sealer.last_checked_at.unwrap() {
+            // This is the expected path, execution should take <CHECK_INTERVAL and sealer should return false.
+            assert!(!should_seal);
+
+            // Reset `last_checked_at` and re-check.
+            sealer.last_checked_at = Some(first_checked_at - 2 * CHECK_INTERVAL);
+            let should_seal = sealer
+                .should_seal_l1_batch_unconditionally(&manager, &pool)
+                .await
+                .unwrap();
+            assert!(should_seal);
+        } else {
+            // Execution took >=CHECK_INTERVAL, it's ok, we don't want to fail the test because of it.
+            // Sealer should return true in this case.
+            assert!(should_seal);
+        }
+    }
+}

--- a/core/node/state_keeper/src/seal_criteria/mod.rs
+++ b/core/node/state_keeper/src/seal_criteria/mod.rs
@@ -17,13 +17,17 @@ use zksync_multivm::{
     interface::{DeduplicatedWritesMetrics, Halt, TransactionExecutionMetrics, VmExecutionMetrics},
     vm_latest::TransactionVmExt,
 };
-use zksync_types::{utils::display_timestamp, ProtocolVersionId, Transaction};
+use zksync_types::{ProtocolVersionId, Transaction};
 
-pub use self::conditional_sealer::{ConditionalSealer, NoopSealer, SequencerSealer};
-use crate::{metrics::AGGREGATION_METRICS, updates::UpdatesManager, utils::millis_since};
+pub use self::{
+    conditional_sealer::{ConditionalSealer, NoopSealer, SequencerSealer},
+    io_criteria::IoSealCriteria,
+};
+use crate::metrics::AGGREGATION_METRICS;
 
 mod conditional_sealer;
 pub(super) mod criteria;
+pub(super) mod io_criteria;
 
 fn halt_as_metric_label(halt: &Halt) -> &'static str {
     match halt {
@@ -193,149 +197,4 @@ pub(super) trait SealCriterion: fmt::Debug + Send + Sync + 'static {
     // We need self here only for rust restrictions for creating an object from trait
     // https://doc.rust-lang.org/reference/items/traits.html#object-safety
     fn prom_criterion_name(&self) -> &'static str;
-}
-
-/// I/O-dependent seal criteria.
-pub trait IoSealCriteria {
-    /// Checks whether an L1 batch should be sealed unconditionally (i.e., regardless of metrics
-    /// related to transaction execution) given the provided `manager` state.
-    fn should_seal_l1_batch_unconditionally(&mut self, manager: &UpdatesManager) -> bool;
-    /// Checks whether an L2 block should be sealed given the provided `manager` state.
-    fn should_seal_l2_block(&mut self, manager: &UpdatesManager) -> bool;
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(super) struct TimeoutSealer {
-    block_commit_deadline_ms: u64,
-    l2_block_commit_deadline_ms: u64,
-}
-
-impl TimeoutSealer {
-    pub fn new(config: &StateKeeperConfig) -> Self {
-        Self {
-            block_commit_deadline_ms: config.block_commit_deadline_ms,
-            l2_block_commit_deadline_ms: config.l2_block_commit_deadline_ms,
-        }
-    }
-}
-
-impl IoSealCriteria for TimeoutSealer {
-    fn should_seal_l1_batch_unconditionally(&mut self, manager: &UpdatesManager) -> bool {
-        const RULE_NAME: &str = "no_txs_timeout";
-
-        if manager.pending_executed_transactions_len() == 0 {
-            // Regardless of which sealers are provided, we never want to seal an empty batch.
-            return false;
-        }
-
-        let block_commit_deadline_ms = self.block_commit_deadline_ms;
-        // Verify timestamp
-        let should_seal_timeout =
-            millis_since(manager.batch_timestamp()) > block_commit_deadline_ms;
-
-        if should_seal_timeout {
-            AGGREGATION_METRICS.l1_batch_reason_inc_criterion(RULE_NAME);
-            tracing::debug!(
-                "Decided to seal L1 batch using rule `{RULE_NAME}`; batch timestamp: {}, \
-                 commit deadline: {block_commit_deadline_ms}ms",
-                display_timestamp(manager.batch_timestamp())
-            );
-        }
-        should_seal_timeout
-    }
-
-    fn should_seal_l2_block(&mut self, manager: &UpdatesManager) -> bool {
-        !manager.l2_block.executed_transactions.is_empty()
-            && millis_since(manager.l2_block.timestamp) > self.l2_block_commit_deadline_ms
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(super) struct L2BlockMaxPayloadSizeSealer {
-    max_payload_size: usize,
-}
-
-impl L2BlockMaxPayloadSizeSealer {
-    pub fn new(config: &StateKeeperConfig) -> Self {
-        Self {
-            max_payload_size: config.l2_block_max_payload_size,
-        }
-    }
-
-    pub fn should_seal_l2_block(&mut self, manager: &UpdatesManager) -> bool {
-        manager.l2_block.payload_encoding_size >= self.max_payload_size
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::tests::{
-        create_execution_result, create_transaction, create_updates_manager, seconds_since_epoch,
-    };
-
-    fn apply_tx_to_manager(tx: Transaction, manager: &mut UpdatesManager) {
-        manager.extend_from_executed_transaction(
-            tx,
-            create_execution_result([]),
-            VmExecutionMetrics::default(),
-            vec![],
-        );
-    }
-
-    /// This test mostly exists to make sure that we can't seal empty L2 blocks on the main node.
-    #[test]
-    fn timeout_l2_block_sealer() {
-        let mut timeout_l2_block_sealer = TimeoutSealer {
-            block_commit_deadline_ms: 10_000,
-            l2_block_commit_deadline_ms: 10_000,
-        };
-
-        let mut manager = create_updates_manager();
-        // Empty L2 block should not trigger.
-        manager.l2_block.timestamp = seconds_since_epoch() - 10;
-        assert!(
-            !timeout_l2_block_sealer.should_seal_l2_block(&manager),
-            "Empty L2 block shouldn't be sealed"
-        );
-
-        // Non-empty L2 block should trigger.
-        apply_tx_to_manager(create_transaction(10, 100), &mut manager);
-        assert!(
-            timeout_l2_block_sealer.should_seal_l2_block(&manager),
-            "Non-empty L2 block with old timestamp should be sealed"
-        );
-
-        // Check the timestamp logic. This relies on the fact that the test shouldn't run
-        // for more than 10 seconds (while the test itself is trivial, it may be preempted
-        // by other tests).
-        manager.l2_block.timestamp = seconds_since_epoch();
-        assert!(
-            !timeout_l2_block_sealer.should_seal_l2_block(&manager),
-            "Non-empty L2 block with too recent timestamp shouldn't be sealed"
-        );
-    }
-
-    #[test]
-    fn max_size_l2_block_sealer() {
-        let tx = create_transaction(10, 100);
-        let tx_encoding_size =
-            zksync_protobuf::repr::encode::<zksync_dal::consensus::proto::Transaction>(&tx).len();
-
-        let mut max_payload_sealer = L2BlockMaxPayloadSizeSealer {
-            max_payload_size: tx_encoding_size,
-        };
-
-        let mut manager = create_updates_manager();
-        assert!(
-            !max_payload_sealer.should_seal_l2_block(&manager),
-            "Empty L2 block shouldn't be sealed"
-        );
-
-        apply_tx_to_manager(tx, &mut manager);
-        assert!(
-            max_payload_sealer.should_seal_l2_block(&manager),
-            "L2 block with payload encoding size equal or greater than max payload size should be sealed"
-        );
-    }
 }

--- a/core/node/state_keeper/src/testonly/test_batch_executor.rs
+++ b/core/node/state_keeper/src/testonly/test_batch_executor.rs
@@ -672,9 +672,13 @@ impl TestIO {
     }
 }
 
+#[async_trait]
 impl IoSealCriteria for TestIO {
-    fn should_seal_l1_batch_unconditionally(&mut self, manager: &UpdatesManager) -> bool {
-        (self.l1_batch_seal_fn)(manager)
+    async fn should_seal_l1_batch_unconditionally(
+        &mut self,
+        manager: &UpdatesManager,
+    ) -> anyhow::Result<bool> {
+        Ok((self.l1_batch_seal_fn)(manager))
     }
 
     fn should_seal_l2_block(&mut self, manager: &UpdatesManager) -> bool {

--- a/core/node/state_keeper/src/tests/mod.rs
+++ b/core/node/state_keeper/src/tests/mod.rs
@@ -66,7 +66,12 @@ pub(crate) fn pending_batch_data(pending_l2_blocks: Vec<L2BlockExecutionData>) -
 
 pub(super) fn create_updates_manager() -> UpdatesManager {
     let l1_batch_env = default_l1_batch_env(1, 1, Address::default());
-    UpdatesManager::new(&l1_batch_env, &default_system_env(), Default::default())
+    UpdatesManager::new(
+        &l1_batch_env,
+        &default_system_env(),
+        Default::default(),
+        Default::default(),
+    )
 }
 
 pub(super) fn create_transaction(fee_per_gas: u64, gas_per_pubdata: u64) -> Transaction {

--- a/core/node/state_keeper/src/updates/mod.rs
+++ b/core/node/state_keeper/src/updates/mod.rs
@@ -41,6 +41,7 @@ pub struct UpdatesManager {
     pub storage_writes_deduplicator: StorageWritesDeduplicator,
     pubdata_params: PubdataParams,
     next_l2_block_params: Option<L2BlockParams>,
+    previous_batch_protocol_version: ProtocolVersionId,
 }
 
 impl UpdatesManager {
@@ -48,6 +49,7 @@ impl UpdatesManager {
         l1_batch_env: &L1BatchEnv,
         system_env: &SystemEnv,
         pubdata_params: PubdataParams,
+        previous_batch_protocol_version: ProtocolVersionId,
     ) -> Self {
         let protocol_version = system_env.version;
         Self {
@@ -69,6 +71,7 @@ impl UpdatesManager {
             storage_view_cache: None,
             pubdata_params,
             next_l2_block_params: None,
+            previous_batch_protocol_version,
         }
     }
 
@@ -131,6 +134,10 @@ impl UpdatesManager {
 
     pub fn protocol_version(&self) -> ProtocolVersionId {
         self.protocol_version
+    }
+
+    pub fn previous_batch_protocol_version(&self) -> ProtocolVersionId {
+        self.previous_batch_protocol_version
     }
 
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## What ❔

Add protocol upgrade sealer which 
a) seals batch when there is a pending protocol upgrade
b) seals first batch after protocol upgrade with 1 tx

## Why ❔

Makes protocol upgrades happen faster for chains with low TPS.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

None

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
