### PR TITLE
feat: Port core changes for gateway the new gateway scripts

### DIFF
--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -1537,6 +1537,8 @@ impl ExternalNodeConfig {
             shared_bridge: self.remote.l1_shared_bridge_proxy_addr,
             erc_20_bridge: self.remote.l1_erc20_bridge_proxy_addr,
             base_token_address: self.remote.base_token_addr,
+            // We don't need chain admin for external node
+            chain_admin: None,
         }
     }
 
@@ -1552,8 +1554,6 @@ impl ExternalNodeConfig {
             },
             chain_contracts_config: ChainContracts {
                 diamond_proxy_addr: self.l1_diamond_proxy_address(),
-                // We don't need chain admin for external node
-                chain_admin: None,
             },
         }
     }

--- a/core/lib/basic_types/src/settlement.rs
+++ b/core/lib/basic_types/src/settlement.rs
@@ -20,4 +20,8 @@ impl SettlementLayer {
             Self::L1(chain_id) | Self::Gateway(chain_id) => *chain_id,
         }
     }
+    pub fn for_tests() -> Self {
+        // 9 is a common chain id for localhost
+        Self::L1(SLChainId(9))
+    }
 }

--- a/core/lib/basic_types/src/settlement.rs
+++ b/core/lib/basic_types/src/settlement.rs
@@ -5,6 +5,7 @@ use crate::SLChainId;
 /// An enum which is used to describe whether a zkSync network settles to L1 or to the gateway.
 /// Gateway is an Ethereum-compatible L2 and so it requires different treatment with regards to DA handling.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", content = "chain_id")]
 pub enum SettlementLayer {
     L1(SLChainId),
     Gateway(SLChainId),

--- a/core/lib/config/src/configs/contracts/chain.rs
+++ b/core/lib/config/src/configs/contracts/chain.rs
@@ -89,6 +89,7 @@ impl AllContractsConfig {
             shared_bridge: self.l1_shared_bridge_proxy_addr,
             erc_20_bridge: self.l1_erc20_bridge_proxy_addr,
             base_token_address: self.base_token_addr,
+            chain_admin: Some(self.chain_admin_addr),
         }
     }
 
@@ -119,7 +120,6 @@ impl AllContractsConfig {
             },
             chain_contracts_config: ChainContracts {
                 diamond_proxy_addr: self.diamond_proxy_addr,
-                chain_admin: Some(self.chain_admin_addr),
             },
         }
     }
