### PR TITLE
feat(state-keeper): Make sealers aware of settlement layer

### DIFF
--- a/core/lib/basic_types/src/settlement.rs
+++ b/core/lib/basic_types/src/settlement.rs
@@ -4,7 +4,7 @@ use crate::SLChainId;
 
 /// An enum which is used to describe whether a zkSync network settles to L1 or to the gateway.
 /// Gateway is an Ethereum-compatible L2 and so it requires different treatment with regards to DA handling.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
 pub enum SettlementLayer {
     L1(SLChainId),
     Gateway(SLChainId),

--- a/core/lib/types/src/aggregated_operations.rs
+++ b/core/lib/types/src/aggregated_operations.rs
@@ -42,10 +42,105 @@ impl FromStr for AggregatedActionType {
     }
 }
 
-/// Additional gas cost of processing `Execute` operation per batch.
-/// It's applicable iff SL is Ethereum.
-pub const L1_BATCH_EXECUTE_BASE_COST: u32 = 30_000;
+#[derive(Debug)]
+pub struct GasConsts;
 
-/// Additional gas cost of processing `Execute` operation per L1->L2 tx.
-/// It's applicable iff SL is Ethereum.
-pub const L1_OPERATION_EXECUTE_COST: u32 = 12_500;
+#[derive(Debug)]
+pub struct CommitGasConsts {
+    pub base: u32,
+    pub per_batch: u32,
+}
+
+#[derive(Debug)]
+pub struct ExecuteCosts {
+    pub base: u32,
+    pub per_batch: u32,
+    pub per_l1_l2_tx: u32,
+}
+
+impl GasConsts {
+    /// Base gas cost of processing aggregated `Execute` operation.
+    /// It's applicable iff SL is Ethereum.
+    const AGGR_L1_BATCH_EXECUTE_BASE_COST: u32 = 200_000;
+    /// Base gas cost of processing aggregated `Execute` operation.
+    /// It's applicable if SL is  Gateway.
+    const AGGR_GATEWAY_BATCH_EXECUTE_BASE_COST: u32 = 300_000;
+
+    /// Base gas cost of processing aggregated `Commit` operation.
+    /// It's applicable if SL is Ethereum.
+    const AGGR_L1_BATCH_COMMIT_BASE_COST: u32 = 242_000;
+
+    /// Additional gas cost of processing `Commit` operation per batch.
+    /// It's applicable if SL is Ethereum.
+    const L1_BATCH_COMMIT_BASE_COST: u32 = 31_000;
+
+    /// Additional gas cost of processing `Commit` operation per batch.
+    /// It's applicable if SL is Gateway.
+    const AGGR_GATEWAY_BATCH_COMMIT_BASE_COST: u32 = 150_000;
+
+    /// Additional gas cost of processing `Commit` operation per batch.
+    /// It's applicable if SL is Gateway.
+    const GATEWAY_BATCH_COMMIT_BASE_COST: u32 = 200_000;
+
+    /// All gas cost of processing `PROVE` operation per batch.
+    /// It's applicable if SL is GATEWAY.
+    /// TODO calculate it properly
+    const GATEWAY_BATCH_PROOF_GAS_COST: u32 = 1_600_000;
+
+    /// All gas cost of processing `PROVE` operation per batch.
+    /// It's applicable if SL is Ethereum.
+    const L1_BATCH_PROOF_GAS_COST_ETHEREUM: u32 = 800_000;
+
+    /// Base gas cost of processing `EXECUTION` operation per batch.
+    /// It's applicable if SL is GATEWAY.
+    const GATEWAY_BATCH_EXECUTION_COST: u32 = 100_000;
+    /// Gas cost of processing `l1_operation` in batch.
+    /// It's applicable if SL is GATEWAY.
+    const GATEWAY_L1_OPERATION_COST: u32 = 4_000;
+
+    /// Additional gas cost of processing `Execute` operation per batch.
+    /// It's applicable iff SL is Ethereum.
+    const L1_BATCH_EXECUTE_BASE_COST: u32 = 30_000;
+
+    /// Additional gas cost of processing `Execute` operation per L1->L2 tx.
+    /// It's applicable iff SL is Ethereum.
+    const L1_OPERATION_EXECUTE_COST: u32 = 12_500;
+
+    pub fn commit_costs(is_gateway: bool) -> CommitGasConsts {
+        if is_gateway {
+            CommitGasConsts {
+                base: Self::GATEWAY_BATCH_COMMIT_BASE_COST,
+                per_batch: Self::AGGR_GATEWAY_BATCH_COMMIT_BASE_COST,
+            }
+        } else {
+            CommitGasConsts {
+                base: Self::L1_BATCH_COMMIT_BASE_COST,
+                per_batch: Self::AGGR_L1_BATCH_COMMIT_BASE_COST,
+            }
+        }
+    }
+
+    pub fn proof_costs(is_gateway: bool) -> u32 {
+        if is_gateway {
+            Self::GATEWAY_BATCH_PROOF_GAS_COST
+        } else {
+            Self::L1_BATCH_PROOF_GAS_COST_ETHEREUM
+        }
+    }
+
+    pub fn execute_costs(is_gateway: bool) -> ExecuteCosts {
+        if is_gateway {
+            ExecuteCosts {
+                base: Self::AGGR_GATEWAY_BATCH_EXECUTE_BASE_COST,
+                per_batch: Self::GATEWAY_BATCH_EXECUTION_COST,
+                per_l1_l2_tx: Self::GATEWAY_L1_OPERATION_COST,
+            }
+        } else {
+            ExecuteCosts {
+                base: Self::AGGR_L1_BATCH_EXECUTE_BASE_COST,
+                per_batch: Self::L1_BATCH_EXECUTE_BASE_COST,
+                per_l1_l2_tx: Self::L1_OPERATION_EXECUTE_COST,
+            }
+        }
+    }
+}

