### PR TITLE
Add a DB index to factory_deps table

### DIFF
--- a/core/lib/dal/migrations/20250417173440_add-factory-deps-miniblock-index.down.sql
+++ b/core/lib/dal/migrations/20250417173440_add-factory-deps-miniblock-index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_factory_deps_miniblock_number;

--- a/core/lib/dal/migrations/20250417173440_add-factory-deps-miniblock-index.up.sql
+++ b/core/lib/dal/migrations/20250417173440_add-factory-deps-miniblock-index.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_factory_deps_miniblock_number
+    ON factory_deps (miniblock_number)


### PR DESCRIPTION
## What ❔

Index in `factory_deps` table on miniblock_number column
## Why ❔

Improve query performance