### PR TITLE
fix: prover gateway failing to decode response body

### DIFF
--- a/core/node/proof_data_handler/src/lib.rs
+++ b/core/node/proof_data_handler/src/lib.rs
@@ -10,7 +10,7 @@ use zksync_dal::{ConnectionPool, Core};
 use zksync_object_store::ObjectStore;
 use zksync_prover_interface::api::{
     ProofGenerationDataRequest, ProofGenerationDataResponse, RegisterTeeAttestationRequest,
-    SubmitProofRequest, SubmitTeeProofRequest, TeeProofGenerationDataRequest,
+    SubmitProofRequest, SubmitProofResponse, SubmitTeeProofRequest, TeeProofGenerationDataRequest,
 };
 use zksync_types::{commitment::L1BatchCommitmentMode, L1BatchNumber, L2ChainId};
 
@@ -98,9 +98,15 @@ fn create_proof_processing_router(
                 move |l1_batch_number: Path<u32>, payload: Json<SubmitProofRequest>| async move {
                     let l1_batch_number = L1BatchNumber(l1_batch_number.0);
                     let Json(SubmitProofRequest::Proof(proof)) = payload;
-                    submit_proof_processor
+                    match submit_proof_processor
                         .save_proof(l1_batch_number, (*proof).into())
                         .await
+                    {
+                        Ok(_) => {
+                            (StatusCode::OK, Json(SubmitProofResponse::Success)).into_response()
+                        }
+                        Err(e) => e.into_response(),
+                    }
                 },
             ),
         );


### PR DESCRIPTION
## What ❔

Fix of gateway fail to decode response body. Data handler submits different response to received proof than gateway receives, so gateway tries to push the same proof forward.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
