### PR TITLE
chore(nix): update dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,13 +76,14 @@
             ];
 
             buildInputs = with pkgs;[
-              libclang.dev
-              openssl.dev
-              snappy.dev
-              lz4.dev
-              bzip2.dev
+              libclang
+              openssl
+              snappy
+              lz4
+              bzip2
+              snappy
               rocksdb_8_3
-              snappy.dev
+              postgresql
             ];
 
             src = with pkgs.lib.fileset; let root = ./core/.; in toSource {


### PR DESCRIPTION
## What ❔

- Added missing runtime dependencies (e.g., libclang, openssl, lz4, bzip2, postgresql) to `flake.nix`.

## Why ❔

better development shell with nix

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
