### PR TITLE
fix(gateway-migration): Allow prove, execute txs to be sent during the migration

### DIFF
--- a/core/node/eth_sender/src/eth_tx_aggregator.rs
+++ b/core/node/eth_sender/src/eth_tx_aggregator.rs
@@ -599,8 +599,11 @@ impl EthTxAggregator {
         if gateway_migration_state == GatewayMigrationState::InProgress {
             let reason = Some("Gateway migration started");
             op_restrictions.commit_restriction = reason;
-            op_restrictions.prove_restriction = reason;
-            op_restrictions.execute_restriction = reason;
+            // For the migration from gateway to L1, we need to wait for all blocks to be executed
+            if !self.settlement_layer.is_gateway() {
+                op_restrictions.prove_restriction = reason;
+                op_restrictions.execute_restriction = reason;
+            }
         }
 
         if let Some(agg_op) = self


### PR DESCRIPTION

## What ❔

Allow execute and prove txs to be sent, when we migrate from gateway. 

## Why ❔

All blocks should be executed during the migration from gateway to l1. So we have to allow them to be sent. 

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
