### PR TITLE
fix: bincode file extension

### DIFF
--- a/core/lib/prover_interface/src/legacy.rs
+++ b/core/lib/prover_interface/src/legacy.rs
@@ -132,7 +132,7 @@ impl StoredObject for L1BatchProofForL1<Bincode> {
         if let L1BatchProofForL1Key::Prover((l1_batch_id, protocol_version)) = key {
             let semver_suffix = protocol_version.to_string().replace('.', "_");
             Some(format!(
-                "l1_batch_proof_{batch_number}_{semver_suffix}.cbor",
+                "l1_batch_proof_{batch_number}_{semver_suffix}.bin",
                 batch_number = l1_batch_id.batch_number().0
             ))
         } else {
@@ -145,14 +145,14 @@ impl StoredObject for L1BatchProofForL1<Bincode> {
             L1BatchProofForL1Key::Core((l1_batch_number, protocol_version)) => {
                 let semver_suffix = protocol_version.to_string().replace('.', "_");
                 format!(
-                    "l1_batch_proof_{batch_number}_{semver_suffix}.cbor",
+                    "l1_batch_proof_{batch_number}_{semver_suffix}.bin",
                     batch_number = l1_batch_number.0
                 )
             }
             L1BatchProofForL1Key::Prover((l1_batch_id, protocol_version)) => {
                 let semver_suffix = protocol_version.to_string().replace('.', "_");
                 format!(
-                    "l1_batch_proof_{batch_number}_{chain_id}_{semver_suffix}.cbor",
+                    "l1_batch_proof_{batch_number}_{chain_id}_{semver_suffix}.bin",
                     batch_number = l1_batch_id.batch_number().0,
                     chain_id = l1_batch_id.chain_id()
                 )


### PR DESCRIPTION
## What ❔

Fixes using `.cbor` file extension instead of `.bin` for bincode-encoded files

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
