### PR TITLE
fix: address issue with evm verification with immutable ref 

### DIFF
--- a/core/lib/contract_verifier/src/compilers/mod.rs
+++ b/core/lib/contract_verifier/src/compilers/mod.rs
@@ -67,7 +67,9 @@ fn process_contract_name(original_name: &str, extension: &str) -> (String, Strin
 
 /// Parses `/evm/deployedBytecode/immutableReferences`
 /// If the path doesn't exist or isn't an object, returns `None`.
-fn parse_immutable_refs(refs_val: Option<&Value>) -> Option<HashMap<String, Vec<ImmutableReference>>> {
+fn parse_immutable_refs(
+    refs_val: Option<&Value>,
+) -> Option<HashMap<String, Vec<ImmutableReference>>> {
     let obj = refs_val?.as_object()?;
 
     let mut map = HashMap::new();
@@ -159,9 +161,10 @@ fn parse_standard_json_output(
         None
     };
 
-    // Need to extract immutable references if any are present 
-    let immutable_refs = parse_immutable_refs(contract.pointer("/evm/deployedBytecode/immutableReferences"))
-    .unwrap_or_default();
+    // Need to extract immutable references if any are present
+    let immutable_refs =
+        parse_immutable_refs(contract.pointer("/evm/deployedBytecode/immutableReferences"))
+            .unwrap_or_default();
 
     let mut abi = contract["abi"].clone();
     if abi.is_null() {

--- a/core/lib/contract_verifier/src/compilers/mod.rs
+++ b/core/lib/contract_verifier/src/compilers/mod.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 
 use anyhow::Context as _;
 use serde::{Deserialize, Serialize};
-use zksync_types::contract_verification::api::CompilationArtifacts;
+use serde_json::Value;
+use zksync_types::contract_verification::api::{CompilationArtifacts, ImmutableReference};
 
 pub(crate) use self::{
     solc::{Solc, SolcInput},
@@ -61,6 +62,39 @@ fn process_contract_name(original_name: &str, extension: &str) -> (String, Strin
             format!("{original_name}.{extension}"),
             original_name.to_owned(),
         )
+    }
+}
+
+/// Parses `/evm/deployedBytecode/immutableReferences`
+/// If the path doesn't exist or isn't an object, returns `None`.
+fn parse_immutable_refs(refs_val: Option<&Value>) -> Option<HashMap<String, Vec<ImmutableReference>>> {
+    let obj = refs_val?.as_object()?;
+
+    let mut map = HashMap::new();
+    for (placeholder_key, spans_val) in obj {
+        if let Some(spans_arr) = spans_val.as_array() {
+            let mut spans_vec = Vec::new();
+            for item in spans_arr {
+                let start = item
+                    .get("start")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or_default() as usize;
+                let length = item
+                    .get("length")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or_default() as usize;
+                spans_vec.push(ImmutableReference { start, length });
+            }
+            if !spans_vec.is_empty() {
+                map.insert(placeholder_key.clone(), spans_vec);
+            }
+        }
+    }
+
+    if map.is_empty() {
+        None
+    } else {
+        Some(map)
     }
 }
 
@@ -125,6 +159,10 @@ fn parse_standard_json_output(
         None
     };
 
+    // Need to extract immutable references if any are present 
+    let immutable_refs = parse_immutable_refs(contract.pointer("/evm/deployedBytecode/immutableReferences"))
+    .unwrap_or_default();
+
     let mut abi = contract["abi"].clone();
     if abi.is_null() {
         // ABI is undefined for Yul contracts when compiled with standalone `solc`. For uniformity with `zksolc`,
@@ -142,6 +180,7 @@ fn parse_standard_json_output(
         bytecode,
         deployed_bytecode,
         abi,
+        immutable_refs,
     })
 }
 

--- a/core/lib/contract_verifier/src/compilers/zksolc.rs
+++ b/core/lib/contract_verifier/src/compilers/zksolc.rs
@@ -167,6 +167,7 @@ impl ZkSolc {
             bytecode,
             deployed_bytecode: None,
             abi: serde_json::Value::Array(Vec::new()),
+            immutable_refs: Default::default(),
         })
     }
 

