### PR TITLE
feat(eth-sender): set `from_addr` for non-blob txs

### DIFF
--- a/core/lib/dal/.sqlx/query-14a1e9bf60809d904c26a757d672d52328dd3aaedf057bf33aa5ff5cf3f36c75.json
+++ b/core/lib/dal/.sqlx/query-14a1e9bf60809d904c26a757d672d52328dd3aaedf057bf33aa5ff5cf3f36c75.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                *\n            FROM\n                eth_txs\n            WHERE\n                from_addr IS NOT DISTINCT FROM $2 -- can't just use equality as NULL != NULL\n                AND is_gateway = $3\n                AND id > COALESCE(\n                    (SELECT\n                        eth_tx_id\n                    FROM\n                        eth_txs_history\n                    JOIN eth_txs ON eth_txs.id = eth_txs_history.eth_tx_id\n                    WHERE\n                        eth_txs_history.sent_at_block IS NOT NULL\n                        AND eth_txs.from_addr IS NOT DISTINCT FROM $2\n                        AND is_gateway = $3\n                        AND sent_successfully = TRUE\n                    ORDER BY eth_tx_id DESC LIMIT 1),\n                    0\n                )\n            ORDER BY\n                id\n            LIMIT\n                $1\n            ",
+  "query": "\n            SELECT\n                *\n            FROM\n                eth_txs\n            WHERE\n                (\n                    from_addr = $1\n                    OR\n                    (from_addr IS NULL AND $2)\n                )\n                AND confirmed_eth_tx_history_id IS NULL\n                AND is_gateway = $3\n                AND id <= COALESCE(\n                    (SELECT\n                        eth_tx_id\n                    FROM\n                        eth_txs_history\n                    JOIN eth_txs ON eth_txs.id = eth_txs_history.eth_tx_id\n                    WHERE\n                        eth_txs_history.sent_at_block IS NOT NULL\n                        AND (\n                            from_addr = $1\n                            OR\n                            (from_addr IS NULL AND $2)\n                        )\n                        AND is_gateway = $3\n                    ORDER BY eth_tx_id DESC LIMIT 1),\n                    0\n                )\n            ORDER BY\n                id\n            ",
   "describe": {
     "columns": [
       {
@@ -86,8 +86,8 @@
     ],
     "parameters": {
       "Left": [
-        "Int8",
         "Bytea",
+        "Bool",
         "Bool"
       ]
     },
@@ -110,5 +110,5 @@
       true
     ]
   },
-  "hash": "55d807cafe778ec9ea4ef8f49b02752faca0ead95ff177e266447486bb161f93"
+  "hash": "14a1e9bf60809d904c26a757d672d52328dd3aaedf057bf33aa5ff5cf3f36c75"
 }

