### PR TITLE
fix(api): Fix `contractAddress` in transaction receipts for unparseable deployment calldata

### DIFF
--- a/core/lib/types/src/tx/execute.rs
+++ b/core/lib/types/src/tx/execute.rs
@@ -246,31 +246,33 @@ pub enum DeploymentParams {
 }
 
 impl DeploymentParams {
-    pub fn decode(calldata: &[u8]) -> anyhow::Result<Option<Self>> {
+    /// Returns `None` if calldata doesn't correspond to the 4 deploying `ContractDeployer` methods,
+    /// or if it cannot be decoded.
+    pub fn decode(calldata: &[u8]) -> Option<Self> {
         if calldata.len() < 4 {
-            return Ok(None);
+            return None;
         }
         let (short_signature, token_data) = calldata.split_at(4);
-        Ok(match short_signature {
+        match short_signature {
             sig if sig == *CREATE_FUNCTION => {
-                ethabi::decode(CREATE_PARAMS, token_data)?;
+                ethabi::decode(CREATE_PARAMS, token_data).ok()?;
                 Some(Self::Create)
             }
             sig if sig == *CREATE2_FUNCTION => {
-                let tokens = ethabi::decode(CREATE_PARAMS, token_data)?;
+                let tokens = ethabi::decode(CREATE_PARAMS, token_data).ok()?;
                 Some(Self::Create2(Create2DeploymentParams::from_tokens(tokens)))
             }
             sig if sig == *CREATE_ACC_FUNCTION => {
-                ethabi::decode(CREATE_ACC_PARAMS, token_data)?;
+                ethabi::decode(CREATE_ACC_PARAMS, token_data).ok()?;
                 Some(Self::CreateAccount)
             }
             sig if sig == *CREATE2_ACC_FUNCTION => {
-                let tokens = ethabi::decode(CREATE_ACC_PARAMS, token_data)?;
+                let tokens = ethabi::decode(CREATE_ACC_PARAMS, token_data).ok()?;
                 Some(Self::Create2Account(Create2DeploymentParams::from_tokens(
                     tokens,
                 )))
             }
             _ => None,
-        })
+        }
     }
 }


### PR DESCRIPTION
## What ❔

Fixes internal server errors occurring for Web3 RPC methods returning transaction receipts (e.g., `eth_getBlockReceipts`) if the receipt corresponds to a transaction calling `ContractDeployer` with unparseable calldata.

## Why ❔

Returning an internal server error is incorrect in this case. Instead, `contractAddress` should be set to `null` for such transactions.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.