### PR TITLE
fix(mempool): keep nonces in memory for stashed accounts

### DIFF
--- a/core/lib/mempool/src/types.rs
+++ b/core/lib/mempool/src/types.rs
@@ -83,6 +83,14 @@ impl AccountTransactions {
         self.transactions.len()
     }
 
+    pub fn nonce(&self) -> Nonce {
+        self.nonce
+    }
+
+    pub fn clear_txs(&mut self) {
+        self.transactions.clear();
+    }
+
     fn score_for_transaction(transaction: &L2Tx) -> MempoolScore {
         MempoolScore {
             account: transaction.initiator_account(),


### PR DESCRIPTION
## What ❔

Mempool should keep nonces for stashed accounts.

## Why ❔

MempoolStore keeps track of nonces. It gets account nonce from mempool actor when it inserts first tx for the particular account. Previously `MempoolStore` dropped info about nonce for stashed account so it was reloaded when mempool actor inserts next tx for the stashed account. Mempool actor gets nonces from storage which doesn't take pending block into account. So if there is a tx from stashed account in pending block then incorrect nonce will be loaded which will effectively "freeze" the account until the next node restart.
The easiest way to fix it is to keep nonce for stashed accounts. This way mempool will load nonces from storage only for "new" accounts i.e. there won't be any tx in pending block for such accounts.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