--- a/core/lib/dal/.sqlx/query-3e2fd6f945c2365388694b338fc36d05708fb879aeb2bba31887b7a9cdf5d465.json
+++ b/core/lib/dal/.sqlx/query-3e2fd6f945c2365388694b338fc36d05708fb879aeb2bba31887b7a9cdf5d465.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                *\n            FROM\n                eth_txs\n            WHERE\n                from_addr IS NOT DISTINCT FROM $1 -- can't just use equality as NULL != NULL\n                AND confirmed_eth_tx_history_id IS NULL\n                AND is_gateway = $2\n                AND id <= COALESCE(\n                    (SELECT\n                        eth_tx_id\n                    FROM\n                        eth_txs_history\n                    JOIN eth_txs ON eth_txs.id = eth_txs_history.eth_tx_id\n                    WHERE\n                        eth_txs_history.sent_at_block IS NOT NULL\n                        AND eth_txs.from_addr IS NOT DISTINCT FROM $1\n                        AND is_gateway = $2\n                    ORDER BY eth_tx_id DESC LIMIT 1),\n                    0\n                )\n            ORDER BY\n                id\n            ",
+  "query": "\n            SELECT\n                *\n            FROM\n                eth_txs\n            WHERE\n                (\n                    from_addr = $2\n                    OR\n                    (from_addr IS NULL AND $3)\n                )\n                AND is_gateway = $4\n                AND id > COALESCE(\n                    (SELECT\n                        eth_tx_id\n                    FROM\n                        eth_txs_history\n                    JOIN eth_txs ON eth_txs.id = eth_txs_history.eth_tx_id\n                    WHERE\n                        eth_txs_history.sent_at_block IS NOT NULL\n                        AND (\n                            from_addr = $2\n                            OR\n                            (from_addr IS NULL AND $3)\n                        )\n                        AND is_gateway = $4\n                        AND sent_successfully = TRUE\n                    ORDER BY eth_tx_id DESC LIMIT 1),\n                    0\n                )\n            ORDER BY\n                id\n            LIMIT\n                $1\n            ",
   "describe": {
     "columns": [
       {
@@ -86,7 +86,9 @@
     ],
     "parameters": {
       "Left": [
+        "Int8",
         "Bytea",
+        "Bool",
         "Bool"
       ]
     },
@@ -109,5 +111,5 @@
       true
     ]
   },
-  "hash": "a8cc4da6200478a72a1b490d302b8a0949212bf66c602024aaa9843b4c66f965"
+  "hash": "3e2fd6f945c2365388694b338fc36d05708fb879aeb2bba31887b7a9cdf5d465"
 }

