### PR TITLE
perf(db): drop ix_initial_writes_t1

### DIFF
--- a/core/lib/dal/migrations/20250425113231_drop_ix_initial_writes_t1.down.sql
+++ b/core/lib/dal/migrations/20250425113231_drop_ix_initial_writes_t1.down.sql
@@ -1,0 +1,2 @@
+CREATE INDEX ix_initial_writes_t1
+    ON initial_writes (hashed_key) include (l1_batch_number);

--- a/core/lib/dal/migrations/20250425113231_drop_ix_initial_writes_t1.up.sql
+++ b/core/lib/dal/migrations/20250425113231_drop_ix_initial_writes_t1.up.sql
@@ -1,0 +1,1 @@
+DROP INDEX ix_initial_writes_t1;


### PR DESCRIPTION
## What ❔

Drops DB index `ix_initial_writes_t1`

## Why ❔

Should speed up insertion to `initial_writes`. Index removal will make query `get_l1_batch_number_for_initial_write` marginally slower. It's a trade-off.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

DB migration

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