--- a/core/lib/contract_verifier/src/compilers/zkvyper.rs
+++ b/core/lib/contract_verifier/src/compilers/zkvyper.rs
@@ -83,6 +83,7 @@ impl ZkVyper {
                     abi: artifact["abi"].clone(),
                     bytecode,
                     deployed_bytecode: None,
+                    immutable_refs: Default::default(),
                 });
             }
         }

--- a/core/lib/contract_verifier/src/lib.rs
+++ b/core/lib/contract_verifier/src/lib.rs
@@ -272,7 +272,10 @@ impl ContractVerifier {
         };
         let mut deployed_code = deployed_bytecode.to_vec();
 
-        // patch immutable references if any
+        // If contract contains immutable references (e.g. places to be filled during constructor execution),
+        // rewrite them with zeroes, as we can't know the values just yet.
+        // We're checking the constructor arguments as well, so assuming tha constructor arguments
+        // are the same, the immutable values should also be the same.
         artifacts.patch_immutable_bytecodes(&mut compiled_code, &mut deployed_code);
 
         let compiled_identifier =

--- a/core/lib/contract_verifier/src/lib.rs
+++ b/core/lib/contract_verifier/src/lib.rs
@@ -271,7 +271,7 @@ impl ContractVerifier {
             .context("invalid stored EVM bytecode")?,
         };
         let mut deployed_code = deployed_bytecode.to_vec();
-        
+
         // patch immutable references if any
         artifacts.patch_immutable_bytecodes(&mut compiled_code, &mut deployed_code);
 

--- a/core/lib/contract_verifier/src/tests/mod.rs
+++ b/core/lib/contract_verifier/src/tests/mod.rs
@@ -9,7 +9,7 @@ use zksync_node_test_utils::{create_l1_batch, create_l2_block};
 use zksync_types::{
     address_to_h256,
     bytecode::{pad_evm_bytecode, BytecodeHash},
-    contract_verification::api::{CompilerVersions, SourceCodeData, VerificationIncomingRequest},
+    contract_verification::api::{CompilerVersions, SourceCodeData, VerificationIncomingRequest, ImmutableReference},
     get_code_key, get_known_code_key,
     l2::L2Tx,
     tx::IncludedTxLocation,
@@ -85,6 +85,21 @@ object "Empty" {
         code { }
     }
 }
+"#;
+const COUNTER_CONTRACT_WITH_IMMUTABLE: &str = r#"
+    contract CounterWithImmutable {
+        uint256 public immutable base;
+        uint256 public value;
+
+        constructor(uint256 _base, uint256 _value) {
+            base = _base;
+            value = _value;
+        }
+
+        function increment(uint256 x) external {
+            value += (base + x);
+        }
+    }
 "#;
 
 #[derive(Debug, Clone, Copy)]