--- a/core/lib/dal/src/eth_sender_dal.rs
+++ b/core/lib/dal/src/eth_sender_dal.rs
@@ -26,7 +26,7 @@ impl EthSenderDal<'_, '_> {
     pub async fn get_inflight_txs(
         &mut self,
         operator_address: Address,
-        consider_null_operator_address: bool,
+        consider_null_operator_address: bool, // TODO (PLA-1118): remove this parameter
         is_gateway: bool,
     ) -> sqlx::Result<Vec<EthTx>> {
         let txs = sqlx::query_as!(
@@ -209,7 +209,7 @@ impl EthSenderDal<'_, '_> {
         &mut self,
         limit: u64,
         operator_address: Address,
-        consider_null_operator_address: bool,
+        consider_null_operator_address: bool, // TODO (PLA-1118): remove this parameter
         is_gateway: bool,
     ) -> sqlx::Result<Vec<EthTx>> {
         let txs = sqlx::query_as!(

--- a/core/lib/dal/src/eth_sender_dal.rs
+++ b/core/lib/dal/src/eth_sender_dal.rs
@@ -25,7 +25,8 @@ pub struct EthSenderDal<'a, 'c> {
 impl EthSenderDal<'_, '_> {
     pub async fn get_inflight_txs(
         &mut self,
-        operator_address: Option<Address>,
+        operator_address: Address,
+        consider_null_operator_address: bool,
         is_gateway: bool,
     ) -> sqlx::Result<Vec<EthTx>> {
         let txs = sqlx::query_as!(
@@ -36,9 +37,13 @@ impl EthSenderDal<'_, '_> {
             FROM
                 eth_txs
             WHERE
-                from_addr IS NOT DISTINCT FROM $1 -- can't just use equality as NULL != NULL
+                (
+                    from_addr = $1
+                    OR
+                    (from_addr IS NULL AND $2)
+                )
                 AND confirmed_eth_tx_history_id IS NULL
-                AND is_gateway = $2
+                AND is_gateway = $3
                 AND id <= COALESCE(
                     (SELECT
                         eth_tx_id
@@ -47,16 +52,21 @@ impl EthSenderDal<'_, '_> {
                     JOIN eth_txs ON eth_txs.id = eth_txs_history.eth_tx_id
                     WHERE
                         eth_txs_history.sent_at_block IS NOT NULL
-                        AND eth_txs.from_addr IS NOT DISTINCT FROM $1
-                        AND is_gateway = $2
+                        AND (
+                            from_addr = $1
+                            OR
+                            (from_addr IS NULL AND $2)
+                        )
+                        AND is_gateway = $3
                     ORDER BY eth_tx_id DESC LIMIT 1),
                     0
                 )
             ORDER BY
                 id
             "#,
-            operator_address.as_ref().map(|h160| h160.as_bytes()),
-            is_gateway
+            operator_address.as_bytes(),
+            consider_null_operator_address,
+            is_gateway,
         )
         .fetch_all(self.storage.conn())
         .await?;
@@ -198,7 +208,8 @@ impl EthSenderDal<'_, '_> {
     pub async fn get_new_eth_txs(
         &mut self,
         limit: u64,
-        operator_address: &Option<Address>,
+        operator_address: Address,
+        consider_null_operator_address: bool,
         is_gateway: bool,
     ) -> sqlx::Result<Vec<EthTx>> {
         let txs = sqlx::query_as!(
@@ -209,8 +220,12 @@ impl EthSenderDal<'_, '_> {
             FROM
                 eth_txs
             WHERE
-                from_addr IS NOT DISTINCT FROM $2 -- can't just use equality as NULL != NULL
-                AND is_gateway = $3
+                (
+                    from_addr = $2
+                    OR
+                    (from_addr IS NULL AND $3)
+                )
+                AND is_gateway = $4
                 AND id > COALESCE(
                     (SELECT
                         eth_tx_id
@@ -219,8 +234,12 @@ impl EthSenderDal<'_, '_> {
                     JOIN eth_txs ON eth_txs.id = eth_txs_history.eth_tx_id
                     WHERE
                         eth_txs_history.sent_at_block IS NOT NULL
-                        AND eth_txs.from_addr IS NOT DISTINCT FROM $2
-                        AND is_gateway = $3
+                        AND (
+                            from_addr = $2
+                            OR
+                            (from_addr IS NULL AND $3)
+                        )
+                        AND is_gateway = $4
                         AND sent_successfully = TRUE
                     ORDER BY eth_tx_id DESC LIMIT 1),
                     0
@@ -231,7 +250,8 @@ impl EthSenderDal<'_, '_> {
                 $1
             "#,
             limit as i64,
-            operator_address.as_ref().map(|h160| h160.as_bytes()),
+            operator_address.as_bytes(),
+            consider_null_operator_address,
             is_gateway
         )
         .fetch_all(self.storage.conn())

--- a/core/node/eth_sender/src/aggregator.rs
+++ b/core/node/eth_sender/src/aggregator.rs
@@ -16,7 +16,7 @@ use zksync_types::{
     protocol_version::{L1VerifierConfig, ProtocolSemanticVersion},
     pubdata_da::PubdataSendingMode,
     settlement::SettlementLayer,
-    Address, L1BatchNumber, ProtocolVersionId,
+    L1BatchNumber, ProtocolVersionId,
 };
 
 use super::{
@@ -106,13 +106,12 @@ impl Aggregator {
     pub async fn new(
         config: SenderConfig,
         blob_store: Arc<dyn ObjectStore>,
-        custom_commit_sender_addr: Option<Address>,
+        custom_commit_sender_addr: bool,
         commitment_mode: L1BatchCommitmentMode,
         pool: ConnectionPool<Core>,
         settlement_layer: SettlementLayer,
     ) -> anyhow::Result<Self> {
-        let operate_4844_mode: bool =
-            custom_commit_sender_addr.is_some() && !settlement_layer.is_gateway();
+        let operate_4844_mode: bool = custom_commit_sender_addr && !settlement_layer.is_gateway();
 
         // We do not have a reliable lower bound for gas needed to execute batches on gateway so we do not aggregate.
         let execute_criteria: Vec<Box<dyn L1BatchPublishCriterion>> = if settlement_layer

--- a/core/node/eth_sender/src/eth_tx_aggregator.rs
+++ b/core/node/eth_sender/src/eth_tx_aggregator.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use tokio::sync::watch;
 use zksync_config::configs::eth_sender::SenderConfig;
 use zksync_contracts::BaseSystemContractsHashes;
@@ -23,7 +25,7 @@ use zksync_types::{
     pubdata_da::PubdataSendingMode,
     server_notification::GatewayMigrationState,
     settlement::SettlementLayer,
-    web3::{contract::Error as Web3ContractError, BlockNumber, CallRequest},
+    web3::{contract::Error as Web3ContractError, CallRequest},
     Address, L2ChainId, ProtocolVersionId, SLChainId, H256, U256,
 };
 
@@ -66,19 +68,17 @@ pub struct EthTxAggregator {
     pub(super) state_transition_chain_contract: Address,
     state_transition_manager_address: Address,
     functions: ZkSyncFunctions,
-    base_nonce: u64,
-    base_nonce_custom_commit_sender: Option<u64>,
     rollup_chain_id: L2ChainId,
     /// If set to `Some` node is operating in the 4844 mode with two operator
     /// addresses at play: the main one and the custom address for sending commit
-    /// transactions. The `Some` then contains the address of this custom operator
-    /// address.
-    custom_commit_sender_addr: Option<Address>,
+    /// transactions. The `Some` then contains client for this custom operator address.
+    eth_client_blobs: Option<Box<dyn BoundEthInterface>>,
     pool: ConnectionPool<Core>,
     sl_chain_id: SLChainId,
     health_updater: HealthUpdater,
     priority_tree_start_index: Option<usize>,
     settlement_layer: SettlementLayer,
+    initial_pending_nonces: HashMap<Address, u64>,
 }
 
 struct TxData {
@@ -95,29 +95,26 @@ impl EthTxAggregator {
         config: SenderConfig,
         aggregator: Aggregator,
         eth_client: Box<dyn BoundEthInterface>,
+        eth_client_blobs: Option<Box<dyn BoundEthInterface>>,
         config_timelock_contract_address: Address,
         state_transition_manager_address: Address,
         l1_multicall3_address: Address,
         state_transition_chain_contract: Address,
         rollup_chain_id: L2ChainId,
-        custom_commit_sender_addr: Option<Address>,
         settlement_layer: SettlementLayer,
     ) -> Self {
         let eth_client = eth_client.for_component("eth_tx_aggregator");
-        let functions = ZkSyncFunctions::default();
-        let base_nonce = eth_client.pending_nonce().await.unwrap().as_u64();
+        let eth_client_blobs = eth_client_blobs.map(|c| c.for_component("eth_tx_aggregator"));
 
-        let base_nonce_custom_commit_sender = match custom_commit_sender_addr {
-            Some(addr) => Some(
-                (*eth_client)
-                    .as_ref()
-                    .nonce_at_for_account(addr, BlockNumber::Pending)
-                    .await
-                    .unwrap()
-                    .as_u64(),
-            ),
-            None => None,
-        };
+        let functions = ZkSyncFunctions::default();
+
+        let mut initial_pending_nonces = HashMap::new();
+        for client in eth_client_blobs.iter().chain(std::iter::once(&eth_client)) {
+            let address = client.sender_account();
+            let nonce = client.pending_nonce().await.unwrap().as_u64();
+
+            initial_pending_nonces.insert(address, nonce);
+        }
 
         let sl_chain_id = (*eth_client).as_ref().fetch_chain_id().await.unwrap();
 
@@ -130,15 +127,14 @@ impl EthTxAggregator {
             l1_multicall3_address,
             state_transition_chain_contract,
             functions,
-            base_nonce,
-            base_nonce_custom_commit_sender,
             rollup_chain_id,
-            custom_commit_sender_addr,
+            eth_client_blobs,
             pool,
             sl_chain_id,
             health_updater: ReactiveHealthCheck::new("eth_tx_aggregator").1,
             priority_tree_start_index: None,
             settlement_layer,
+            initial_pending_nonces,
         }
     }
 
@@ -784,8 +780,12 @@ impl EthTxAggregator {
         // var whatever it actually is: a `None` for single-addr operator or `Some`
         // for multi-addr operator in 4844 mode.
         let sender_addr = match (op_type, is_gateway) {
-            (AggregatedActionType::Commit, false) => self.custom_commit_sender_addr,
-            (_, _) => None,
+            (AggregatedActionType::Commit, false) => self
+                .eth_client_blobs
+                .as_ref()
+                .map(|c| c.sender_account())
+                .unwrap_or_else(|| self.eth_client.sender_account()),
+            (_, _) => self.eth_client.sender_account(),
         };
         let nonce = self.get_next_nonce(&mut transaction, sender_addr).await?;
         let encoded_aggregated_op =
@@ -818,7 +818,7 @@ impl EthTxAggregator {
                 op_type,
                 timelock_contract_address,
                 Some(eth_tx_predicted_gas),
-                sender_addr,
+                Some(sender_addr),
                 encoded_aggregated_op.sidecar,
                 is_gateway,
             )
@@ -843,23 +843,18 @@ impl EthTxAggregator {
     async fn get_next_nonce(
         &self,
         storage: &mut Connection<'_, Core>,
-        from_addr: Option<Address>,
+        from_addr: Address,
     ) -> Result<u64, EthSenderError> {
         let is_gateway = self.settlement_layer.is_gateway();
         let db_nonce = storage
             .eth_sender_dal()
-            .get_next_nonce(from_addr, is_gateway)
+            .get_next_nonce(Some(from_addr), is_gateway)
             .await
             .unwrap()
             .unwrap_or(0);
         // Between server starts we can execute some txs using operator account or remove some txs from the database
         // At the start we have to consider this fact and get the max nonce.
-        let l1_nonce = if from_addr.is_none() {
-            self.base_nonce
-        } else {
-            self.base_nonce_custom_commit_sender
-                .expect("custom base nonce is expected to be initialized; qed")
-        };
+        let l1_nonce = self.initial_pending_nonces[&from_addr];
         tracing::info!(
             "Next nonce from db: {}, nonce from L1: {} for address: {:?}",
             db_nonce,

--- a/core/node/eth_sender/src/eth_tx_manager.rs
+++ b/core/node/eth_sender/src/eth_tx_manager.rs
@@ -132,6 +132,7 @@ impl EthTxManager {
             .await
             .unwrap();
 
+        let operator_type = self.operator_type(tx);
         let EthFees {
             base_fee_per_gas,
             priority_fee_per_gas,
@@ -140,10 +141,8 @@ impl EthTxManager {
         } = self.fees_oracle.calculate_fees(
             &previous_sent_tx,
             time_in_mempool_in_l1_blocks,
-            self.operator_type(tx),
+            operator_type,
         )?;
-
-        let operator_type = self.operator_type(tx);
 
         let blob_gas_price = if tx.blob_sidecar.is_some() {
             Some(
@@ -345,13 +344,10 @@ impl EthTxManager {
         }
     }
 
-    pub(crate) fn operator_address(&self, operator_type: OperatorType) -> Option<Address> {
-        if operator_type == OperatorType::Blob {
-            self.l1_interface.get_blobs_operator_account()
-        } else {
-            None
-        }
+    pub(crate) fn operator_address(&self, operator_type: OperatorType) -> Address {
+        self.l1_interface.get_operator_account(operator_type)
     }
+
     // Monitors the in-flight transactions, marks mined ones as confirmed,
     // returns the one that has to be resent (if there is one).
     pub(super) async fn monitor_inflight_transactions_single_operator(
@@ -370,6 +366,7 @@ impl EthTxManager {
                 .eth_sender_dal()
                 .get_inflight_txs(
                     self.operator_address(operator_type),
+                    operator_type != OperatorType::Blob,
                     operator_type == OperatorType::Gateway,
                 )
                 .await
@@ -523,10 +520,15 @@ impl EthTxManager {
     fn operator_type(&self, tx: &EthTx) -> OperatorType {
         if tx.is_gateway {
             OperatorType::Gateway
-        } else if tx.from_addr.is_none() {
-            OperatorType::NonBlob
         } else {
-            OperatorType::Blob
+            match tx.from_addr {
+                Some(a) if a == self.operator_address(OperatorType::NonBlob) => {
+                    OperatorType::NonBlob
+                }
+                Some(a) if a == self.operator_address(OperatorType::Blob) => OperatorType::Blob,
+                Some(a) => panic!("Cannot infer operator type for {a:#?}"),
+                None => OperatorType::NonBlob,
+            }
         }
     }
 
@@ -649,6 +651,7 @@ impl EthTxManager {
             .eth_sender_dal()
             .get_inflight_txs(
                 self.operator_address(operator_type),
+                operator_type != OperatorType::Blob,
                 operator_type == OperatorType::Gateway,
             )
             .await
@@ -665,7 +668,8 @@ impl EthTxManager {
                 .eth_sender_dal()
                 .get_new_eth_txs(
                     number_of_available_slots_for_eth_txs,
-                    &self.operator_address(operator_type),
+                    self.operator_address(operator_type),
+                    operator_type != OperatorType::Blob,
                     operator_type == OperatorType::Gateway,
                 )
                 .await

--- a/core/node/eth_sender/src/tester.rs
+++ b/core/node/eth_sender/src/tester.rs
@@ -251,17 +251,13 @@ impl EthSenderTester {
             .get_eth_sender_config_for_sender_layer_data_layer()
             .unwrap();
 
-        let custom_commit_sender_addr =
-            if aggregator_operate_4844_mode && commitment_mode == L1BatchCommitmentMode::Rollup {
-                Some(gateway_blobs.sender_account())
-            } else {
-                None
-            };
+        let use_blob_operator =
+            aggregator_operate_4844_mode && commitment_mode == L1BatchCommitmentMode::Rollup;
 
         let aggregator = Aggregator::new(
             aggregator_config.clone(),
             MockObjectStore::arc(),
-            custom_commit_sender_addr,
+            use_blob_operator,
             commitment_mode,
             connection_pool.clone(),
             SettlementLayer::L1(chain_id),
@@ -279,13 +275,13 @@ impl EthSenderTester {
             // Aggregator - unused
             aggregator,
             gateway.clone(),
+            use_blob_operator.then(|| gateway_blobs.clone() as Box<dyn BoundEthInterface>),
             // ZKsync contract address
             Address::random(),
             STATE_TRANSITION_MANAGER_CONTRACT_ADDRESS,
             contracts_config.l1_multicall3_addr,
             STATE_TRANSITION_CONTRACT_ADDRESS,
             Default::default(),
-            custom_commit_sender_addr,
             SettlementLayer::L1(chain_id),
         )
         .await;
@@ -623,12 +619,14 @@ impl EthSenderTester {
 
     pub async fn assert_inflight_txs_count_equals(&mut self, value: usize) {
         let inflight_count = if !self.settlement_layer.is_gateway() {
-            //sanity check
-            assert!(self.manager.operator_address(OperatorType::Blob).is_some());
             self.storage()
                 .await
                 .eth_sender_dal()
-                .get_inflight_txs(self.manager.operator_address(OperatorType::NonBlob), false)
+                .get_inflight_txs(
+                    self.manager.operator_address(OperatorType::NonBlob),
+                    false,
+                    false,
+                )
                 .await
                 .unwrap()
                 .len()
@@ -636,7 +634,11 @@ impl EthSenderTester {
                     .storage()
                     .await
                     .eth_sender_dal()
-                    .get_inflight_txs(self.manager.operator_address(OperatorType::Blob), false)
+                    .get_inflight_txs(
+                        self.manager.operator_address(OperatorType::Blob),
+                        false,
+                        false,
+                    )
                     .await
                     .unwrap()
                     .len()
@@ -644,7 +646,11 @@ impl EthSenderTester {
             self.storage()
                 .await
                 .eth_sender_dal()
-                .get_inflight_txs(None, true)
+                .get_inflight_txs(
+                    self.manager.operator_address(OperatorType::Gateway),
+                    false,
+                    true,
+                )
                 .await
                 .unwrap()
                 .len()

--- a/core/node/eth_sender/src/tester.rs
+++ b/core/node/eth_sender/src/tester.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
 use zksync_config::{
     configs::eth_sender::{ProofSendingMode, SenderConfig},
@@ -226,6 +226,7 @@ impl EthSenderTester {
                 assert_eq!(call.to, Some(contracts_config.l1_multicall3_addr));
                 crate::tests::mock_multicall_response(call)
             })
+            .with_sender(Address::from_str("0xb10b000000000000000000000000000000000000").unwrap())
             .build();
         gateway_blobs.advance_block_number(Self::WAIT_CONFIRMATIONS);
         let gateway_blobs = Box::new(gateway_blobs);

--- a/core/node/eth_sender/src/tests.rs
+++ b/core/node/eth_sender/src/tests.rs
@@ -266,6 +266,7 @@ async fn resend_each_block(commitment_mode: L1BatchCommitmentMode) -> anyhow::Re
             .eth_sender_dal()
             .get_inflight_txs(
                 tester.manager.operator_address(OperatorType::NonBlob),
+                false,
                 false
             )
             .await
@@ -322,6 +323,7 @@ async fn resend_each_block(commitment_mode: L1BatchCommitmentMode) -> anyhow::Re
             .eth_sender_dal()
             .get_inflight_txs(
                 tester.manager.operator_address(OperatorType::NonBlob),
+                false,
                 false
             )
             .await

--- a/zkstack_cli/Cargo.lock
+++ b/zkstack_cli/Cargo.lock
@@ -5919,13 +5919,38 @@ dependencies = [
  "elsa",
  "once_cell",
  "prometheus-client",
- "vise-macros",
+ "vise-macros 0.2.0",
+]
+
+[[package]]
+name = "vise"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269640ec8679c379b8ffefbd4623f7a435f40c159b87bee4620fd9585ea573ba"
+dependencies = [
+ "compile-fmt",
+ "ctor",
+ "elsa",
+ "once_cell",
+ "prometheus-client",
+ "vise-macros 0.3.0",
 ]
 
 [[package]]
 name = "vise-macros"
 version = "0.2.0"
 source = "git+https://github.com/matter-labs/vise.git?rev=51669f42f60c50b3a521662a4ecd71212a303299#51669f42f60c50b3a521662a4ecd71212a303299"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "vise-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03810422b55b87bb8cba95a3708664c049125789a8d79ee524da6ed07ed067d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6666,7 +6691,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vise",
+ "vise 0.2.0",
 ]
 
 [[package]]
@@ -6859,7 +6884,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tracing",
- "vise",
+ "vise 0.3.0",
  "zksync_types",
 ]
 


### PR DESCRIPTION
## What ❔

Set `from_addr` for non-blob txs

## Why ❔

Makes data in DB less awkward, now it will be possible to get `from_addr` for any eth tx. Also helps with operator key rotation. I have tested locally that all you need to do to change operator (blob or non-blob) is to a) add new validator on L1; b) stop eth manager and wait for all txs to be confirmed; c) change wallet address and pk in config. No manual changes in DB.
Also, I've tested locally that code works with in-flight/unsent txs for which from_addr=null. I initialized server from `main`, created some bacthes so that there were some inflight and some unsent eth txs with from_addr=null. Then launched server from this branch and in-flight txs were confirmed; unsent txs were sent and confirmed.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
