### PR TITLE
fix(en): Fix state keeper cache recovery with pruning enabled

### DIFF
--- a/core/lib/state/src/rocksdb/mod.rs
+++ b/core/lib/state/src/rocksdb/mod.rs
@@ -410,7 +410,10 @@ impl RocksdbStorage {
                 .await
                 .with_context(|| format!("failed saving L1 batch #{current_l1_batch_number}"))?;
             #[cfg(test)]
-            (self.listener.on_l1_batch_synced.write().await)(current_l1_batch_number - 1);
+            self.listener
+                .on_l1_batch_synced
+                .handle(current_l1_batch_number - 1)
+                .await;
         }
 
         latency.observe();

--- a/core/lib/state/src/rocksdb/mod.rs
+++ b/core/lib/state/src/rocksdb/mod.rs
@@ -48,9 +48,13 @@ fn serialize_l1_batch_number(block_number: u32) -> [u8; 4] {
     block_number.to_le_bytes()
 }
 
+fn try_deserialize_l1_batch_number(bytes: &[u8]) -> anyhow::Result<u32> {
+    let bytes: [u8; 4] = bytes.try_into().context("incorrect block number format")?;
+    Ok(u32::from_le_bytes(bytes))
+}
+
 fn deserialize_l1_batch_number(bytes: &[u8]) -> u32 {
-    let bytes: [u8; 4] = bytes.try_into().expect("incorrect block number format");
-    u32::from_le_bytes(bytes)
+    try_deserialize_l1_batch_number(bytes).unwrap()
 }
 
 /// RocksDB column families used by the state keeper.
@@ -287,19 +291,14 @@ impl From<RocksDB<StateKeeperColumnFamily>> for RocksdbStorage {
 }
 
 impl RocksdbStorage {
+    // Named for backward compatibility
     const L1_BATCH_NUMBER_KEY: &'static [u8] = b"block_number";
-    #[allow(dead_code)]
-    const ENUM_INDEX_MIGRATION_CURSOR: &'static [u8] = b"enum_index_migration_cursor";
+    const RECOVERY_L1_BATCH_NUMBER_KEY: &'static [u8] = b"recovery_l1_batch";
 
     /// Desired size of log chunks loaded from Postgres during snapshot recovery.
     /// This is intentionally not configurable because chunks must be the same for the entire recovery
     /// (i.e., not changed after a node restart).
     const DESIRED_LOG_CHUNK_SIZE: u64 = 200_000;
-
-    #[allow(dead_code)]
-    fn is_special_key(key: &[u8]) -> bool {
-        key == Self::L1_BATCH_NUMBER_KEY || key == Self::ENUM_INDEX_MIGRATION_CURSOR
-    }
 
     /// Creates a new storage builder with the provided RocksDB `path`.
     ///
@@ -595,7 +594,10 @@ impl RocksdbStorage {
                     Self::L1_BATCH_NUMBER_KEY,
                     &serialize_l1_batch_number(l1_batch_number.0),
                 );
+                // Having an L1 batch number means that recovery is complete.
+                batch.delete_cf(cf, Self::RECOVERY_L1_BATCH_NUMBER_KEY);
             }
