### PR TITLE
fix(contracts): Move server notifier to l1

### DIFF
--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -1537,6 +1537,7 @@ impl ExternalNodeConfig {
             shared_bridge: self.remote.l1_shared_bridge_proxy_addr,
             erc_20_bridge: self.remote.l1_erc20_bridge_proxy_addr,
             base_token_address: self.remote.base_token_addr,
+            server_notifier_addr: self.remote.l1_server_notifier_addr,
             // We don't need chain admin for external node
             chain_admin: None,
         }
@@ -1547,7 +1548,6 @@ impl ExternalNodeConfig {
             ecosystem_contracts: EcosystemCommonContracts {
                 bridgehub_proxy_addr: self.remote.l1_bridgehub_proxy_addr,
                 state_transition_proxy_addr: self.remote.l1_state_transition_proxy_addr,
-                server_notifier_addr: self.remote.l1_server_notifier_addr,
                 // Multicall 3 is useless for external node
                 multicall3: None,
                 validator_timelock_addr: None,

--- a/core/lib/config/src/configs/contracts/chain.rs
+++ b/core/lib/config/src/configs/contracts/chain.rs
@@ -90,6 +90,7 @@ impl AllContractsConfig {
             erc_20_bridge: self.l1_erc20_bridge_proxy_addr,
             base_token_address: self.base_token_addr,
             chain_admin: Some(self.chain_admin_addr),
+            server_notifier_addr: self.server_notifier_addr,
         }
     }
 
@@ -114,7 +115,6 @@ impl AllContractsConfig {
             ecosystem_contracts: EcosystemCommonContracts {
                 bridgehub_proxy_addr: Some(self.bridgehub_proxy_addr),
                 state_transition_proxy_addr: self.state_transition_proxy_addr,
-                server_notifier_addr: self.server_notifier_addr,
                 multicall3: Some(self.l1_multicall3_addr),
                 validator_timelock_addr: Some(self.validator_timelock_addr),
             },

--- a/core/lib/config/src/configs/contracts/ecosystem.rs
+++ b/core/lib/config/src/configs/contracts/ecosystem.rs
@@ -13,6 +13,7 @@ pub struct L1SpecificContracts {
     pub erc_20_bridge: Option<Address>,
     pub base_token_address: Address,
     pub chain_admin: Option<Address>,
+    pub server_notifier_addr: Option<Address>,
 }
 
 /// Ecosystem contracts that are presented on all Settlement Layers
@@ -20,8 +21,6 @@ pub struct L1SpecificContracts {
 pub struct EcosystemCommonContracts {
     pub bridgehub_proxy_addr: Option<Address>,
     pub state_transition_proxy_addr: Option<Address>,
-    // TODO(X): should be moved to `L1SpecificContracts` since this contract should never be used not on L1.
-    pub server_notifier_addr: Option<Address>,
     pub multicall3: Option<Address>,
     pub validator_timelock_addr: Option<Address>,
 }

--- a/core/lib/eth_client/src/contracts_loader.rs
+++ b/core/lib/eth_client/src/contracts_loader.rs
@@ -25,6 +25,17 @@ pub async fn get_diamond_proxy_contract(
         .await
 }
 
+pub async fn get_server_notifier_addr(
+    sl_client: &dyn EthInterface,
+    ctm_address: Address,
+) -> Result<Option<Address>, ContractCallError> {
+    CallFunctionArgs::new("serverNotifierAddress", ())
+        .for_contract(ctm_address, &state_transition_manager_contract())
+        .call(sl_client)
+        .await
+        .map(|a: Address| if a.is_zero() { None } else { Some(a) })
+}
+
 /// Load contacts specific for each settlement layer, using bridgehub contract
 pub async fn load_settlement_layer_contracts(
     sl_client: &dyn EthInterface,
@@ -55,12 +66,6 @@ pub async fn load_settlement_layer_contracts(
             .call(sl_client)
             .await?;
 
-    let server_notifier_addr = CallFunctionArgs::new("serverNotifierAddress", ())
-        .for_contract(ctm_address, &state_transition_manager_contract())
-        .call(sl_client)
-        .await
-        .map(|a: Address| if a.is_zero() { None } else { Some(a) })?;
-
     let validator_timelock_addr = CallFunctionArgs::new("validatorTimelock", ())
         .for_contract(ctm_address, &state_transition_manager_contract())
         .call(sl_client)
@@ -70,7 +75,6 @@ pub async fn load_settlement_layer_contracts(
         ecosystem_contracts: EcosystemCommonContracts {
             bridgehub_proxy_addr: Some(bridgehub_address),
             state_transition_proxy_addr: Some(ctm_address),
-            server_notifier_addr,
             validator_timelock_addr: Some(validator_timelock_addr),
             multicall3,
         },

--- a/core/node/api_server/src/web3/namespaces/en.rs
+++ b/core/node/api_server/src/web3/namespaces/en.rs
@@ -168,11 +168,7 @@ impl EnNamespace {
             transparent_proxy_admin_addr: Address::zero(),
             l1_bytecodes_supplier_addr: self.state.api_config.l1_bytecodes_supplier_addr,
             l1_wrapped_base_token_store: self.state.api_config.l1_wrapped_base_token_store,
-            server_notifier_addr: self
-                .state
-                .api_config
-                .l1_ecosystem_contracts
-                .server_notifier_addr,
+            server_notifier_addr: self.state.api_config.server_notifier_addr,
         })
     }
 

--- a/core/node/api_server/src/web3/state.rs
+++ b/core/node/api_server/src/web3/state.rs
@@ -164,6 +164,7 @@ pub struct InternalApiConfig {
     pub estimate_gas_optimize_search: bool,
     pub bridge_addresses: api::BridgeAddresses,
     pub l1_ecosystem_contracts: EcosystemCommonContracts,
+    pub server_notifier_addr: Option<Address>,
     pub l1_bytecodes_supplier_addr: Option<Address>,
     pub l1_wrapped_base_token_store: Option<Address>,
     pub l1_diamond_proxy_addr: Address,
@@ -206,6 +207,7 @@ impl InternalApiConfig {
                 l2_legacy_shared_bridge: l2_contracts.legacy_shared_bridge_addr,
             },
             l1_ecosystem_contracts: l1_contracts_config.ecosystem_contracts.clone(),
+            server_notifier_addr: l1_ecosystem_contracts.server_notifier_addr,
             l1_bytecodes_supplier_addr: l1_ecosystem_contracts.bytecodes_supplier_addr,
             l1_wrapped_base_token_store: l1_ecosystem_contracts.wrapped_base_token_store,
             l1_diamond_proxy_addr: l1_contracts_config

--- a/core/node/node_framework/src/implementations/layers/eth_watch.rs
+++ b/core/node/node_framework/src/implementations/layers/eth_watch.rs
@@ -80,7 +80,7 @@ impl EthWatchLayer {
                 .ecosystem_contracts
                 .state_transition_proxy_addr,
             l1_ecosystem_contracts_resource.chain_admin,
-            contracts_resource.ecosystem_contracts.server_notifier_addr,
+            l1_ecosystem_contracts_resource.server_notifier_addr,
             self.eth_watch_config.confirmations_for_eth_event,
             self.chain_id,
         )

--- a/core/node/node_framework/src/implementations/layers/settlement_layer_data.rs
+++ b/core/node/node_framework/src/implementations/layers/settlement_layer_data.rs
@@ -9,7 +9,9 @@ use zksync_contracts::getters_facet_contract;
 use zksync_dal::{Core, CoreDal};
 use zksync_db_connection::connection::Connection;
 use zksync_eth_client::{
-    contracts_loader::{get_settlement_layer_from_l1, load_settlement_layer_contracts},
+    contracts_loader::{
+        get_server_notifier_addr, get_settlement_layer_from_l1, load_settlement_layer_contracts,
+    },
     EthInterface,
 };
 use zksync_gateway_migrator::current_settlement_layer;
@@ -100,6 +102,24 @@ impl WiringLayer for SettlementLayerData<MainNodeConfig> {
         // it's safe only for l1 contracts
         .unwrap_or(self.config.l1_sl_specific_contracts.unwrap());
 
+        let mut l1_specific_contracts = self.config.l1_specific_contracts.clone();
+        // In the future we will be able to load all contracts from the l1 chain. Now for not adding
+        // new config variable we are loading only the server notifier address
+        if l1_specific_contracts.server_notifier_addr.is_none() {
+            l1_specific_contracts.server_notifier_addr = if let Some(state_transition_proxy_addr) =
+                sl_l1_contracts
+                    .ecosystem_contracts
+                    .state_transition_proxy_addr
+            {
+                get_server_notifier_addr(&input.eth_client.0, state_transition_proxy_addr)
+                    .await
+                    .ok()
+                    .flatten()
+            } else {
+                None
+            };
+        }
+
         let pool = input.pool.get().await?;
 
         let l2_eth_client = get_l2_client(self.config.gateway_rpc_url).await?;
@@ -140,9 +160,7 @@ impl WiringLayer for SettlementLayerData<MainNodeConfig> {
         Ok(Output {
             initial_settlement_mode: SettlementModeResource(final_settlement_mode),
             contracts: SettlementLayerContractsResource(sl_chain_contracts),
-            l1_ecosystem_contracts: L1EcosystemContractsResource(
-                self.config.l1_specific_contracts.clone(),
-            ),
+            l1_ecosystem_contracts: L1EcosystemContractsResource(l1_specific_contracts),
             l2_contracts: L2ContractsResource(self.config.l2_contracts),
             l1_contracts: L1ChainContractsResource(sl_l1_contracts),
             l2_eth_client,


### PR DESCRIPTION
## What ❔
Move server-notifier to l1 specific address

## Why ❔
Server notifier is required only for l1 


## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
