### PR TITLE
test: increase timeout for recovery tests

### DIFF
--- a/core/tests/recovery-test/package.json
+++ b/core/tests/recovery-test/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "mocha": {
-    "timeout": 240000,
+    "timeout": 600000,
     "exit": true,
     "color": false,
     "slow": 0,


### PR DESCRIPTION
## What ❔

Increase timeout for recovery tests.

## Why ❔

We now run integration tests 10 times on merge into main, so recovery takes longer.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
