### PR TITLE
fix(en): Fix chunked genesis recovery

### DIFF
--- a/core/lib/state/src/rocksdb/recovery.rs
+++ b/core/lib/state/src/rocksdb/recovery.rs
@@ -68,13 +68,17 @@ impl InitParameters {
         })
     }
 
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[tracing::instrument(skip_all, ret)]
     async fn is_genesis_recovery_needed(
         storage: &mut Connection<'_, Core>,
     ) -> anyhow::Result<bool> {
-        let sealed_l1_batch = storage.blocks_dal().get_sealed_l1_batch_number().await?;
-        if sealed_l1_batch != Some(L1BatchNumber(0)) {
-            tracing::debug!(?sealed_l1_batch, "Latest sealed L1 batch mismatch");
+        let earliest_l2_block = storage.blocks_dal().get_earliest_l2_block_number().await?;
+        tracing::debug!(?earliest_l2_block, "Got earliest L2 block from Postgres");
+        if earliest_l2_block != Some(L2BlockNumber(0)) {
+            tracing::info!(
+                ?earliest_l2_block,
+                "There is no genesis block in Postgres; genesis recovery is impossible"
+            );
             return Ok(false);
         }
 
@@ -95,14 +99,16 @@ impl RocksdbStorage {
     /// # Return value
     ///
     /// Returns the next L1 batch that should be fed to the storage.
+    #[tracing::instrument(skip_all, ret)]
     pub(super) async fn ensure_ready(
         &mut self,
         storage: &mut Connection<'_, Core>,
         desired_log_chunk_size: u64,
         stop_receiver: &watch::Receiver<bool>,
     ) -> Result<(Strategy, L1BatchNumber), RocksdbSyncError> {
-        if let Some(number) = self.l1_batch_number().await {
-            return Ok((Strategy::Complete, number));
+        if let Some(l1_batch_number) = self.l1_batch_number().await {
+            tracing::info!(?l1_batch_number, "RocksDB storage is ready");
+            return Ok((Strategy::Complete, l1_batch_number));
         }
 
         let init_params = InitParameters::new(storage, desired_log_chunk_size).await?;
@@ -111,6 +117,7 @@ impl RocksdbStorage {
                 .await?;
             (Strategy::Recovery, init_params.l1_batch + 1)
         } else {
+            tracing::info!("Initializing RocksDB storage from genesis");
             // No recovery snapshot; we're initializing the cache from the genesis
             (Strategy::Genesis, L1BatchNumber(0))
         })


### PR DESCRIPTION
## What ❔

- Fixes the `is_genesis_recovery_needed()` check. It now checks that the genesis is present in Postgres.
- Adds a couple more logs related to genesis recovery.

## Why ❔

The `is_genesis_recovery_needed()` check previously checked whether Postgres *only* contains genesis (i.e., has no later batches). This is logically incorrect; if an EN is restored from a Postgres dump, or if the state keeper cache / tree is dropped for whatever reason and is re-synced, then there can be more batches in Postgres.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.