### PR TITLE
feat(prover): Add support of H100 into provers and gpu-checker

### DIFF
--- a/.github/workflows/build-prover-template.yml
+++ b/.github/workflows/build-prover-template.yml
@@ -30,12 +30,13 @@ on:
       CUDA_ARCH:
         description: "CUDA Arch to build"
         type: string
-        default: "75;80;89"
+        default: "75;80;89;90"
         required: false
         # Details: https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
         # L4: 89
         # T4: 75
         # A100: 80
+        # H100: 90
     outputs:
       protocol_version:
         description: "Protocol version of the binary"

--- a/docker/gpu-checker/Dockerfile
+++ b/docker/gpu-checker/Dockerfile
@@ -1,11 +1,12 @@
-ARG CIRCUIT_FILE="10330_48_1_BasicCircuits_0"
+ARG CIRCUIT_FILE="1286_48_1_BasicCircuits_0"
 
 FROM nvidia/cuda:12.4.0-devel-ubuntu22.04 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 ARG CIRCUIT_FILE
-ARG CUDA_ARCH="75;80;89"
+# https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
+ARG CUDA_ARCH="75;80;89;90"
 ENV CUDAARCHS=${CUDA_ARCH}
 
 # set of args for use of sccache

--- a/prover/crates/bin/gpu_checker/README.md
+++ b/prover/crates/bin/gpu_checker/README.md
@@ -33,8 +33,8 @@ Find circuit file from a recent prover batch like `10330_48_1_BasicCircuits_0.bi
 it into `prover/`.
 
 ```bash
-docker build -t us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/gpu_checker:v0.2.0 -f docker/gpu-checker/Dockerfile --progress=plain . 2>&1 | tee build.log
-docker push us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/gpu_checker:v0.2.0
+docker build -t us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/gpu_checker:v0.3.0 -f docker/gpu-checker/Dockerfile --progress=plain . 2>&1 | tee build.log
+docker push us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/gpu_checker:v0.3.0
 ```
 
 ## Run gpu-checker

--- a/prover/crates/bin/gpu_checker/gpu_checker.yaml
+++ b/prover/crates/bin/gpu_checker/gpu_checker.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: gpu-checker
-      image: us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/gpu_checker:v0.1.0
+      image: us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/gpu_checker:v0.3.0
       imagePullPolicy: IfNotPresent
       resources:
         limits:

--- a/prover/crates/bin/prover_autoscaler/src/key.rs
+++ b/prover/crates/bin/prover_autoscaler/src/key.rs
@@ -28,6 +28,8 @@ pub enum Gpu {
     #[strum(ascii_case_insensitive)]
     L4,
     #[strum(ascii_case_insensitive)]
+    H100,
+    #[strum(ascii_case_insensitive)]
     T4,
     #[strum(ascii_case_insensitive)]
     V100,


### PR DESCRIPTION
## What ❔

Add support of H100 into provers and gpu-checker.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To allow usage of H100.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
