### PR TITLE
chore: updated max circuits

### DIFF
--- a/core/lib/multivm/src/versions/vm_latest/constants.rs
+++ b/core/lib/multivm/src/versions/vm_latest/constants.rs
@@ -12,8 +12,9 @@ pub(crate) const BOOTLOADER_BATCH_TIP_OVERHEAD: u32 = 400_000_000;
 pub(crate) const BOOTLOADER_BATCH_TIP_CIRCUIT_STATISTICS_OVERHEAD: u32 = 12_000;
 pub(crate) const BOOTLOADER_BATCH_TIP_METRICS_SIZE_OVERHEAD: u32 = 2000;
 
-/// In the version `1.5.0` the maximal number of circuits per batch has been increased from `24100` to `34100`.
-pub(crate) const MAX_BASE_LAYER_CIRCUITS: usize = 34100;
+/// In the version `1.5.2` the maximal number of circuits per batch has been decreased to '28000'.
+// Please see scheduler capacity in https://github.com/matter-labs/zksync-protocol/blob/main/crates/circuit_definitions/src/circuit_definitions/recursion_layer/mod.rs#L38
+pub(crate) const MAX_BASE_LAYER_CIRCUITS: usize = 28_000;
 
 /// The size of the bootloader memory in bytes which is used by the protocol.
 /// While the maximal possible size is a lot higher, we restrict ourselves to a certain limit to reduce


### PR DESCRIPTION
## What ❔
With new circuit types, the scheduler capacity has dropped a little.