### PR TITLE
fix: Fix `ObservabilityGuard` hanging up on drop

### DIFF
--- a/core/lib/vlog/src/lib.rs
+++ b/core/lib/vlog/src/lib.rs
@@ -1,7 +1,7 @@
 //! This crate contains the observability subsystem.
 //! It is responsible for providing a centralized interface for consistent observability configuration.
 
-use std::time::Duration;
+use std::{fmt, sync::mpsc, thread, time::Duration};
 
 use ::sentry::ClientInitGuard;
 use anyhow::Context as _;
@@ -13,6 +13,29 @@ pub mod logs;
 pub mod opentelemetry;
 pub mod prometheus;
 pub mod sentry;
+
+/// Internal trait used in `ObservabilityGuard::with_timeout()` to inspect action results.
+trait InspectResults {
+    fn inspect_results(&self, action_name: &str);
+}
+
+impl<E: fmt::Debug> InspectResults for Result<(), E> {
+    fn inspect_results(&self, action_name: &str) {
+        if let Err(err) = self {
+            tracing::warn!("Failed {action_name}: {err:?}");
+        }
+    }
+}
+
+impl<E: fmt::Debug> InspectResults for Vec<Result<(), E>> {
+    fn inspect_results(&self, action_name: &str) {
+        for partial_res in self {
+            if let Err(err) = partial_res {
+                tracing::warn!("Failed {action_name}: {err:?}");
+            }
+        }
+    }
+}
 
 /// Builder for the observability subsystem.
 /// Currently capable of configuring logging output and sentry integration.
@@ -35,9 +58,8 @@ pub struct ObservabilityGuard {
 }
 
 impl ObservabilityGuard {
-    /// Forces flushing of pending events.
-    /// This method is blocking.
-    pub fn force_flush(&self) {
+    /// Forces flushing of pending events. This method is blocking.
+    fn force_flush(&mut self) {
         // We don't want to wait for too long.
         const FLUSH_TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -46,22 +68,55 @@ impl ObservabilityGuard {
             tracing::info!("Sentry events are flushed");
         }
 
-        if let Some(provider) = &self.otlp_tracing_provider {
-            for result in provider.force_flush() {
-                if let Err(err) = result {
-                    tracing::warn!("Flushing the spans failed: {err:?}");
-                }
-            }
-            tracing::info!("Spans are flushed");
-        }
+        Self::with_timeout(
+            FLUSH_TIMEOUT,
+            "flushing tracing spans",
+            &mut self.otlp_tracing_provider,
+            opentelemetry_sdk::trace::TracerProvider::force_flush,
+        );
+        Self::with_timeout(
+            FLUSH_TIMEOUT,
+            "flushing tracing logs",
+            &mut self.otlp_logging_provider,
+            opentelemetry_sdk::logs::LoggerProvider::force_flush,
+        );
+    }
 
-        if let Some(provider) = &self.otlp_logging_provider {
-            for result in provider.force_flush() {
-                if let Err(err) = result {
-                    tracing::warn!("Flushing the logs failed: {err:?}");
+    /// Performs an action on the OpenTelemetry provider. If the action times out, the provider is lost, but the control flow proceeds
+    /// (= a node doesn't hang up during shutdown).
+    ///
+    /// Motivated by OpenTelemetry providers hanging up indefinitely on flushing / shutdown if the configured telemetry URL is unreachable.
+    fn with_timeout<T, R>(
+        timeout: Duration,
+        action_name: &'static str,
+        maybe_provider: &mut Option<T>,
+        action: fn(&T) -> R,
+    ) where
+        T: Send + 'static,
+        R: InspectResults + Send + 'static,
+    {
+        if let Some(provider) = maybe_provider.take() {
+            let (result_sender, result_receiver) = mpsc::sync_channel(1);
+            let join_handle = thread::spawn(move || {
+                result_sender.send((action(&provider), provider)).ok();
+            });
+            match result_receiver.recv_timeout(timeout) {
+                Ok((results, provider)) => {
+                    tracing::info!("Completed {action_name}");
+                    *maybe_provider = Some(provider);
+                    results.inspect_results(action_name);
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    if join_handle.join().is_err() {
+                        tracing::error!("Panicked while {action_name}");
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    tracing::warn!(?timeout, "Timed out {action_name}");
                 }
             }
-            tracing::info!("Logs are flushed");
+        } else {
+            tracing::debug!("Skipped {action_name}: no provider present");
         }
     }
 
@@ -76,20 +131,19 @@ impl ObservabilityGuard {
             sentry_guard.close(Some(SHUTDOWN_TIMEOUT));
             tracing::info!("Sentry client is shut down");
         }
-        if let Some(provider) = self.otlp_tracing_provider.take() {
-            if let Err(err) = provider.shutdown() {
-                tracing::warn!("Shutting down the OTLP tracing provider failed: {err:?}");
-            } else {
-                tracing::info!("OTLP tracing provider is shut down");
-            }
-        }
-        if let Some(provider) = self.otlp_logging_provider.take() {
-            if let Err(err) = provider.shutdown() {
-                tracing::warn!("Shutting down the OTLP logs provider failed: {err:?}");
-            } else {
-                tracing::info!("OTLP logs provider is shut down");
-            }
-        }
+
+        Self::with_timeout(
+            SHUTDOWN_TIMEOUT,
+            "shutting down OTLP tracing provider",
+            &mut self.otlp_tracing_provider,
+            opentelemetry_sdk::trace::TracerProvider::shutdown,
+        );
+        Self::with_timeout(
+            SHUTDOWN_TIMEOUT,
+            "shutting down OTLP logging provider",
+            &mut self.otlp_logging_provider,
+            opentelemetry_sdk::logs::LoggerProvider::shutdown,
+        );
     }
 }
 
@@ -168,5 +222,32 @@ impl ObservabilityBuilder {
     /// Initializes the observability subsystem.
     pub fn build(self) -> ObservabilityGuard {
         self.try_build().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use super::*;
+    use crate::opentelemetry::OpenTelemetryLevel;
+
+    #[tokio::test]
+    async fn otlp_provider_does_not_hang_up_on_shutdown() {
+        let bogus_url = "http://non-existing-address-leading-to-otlp-flushing-hanging-up"
+            .parse::<Url>()
+            .unwrap();
+        let _guard = ObservabilityBuilder::new()
+            .with_opentelemetry(Some(OpenTelemetry {
+                opentelemetry_level: OpenTelemetryLevel::TRACE,
+                tracing_endpoint: Some(bogus_url.clone()),
+                logging_endpoint: Some(bogus_url),
+                service: Default::default(),
+            }))
+            .try_build()
+            .ok();
+        tracing::info_span!("test").in_scope(|| {
+            tracing::info!("This is a log");
+        });
     }
 }


### PR DESCRIPTION
## What ❔

Adds timeouts for flushing / shutdown of OTel providers in `ObservabilityGuard`.

## Why ❔

If the telemetry URL is unreachable, OTel providers will hang up indefinitely during `ObservabilityGuard` drop, meaning that a process using the guard (e.g., a node) will not shut down.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.