--- a/core/node/api_server/src/tx_sender/mod.rs
+++ b/core/node/api_server/src/tx_sender/mod.rs
@@ -28,6 +28,7 @@ use zksync_types::{
     fee_model::BatchFeeInput,
     get_intrinsic_constants, h256_to_u256,
     l2::{error::TxCheckError::TxDuplication, L2Tx},
+    settlement::SettlementLayer,
     transaction_request::CallOverrides,
     utils::storage_key_for_eth_balance,
     vm::FastVmMode,
@@ -53,6 +54,7 @@ pub(crate) mod tests;
 pub mod tx_sink;
 pub mod whitelist;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn build_tx_sender(
     tx_sender_config: &TxSenderConfig,
     web3_json_config: &Web3JsonRpcConfig,
@@ -61,8 +63,9 @@ pub async fn build_tx_sender(
     master_pool: ConnectionPool<Core>,
     batch_fee_model_input_provider: Arc<dyn BatchFeeModelInputProvider>,
     storage_caches: PostgresStorageCaches,
+    settlement_layer: SettlementLayer,
 ) -> anyhow::Result<(TxSender, VmConcurrencyBarrier)> {
-    let sequencer_sealer = SequencerSealer::new(state_keeper_config.clone());
+    let sequencer_sealer = SequencerSealer::new(state_keeper_config.clone(), settlement_layer);
     let master_pool_sink = MasterPoolSink::new(master_pool);
     let tx_sender_builder = TxSenderBuilder::new(
         tx_sender_config.clone(),

--- a/core/node/api_server/src/tx_sender/tests/call.rs
+++ b/core/node/api_server/src/tx_sender/tests/call.rs
@@ -39,10 +39,13 @@ async fn eth_call_requires_single_connection() {
         }
     });
     let tx_executor = SandboxExecutor::mock(tx_executor).await;
+    let sl = SettlementLayer::L1(SLChainId(10));
+
     let (tx_sender, _) = create_test_tx_sender(
         pool.clone(),
         genesis_params.config().l2_chain_id,
         tx_executor,
+        sl,
     )
     .await;
     let call_overrides = CallOverrides {

--- a/core/node/eth_sender/src/publish_criterion.rs
+++ b/core/node/eth_sender/src/publish_criterion.rs
@@ -4,9 +4,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use zksync_dal::{Connection, Core, CoreDal};
 use zksync_types::{
-    aggregated_operations::{
-        AggregatedActionType, L1_BATCH_EXECUTE_BASE_COST, L1_OPERATION_EXECUTE_COST,
-    },
+    aggregated_operations::{AggregatedActionType, ExecuteCosts, GasConsts},
     commitment::L1BatchWithMetadata,
     L1BatchNumber,
 };
@@ -259,100 +257,5 @@ impl L1BatchPublishCriterion for L1GasCriterion {
             METRICS.block_aggregation_reason[&(op, "gas").into()].inc();
         }
         last_l1_batch
-    }
-}
-
-#[derive(Debug)]
-struct GasConsts;
-
-#[derive(Debug)]
-struct CommitGasConsts {
-    base: u32,
-    per_batch: u32,
-}
-
-#[derive(Debug)]
-struct ExecuteCosts {
-    base: u32,
-    per_batch: u32,
-    per_l1_l2_tx: u32,
-}
-
-impl GasConsts {
-    /// Base gas cost of processing aggregated `Execute` operation.
-    /// It's applicable iff SL is Ethereum.
-    const AGGR_L1_BATCH_EXECUTE_BASE_COST: u32 = 200_000;
-    /// Base gas cost of processing aggregated `Execute` operation.
-    /// It's applicable if SL is  Gateway.
-    const AGGR_GATEWAY_BATCH_EXECUTE_BASE_COST: u32 = 300_000;
-
-    /// Base gas cost of processing aggregated `Commit` operation.
-    /// It's applicable if SL is Ethereum.
-    const AGGR_L1_BATCH_COMMIT_BASE_COST: u32 = 242_000;
-
-    /// Additional gas cost of processing `Commit` operation per batch.
-    /// It's applicable if SL is Ethereum.
-    const L1_BATCH_COMMIT_BASE_COST: u32 = 31_000;
-
-    /// Additional gas cost of processing `Commit` operation per batch.
-    /// It's applicable if SL is Gateway.
-    const AGGR_GATEWAY_BATCH_COMMIT_BASE_COST: u32 = 150_000;
-
-    /// Additional gas cost of processing `Commit` operation per batch.
-    /// It's applicable if SL is Gateway.
-    const GATEWAY_BATCH_COMMIT_BASE_COST: u32 = 200_000;
-
-    /// All gas cost of processing `PROVE` operation per batch.
-    /// It's applicable if SL is GATEWAY.
-    /// TODO calculate it properly
-    const GATEWAY_BATCH_PROOF_GAS_COST: u32 = 1_600_000;
-
-    /// All gas cost of processing `PROVE` operation per batch.
-    /// It's applicable if SL is Ethereum.
-    const L1_BATCH_PROOF_GAS_COST_ETHEREUM: u32 = 800_000;
-
-    /// Base gas cost of processing `EXECUTION` operation per batch.
-    /// It's applicable if SL is GATEWAY.
-    const GATEWAY_BATCH_EXECUTION_COST: u32 = 100_000;
-    /// Gas cost of processing `l1_operation` in batch.
-    /// It's applicable if SL is GATEWAY.
-    const GATEWAY_L1_OPERATION_COST: u32 = 4_000;
-
-    fn commit_costs(is_gateway: bool) -> CommitGasConsts {
-        if is_gateway {
-            CommitGasConsts {
-                base: Self::GATEWAY_BATCH_COMMIT_BASE_COST,
-                per_batch: Self::AGGR_GATEWAY_BATCH_COMMIT_BASE_COST,
-            }
-        } else {
-            CommitGasConsts {
-                base: Self::L1_BATCH_COMMIT_BASE_COST,
-                per_batch: Self::AGGR_L1_BATCH_COMMIT_BASE_COST,
-            }
-        }
-    }
-
-    fn proof_costs(is_gateway: bool) -> u32 {
-        if is_gateway {
-            Self::GATEWAY_BATCH_PROOF_GAS_COST
-        } else {
-            Self::L1_BATCH_PROOF_GAS_COST_ETHEREUM
-        }
-    }
-
-    fn execute_costs(is_gateway: bool) -> ExecuteCosts {
-        if is_gateway {
-            ExecuteCosts {
-                base: Self::AGGR_GATEWAY_BATCH_EXECUTE_BASE_COST,
-                per_batch: Self::GATEWAY_BATCH_EXECUTION_COST,
-                per_l1_l2_tx: Self::GATEWAY_L1_OPERATION_COST,
-            }
-        } else {
-            ExecuteCosts {
-                base: Self::AGGR_L1_BATCH_EXECUTE_BASE_COST,
-                per_batch: L1_BATCH_EXECUTE_BASE_COST,
-                per_l1_l2_tx: L1_OPERATION_EXECUTE_COST,
-            }
-        }
     }
 }

--- a/core/node/node_framework/src/implementations/layers/consistency_checker.rs
+++ b/core/node/node_framework/src/implementations/layers/consistency_checker.rs
@@ -7,7 +7,7 @@ use crate::{
         eth_interface::SettlementLayerClientResource,
         healthcheck::AppHealthCheckResource,
         pools::{MasterPool, PoolResource},
-        settlement_layer::SettlementModeResource,
+        settlement_layer::SettlementLayerResource,
     },
     service::StopReceiver,
     task::{Task, TaskId},
@@ -26,7 +26,7 @@ pub struct ConsistencyCheckerLayer {
 #[context(crate = crate)]
 pub struct Input {
     pub settlement_layer_client: SettlementLayerClientResource,
-    pub settlement_mode: SettlementModeResource,
+    pub settlement_mode: SettlementLayerResource,
     pub sl_chain_contracts: SettlementLayerContractsResource,
     pub master_pool: PoolResource<MasterPool>,
     #[context(default)]

--- a/core/node/node_framework/src/implementations/layers/eth_sender/aggregator.rs
+++ b/core/node/node_framework/src/implementations/layers/eth_sender/aggregator.rs
@@ -16,7 +16,7 @@ use crate::{
         healthcheck::AppHealthCheckResource,
         object_store::ObjectStoreResource,
         pools::{MasterPool, PoolResource, ReplicaPool},
-        settlement_layer::SettlementModeResource,
+        settlement_layer::SettlementLayerResource,
     },
     service::StopReceiver,
     task::{Task, TaskId},
@@ -57,7 +57,7 @@ pub struct Input {
     pub eth_client_blobs: Option<BoundEthInterfaceForBlobsResource>,
     pub eth_client_gateway: Option<BoundEthInterfaceForL2Resource>,
     pub object_store: ObjectStoreResource,
-    pub settlement_mode: SettlementModeResource,
+    pub settlement_mode: SettlementLayerResource,
     pub sender_config: SenderConfig,
     #[context(default)]
     pub circuit_breakers: CircuitBreakersResource,

--- a/core/node/node_framework/src/implementations/layers/eth_watch.rs
+++ b/core/node/node_framework/src/implementations/layers/eth_watch.rs
@@ -16,7 +16,7 @@ use crate::{
             EthInterfaceResource, SettlementLayerClient, SettlementLayerClientResource,
         },
         pools::{MasterPool, PoolResource},
-        settlement_layer::SettlementModeResource,
+        settlement_layer::SettlementLayerResource,
     },
     service::StopReceiver,
     task::{Task, TaskId},
@@ -43,7 +43,7 @@ pub struct Input {
     pub master_pool: PoolResource<MasterPool>,
     pub eth_client: EthInterfaceResource,
     pub client: SettlementLayerClientResource,
-    pub settlement_mode: SettlementModeResource,
+    pub settlement_mode: SettlementLayerResource,
 }
 
 #[derive(Debug, IntoContext)]

--- a/core/node/node_framework/src/implementations/layers/gateway_migrator_layer.rs
+++ b/core/node/node_framework/src/implementations/layers/gateway_migrator_layer.rs
@@ -8,7 +8,7 @@ use crate::{
         contracts::L1ChainContractsResource,
         eth_interface::{EthInterfaceResource, L2InterfaceResource},
         pools::{MasterPool, PoolResource},
-        settlement_layer::SettlementModeResource,
+        settlement_layer::SettlementLayerResource,
     },
     wiring_layer::{WiringError, WiringLayer},
     FromContext, IntoContext, StopReceiver, Task, TaskId,
@@ -26,7 +26,7 @@ pub struct Input {
     eth_client: EthInterfaceResource,
     gateway_client: Option<L2InterfaceResource>,
     contracts: L1ChainContractsResource,
-    settlement_mode_resource: SettlementModeResource,
+    settlement_mode_resource: SettlementLayerResource,
     pool: PoolResource<MasterPool>,
 }
 

--- a/core/node/node_framework/src/implementations/layers/settlement_layer_client.rs
+++ b/core/node/node_framework/src/implementations/layers/settlement_layer_client.rs
@@ -6,7 +6,7 @@ use zksync_web3_decl::client::Client;
 use crate::{
     implementations::resources::{
         eth_interface::{SettlementLayerClient, SettlementLayerClientResource},
-        settlement_layer::SettlementModeResource,
+        settlement_layer::SettlementLayerResource,
     },
     wiring_layer::{WiringError, WiringLayer},
     IntoContext,
@@ -31,7 +31,7 @@ impl SettlementLayerClientLayer {
 #[derive(Debug, FromContext)]
 #[context(crate = crate)]
 pub struct Input {
-    initial_settlement_mode: SettlementModeResource,
+    initial_settlement_mode: SettlementLayerResource,
 }
 
 #[derive(Debug, IntoContext)]

--- a/core/node/node_framework/src/implementations/layers/settlement_layer_data.rs
+++ b/core/node/node_framework/src/implementations/layers/settlement_layer_data.rs
@@ -30,7 +30,7 @@ use crate::{
         },
         eth_interface::{EthInterfaceResource, L2InterfaceResource},
         pools::{MasterPool, PoolResource},
-        settlement_layer::SettlementModeResource,
+        settlement_layer::SettlementLayerResource,
     },
     wiring_layer::{WiringError, WiringLayer},
     FromContext, IntoContext,
@@ -69,7 +69,7 @@ pub struct Input {
 #[derive(Debug, IntoContext)]
 #[context(crate = crate)]
 pub struct Output {
-    initial_settlement_mode: SettlementModeResource,
+    initial_settlement_mode: SettlementLayerResource,
     contracts: SettlementLayerContractsResource,
     l1_ecosystem_contracts: L1EcosystemContractsResource,
     l1_contracts: L1ChainContractsResource,
@@ -138,7 +138,7 @@ impl WiringLayer for SettlementLayerData<MainNodeConfig> {
         };
 
         Ok(Output {
-            initial_settlement_mode: SettlementModeResource(final_settlement_mode),
+            initial_settlement_mode: SettlementLayerResource(final_settlement_mode),
             contracts: SettlementLayerContractsResource(sl_chain_contracts),
             l1_ecosystem_contracts: L1EcosystemContractsResource(
                 self.config.l1_specific_contracts.clone(),
@@ -244,7 +244,7 @@ impl WiringLayer for SettlementLayerData<ENConfig> {
             l1_contracts: L1ChainContractsResource(self.config.l1_chain_contracts),
             l1_ecosystem_contracts: L1EcosystemContractsResource(self.config.l1_specific_contracts),
             l2_contracts: L2ContractsResource(self.config.l2_contracts),
-            initial_settlement_mode: SettlementModeResource(initial_sl_mode),
+            initial_settlement_mode: SettlementLayerResource(initial_sl_mode),
             l2_eth_client,
             eth_sender_config: None,
         })

--- a/core/node/node_framework/src/implementations/layers/state_keeper/mempool_io.rs
+++ b/core/node/node_framework/src/implementations/layers/state_keeper/mempool_io.rs
@@ -11,6 +11,7 @@ use crate::{
         contracts::{L2ContractsResource, SettlementLayerContractsResource},
         fee_input::SequencerFeeInputResource,
         pools::{MasterPool, PoolResource},
+        settlement_layer::SettlementLayerResource,
         state_keeper::{ConditionalSealerResource, StateKeeperIOResource},
     },
     service::StopReceiver,
@@ -50,6 +51,7 @@ pub struct Input {
     pub master_pool: PoolResource<MasterPool>,
     pub contracts_resource: SettlementLayerContractsResource,
     pub l2_contracts_resource: L2ContractsResource,
+    pub settlement_layer_resource: SettlementLayerResource,
 }
 
 #[derive(Debug, IntoContext)]
@@ -140,7 +142,8 @@ impl WiringLayer for MempoolIOLayer {
         )?;
 
         // Create sealer.
-        let sealer = SequencerSealer::new(self.state_keeper_config);
+        let sealer =
+            SequencerSealer::new(self.state_keeper_config, input.settlement_layer_resource.0);
 
         Ok(Output {
             state_keeper_io: io.into(),

--- a/core/node/node_framework/src/implementations/resources/settlement_layer.rs
+++ b/core/node/node_framework/src/implementations/resources/settlement_layer.rs
@@ -4,9 +4,9 @@ use zksync_types::settlement::SettlementLayer;
 use crate::Resource;
 
 #[derive(Debug, Clone)]
-pub struct SettlementModeResource(pub SettlementLayer);
+pub struct SettlementLayerResource(pub SettlementLayer);
 
-impl Resource for SettlementModeResource {
+impl Resource for SettlementLayerResource {
     fn name() -> String {
         "common/settlement_mode".into()
     }

--- a/core/node/state_keeper/src/seal_criteria/criteria/gas_for_batch_tip.rs
+++ b/core/node/state_keeper/src/seal_criteria/criteria/gas_for_batch_tip.rs
@@ -1,5 +1,5 @@
 use zksync_multivm::utils::gas_bootloader_batch_tip_overhead;
-use zksync_types::ProtocolVersionId;
+use zksync_types::{settlement::SettlementLayer, ProtocolVersionId};
 
 use crate::seal_criteria::{
     SealCriterion, SealData, SealResolution, StateKeeperConfig, UnexecutableReason,
@@ -19,6 +19,7 @@ impl SealCriterion for GasForBatchTipCriterion {
         _block_data: &SealData,
         tx_data: &SealData,
         protocol_version: ProtocolVersionId,
+        _settlement_layer: &SettlementLayer,
     ) -> SealResolution {
         let batch_tip_overhead = gas_bootloader_batch_tip_overhead(protocol_version.into());
         let is_tx_first = tx_count == 1;
@@ -42,6 +43,7 @@ impl SealCriterion for GasForBatchTipCriterion {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
+    use zksync_types::SLChainId;
 
     use super::*;
 
@@ -49,6 +51,7 @@ mod tests {
     fn test_gas_for_batch_tip_seal_criterion() {
         // Create an empty config.
         let config = StateKeeperConfig::default();
+        let sl = SettlementLayer::L1(SLChainId(10));
 
         let criterion = GasForBatchTipCriterion;
         let protocol_version = ProtocolVersionId::latest();
@@ -65,6 +68,7 @@ mod tests {
             &seal_data,
             &seal_data,
             protocol_version,
+            &sl,
         );
         assert_eq!(almost_full_block_resolution, SealResolution::NoSeal);
 
@@ -80,6 +84,7 @@ mod tests {
             &seal_data,
             &seal_data,
             protocol_version,
+            &sl,
         );
         assert_matches!(
             full_block_first_tx_resolution,
@@ -94,6 +99,7 @@ mod tests {
             &seal_data,
             &seal_data,
             protocol_version,
+            &sl,
         );
         assert_eq!(
             full_block_second_tx_resolution,

--- a/core/node/state_keeper/src/seal_criteria/criteria/pubdata_bytes.rs
+++ b/core/node/state_keeper/src/seal_criteria/criteria/pubdata_bytes.rs
@@ -1,5 +1,5 @@
 use zksync_multivm::utils::execution_metrics_bootloader_batch_tip_overhead;
-use zksync_types::ProtocolVersionId;
+use zksync_types::{settlement::SettlementLayer, ProtocolVersionId};
 
 use crate::seal_criteria::{
     SealCriterion, SealData, SealResolution, StateKeeperConfig, UnexecutableReason,
@@ -24,6 +24,7 @@ impl SealCriterion for PubDataBytesCriterion {
         block_data: &SealData,
         tx_data: &SealData,
         protocol_version: ProtocolVersionId,
+        _settlement_layer: &SettlementLayer,
     ) -> SealResolution {
         let max_pubdata_per_l1_batch = self.max_pubdata_per_batch as usize;
         let reject_bound =
@@ -68,11 +69,13 @@ impl SealCriterion for PubDataBytesCriterion {
 #[cfg(test)]
 mod tests {
     use zksync_multivm::interface::VmExecutionMetrics;
+    use zksync_types::SLChainId;
 
     use super::*;
 
     #[test]
     fn seal_criterion() {
+        let settlement_layer = SettlementLayer::L1(SLChainId(10));
         // Create an empty config and only setup fields relevant for the test.
         let config = StateKeeperConfig {
             reject_tx_at_eth_params_percentage: 0.95,
@@ -107,6 +110,7 @@ mod tests {
             },
             &SealData::default(),
             ProtocolVersionId::latest(),
+            &settlement_layer,
         );
         assert_eq!(empty_block_resolution, SealResolution::NoSeal);
 
@@ -129,6 +133,7 @@ mod tests {
             },
             &SealData::default(),
             ProtocolVersionId::latest(),
+            &settlement_layer,
         );
         assert_eq!(full_block_resolution, SealResolution::IncludeAndSeal);
 
@@ -147,6 +152,7 @@ mod tests {
             },
             &SealData::default(),
             ProtocolVersionId::latest(),
+            &settlement_layer,
         );
         assert_eq!(full_block_resolution, SealResolution::ExcludeAndSeal);
     }

--- a/core/node/state_keeper/src/seal_criteria/criteria/slots.rs
+++ b/core/node/state_keeper/src/seal_criteria/criteria/slots.rs
@@ -1,5 +1,5 @@
 use zksync_multivm::utils::get_bootloader_max_txs_in_batch;
-use zksync_types::ProtocolVersionId;
+use zksync_types::{settlement::SettlementLayer, ProtocolVersionId};
 
 use crate::seal_criteria::{SealCriterion, SealData, SealResolution, StateKeeperConfig};
 
@@ -17,6 +17,7 @@ impl SealCriterion for SlotsCriterion {
         _block_data: &SealData,
         _tx_data: &SealData,
         protocol_version: ProtocolVersionId,
+        _settlement_layer: &SettlementLayer,
     ) -> SealResolution {
         let max_txs_in_batch = get_bootloader_max_txs_in_batch(protocol_version.into());
         assert!(
@@ -39,10 +40,13 @@ impl SealCriterion for SlotsCriterion {
 
 #[cfg(test)]
 mod tests {
+    use zksync_types::SLChainId;
+
     use super::*;
 
     #[test]
     fn test_slots_seal_criterion() {
+        let settlement_layer = SettlementLayer::L1(SLChainId(10));
         // Create an empty config and only setup fields relevant for the test.
         let config = StateKeeperConfig {
             transaction_slots: 2,
@@ -59,6 +63,7 @@ mod tests {
             &SealData::default(),
             &SealData::default(),
             ProtocolVersionId::latest(),
+            &settlement_layer,
         );
         assert_eq!(almost_full_block_resolution, SealResolution::NoSeal);
 
@@ -70,6 +75,7 @@ mod tests {
             &SealData::default(),
             &SealData::default(),
             ProtocolVersionId::latest(),
+            &settlement_layer,
         );
         assert_eq!(full_block_resolution, SealResolution::IncludeAndSeal);
     }

--- a/core/node/state_keeper/src/seal_criteria/criteria/tx_encoding_size.rs
+++ b/core/node/state_keeper/src/seal_criteria/criteria/tx_encoding_size.rs
@@ -1,5 +1,5 @@
 use zksync_multivm::utils::get_bootloader_encoding_space;
-use zksync_types::ProtocolVersionId;
+use zksync_types::{settlement::SettlementLayer, ProtocolVersionId};
 
 use crate::seal_criteria::{
     SealCriterion, SealData, SealResolution, StateKeeperConfig, UnexecutableReason,
@@ -18,6 +18,7 @@ impl SealCriterion for TxEncodingSizeCriterion {
         block_data: &SealData,
         tx_data: &SealData,
         protocol_version_id: ProtocolVersionId,
+        _settlement_layer: &SettlementLayer,
     ) -> SealResolution {
         let bootloader_tx_encoding_space =
             get_bootloader_encoding_space(protocol_version_id.into());
@@ -46,10 +47,14 @@ impl SealCriterion for TxEncodingSizeCriterion {
 
 #[cfg(test)]
 mod tests {
+    use zksync_types::SLChainId;
+
     use super::*;
 
     #[test]
     fn seal_criterion() {
+        let sl = SettlementLayer::L1(SLChainId(10));
+
         let bootloader_tx_encoding_space =
             get_bootloader_encoding_space(ProtocolVersionId::latest().into());
 
@@ -70,6 +75,7 @@ mod tests {
             &SealData::default(),
             &SealData::default(),
             ProtocolVersionId::latest(),
+            &sl,
         );
         assert_eq!(empty_block_resolution, SealResolution::NoSeal);
 
@@ -84,6 +90,7 @@ mod tests {
                 ..SealData::default()
             },
             ProtocolVersionId::latest(),
+            &sl,
         );
         assert_eq!(
             unexecutable_resolution,
@@ -104,6 +111,7 @@ mod tests {
                 ..SealData::default()
             },
             ProtocolVersionId::latest(),
+            &sl,
         );
         assert_eq!(exclude_and_seal_resolution, SealResolution::ExcludeAndSeal);
 
@@ -121,6 +129,7 @@ mod tests {
                 ..SealData::default()
             },
             ProtocolVersionId::latest(),
+            &sl,
         );
         assert_eq!(include_and_seal_resolution, SealResolution::IncludeAndSeal);
     }

--- a/core/node/state_keeper/src/seal_criteria/mod.rs
+++ b/core/node/state_keeper/src/seal_criteria/mod.rs
@@ -17,7 +17,9 @@ use zksync_multivm::{
     interface::{DeduplicatedWritesMetrics, Halt, TransactionExecutionMetrics, VmExecutionMetrics},
     vm_latest::TransactionVmExt,
 };
-use zksync_types::{utils::display_timestamp, ProtocolVersionId, Transaction};
+use zksync_types::{
+    settlement::SettlementLayer, utils::display_timestamp, ProtocolVersionId, Transaction,
+};
 
 pub use self::conditional_sealer::{ConditionalSealer, NoopSealer, SequencerSealer};
 use crate::{metrics::AGGREGATION_METRICS, updates::UpdatesManager, utils::millis_since};
@@ -188,6 +190,7 @@ pub(super) trait SealCriterion: fmt::Debug + Send + Sync + 'static {
         block_data: &SealData,
         tx_data: &SealData,
         protocol_version: ProtocolVersionId,
+        sl_mode: &SettlementLayer,
     ) -> SealResolution;
 
     // We need self here only for rust restrictions for creating an object from trait


### PR DESCRIPTION
## What ❔

Add settlement mode to sealers 


## Why ❔

Some sealers are rely on settlement layer tx gas usage. And we have to make them aware of this change

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
