### PR TITLE
fix(gateway-migrator): Do not fail gateway migrator during the problems with network

### DIFF
--- a/core/node/gateway_migrator/Cargo.toml
+++ b/core/node/gateway_migrator/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "zksync_gateway_migrator"
+description = "Component that handles the migration of the zkSync network from/to gateway"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/core/node/gateway_migrator/src/lib.rs
+++ b/core/node/gateway_migrator/src/lib.rs
@@ -86,8 +86,11 @@ impl GatewayMigrator {
                     tracing::info!("Transient error fetching data from SL: {err}");
                 }
                 Err(err) => {
+                    // If we have an error related to the getting data from the contract,
+                    // it's safe to ignore it and continue the loop. The only real problem
+                    // could be with missconfigured contracts, but in this case,
+                    // other components will fail
                     tracing::error!("Failed to fetch data from SL: {err}");
-                    return Err(err.into());
                 }
             }
 


### PR DESCRIPTION

## What ❔

Remove handling the errors from gateway migrator. 

## Why ❔

We shouldn't fail the whole system if some unexpected behaviour occured on l1. 

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
