### PR TITLE
fix: More stable settlement layer fetching

### DIFF
--- a/core/bin/block_reverter/src/main.rs
+++ b/core/bin/block_reverter/src/main.rs
@@ -9,7 +9,8 @@ use tokio::{
 use zksync_block_reverter::{
     eth_client::{
         clients::{Client, PKSigningClient, L1},
-        contracts_loader::{get_settlement_layer_from_bridgehub, load_settlement_layer_contracts}, EthInterface,
+        contracts_loader::{get_settlement_layer_from_bridgehub, load_settlement_layer_contracts},
+        EthInterface,
     },
     BlockReverter, BlockReverterEthConfig, NodeRole,
 };
@@ -26,7 +27,9 @@ use zksync_dal::{ConnectionPool, Core};
 use zksync_env_config::{object_store::SnapshotsObjectStoreConfig, FromEnv};
 use zksync_object_store::ObjectStoreFactory;
 use zksync_protobuf_config::proto;
-use zksync_types::{settlement::SettlementLayer, Address, L1BatchNumber, SLChainId, L2_BRIDGEHUB_ADDRESS};
+use zksync_types::{
+    settlement::SettlementLayer, Address, L1BatchNumber, SLChainId, L2_BRIDGEHUB_ADDRESS,
+};
 
 #[derive(Debug, Parser)]
 #[command(author = "Matter Labs", version, about = "Block revert utility", long_about = None)]
@@ -252,9 +255,12 @@ async fn main() -> anyhow::Result<()> {
     let settlement_mode = get_settlement_layer_from_bridgehub(
         &l1_client,
         l1_client.fetch_chain_id().await?,
-        sl_l1_contracts.ecosystem_contracts.bridgehub_proxy_addr.context("Missing bridgehub")?,
+        sl_l1_contracts
+            .ecosystem_contracts
+            .bridgehub_proxy_addr
+            .context("Missing bridgehub")?,
         SLChainId(zksync_network_id.as_u64()),
-        &bridgehub_contract()
+        &bridgehub_contract(),
     )
     .await?
     .context("Missing settlement layer on L1")?;

--- a/core/bin/block_reverter/src/main.rs
+++ b/core/bin/block_reverter/src/main.rs
@@ -20,7 +20,7 @@ use zksync_config::{
     },
     ContractsConfig, DBConfig, EthConfig, GenesisConfig, PostgresConfig,
 };
-use zksync_contracts::{bridgehub_contract, getters_facet_contract};
+use zksync_contracts::bridgehub_contract;
 use zksync_core_leftovers::temp_config_store::read_yaml_repr;
 use zksync_dal::{ConnectionPool, Core};
 use zksync_env_config::{object_store::SnapshotsObjectStoreConfig, FromEnv};

--- a/core/lib/eth_client/src/contracts_loader.rs
+++ b/core/lib/eth_client/src/contracts_loader.rs
@@ -2,7 +2,7 @@ use zksync_config::configs::contracts::{
     chain::ChainContracts, ecosystem::EcosystemCommonContracts, SettlementLayerSpecificContracts,
 };
 use zksync_contracts::{
-    bridgehub_contract, getters_facet_contract, hyperchain_contract,
+    bridgehub_contract, hyperchain_contract,
     state_transition_manager_contract,
 };
 use zksync_types::{

--- a/core/lib/eth_client/src/contracts_loader.rs
+++ b/core/lib/eth_client/src/contracts_loader.rs
@@ -2,8 +2,7 @@ use zksync_config::configs::contracts::{
     chain::ChainContracts, ecosystem::EcosystemCommonContracts, SettlementLayerSpecificContracts,
 };
 use zksync_contracts::{
-    bridgehub_contract, hyperchain_contract,
-    state_transition_manager_contract,
+    bridgehub_contract, hyperchain_contract, state_transition_manager_contract,
 };
 use zksync_types::{
     ethabi::{Contract, Token},
@@ -91,13 +90,14 @@ pub async fn get_settlement_layer_from_bridgehub(
     chain_id: SLChainId,
     bridgehub_abi: &Contract,
 ) -> Result<Option<SettlementLayer>, ContractCallError> {
-    let settlement_layer_chain_id: U256 = CallFunctionArgs::new("settlementLayer", U256::from(chain_id.0))
-        .for_contract(bridgehub_address, bridgehub_abi)
-        .call(eth_client)
-        .await?;
+    let settlement_layer_chain_id: U256 =
+        CallFunctionArgs::new("settlementLayer", U256::from(chain_id.0))
+            .for_contract(bridgehub_address, bridgehub_abi)
+            .call(eth_client)
+            .await?;
     if settlement_layer_chain_id == U256::zero() {
         return Ok(None);
-        // This is only the case for chains that did not pass v26 upgrade, which 
+        // This is only the case for chains that did not pass v26 upgrade, which
         // is not the case for any active chain.
         // anyhow::bail!("Chain does not settlement layer registered on L1 bridgehub");
     }

--- a/core/node/gateway_migrator/src/lib.rs
+++ b/core/node/gateway_migrator/src/lib.rs
@@ -2,13 +2,13 @@ use std::time::Duration;
 
 use anyhow::{bail, Context};
 use tokio::sync::watch;
-use zksync_basic_types::{ethabi::Contract, settlement::SettlementLayer, L2ChainId};
+use zksync_basic_types::{ethabi::Contract, settlement::SettlementLayer, L2ChainId, SLChainId};
 use zksync_config::configs::contracts::SettlementLayerSpecificContracts;
-use zksync_contracts::getters_facet_contract;
+use zksync_contracts::{bridgehub_contract, getters_facet_contract};
 use zksync_dal::{Connection, ConnectionPool, Core, CoreDal};
 use zksync_eth_client::{
     contracts_loader::{
-        get_diamond_proxy_contract, get_settlement_layer_address, get_settlement_layer_from_l1,
+        get_diamond_proxy_contract, get_settlement_layer_address, get_settlement_layer_from_bridgehub
     },
     ContractCallError, EthInterface,
 };
@@ -32,8 +32,7 @@ pub struct GatewayMigrator {
     l1_settlement_layer_specific_contracts: SettlementLayerSpecificContracts,
     settlement_layer: SettlementLayer,
     l2_chain_id: L2ChainId,
-    getters_facet_abi: Contract,
-    pool: ConnectionPool<Core>,
+    bridgehub_abi: Contract,
 }
 
 impl GatewayMigrator {
@@ -42,18 +41,16 @@ impl GatewayMigrator {
         gateway_client: Option<Box<dyn EthInterface>>,
         initial_settlement_layer: SettlementLayer,
         l2_chain_id: L2ChainId,
-        pool: ConnectionPool<Core>,
         l1_settlement_layer_specific_contracts: SettlementLayerSpecificContracts,
     ) -> Self {
-        let abi = getters_facet_contract();
+        let abi = bridgehub_contract();
         Self {
             eth_client,
             gateway_client,
             l1_settlement_layer_specific_contracts,
             settlement_layer: initial_settlement_layer,
             l2_chain_id,
-            getters_facet_abi: abi,
-            pool,
+            bridgehub_abi: abi,
         }
     }
 
@@ -69,8 +66,7 @@ impl GatewayMigrator {
                 gateway_client,
                 &self.l1_settlement_layer_specific_contracts,
                 self.l2_chain_id,
-                &mut self.pool.connection_tagged("gateway_migrator").await?,
-                &self.getters_facet_abi,
+                &self.bridgehub_abi,
             )
             .await;
 
@@ -105,82 +101,62 @@ pub async fn current_settlement_layer(
     gateway_client: Option<&dyn EthInterface>,
     sl_l1_contracts: &SettlementLayerSpecificContracts,
     l2_chain_id: L2ChainId,
-    storage: &mut Connection<'_, Core>,
-    abi: &Contract,
+    bridgehub_abi: &Contract,
 ) -> Result<SettlementLayer, GatewayMigratorError> {
-    let settlement_mode_from_l1 = get_settlement_layer_from_l1(
+    let l1_chain_id = l1_client.fetch_chain_id().await.map_err(|e| GatewayMigratorError::Internal(e.into()))?;
+
+    let l1_bridgehub = sl_l1_contracts
+        .ecosystem_contracts
+        .bridgehub_proxy_addr
+        .unwrap();
+
+    let settlement_mode_from_l1 = get_settlement_layer_from_bridgehub(
         l1_client,
-        sl_l1_contracts.chain_contracts_config.diamond_proxy_addr,
-        abi,
+        l1_chain_id,
+        l1_bridgehub,
+        SLChainId(l2_chain_id.as_u64()),
+        bridgehub_abi,
     )
-    .await?;
+    .await?
+    .context("Chain does not have settlement layer on L1")?;
 
-    // Check how many transaction from the opposite settlement mode we have.
-    // This function supposed to be used during the start of the server or during the switch.
-    // And we can't start with new settlement mode while we have inflight transactions
-    let inflight_count = storage
-        .eth_sender_dal()
-        .get_inflight_txs_count_for_gateway_migration(!settlement_mode_from_l1.is_gateway())
-        .await
-        .context("Failed to get txs count")?;
-
-    let use_settlement_mode_from_l1 = if inflight_count != 0 {
-        false
-    } else {
-        let (sl_client, bridge_hub_address) = match settlement_mode_from_l1 {
-            SettlementLayer::L1(_) => (
-                l1_client,
-                sl_l1_contracts
-                    .ecosystem_contracts
-                    .bridgehub_proxy_addr
-                    .unwrap(),
-            ),
-            SettlementLayer::Gateway(_) => (gateway_client.unwrap(), L2_BRIDGEHUB_ADDRESS),
-        };
-
-        // Load chain contracts from sl
-        let diamond_proxy_addr =
-            get_diamond_proxy_contract(sl_client, bridge_hub_address, l2_chain_id).await?;
-        // Deploying contracts on gateway are going through l1->l2 communication,
-        // even though the settlement layer has changed on l1.
-        // Gateway should process l1->l2 transaction.
-        // Even though when we switched from gateway to l1,
-        // we don't need to wait for contracts deployment,
-        // we have to wait for l2->l1 communication to be finalized
-        if !diamond_proxy_addr.is_zero() {
-            let settlement_layer_address =
-                get_settlement_layer_address(sl_client, diamond_proxy_addr, abi).await?;
-            // When we settle to the current chain, settlement mode should zero
-            settlement_layer_address.is_zero()
-        } else {
-            match settlement_mode_from_l1 {
-                // if we want to settle to l1, but no contracts deployed, that means it's pre gateway upgrade and we need to settle to l1
-                SettlementLayer::L1(_) => true,
-                // if we want to settle to gateway, but no contracts deployed, that means the migration has not been completed yet. We need to continue settle to L1
-                SettlementLayer::Gateway(_) => false,
-            }
+    let final_settlement_mode = match settlement_mode_from_l1 {
+        sl_layer @ SettlementLayer::L1(_) => {
+            // Bridgehub on L1 is only toggled when chain is indeed ready to settle on L1.
+            return Ok(sl_layer)
         }
-    };
+        SettlementLayer::Gateway(gw_chain_id) => {
+            let gw_client = gateway_client.context("Missing gateway client")?;
+            let gw_chain_id_from_provider = gw_client.fetch_chain_id().await.map_err(|e| GatewayMigratorError::Internal(e.into()))?;
+            assert_eq!(gw_chain_id, gw_chain_id_from_provider, "GW chain id is not the same as in the GW provider");
 
-    let final_settlement_mode = if use_settlement_mode_from_l1 {
-        settlement_mode_from_l1
-    } else {
-        // If it's impossible to use settlement_mode_from_l1 server have to use the opposite settlement_layer
-        match settlement_mode_from_l1 {
-            SettlementLayer::L1(_) => {
-                let chain_id = gateway_client
-                    .unwrap()
-                    .fetch_chain_id()
-                    .await
-                    .map_err(ContractCallError::from)?;
-                SettlementLayer::Gateway(chain_id)
-            }
-            SettlementLayer::Gateway(_) => {
-                let chain_id = l1_client
-                    .fetch_chain_id()
-                    .await
-                    .map_err(ContractCallError::from)?;
-                SettlementLayer::L1(chain_id)
+            // We only need to check whether GW is ready
+
+            let settlement_layer_from_gw = get_settlement_layer_from_bridgehub(
+                gw_client, 
+                l1_chain_id, 
+                L2_BRIDGEHUB_ADDRESS, 
+                SLChainId(l2_chain_id.as_u64()), 
+                bridgehub_abi
+            ).await?;
+
+            let chain_finalized_migration_to_gw = match settlement_layer_from_gw {
+                Some(SettlementLayer::Gateway(chain_id_from_gw_bridgehub)) => {
+                    // Inequality is only possible if there are more than 1 gateways, but the server is
+                    // not ready for this case.
+                    assert_eq!(gw_chain_id_from_provider, chain_id_from_gw_bridgehub, "Unexpected GW chain id");
+
+                    true
+                },
+                _ => {
+                    false
+                }
+            };
+
+            if chain_finalized_migration_to_gw {
+                SettlementLayer::Gateway(gw_chain_id_from_provider)
+            } else {
+                SettlementLayer::L1(l1_chain_id)
             }
         }
     };

--- a/core/node/gateway_migrator/src/lib.rs
+++ b/core/node/gateway_migrator/src/lib.rs
@@ -4,12 +4,9 @@ use anyhow::{bail, Context};
 use tokio::sync::watch;
 use zksync_basic_types::{ethabi::Contract, settlement::SettlementLayer, L2ChainId, SLChainId};
 use zksync_config::configs::contracts::SettlementLayerSpecificContracts;
-use zksync_contracts::{bridgehub_contract, getters_facet_contract};
-use zksync_dal::{Connection, ConnectionPool, Core, CoreDal};
+use zksync_contracts::bridgehub_contract;
 use zksync_eth_client::{
-    contracts_loader::{
-        get_diamond_proxy_contract, get_settlement_layer_address, get_settlement_layer_from_bridgehub
-    },
+    contracts_loader::get_settlement_layer_from_bridgehub,
     ContractCallError, EthInterface,
 };
 use zksync_system_constants::L2_BRIDGEHUB_ADDRESS;

--- a/core/node/node_framework/src/implementations/layers/gateway_migrator_layer.rs
+++ b/core/node/node_framework/src/implementations/layers/gateway_migrator_layer.rs
@@ -27,7 +27,6 @@ pub struct Input {
     gateway_client: Option<L2InterfaceResource>,
     contracts: L1ChainContractsResource,
     settlement_mode_resource: SettlementModeResource,
-    pool: PoolResource<MasterPool>,
 }
 
 #[derive(Debug, IntoContext)]
@@ -54,7 +53,6 @@ impl WiringLayer for GatewayMigratorLayer {
                 .map(|a| Box::new(a.0) as Box<dyn EthInterface>),
             input.settlement_mode_resource.0,
             self.l2_chain_id,
-            input.pool.get().await?,
             input.contracts.0,
         );
 

--- a/core/node/node_framework/src/implementations/layers/gateway_migrator_layer.rs
+++ b/core/node/node_framework/src/implementations/layers/gateway_migrator_layer.rs
@@ -7,7 +7,6 @@ use crate::{
     implementations::resources::{
         contracts::L1ChainContractsResource,
         eth_interface::{EthInterfaceResource, L2InterfaceResource},
-        pools::{MasterPool, PoolResource},
         settlement_layer::SettlementModeResource,
     },
     wiring_layer::{WiringError, WiringLayer},

--- a/core/node/node_framework/src/implementations/layers/settlement_layer_data.rs
+++ b/core/node/node_framework/src/implementations/layers/settlement_layer_data.rs
@@ -5,7 +5,7 @@ use zksync_config::configs::{
     },
     eth_sender::SenderConfig,
 };
-use zksync_contracts::{bridgehub_contract, getters_facet_contract};
+use zksync_contracts::bridgehub_contract;
 use zksync_dal::{Core, CoreDal};
 use zksync_db_connection::connection::Connection;
 use zksync_eth_client::{

--- a/core/node/node_framework/src/implementations/layers/settlement_layer_data.rs
+++ b/core/node/node_framework/src/implementations/layers/settlement_layer_data.rs
@@ -10,7 +10,7 @@ use zksync_dal::{Core, CoreDal};
 use zksync_db_connection::connection::Connection;
 use zksync_eth_client::{
     contracts_loader::{
-        get_server_notifier_addr, get_settlement_layer_from_bridgehub,
+        get_server_notifier_addr, get_settlement_layer_from_l1_bridgehub,
         load_settlement_layer_contracts,
     },
     EthInterface,
@@ -214,14 +214,8 @@ impl WiringLayer for SettlementLayerData<ENConfig> {
             // If it's the new chain it's safe to check the actual sl onchain,
             // in the worst case scenario chain
             // en will be restarted right after the first batch and fill the database with correct values
-            get_settlement_layer_from_bridgehub(
+            get_settlement_layer_from_l1_bridgehub(
                 &input.eth_client.0.as_ref(),
-                input
-                    .eth_client
-                    .0
-                    .fetch_chain_id()
-                    .await
-                    .context("Failed to fetch ETH client chain id")?,
                 self.config
                     .l1_chain_contracts
                     .ecosystem_contracts
@@ -232,7 +226,6 @@ impl WiringLayer for SettlementLayerData<ENConfig> {
             )
             .await
             .context("Error occured while getting current SL mode")?
-            .context("Missing settlement layer on L1 bridgehub")?
         };
 
         let l2_eth_client = get_l2_client(self.config.gateway_rpc_url).await?;

--- a/core/node/node_framework/src/implementations/layers/settlement_layer_data.rs
+++ b/core/node/node_framework/src/implementations/layers/settlement_layer_data.rs
@@ -10,7 +10,8 @@ use zksync_dal::{Core, CoreDal};
 use zksync_db_connection::connection::Connection;
 use zksync_eth_client::{
     contracts_loader::{
-        get_server_notifier_addr, get_settlement_layer_from_bridgehub, load_settlement_layer_contracts
+        get_server_notifier_addr, get_settlement_layer_from_bridgehub,
+        load_settlement_layer_contracts,
     },
     EthInterface,
 };
@@ -214,11 +215,20 @@ impl WiringLayer for SettlementLayerData<ENConfig> {
             // in the worst case scenario chain
             // en will be restarted right after the first batch and fill the database with correct values
             get_settlement_layer_from_bridgehub(
-                &input.eth_client.0.as_ref(), 
-                input.eth_client.0.fetch_chain_id().await.context("Failed to fetch ETH client chain id")?, 
-                self.config.l1_chain_contracts.ecosystem_contracts.bridgehub_proxy_addr.context("Missing L1 bridgehub")?,
+                &input.eth_client.0.as_ref(),
+                input
+                    .eth_client
+                    .0
+                    .fetch_chain_id()
+                    .await
+                    .context("Failed to fetch ETH client chain id")?,
+                self.config
+                    .l1_chain_contracts
+                    .ecosystem_contracts
+                    .bridgehub_proxy_addr
+                    .context("Missing L1 bridgehub")?,
                 SLChainId(self.config.chain_id.as_u64()),
-                &bridgehub_contract()
+                &bridgehub_contract(),
             )
             .await
             .context("Error occured while getting current SL mode")?

--- a/core/node/node_framework/src/implementations/layers/settlement_layer_data.rs
+++ b/core/node/node_framework/src/implementations/layers/settlement_layer_data.rs
@@ -5,12 +5,12 @@ use zksync_config::configs::{
     },
     eth_sender::SenderConfig,
 };
-use zksync_contracts::getters_facet_contract;
+use zksync_contracts::{bridgehub_contract, getters_facet_contract};
 use zksync_dal::{Core, CoreDal};
 use zksync_db_connection::connection::Connection;
 use zksync_eth_client::{
     contracts_loader::{
-        get_server_notifier_addr, get_settlement_layer_from_l1, load_settlement_layer_contracts,
+        get_server_notifier_addr, get_settlement_layer_from_bridgehub, load_settlement_layer_contracts
     },
     EthInterface,
 };
@@ -120,8 +120,6 @@ impl WiringLayer for SettlementLayerData<MainNodeConfig> {
             };
         }
 
-        let pool = input.pool.get().await?;
-
         let l2_eth_client = get_l2_client(self.config.gateway_rpc_url).await?;
 
         let final_settlement_mode = current_settlement_layer(
@@ -129,8 +127,7 @@ impl WiringLayer for SettlementLayerData<MainNodeConfig> {
             l2_eth_client.as_ref().map(|a| &a.0 as &dyn EthInterface),
             &sl_l1_contracts,
             self.config.l2_chain_id,
-            &mut pool.connection().await.context("Can't connect")?,
-            &getters_facet_contract(),
+            &bridgehub_contract(),
         )
         .await
         .context("Error occured while getting current SL mode")?;
@@ -216,16 +213,16 @@ impl WiringLayer for SettlementLayerData<ENConfig> {
             // If it's the new chain it's safe to check the actual sl onchain,
             // in the worst case scenario chain
             // en will be restarted right after the first batch and fill the database with correct values
-            get_settlement_layer_from_l1(
-                &input.eth_client.0.as_ref(),
-                self.config
-                    .l1_chain_contracts
-                    .chain_contracts_config
-                    .diamond_proxy_addr,
-                &getters_facet_contract(),
+            get_settlement_layer_from_bridgehub(
+                &input.eth_client.0.as_ref(), 
+                input.eth_client.0.fetch_chain_id().await.context("Failed to fetch ETH client chain id")?, 
+                self.config.l1_chain_contracts.ecosystem_contracts.bridgehub_proxy_addr.context("Missing L1 bridgehub")?,
+                SLChainId(self.config.chain_id.as_u64()),
+                &bridgehub_contract()
             )
             .await
             .context("Error occured while getting current SL mode")?
+            .context("Missing settlement layer on L1 bridgehub")?
         };
 
         let l2_eth_client = get_l2_client(self.config.gateway_rpc_url).await?;


### PR DESCRIPTION
## What ❔

Instead of fetching from diamond proxy, we fetch chain id directly from bridgehub + the ability to handle the case mid migration from Gateway

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