@@ -129,7 +129,6 @@ impl AllContractsConfig {
 #[derive(Debug, Clone)]
 pub struct ChainContracts {
     pub diamond_proxy_addr: Address,
-    pub chain_admin: Option<Address>,
 }
 
 // Contracts deployed to the l2

--- a/core/lib/config/src/configs/contracts/ecosystem.rs
+++ b/core/lib/config/src/configs/contracts/ecosystem.rs
@@ -12,6 +12,7 @@ pub struct L1SpecificContracts {
     pub shared_bridge: Option<Address>,
     pub erc_20_bridge: Option<Address>,
     pub base_token_address: Address,
+    pub chain_admin: Option<Address>,
 }
 
 /// Ecosystem contracts that are presented on all Settlement Layers
@@ -19,6 +20,7 @@ pub struct L1SpecificContracts {
 pub struct EcosystemCommonContracts {
     pub bridgehub_proxy_addr: Option<Address>,
     pub state_transition_proxy_addr: Option<Address>,
+    // TODO(X): should be moved to `L1SpecificContracts` since this contract should never be used not on L1.
     pub server_notifier_addr: Option<Address>,
     pub multicall3: Option<Address>,
     pub validator_timelock_addr: Option<Address>,

--- a/core/lib/config/src/configs/contracts/gateway.rs
+++ b/core/lib/config/src/configs/contracts/gateway.rs
@@ -1,0 +1,55 @@
+use zksync_basic_types::{web3::Bytes, Address, SLChainId};
+
+use super::chain::AllContractsConfig;
+
+/// Config that is only stored for the gateway chain.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+pub struct GatewayConfig {
+    pub state_transition_proxy_addr: Address,
+    pub validator_timelock_addr: Address,
+    pub multicall3_addr: Address,
+    pub relayed_sl_da_validator: Address,
+    pub validium_da_validator: Address,
+    pub diamond_cut_data: Bytes,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+pub struct GatewayChainConfig {
+    pub state_transition_proxy_addr: Option<Address>,
+    pub validator_timelock_addr: Option<Address>,
+    pub multicall3_addr: Address,
+    pub diamond_proxy_addr: Address,
+    pub gateway_chain_id: SLChainId,
+}
+
+impl GatewayChainConfig {
+    pub fn from_gateway_and_chain_data(
+        gateway_config: &GatewayConfig,
+        diamond_proxy_addr: Address,
+        gateway_chain_id: SLChainId,
+    ) -> Self {
+        Self {
+            state_transition_proxy_addr: Some(gateway_config.state_transition_proxy_addr),
+            validator_timelock_addr: Some(gateway_config.validator_timelock_addr),
+            multicall3_addr: gateway_config.multicall3_addr,
+            diamond_proxy_addr,
+            gateway_chain_id,
+        }
+    }
+
+    pub fn from_contracts_and_chain_id(
+        contracts: AllContractsConfig,
+        gateway_chain_id: SLChainId,
+    ) -> Self {
+        let sl_contracts = contracts.settlement_layer_specific_contracts();
+        Self {
+            state_transition_proxy_addr: sl_contracts
+                .ecosystem_contracts
+                .state_transition_proxy_addr,
+            validator_timelock_addr: sl_contracts.ecosystem_contracts.validator_timelock_addr,
+            multicall3_addr: sl_contracts.ecosystem_contracts.multicall3.unwrap(),
+            diamond_proxy_addr: sl_contracts.chain_contracts_config.diamond_proxy_addr,
+            gateway_chain_id,
+        }
+    }
+}

--- a/core/lib/contracts/src/lib.rs
+++ b/core/lib/contracts/src/lib.rs
@@ -104,7 +104,6 @@ fn read_file_to_json_value(path: impl AsRef<Path> + std::fmt::Debug) -> Option<s
 fn load_contract_if_present<P: AsRef<Path> + std::fmt::Debug>(path: P) -> Option<Contract> {
     let zksync_home = home_path();
     let path = Path::new(&zksync_home).join(path);
-    println!("PATH : {:#?}", path);
     path.exists().then(|| {
         serde_json::from_value(read_file_to_json_value(&path).unwrap()["abi"].take())
             .unwrap_or_else(|e| panic!("Failed to parse contract abi from file {:?}: {}", path, e))

--- a/core/lib/contracts/src/lib.rs
+++ b/core/lib/contracts/src/lib.rs
@@ -104,6 +104,7 @@ fn read_file_to_json_value(path: impl AsRef<Path> + std::fmt::Debug) -> Option<s
 fn load_contract_if_present<P: AsRef<Path> + std::fmt::Debug>(path: P) -> Option<Contract> {
     let zksync_home = home_path();
     let path = Path::new(&zksync_home).join(path);
+    println!("PATH : {:#?}", path);
     path.exists().then(|| {
         serde_json::from_value(read_file_to_json_value(&path).unwrap()["abi"].take())
             .unwrap_or_else(|e| panic!("Failed to parse contract abi from file {:?}: {}", path, e))

--- a/core/lib/dal/src/server_notifications.rs
+++ b/core/lib/dal/src/server_notifications.rs
@@ -1,5 +1,5 @@
 use zksync_db_connection::{connection::Connection, error::DalResult, instrument::InstrumentExt};
-use zksync_types::{L1BlockNumber, H256};
+use zksync_types::{server_notification::GatewayMigrationNotification, L1BlockNumber, H256};
 
 use crate::{models::server_notification::ServerNotification, Core};
 
@@ -65,5 +65,22 @@ impl ServerNotificationsDal<'_, '_> {
         });
 
         Ok(rows)
+    }
+
+    pub async fn get_latest_gateway_migration_notification(
+        &mut self,
+    ) -> DalResult<Option<GatewayMigrationNotification>> {
+        let notification = self
+            .get_last_notification_by_topics(
+                &GatewayMigrationNotification::get_server_notifier_topics(),
+            )
+            .await?;
+
+        let notification = notification.map(|notification| {
+            GatewayMigrationNotification::from_topic(notification.main_topic)
+                .expect("Invalid topic")
+        });
+
+        Ok(notification)
     }
 }

--- a/core/lib/eth_client/src/contracts_loader.rs
+++ b/core/lib/eth_client/src/contracts_loader.rs
@@ -66,12 +66,6 @@ pub async fn load_settlement_layer_contracts(
         .call(sl_client)
         .await?;
 
-    let chain_admin =
-        CallFunctionArgs::new("getChainAdmin", Token::Uint(l2_chain_id.as_u64().into()))
-            .for_contract(ctm_address, &state_transition_manager_contract())
-            .call(sl_client)
-            .await?;
-
     Ok(Some(SettlementLayerSpecificContracts {
         ecosystem_contracts: EcosystemCommonContracts {
             bridgehub_proxy_addr: Some(bridgehub_address),
@@ -82,7 +76,6 @@ pub async fn load_settlement_layer_contracts(
         },
         chain_contracts_config: ChainContracts {
             diamond_proxy_addr: diamond_proxy,
-            chain_admin: Some(chain_admin),
         },
     }))
 }

--- a/core/lib/types/src/api/mod.rs
+++ b/core/lib/types/src/api/mod.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use serde_with::{hex::Hex, serde_as};
 use zksync_basic_types::{
     commitment::PubdataType,
+    settlement::SettlementLayer,
     web3::{AccessList, Bytes, Index},
     Bloom, L1BatchNumber, SLChainId, H160, H256, H64, U256, U64,
 };
@@ -16,6 +17,7 @@ pub use crate::transaction_request::{
 use crate::{
     debug_flat_call::{DebugCallFlat, ResultDebugCallFlat},
     protocol_version::L1VerifierConfig,
+    server_notification::{GatewayMigrationNotification, GatewayMigrationState},
     tee_types::TeeType,
     Address, L2BlockNumber, ProtocolVersionId,
 };
@@ -986,6 +988,14 @@ pub struct DataAvailabilityDetails {
 pub struct L1ToL2TxsStatus {
     pub l1_to_l2_txs_in_mempool: usize,
     pub l1_to_l2_txs_paused: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GatewayMigrationStatus {
+    pub latest_notification: Option<GatewayMigrationNotification>,
+    pub state: GatewayMigrationState,
+    pub settlement_layer: SettlementLayer,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/core/lib/types/src/lib.rs
+++ b/core/lib/types/src/lib.rs
@@ -55,6 +55,7 @@ pub mod eth_sender;
 pub mod helpers;
 #[cfg(feature = "protobuf")]
 pub mod proto;
+pub mod server_notification;
 pub mod transaction_request;
 pub mod utils;
 

--- a/core/lib/types/src/server_notification.rs
+++ b/core/lib/types/src/server_notification.rs
@@ -36,13 +36,11 @@ pub enum GatewayMigrationNotification {
 
 pub static MIGRATE_FROM_GATEWAY_NOTIFICATION_SIGNATURE: Lazy<H256> = Lazy::new(|| {
     let contract = server_notifier_contract();
-
     contract.event("MigrateFromGateway").unwrap().signature()
 });
 
 pub static MIGRATE_TO_GATEWAY_NOTIFICATION_SIGNATURE: Lazy<H256> = Lazy::new(|| {
     let contract = server_notifier_contract();
-
     contract.event("MigrateToGateway").unwrap().signature()
 });
 

--- a/core/lib/types/src/server_notification.rs
+++ b/core/lib/types/src/server_notification.rs
@@ -1,0 +1,66 @@
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use zksync_basic_types::{settlement::SettlementLayer, H256};
+use zksync_contracts::server_notifier_contract;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GatewayMigrationState {
+    InProgress,
+    NotInProgress,
+}
+
+impl GatewayMigrationState {
+    pub fn from_sl_and_notification(
+        settlement_layer: SettlementLayer,
+        notification: Option<GatewayMigrationNotification>,
+    ) -> Self {
+        notification
+            .map(|a| match (a, settlement_layer) {
+                (GatewayMigrationNotification::ToGateway, SettlementLayer::L1(_))
+                | (GatewayMigrationNotification::FromGateway, SettlementLayer::Gateway(_)) => {
+                    GatewayMigrationState::InProgress
+                }
+                _ => GatewayMigrationState::NotInProgress,
+            })
+            .unwrap_or(GatewayMigrationState::NotInProgress)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GatewayMigrationNotification {
+    FromGateway,
+    ToGateway,
+}
+
+pub static MIGRATE_FROM_GATEWAY_NOTIFICATION_SIGNATURE: Lazy<H256> = Lazy::new(|| {
+    let contract = server_notifier_contract();
+
+    contract.event("MigrateFromGateway").unwrap().signature()
+});
+
+pub static MIGRATE_TO_GATEWAY_NOTIFICATION_SIGNATURE: Lazy<H256> = Lazy::new(|| {
+    let contract = server_notifier_contract();
+
+    contract.event("MigrateToGateway").unwrap().signature()
+});
+
+impl GatewayMigrationNotification {
+    pub fn get_server_notifier_topics() -> Vec<H256> {
+        vec![
+            *MIGRATE_FROM_GATEWAY_NOTIFICATION_SIGNATURE,
+            *MIGRATE_TO_GATEWAY_NOTIFICATION_SIGNATURE,
+        ]
+    }
+
+    pub fn from_topic(topic: H256) -> Option<Self> {
+        if topic == *MIGRATE_FROM_GATEWAY_NOTIFICATION_SIGNATURE {
+            Some(Self::FromGateway)
+        } else if topic == *MIGRATE_TO_GATEWAY_NOTIFICATION_SIGNATURE {
+            Some(Self::ToGateway)
+        } else {
+            None
+        }
+    }
+}

--- a/core/lib/web3_decl/src/namespaces/unstable.rs
+++ b/core/lib/web3_decl/src/namespaces/unstable.rs
@@ -3,7 +3,8 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
 use zksync_types::{
     api::{
-        ChainAggProof, DataAvailabilityDetails, L1ToL2TxsStatus, TeeProof, TransactionExecutionInfo,
+        ChainAggProof, DataAvailabilityDetails, GatewayMigrationStatus, L1ToL2TxsStatus, TeeProof,
+        TransactionExecutionInfo,
     },
     tee_types::TeeType,
     L1BatchNumber, L2ChainId, H256,
@@ -55,4 +56,7 @@ pub trait UnstableNamespace {
 
     #[method(name = "l1ToL2TxsStatus")]
     async fn l1_to_l2_txs_status(&self) -> RpcResult<L1ToL2TxsStatus>;
+
+    #[method(name = "gatewayMigrationStatus")]
+    async fn gateway_migration_status(&self) -> RpcResult<GatewayMigrationStatus>;
 }

--- a/core/node/api_server/src/web3/backend_jsonrpsee/namespaces/unstable.rs
+++ b/core/node/api_server/src/web3/backend_jsonrpsee/namespaces/unstable.rs
@@ -1,6 +1,7 @@
 use zksync_types::{
     api::{
-        ChainAggProof, DataAvailabilityDetails, L1ToL2TxsStatus, TeeProof, TransactionExecutionInfo,
+        ChainAggProof, DataAvailabilityDetails, GatewayMigrationStatus, L1ToL2TxsStatus, TeeProof,
+        TransactionExecutionInfo,
     },
     tee_types::TeeType,
     L1BatchNumber, L2ChainId, H256,
@@ -64,6 +65,12 @@ impl UnstableNamespaceServer for UnstableNamespace {
 
     async fn l1_to_l2_txs_status(&self) -> RpcResult<L1ToL2TxsStatus> {
         self.l1_to_l2_txs_status_impl()
+            .await
+            .map_err(|err| self.current_method().map_err(err))
+    }
+
+    async fn gateway_migration_status(&self) -> RpcResult<GatewayMigrationStatus> {
+        self.gateway_migration_status_impl()
             .await
             .map_err(|err| self.current_method().map_err(err))
     }

--- a/core/node/api_server/src/web3/namespaces/unstable/mod.rs
+++ b/core/node/api_server/src/web3/namespaces/unstable/mod.rs
@@ -8,8 +8,10 @@ use zksync_dal::{CoreDal, DalError};
 use zksync_mini_merkle_tree::MiniMerkleTree;
 use zksync_types::{
     api::{
-        ChainAggProof, DataAvailabilityDetails, L1ToL2TxsStatus, TeeProof, TransactionExecutionInfo,
+        ChainAggProof, DataAvailabilityDetails, GatewayMigrationStatus, L1ToL2TxsStatus, TeeProof,
+        TransactionExecutionInfo,
     },
+    server_notification::GatewayMigrationState,
     tee_types::TeeType,
     L1BatchNumber, L2ChainId,
 };
@@ -192,6 +194,27 @@ impl UnstableNamespace {
         Ok(L1ToL2TxsStatus {
             l1_to_l2_txs_paused: self.state.api_config.l1_to_l2_txs_paused,
             l1_to_l2_txs_in_mempool,
+        })
+    }
+
+    pub async fn gateway_migration_status_impl(&self) -> Result<GatewayMigrationStatus, Web3Error> {
+        let mut connection = self.state.acquire_connection().await?;
+
+        let latest_notification = connection
+            .server_notifications_dal()
+            .get_latest_gateway_migration_notification()
+            .await
+            .map_err(DalError::generalize)?;
+
+        let state = GatewayMigrationState::from_sl_and_notification(
+            self.state.api_config.settlement_layer,
+            latest_notification,
+        );
+
+        Ok(GatewayMigrationStatus {
+            latest_notification,
+            state,
+            settlement_layer: self.state.api_config.settlement_layer,
         })
     }
 }

--- a/core/node/api_server/src/web3/state.rs
+++ b/core/node/api_server/src/web3/state.rs
@@ -27,8 +27,9 @@ use zksync_dal::{Connection, ConnectionPool, Core, CoreDal, DalError};
 use zksync_metadata_calculator::api_server::TreeApiClient;
 use zksync_node_sync::SyncState;
 use zksync_types::{
-    api, commitment::L1BatchCommitmentMode, l2::L2Tx, transaction_request::CallRequest, Address,
-    L1BatchNumber, L1ChainId, L2BlockNumber, L2ChainId, H256, U256, U64,
+    api, commitment::L1BatchCommitmentMode, l2::L2Tx, settlement::SettlementLayer,
+    transaction_request::CallRequest, Address, L1BatchNumber, L1ChainId, L2BlockNumber, L2ChainId,
+    H256, U256, U64,
 };
 use zksync_web3_decl::{
     client::{DynClient, L2},
@@ -175,6 +176,7 @@ pub struct InternalApiConfig {
     pub timestamp_asserter_address: Option<Address>,
     pub l2_multicall3: Option<Address>,
     pub l1_to_l2_txs_paused: bool,
+    pub settlement_layer: SettlementLayer,
 }
 
 impl InternalApiConfig {
@@ -183,6 +185,7 @@ impl InternalApiConfig {
         l1_contracts_config: &SettlementLayerSpecificContracts,
         l1_ecosystem_contracts: &L1SpecificContracts,
         l2_contracts: &L2Contracts,
+        settlement_layer: SettlementLayer,
     ) -> Self {
         Self {
             l1_chain_id: base.l1_chain_id,
@@ -217,6 +220,7 @@ impl InternalApiConfig {
             timestamp_asserter_address: l2_contracts.timestamp_asserter_addr,
             l2_multicall3: l2_contracts.multicall3,
             l1_to_l2_txs_paused: base.l1_to_l2_txs_paused,
+            settlement_layer,
         }
     }
 
@@ -227,6 +231,7 @@ impl InternalApiConfig {
         l2_contracts: &L2Contracts,
         genesis_config: &GenesisConfig,
         l1_to_l2_txs_paused: bool,
+        settlement_layer: SettlementLayer,
     ) -> Self {
         let base = InternalApiConfigBase::new(genesis_config, web3_config)
             .with_l1_to_l2_txs_paused(l1_to_l2_txs_paused);
@@ -235,6 +240,7 @@ impl InternalApiConfig {
             l1_contracts_config,
             l1_ecosystem_contracts,
             l2_contracts,
+            settlement_layer,
         )
     }
 }

--- a/core/node/api_server/src/web3/tests/mod.rs
+++ b/core/node/api_server/src/web3/tests/mod.rs
@@ -26,10 +26,22 @@ use zksync_system_constants::{
     SYSTEM_CONTEXT_ADDRESS, SYSTEM_CONTEXT_CURRENT_L2_BLOCK_INFO_POSITION,
 };
 use zksync_types::{
-    api, block::{pack_block_info, L2BlockHasher, L2BlockHeader, UnsealedL1BatchHeader}, bytecode::{
+    api,
+    block::{pack_block_info, L2BlockHasher, L2BlockHeader, UnsealedL1BatchHeader},
+    bytecode::{
         testonly::{PADDED_EVM_BYTECODE, PROCESSED_EVM_BYTECODE},
         BytecodeHash,
-    }, fee_model::{BatchFeeInput, FeeParams}, get_deployer_key, get_nonce_key, settlement::SettlementLayer, storage::get_code_key, system_contracts::get_system_smart_contracts, tokens::{TokenInfo, TokenMetadata}, tx::IncludedTxLocation, u256_to_h256, utils::{storage_key_for_eth_balance, storage_key_for_standard_token_balance}, AccountTreeId, Address, L1BatchNumber, Nonce, StorageKey, StorageLog, H256, U256, U64
+    },
+    fee_model::{BatchFeeInput, FeeParams},
+    get_deployer_key, get_nonce_key,
+    settlement::SettlementLayer,
+    storage::get_code_key,
+    system_contracts::get_system_smart_contracts,
+    tokens::{TokenInfo, TokenMetadata},
+    tx::IncludedTxLocation,
+    u256_to_h256,
+    utils::{storage_key_for_eth_balance, storage_key_for_standard_token_balance},
+    AccountTreeId, Address, L1BatchNumber, Nonce, StorageKey, StorageLog, H256, U256, U64,
 };
 use zksync_vm_executor::oneshot::MockOneshotExecutor;
 use zksync_web3_decl::{
@@ -273,7 +285,7 @@ async fn test_http_server(test: impl HttpTest) {
         &contracts_config.l2_contracts(),
         &genesis,
         false,
-        SettlementLayer::for_tests()
+        SettlementLayer::for_tests(),
     );
     api_config.filters_disabled = test.filters_disabled();
     let mut server_builder = TestServerBuilder::new(pool.clone(), api_config)

--- a/core/node/api_server/src/web3/tests/mod.rs
+++ b/core/node/api_server/src/web3/tests/mod.rs
@@ -26,21 +26,10 @@ use zksync_system_constants::{
     SYSTEM_CONTEXT_ADDRESS, SYSTEM_CONTEXT_CURRENT_L2_BLOCK_INFO_POSITION,
 };
 use zksync_types::{
-    api,
-    block::{pack_block_info, L2BlockHasher, L2BlockHeader, UnsealedL1BatchHeader},
-    bytecode::{
+    api, block::{pack_block_info, L2BlockHasher, L2BlockHeader, UnsealedL1BatchHeader}, bytecode::{
         testonly::{PADDED_EVM_BYTECODE, PROCESSED_EVM_BYTECODE},
         BytecodeHash,
-    },
-    fee_model::{BatchFeeInput, FeeParams},
-    get_deployer_key, get_nonce_key,
-    storage::get_code_key,
-    system_contracts::get_system_smart_contracts,
-    tokens::{TokenInfo, TokenMetadata},
-    tx::IncludedTxLocation,
-    u256_to_h256,
-    utils::{storage_key_for_eth_balance, storage_key_for_standard_token_balance},
-    AccountTreeId, Address, L1BatchNumber, Nonce, StorageKey, StorageLog, H256, U256, U64,
+    }, fee_model::{BatchFeeInput, FeeParams}, get_deployer_key, get_nonce_key, settlement::SettlementLayer, storage::get_code_key, system_contracts::get_system_smart_contracts, tokens::{TokenInfo, TokenMetadata}, tx::IncludedTxLocation, u256_to_h256, utils::{storage_key_for_eth_balance, storage_key_for_standard_token_balance}, AccountTreeId, Address, L1BatchNumber, Nonce, StorageKey, StorageLog, H256, U256, U64
 };
 use zksync_vm_executor::oneshot::MockOneshotExecutor;
 use zksync_web3_decl::{
@@ -284,6 +273,7 @@ async fn test_http_server(test: impl HttpTest) {
         &contracts_config.l2_contracts(),
         &genesis,
         false,
+        SettlementLayer::for_tests()
     );
     api_config.filters_disabled = test.filters_disabled();
     let mut server_builder = TestServerBuilder::new(pool.clone(), api_config)

--- a/core/node/api_server/src/web3/tests/ws.rs
+++ b/core/node/api_server/src/web3/tests/ws.rs
@@ -7,7 +7,9 @@ use async_trait::async_trait;
 use http::StatusCode;
 use tokio::sync::watch;
 use zksync_dal::ConnectionPool;
-use zksync_types::{api, settlement::SettlementLayer, Address, Bloom, L1BatchNumber, H160, H256, U64};
+use zksync_types::{
+    api, settlement::SettlementLayer, Address, Bloom, L1BatchNumber, H160, H256, U64,
+};
 use zksync_web3_decl::{
     client::{WsClient, L2},
     jsonrpsee::{
@@ -173,7 +175,7 @@ async fn test_ws_server(test: impl WsTest) {
         &contracts_config.l2_contracts(),
         &genesis_config,
         false,
-        SettlementLayer::for_tests()
+        SettlementLayer::for_tests(),
     );
     let mut storage = pool.connection().await.unwrap();
     test.storage_initialization()

--- a/core/node/api_server/src/web3/tests/ws.rs
+++ b/core/node/api_server/src/web3/tests/ws.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use http::StatusCode;
 use tokio::sync::watch;
 use zksync_dal::ConnectionPool;
-use zksync_types::{api, Address, Bloom, L1BatchNumber, H160, H256, U64};
+use zksync_types::{api, settlement::SettlementLayer, Address, Bloom, L1BatchNumber, H160, H256, U64};
 use zksync_web3_decl::{
     client::{WsClient, L2},
     jsonrpsee::{
@@ -173,6 +173,7 @@ async fn test_ws_server(test: impl WsTest) {
         &contracts_config.l2_contracts(),
         &genesis_config,
         false,
+        SettlementLayer::for_tests()
     );
     let mut storage = pool.connection().await.unwrap();
     test.storage_initialization()

--- a/core/node/consensus/src/testonly.rs
+++ b/core/node/consensus/src/testonly.rs
@@ -36,7 +36,11 @@ use zksync_state_keeper::{
 };
 use zksync_test_contracts::Account;
 use zksync_types::{
-    ethabi, fee_model::{BatchFeeInput, L1PeggedBatchFeeModelInput}, settlement::SettlementLayer, Address, Execute, L1BatchNumber, L2BlockNumber, L2ChainId, PriorityOpId, ProtocolVersionId, Transaction
+    ethabi,
+    fee_model::{BatchFeeInput, L1PeggedBatchFeeModelInput},
+    settlement::SettlementLayer,
+    Address, Execute, L1BatchNumber, L2BlockNumber, L2ChainId, PriorityOpId, ProtocolVersionId,
+    Transaction,
 };
 use zksync_web3_decl::client::{Client, DynClient, L2};
 
@@ -604,7 +608,7 @@ impl StateKeeperRunner {
                     &configs::AllContractsConfig::for_tests().l2_contracts(),
                     &configs::GenesisConfig::for_tests(),
                     false,
-                    SettlementLayer::for_tests()
+                    SettlementLayer::for_tests(),
                 );
                 let mut server = TestServerBuilder::new(self.pool.0.clone(), cfg)
                     .build_http(stop_recv)
@@ -690,7 +694,7 @@ impl StateKeeperRunner {
                     &configs::AllContractsConfig::for_tests().l2_contracts(),
                     &configs::GenesisConfig::for_tests(),
                     false,
-                    SettlementLayer::for_tests()
+                    SettlementLayer::for_tests(),
                 );
                 let mut server = TestServerBuilder::new(self.pool.0.clone(), cfg)
                     .build_http(stop_recv)

--- a/core/node/consensus/src/testonly.rs
+++ b/core/node/consensus/src/testonly.rs
@@ -36,10 +36,7 @@ use zksync_state_keeper::{
 };
 use zksync_test_contracts::Account;
 use zksync_types::{
-    ethabi,
-    fee_model::{BatchFeeInput, L1PeggedBatchFeeModelInput},
-    Address, Execute, L1BatchNumber, L2BlockNumber, L2ChainId, PriorityOpId, ProtocolVersionId,
-    Transaction,
+    ethabi, fee_model::{BatchFeeInput, L1PeggedBatchFeeModelInput}, settlement::SettlementLayer, Address, Execute, L1BatchNumber, L2BlockNumber, L2ChainId, PriorityOpId, ProtocolVersionId, Transaction
 };
 use zksync_web3_decl::client::{Client, DynClient, L2};
 
@@ -607,6 +604,7 @@ impl StateKeeperRunner {
                     &configs::AllContractsConfig::for_tests().l2_contracts(),
                     &configs::GenesisConfig::for_tests(),
                     false,
+                    SettlementLayer::for_tests()
                 );
                 let mut server = TestServerBuilder::new(self.pool.0.clone(), cfg)
                     .build_http(stop_recv)
@@ -692,6 +690,7 @@ impl StateKeeperRunner {
                     &configs::AllContractsConfig::for_tests().l2_contracts(),
                     &configs::GenesisConfig::for_tests(),
                     false,
+                    SettlementLayer::for_tests()
                 );
                 let mut server = TestServerBuilder::new(self.pool.0.clone(), cfg)
                     .build_http(stop_recv)

--- a/core/node/eth_sender/src/eth_tx_aggregator.rs
+++ b/core/node/eth_sender/src/eth_tx_aggregator.rs
@@ -21,7 +21,7 @@ use zksync_types::{
     l2_to_l1_log::UserL2ToL1Log,
     protocol_version::{L1VerifierConfig, PACKED_SEMVER_MINOR_MASK},
     pubdata_da::PubdataSendingMode,
-    server_notification::{GatewayMigrationNotification, GatewayMigrationState},
+    server_notification::GatewayMigrationState,
     settlement::SettlementLayer,
     web3::{contract::Error as Web3ContractError, BlockNumber, CallRequest},
     Address, L2ChainId, ProtocolVersionId, SLChainId, H256, U256,

--- a/core/node/eth_sender/src/eth_tx_aggregator.rs
+++ b/core/node/eth_sender/src/eth_tx_aggregator.rs
@@ -21,6 +21,7 @@ use zksync_types::{
     l2_to_l1_log::UserL2ToL1Log,
     protocol_version::{L1VerifierConfig, PACKED_SEMVER_MINOR_MASK},
     pubdata_da::PubdataSendingMode,
+    server_notification::{GatewayMigrationNotification, GatewayMigrationState},
     settlement::SettlementLayer,
     web3::{contract::Error as Web3ContractError, BlockNumber, CallRequest},
     Address, L2ChainId, ProtocolVersionId, SLChainId, H256, U256,
@@ -35,12 +36,6 @@ use crate::{
     zksync_functions::ZkSyncFunctions,
     Aggregator, EthSenderError,
 };
-
-#[derive(Debug, PartialEq)]
-pub enum GatewayMigrationState {
-    InProgress,
-    NotInProgress,
-}
 
 /// Data queried from L1 using multicall contract.
 #[derive(Debug)]
@@ -880,43 +875,13 @@ impl EthTxAggregator {
     }
 
     async fn gateway_status(&self, storage: &mut Connection<'_, Core>) -> GatewayMigrationState {
-        let to_gateway = self
-            .functions
-            .server_notifier_contract
-            .event("MigrateToGateway")
-            .unwrap()
-            .signature();
-        let from_gateway = self
-            .functions
-            .server_notifier_contract
-            .event("MigrateFromGateway")
-            .unwrap()
-            .signature();
-
         let notification = storage
             .server_notifications_dal()
-            .get_last_notification_by_topics(&[to_gateway, from_gateway])
+            .get_latest_gateway_migration_notification()
             .await
             .unwrap();
 
-        notification
-            .map(|a| match self.settlement_layer {
-                SettlementLayer::L1(_) => {
-                    if a.main_topic == to_gateway {
-                        GatewayMigrationState::InProgress
-                    } else {
-                        GatewayMigrationState::NotInProgress
-                    }
-                }
-                SettlementLayer::Gateway(_) => {
-                    if a.main_topic == from_gateway {
-                        GatewayMigrationState::InProgress
-                    } else {
-                        GatewayMigrationState::NotInProgress
-                    }
-                }
-            })
-            .unwrap_or(GatewayMigrationState::NotInProgress)
+        GatewayMigrationState::from_sl_and_notification(self.settlement_layer, notification)
     }
 }
 

--- a/core/node/eth_sender/src/zksync_functions.rs
+++ b/core/node/eth_sender/src/zksync_functions.rs
@@ -29,7 +29,6 @@ pub(super) struct ZkSyncFunctions {
     pub(super) aggregate3: Function,
 
     pub(super) state_transition_manager_contract: Contract,
-    pub(super) server_notifier_contract: Contract,
 }
 
 fn get_function(contract: &Contract, name: &str) -> Function {
@@ -55,7 +54,6 @@ impl Default for ZkSyncFunctions {
         let zksync_contract = hyperchain_contract();
         let verifier_contract = verifier_contract();
         let multicall_contract = multicall_contract();
-        let server_notifier_contract = server_notifier_contract();
         let state_transition_manager_contract = state_transition_manager_contract();
 
         let post_shared_bridge_commit = POST_SHARED_BRIDGE_COMMIT_FUNCTION.clone();
@@ -96,7 +94,6 @@ impl Default for ZkSyncFunctions {
             multicall_contract,
             aggregate3,
             state_transition_manager_contract,
-            server_notifier_contract,
         }
     }
 }

--- a/core/node/eth_sender/src/zksync_functions.rs
+++ b/core/node/eth_sender/src/zksync_functions.rs
@@ -1,7 +1,7 @@
 use zksync_contracts::{
-    hyperchain_contract, multicall_contract,
-    state_transition_manager_contract, verifier_contract, POST_SHARED_BRIDGE_COMMIT_FUNCTION,
-    POST_SHARED_BRIDGE_EXECUTE_FUNCTION, POST_SHARED_BRIDGE_PROVE_FUNCTION,
+    hyperchain_contract, multicall_contract, state_transition_manager_contract, verifier_contract,
+    POST_SHARED_BRIDGE_COMMIT_FUNCTION, POST_SHARED_BRIDGE_EXECUTE_FUNCTION,
+    POST_SHARED_BRIDGE_PROVE_FUNCTION,
 };
 use zksync_types::ethabi::{Contract, Function};
 

--- a/core/node/eth_sender/src/zksync_functions.rs
+++ b/core/node/eth_sender/src/zksync_functions.rs
@@ -1,5 +1,5 @@
 use zksync_contracts::{
-    hyperchain_contract, multicall_contract, server_notifier_contract,
+    hyperchain_contract, multicall_contract,
     state_transition_manager_contract, verifier_contract, POST_SHARED_BRIDGE_COMMIT_FUNCTION,
     POST_SHARED_BRIDGE_EXECUTE_FUNCTION, POST_SHARED_BRIDGE_PROVE_FUNCTION,
 };

--- a/core/node/eth_watch/src/event_processors/decentralized_upgrades.rs
+++ b/core/node/eth_watch/src/event_processors/decentralized_upgrades.rs
@@ -182,7 +182,7 @@ impl EventProcessor for DecentralizedUpgradesEventProcessor {
     }
 
     fn event_source(&self) -> EventsSource {
-        EventsSource::SL
+        EventsSource::L1
     }
 
     fn event_type(&self) -> EventType {

--- a/core/node/node_framework/src/implementations/layers/base_token/base_token_ratio_persister.rs
+++ b/core/node/node_framework/src/implementations/layers/base_token/base_token_ratio_persister.rs
@@ -102,7 +102,10 @@ impl WiringLayer for BaseTokenRatioPersisterLayer {
                         chain_admin_contract: chain_admin_contract(),
                         getters_facet_contract: getters_facet_contract(),
                         diamond_proxy_contract_address: contracts.diamond_proxy_addr,
-                        chain_admin_contract_address: contracts.chain_admin,
+                        chain_admin_contract_address: input
+                            .l1_ecosystem_contracts_resource
+                            .0
+                            .chain_admin,
                         config: self.config.clone(),
                     },
                     last_persisted_l1_ratio: None,

--- a/core/node/node_framework/src/implementations/layers/eth_watch.rs
+++ b/core/node/node_framework/src/implementations/layers/eth_watch.rs
@@ -79,7 +79,7 @@ impl EthWatchLayer {
             contracts_resource
                 .ecosystem_contracts
                 .state_transition_proxy_addr,
-            contracts_resource.chain_contracts_config.chain_admin,
+            l1_ecosystem_contracts_resource.chain_admin,
             contracts_resource.ecosystem_contracts.server_notifier_addr,
             self.eth_watch_config.confirmations_for_eth_event,
             self.chain_id,

--- a/core/node/node_framework/src/implementations/layers/web3_api/server/mod.rs
+++ b/core/node/node_framework/src/implementations/layers/web3_api/server/mod.rs
@@ -26,6 +26,7 @@ use crate::{
             healthcheck::AppHealthCheckResource,
             main_node_client::MainNodeClientResource,
             pools::{PoolResource, ReplicaPool},
+            settlement_layer::SettlementModeResource,
             sync_state::SyncStateResource,
             web3_api::{MempoolCacheResource, TreeApiClientResource, TxSenderResource},
         },
@@ -141,6 +142,7 @@ pub struct Input {
     pub l1_contracts_resource: L1ChainContractsResource,
     pub l1_ecosystem_contracts_resource: L1EcosystemContractsResource,
     pub l2_contracts_resource: L2ContractsResource,
+    pub initial_settlement_mode: SettlementModeResource,
 }
 
 #[derive(Debug, IntoContext)]
@@ -212,6 +214,7 @@ impl WiringLayer for Web3ServerLayer {
             &l1_contracts,
             &input.l1_ecosystem_contracts_resource.0,
             &input.l2_contracts_resource.0,
+            input.initial_settlement_mode.0,
         );
         let sealed_l2_block_handle = SealedL2BlockNumber::default();
         let bridge_addresses_handle =

--- a/core/tests/revert-test/tests/utils.ts
+++ b/core/tests/revert-test/tests/utils.ts
@@ -117,7 +117,12 @@ export interface SuggestedValues {
 
 /** Parses output of "print-suggested-values" command of the revert block tool. */
 export function parseSuggestedValues(jsonString: string): SuggestedValues {
-    const json = JSON.parse(jsonString);
+    let json;
+    try {
+        json = JSON.parse(jsonString);
+    } catch {
+        console.log(`Failed to parse string: ${jsonString}`);
+    }
     assert(json && typeof json === 'object');
     assert(Number.isInteger(json.last_executed_l1_batch_number));
     assert(Number.isInteger(json.nonce));

--- a/core/tests/upgrade-test/tests/upgrade.test.ts
+++ b/core/tests/upgrade-test/tests/upgrade.test.ts
@@ -68,7 +68,6 @@ describe('Upgrade test', function () {
 
     // The chain admin contract on the settlement layer.
     let l1ChainAdminContract: ethers.Contract;
-    let slChainAdminAddress: string;
     // The diamond proxy contract on the settlement layer.
     let slMainContract: ethers.Contract;
 

--- a/core/tests/upgrade-test/tests/upgrade.test.ts
+++ b/core/tests/upgrade-test/tests/upgrade.test.ts
@@ -56,9 +56,7 @@ describe('Upgrade test', function () {
     let alice: zksync.Wallet;
 
     // The wallet that controls the ecosystem governance on L1.
-    let l1EcosystemGovWallet: ethers.Wallet;
-    // The wallet that controls the ecosystem governance on L1.
-    let slEcosystemGovWallet: ethers.Wallet;
+    let ecosystemGovWallet: ethers.Wallet;
     // The wallet that controls the chain admin on the settlement layer.
     // The settlement layer can be either Gateway or L1. Depending on this,
     // the provider changes.
@@ -70,6 +68,7 @@ describe('Upgrade test', function () {
 
     // The chain admin contract on the settlement layer.
     let l1ChainAdminContract: ethers.Contract;
+    let slChainAdminAddress: string;
     // The diamond proxy contract on the settlement layer.
     let slMainContract: ethers.Contract;
 
@@ -163,12 +162,10 @@ describe('Upgrade test', function () {
         // sending transactions from the same account while using different `Wallet` objects
         // could lead to flacky issues.
         if (chainWalletConfig.governor.private_key == ecosystemWalletConfig.governor.private_key && !gatewayInfo) {
-            slEcosystemGovWallet = slAdminGovWallet;
+            ecosystemGovWallet = slAdminGovWallet;
         } else {
-            slEcosystemGovWallet = new ethers.Wallet(ecosystemWalletConfig.governor.private_key, alice._providerL1());
+            ecosystemGovWallet = new ethers.Wallet(ecosystemWalletConfig.governor.private_key, alice._providerL1());
         }
-
-        l1EcosystemGovWallet = new ethers.Wallet(ecosystemWalletConfig.governor.private_key, alice._providerL1());
 
         upgradeAddress = await deployDefaultUpgradeImpl(slAdminGovWallet);
         forceDeployBytecode = contracts.counterBytecode;
@@ -444,7 +441,7 @@ describe('Upgrade test', function () {
         value: BigNumberish,
         providerForPriorityOp: zksync.Provider | null
     ) {
-        const transaction = await slEcosystemGovWallet.sendTransaction({
+        const transaction = await ecosystemGovWallet.sendTransaction({
             to: ecosystemGovernance,
             value: value,
             data: data,
@@ -482,8 +479,8 @@ describe('Upgrade test', function () {
     async function sendChainAdminOperation(call: Call) {
         const executeMulticallData = l1ChainAdminContract.interface.encodeFunctionData('multicall', [[call], true]);
 
-        const transaction = await l1EcosystemGovWallet.sendTransaction({
-            to: await l1ChainAdminContract.getAddress(),
+        const transaction = await slAdminGovWallet.sendTransaction({
+            to: gatewayInfo ? gatewayInfo.l2ChainAdmin : await l1ChainAdminContract.getAddress(),
             data: executeMulticallData,
             type: 0
         });


### PR DESCRIPTION
## What ❔

- ChainAdmin on SL is not used anymore for watching events. Only L1 is used.
- Added an endpoint for tracking the process of migrating on top of Gateway.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
