### PR TITLE
chore: Increase integration tests timeout

### DIFF
--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/integration.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/integration.rs
@@ -34,7 +34,7 @@ impl<'a> IntegrationTestRunner<'a> {
             shell,
             no_deps,
             ecosystem_config,
-            test_timeout: Duration::from_secs(240),
+            test_timeout: Duration::from_secs(600), // See jest.config.json
             test_suites: vec![],
             test_pattern: None,
         })


### PR DESCRIPTION
## What ❔

Increase timeout for integration tests

## Why ❔

Tests fail often due to timeout and very flaky. Used value from `jest.config.json`

## Is this a breaking change?
- [ ] Yes
- [X] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