+
             for (key, (value, enum_index)) in pending_patch.state {
                 batch.put_cf(
                     cf,
@@ -630,6 +632,41 @@ impl RocksdbStorage {
                 .expect("failed getting L1 batch number from RocksDB")
                 .expect("failed getting L1 batch number from RocksDB");
         number_bytes.map(|bytes| L1BatchNumber(deserialize_l1_batch_number(&bytes)))
+    }
+
+    async fn recovery_l1_batch_number(&self) -> anyhow::Result<Option<L1BatchNumber>> {
+        let cf = StateKeeperColumnFamily::State;
+        let db = self.db.clone();
+        let number_bytes =
+            tokio::task::spawn_blocking(move || db.get_cf(cf, Self::RECOVERY_L1_BATCH_NUMBER_KEY))
+                .await
+                .context("panicked getting L1 batch number from RocksDB")?
+                .context("failed getting L1 batch number from RocksDB")?;
+        number_bytes
+            .map(|bytes| try_deserialize_l1_batch_number(&bytes).map(L1BatchNumber))
+            .transpose()
+    }
+
+    async fn set_recovery_l1_batch_number(
+        &self,
+        batch_number: L1BatchNumber,
+    ) -> anyhow::Result<()> {
+        let db = self.db.clone();
+        let save_task = tokio::task::spawn_blocking(move || {
+            let mut batch = db.new_write_batch();
+            let cf = StateKeeperColumnFamily::State;
+
+            batch.put_cf(
+                cf,
+                Self::RECOVERY_L1_BATCH_NUMBER_KEY,
+                &serialize_l1_batch_number(batch_number.0),
+            );
+            db.write(batch)
+                .context("failed to save state data into RocksDB")
+        });
+        save_task
+            .await
+            .context("panicked when saving recovery L1 batch number into RocksDB")?
     }
 
     fn serialize_state_key(key: H256) -> [u8; 32] {

--- a/core/lib/state/src/rocksdb/recovery.rs
+++ b/core/lib/state/src/rocksdb/recovery.rs
@@ -51,6 +51,11 @@ impl InitParameters {
             .get_applied_snapshot_status()
             .await?;
         let pruning_info = storage.pruning_dal().get_pruning_info().await?;
+        tracing::debug!(
+            ?recovery_status,
+            ?pruning_info,
+            "Fetched snapshot / pruning info"
+        );
 
         let (l1_batch, l2_block) = match (recovery_status, pruning_info.last_hard_pruned) {
             (Some(recovery), None) => {

--- a/core/lib/state/src/rocksdb/recovery.rs
+++ b/core/lib/state/src/rocksdb/recovery.rs
@@ -223,7 +223,7 @@ impl RocksdbStorage {
                     })?;
 
                 #[cfg(test)]
-                (self.listener.on_logs_chunk_recovered.write().await)(chunk_id);
+                self.listener.on_logs_chunk_recovered.handle(chunk_id).await;
             }
             RECOVERY_METRICS.recovered_chunk_count.inc_by(1);
         }

--- a/core/lib/state/src/rocksdb/recovery.rs
+++ b/core/lib/state/src/rocksdb/recovery.rs
@@ -56,7 +56,6 @@ impl InitParameters {
             ?pruning_info,
             "Fetched snapshot / pruning info"
         );
-        dbg!(&pruning_info, &recovery_status);
 
         let (l1_batch, l2_block) = match (recovery_status, pruning_info.last_hard_pruned) {
             (Some(recovery), None) => {
@@ -135,7 +134,6 @@ impl RocksdbStorage {
 
         let init_params = InitParameters::new(storage, desired_log_chunk_size).await?;
         if let Some(recovery_batch_number) = self.recovery_l1_batch_number().await? {
-            dbg!(recovery_batch_number);
             tracing::info!(?recovery_batch_number, "Resuming storage recovery");
             let init_params = init_params.as_ref().context(
                 "Storage is recovering, but Postgres no longer contains necessary metadata",

--- a/core/lib/state/src/test_utils.rs
+++ b/core/lib/state/src/test_utils.rs
@@ -117,15 +117,8 @@ pub(crate) async fn create_l1_batch(
         .unwrap();
 }
 
-pub(crate) async fn prepare_postgres_for_snapshot_recovery(
-    conn: &mut Connection<'_, Core>,
-) -> (SnapshotRecoveryStatus, Vec<StorageLog>) {
-    conn.protocol_versions_dal()
-        .save_protocol_version_with_tx(&ProtocolVersion::default())
-        .await
-        .unwrap();
-
-    let snapshot_recovery = SnapshotRecoveryStatus {
+pub(crate) fn mock_snapshot_recovery_status() -> SnapshotRecoveryStatus {
+    SnapshotRecoveryStatus {
         l1_batch_number: L1BatchNumber(23),
         l1_batch_timestamp: 23,
         l1_batch_root_hash: H256::zero(), // not used
@@ -134,7 +127,18 @@ pub(crate) async fn prepare_postgres_for_snapshot_recovery(
         l2_block_hash: H256::zero(), // not used
         protocol_version: ProtocolVersionId::latest(),
         storage_logs_chunks_processed: vec![true; 100],
-    };
+    }
+}
+
+pub(crate) async fn prepare_postgres_for_snapshot_recovery(
+    conn: &mut Connection<'_, Core>,
+) -> (SnapshotRecoveryStatus, Vec<StorageLog>) {
+    conn.protocol_versions_dal()
+        .save_protocol_version_with_tx(&ProtocolVersion::default())
+        .await
+        .unwrap();
+
+    let snapshot_recovery = mock_snapshot_recovery_status();
     conn.snapshot_recovery_dal()
         .insert_initial_recovery_status(&snapshot_recovery)
         .await


### PR DESCRIPTION
## What ❔

Takes pruning info into account when initiating state keeper cache recovery.

## Why ❔

Just like the Merkle tree previously, SK cache recovery won't work properly if state pruning has occurred (whether on top of genesis, or on top of a snapshot).

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.