### PR TITLE
refactor: clean zks namespace

### DIFF
--- a/core/lib/web3_decl/src/namespaces/zks.rs
+++ b/core/lib/web3_decl/src/namespaces/zks.rs
@@ -88,13 +88,6 @@ pub trait ZksNamespace {
         &self,
         tx_hash: H256,
         index: Option<usize>,
-    ) -> RpcResult<Option<L2ToL1LogProof>>;
-
-    #[method(name = "getL2ToL1LogProofUntilTarget")]
-    async fn get_l2_to_l1_log_proof_until_target(
-        &self,
-        tx_hash: H256,
-        index: Option<usize>,
         log_proof_target: Option<LogProofTarget>,
     ) -> RpcResult<Option<L2ToL1LogProof>>;
 

--- a/core/node/api_server/src/web3/backend_jsonrpsee/namespaces/zks.rs
+++ b/core/node/api_server/src/web3/backend_jsonrpsee/namespaces/zks.rs
@@ -96,16 +96,6 @@ impl ZksNamespaceServer for ZksNamespace {
         &self,
         tx_hash: H256,
         index: Option<usize>,
-    ) -> RpcResult<Option<L2ToL1LogProof>> {
-        self.get_l2_to_l1_log_proof_impl(tx_hash, index, None)
-            .await
-            .map_err(|err| self.current_method().map_err(err))
-    }
-
-    async fn get_l2_to_l1_log_proof_until_target(
-        &self,
-        tx_hash: H256,
-        index: Option<usize>,
         log_proof_target: Option<LogProofTarget>,
     ) -> RpcResult<Option<L2ToL1LogProof>> {
         self.get_l2_to_l1_log_proof_impl(tx_hash, index, log_proof_target)

--- a/core/node/api_server/src/web3/namespaces/zks.rs
+++ b/core/node/api_server/src/web3/namespaces/zks.rs
@@ -512,15 +512,8 @@ impl ZksNamespace {
         log_proof_target: Option<LogProofTarget>,
     ) -> Result<Option<L2ToL1LogProof>, Web3Error> {
         if let Some(handler) = &self.state.l2_l1_log_proof_handler {
-            if log_proof_target.is_some() {
-                return handler
-                    .get_l2_to_l1_log_proof_until_target(tx_hash, index, log_proof_target)
-                    .rpc_context("get_l2_to_l1_log_proof_until_target")
-                    .await
-                    .map_err(Into::into);
-            }
             return handler
-                .get_l2_to_l1_log_proof(tx_hash, index)
+                .get_l2_to_l1_log_proof(tx_hash, index, log_proof_target)
                 .rpc_context("get_l2_to_l1_log_proof")
                 .await
                 .map_err(Into::into);

--- a/core/tests/ts-integration/package.json
+++ b/core/tests/ts-integration/package.json
@@ -36,6 +36,6 @@
     "typescript": "^4.3.5",
     "yaml": "^2.4.2",
     "zksync-ethers": "https://github.com/zksync-sdk/zksync-ethers#sb-use-new-encoding-in-sdk",
-    "zksync-ethers-interop-support": "git+https://github.com/zksync-sdk/zksync-ethers#kl/interop-ethers-support"
+    "zksync-ethers-interop-support": "git+https://github.com/zksync-sdk/zksync-ethers#kl/interop-ethers-support-real"
   }
 }

--- a/zkstack_cli/crates/common/src/zks_provider.rs
+++ b/zkstack_cli/crates/common/src/zks_provider.rs
@@ -136,6 +136,7 @@ where
             self,
             withdrawal_hash,
             Some(l2_to_l1_log_index as usize),
+            None,
         )
         .await
         .map_err(|e| {


### PR DESCRIPTION
## What ❔

Removes `getL2ToL1LogProofUntilTarget` in favor of using just `getL2ToL1LogProof`. Additionally points to [kl/interop-ethers-support-real](https://github.com/zksync-sdk/zksync-ethers/tree/kl/interop-ethers-support-real) for integration tests.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Cleaner namespace

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