@@ -408,6 +423,7 @@ async fn contract_verifier_basics(contract: TestContract) {
             bytecode: vec![0; 32],
             deployed_bytecode: None,
             abi: counter_contract_abi(),
+            immutable_refs: Default::default(),
         }
     });
     let verifier = ContractVerifier::with_resolver(
@@ -528,6 +544,7 @@ async fn verifying_evm_bytecode(contract: TestContract) {
         bytecode: creation_bytecode.clone(),
         deployed_bytecode: Some(deployed_bytecode),
         abi: counter_contract_abi(),
+        immutable_refs: Default::default(),
     };
     let mock_resolver = MockCompilerResolver::solc(move |input| {
         assert_eq!(input.standard_json.language, "Solidity");
@@ -571,6 +588,7 @@ async fn bytecode_mismatch_error() {
         bytecode: vec![0; 32],
         deployed_bytecode: None,
         abi: counter_contract_abi(),
+        immutable_refs: Default::default(),
     });
     let verifier = ContractVerifier::with_resolver(
         Duration::from_secs(60),
@@ -652,11 +670,13 @@ async fn args_mismatch_error(contract: TestContract, bytecode_kind: BytecodeMark
             bytecode: bytecode.clone(),
             deployed_bytecode: None,
             abi: counter_contract_abi(),
+            immutable_refs: Default::default(),
         }),
         BytecodeMarker::Evm => MockCompilerResolver::solc(move |_| CompilationArtifacts {
             bytecode: vec![3_u8; 48],
             deployed_bytecode: Some(bytecode.clone()),
             abi: counter_contract_abi(),
+            immutable_refs: Default::default(),
         }),
     };
     let verifier = ContractVerifier::with_resolver(
@@ -723,6 +743,7 @@ async fn creation_bytecode_mismatch() {
             bytecode: vec![4; 20], // differs from `creation_bytecode`
             deployed_bytecode: Some(deployed_bytecode.clone()),
             abi: counter_contract_abi(),
+            immutable_refs: Default::default(),
         }
     });
     let verifier = ContractVerifier::with_resolver(
@@ -797,4 +818,71 @@ async fn no_compiler_version() {
     assert!(status.compilation_errors.is_none(), "{status:?}");
     let error = status.error.unwrap();
     assert!(error.contains("solc version"), "{error}");
+}
+
+#[tokio::test]
+async fn verifying_evm_with_immutables() {
+    let pool = ConnectionPool::test_pool().await;
+    let mut storage = pool.connection().await.unwrap();
+    prepare_storage(&mut storage).await;
+
+    let creation_bytecode = vec![0x03; 10];
+    let mut deployed_bytecode = vec![0x05; 10];
+    // Place the immutables deployed_bytecode code at offsets 4..6:
+    deployed_bytecode[4..6].copy_from_slice(&[0xAA, 0xBB]);
+
+    let address = Address::repeat_byte(1);
+    mock_evm_deployment(
+        &mut storage,
+        address,
+        creation_bytecode.clone(),
+        &deployed_bytecode,
+        &[],
+    )
+    .await;
+
+    let mut req = test_request(address, COUNTER_CONTRACT_WITH_IMMUTABLE);
+    req.compiler_versions = CompilerVersions::Solc {
+        compiler_solc_version:SOLC_VERSION.to_owned(),
+        compiler_zksolc_version: None,
+    };
+    let request_id = storage
+        .contract_verification_dal()
+        .add_contract_verification_request(&req)
+        .await
+        .unwrap();
+
+    let mut deployed_bytecode_compiled = vec![0x05; 10];
+    deployed_bytecode_compiled[4..6].copy_from_slice(&[0x00, 0x00]);
+
+    let mut imm_map = HashMap::new();
+    imm_map.insert(
+        "somePlaceholder".to_string(),
+        vec![ImmutableReference { start: 4, length: 2 }],
+    );
+
+    let artifacts = CompilationArtifacts {
+        bytecode: creation_bytecode.clone(),
+        deployed_bytecode: Some(deployed_bytecode_compiled),
+        abi: counter_contract_abi(),
+        immutable_refs: imm_map,
+    };
+
+    let mock_resolver = MockCompilerResolver::solc(move |_| {
+        artifacts.clone()
+    });
+
+    let verifier = ContractVerifier::with_resolver(
+        Duration::from_secs(60),
+        pool.clone(),
+        Arc::new(mock_resolver),
+        false,
+    )
+    .await
+    .unwrap();
+
+    let (_stop_sender, stop_receiver) = watch::channel(false);
+    verifier.run(stop_receiver, Some(1)).await.unwrap();
+
+    assert_request_success(&mut storage, request_id, address, &creation_bytecode, &[]).await;
 }

--- a/core/lib/contract_verifier/src/tests/mod.rs
+++ b/core/lib/contract_verifier/src/tests/mod.rs
@@ -9,7 +9,9 @@ use zksync_node_test_utils::{create_l1_batch, create_l2_block};
 use zksync_types::{
     address_to_h256,
     bytecode::{pad_evm_bytecode, BytecodeHash},
-    contract_verification::api::{CompilerVersions, SourceCodeData, VerificationIncomingRequest, ImmutableReference},
+    contract_verification::api::{
+        CompilerVersions, ImmutableReference, SourceCodeData, VerificationIncomingRequest,
+    },
     get_code_key, get_known_code_key,
     l2::L2Tx,
     tx::IncludedTxLocation,
@@ -843,7 +845,7 @@ async fn verifying_evm_with_immutables() {
 
     let mut req = test_request(address, COUNTER_CONTRACT_WITH_IMMUTABLE);
     req.compiler_versions = CompilerVersions::Solc {
-        compiler_solc_version:SOLC_VERSION.to_owned(),
+        compiler_solc_version: SOLC_VERSION.to_owned(),
         compiler_zksolc_version: None,
     };
     let request_id = storage
@@ -858,7 +860,10 @@ async fn verifying_evm_with_immutables() {
     let mut imm_map = HashMap::new();
     imm_map.insert(
         "somePlaceholder".to_string(),
-        vec![ImmutableReference { start: 4, length: 2 }],
+        vec![ImmutableReference {
+            start: 4,
+            length: 2,
+        }],
     );
 
     let artifacts = CompilationArtifacts {
@@ -868,9 +873,7 @@ async fn verifying_evm_with_immutables() {
         immutable_refs: imm_map,
     };
 
-    let mock_resolver = MockCompilerResolver::solc(move |_| {
-        artifacts.clone()
-    });
+    let mock_resolver = MockCompilerResolver::solc(move |_| artifacts.clone());
 
     let verifier = ContractVerifier::with_resolver(
         Duration::from_secs(60),

--- a/core/lib/types/src/contract_verification/api.rs
+++ b/core/lib/types/src/contract_verification/api.rs
@@ -259,7 +259,7 @@ impl CompilationArtifacts {
     /// Patches the provided `compiled_code` and `deployed_code` slices by zeroing
     /// out the bytes corresponding to each immutable reference.
     pub fn patch_immutable_bytecodes(&self, compiled_code: &mut [u8], deployed_code: &mut [u8]) {
-        for (_placeholder, spans) in &self.immutable_refs {
+        for spans in self.immutable_refs.values() {
             for span in spans {
                 let start = span.start;
                 let end = start + span.length;

--- a/core/lib/types/src/contract_verification/api.rs
+++ b/core/lib/types/src/contract_verification/api.rs
@@ -238,11 +238,41 @@ pub struct CompilationArtifacts {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deployed_bytecode: Option<Vec<u8>>,
     pub abi: serde_json::Value,
+    /// Map of placeholders -> list of offsets for each immutable slot.
+    /// Defaults to empty if no immutables are found.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub immutable_refs: HashMap<String, Vec<ImmutableReference>>,
+}
+
+/// Stores each immutable reference offset and length in deployed bytecode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImmutableReference {
+    pub start: usize,
+    pub length: usize,
 }
 
 impl CompilationArtifacts {
     pub fn deployed_bytecode(&self) -> &[u8] {
         self.deployed_bytecode.as_deref().unwrap_or(&self.bytecode)
+    }
+
+    /// Patches the provided `compiled_code` and `deployed_code` slices by zeroing
+    /// out the bytes corresponding to each immutable reference.
+    pub fn patch_immutable_bytecodes(
+        &self,
+        compiled_code: &mut [u8],
+        deployed_code: &mut [u8],
+    ) {
+        for (_placeholder, spans) in &self.immutable_refs {
+            for span in spans {
+                let start = span.start;
+                let end = start + span.length;
+                if end <= compiled_code.len() && end <= deployed_code.len() {
+                    compiled_code[start..end].fill(0);
+                    deployed_code[start..end].fill(0);
+                }
+            }
+        }
     }
 }
 

--- a/core/lib/types/src/contract_verification/api.rs
+++ b/core/lib/types/src/contract_verification/api.rs
@@ -258,11 +258,7 @@ impl CompilationArtifacts {
 
     /// Patches the provided `compiled_code` and `deployed_code` slices by zeroing
     /// out the bytes corresponding to each immutable reference.
-    pub fn patch_immutable_bytecodes(
-        &self,
-        compiled_code: &mut [u8],
-        deployed_code: &mut [u8],
-    ) {
+    pub fn patch_immutable_bytecodes(&self, compiled_code: &mut [u8], deployed_code: &mut [u8]) {
         for (_placeholder, spans) in &self.immutable_refs {
             for span in spans {
                 let start = span.start;

--- a/core/node/contract_verification_server/src/tests/utils.rs
+++ b/core/node/contract_verification_server/src/tests/utils.rs
@@ -78,6 +78,7 @@ pub(super) fn mock_verification_info(
             bytecode: vec![0xff, 32],
             deployed_bytecode: None,
             abi: Default::default(),
+            immutable_refs: Default::default(),
         },
         verified_at: Default::default(),
         verification_problems: Vec::new(),


### PR DESCRIPTION
## What ❔

- addresses issue with evm verification with immutable ref 
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

- Could not verify contracts with immutable refs as it resulted in bytecode mismatch error 
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->
- No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
