### PR TITLE
fix(loadtest): Increase gas limit for loadtest

### DIFF
--- a/core/tests/loadnext/src/sdk/ethereum/mod.rs
+++ b/core/tests/loadnext/src/sdk/ethereum/mod.rs
@@ -427,7 +427,7 @@ impl<S: EthereumSigner> EthereumProvider<S> {
             .sign_prepared_tx(
                 tx_data,
                 Options::with(|f| {
-                    f.gas = Some(U256::from(300000));
+                    f.gas = Some(U256::from(600000));
                     f.value = Some(value);
                     f.gas_price = Some(gas_price)
                 }),


### PR DESCRIPTION
## What ❔

Increase gas limit for loadtest deposit txs 

## Why ❔

We were already very close to the limit and now with migration to the gateway seems it requires a bit more gas than before 

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
