### PR TITLE
fix: Aux output witness object store key

### DIFF
--- a/prover/crates/lib/prover_fri_types/src/lib.rs
+++ b/prover/crates/lib/prover_fri_types/src/lib.rs
@@ -222,8 +222,12 @@ impl StoredObject for AuxOutputWitnessWrapper {
     const BUCKET: Bucket = Bucket::SchedulerWitnessJobsFri;
     type Key<'a> = L1BatchId;
 
+    fn fallback_key(key: Self::Key<'_>) -> Option<String> {
+        Some(format!("aux_output_witness_{}.bin", key.batch_number().0))
+    }
+
     fn encode_key(key: Self::Key<'_>) -> String {
-        format!("aux_output_witness_{key}.bin")
+        format!("aux_output_witness_{}_{}.bin", key.batch_number().0, key.chain_id().as_u64())
     }
 
     serialize_using_bincode!();

--- a/prover/crates/lib/prover_fri_types/src/lib.rs
+++ b/prover/crates/lib/prover_fri_types/src/lib.rs
@@ -227,7 +227,11 @@ impl StoredObject for AuxOutputWitnessWrapper {
     }
 
     fn encode_key(key: Self::Key<'_>) -> String {
-        format!("aux_output_witness_{}_{}.bin", key.batch_number().0, key.chain_id().as_u64())
+        format!(
+            "aux_output_witness_{}_{}.bin",
+            key.batch_number().0,
+            key.chain_id().as_u64()
+        )
     }
 
     serialize_using_bincode!();


### PR DESCRIPTION
## What ❔

Because of custom display implementation, key for the struct is incorrectly formatted.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
