### PR TITLE
ci: add workflow to check core for flaky integration tests

### DIFF
--- a/.github/workflows/check-flaky-tests.yml
+++ b/.github/workflows/check-flaky-tests.yml
@@ -1,0 +1,21 @@
+name: Check flaky tests
+
+# Special workflow to check if the core integration tests are flaky
+# it runs on every push to the main branch and repeats core integration tests 10 times
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+
+  check-flaky-tests:
+    uses: ./.github/workflows/ci-core-reusable.yml


### PR DESCRIPTION
## What ❔

* [x] Add workflow to check core for flaky integration tests

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To have a separate check for flakiness in `main` without interrupting the merge queue tests stability and PRs testing from the main `CI` workflow.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
