### PR TITLE
feat: remove `zks_getL2ToL1MsgProof`

### DIFF
--- a/core/lib/web3_decl/src/namespaces/zks.rs
+++ b/core/lib/web3_decl/src/namespaces/zks.rs
@@ -73,15 +73,6 @@ pub trait ZksNamespace {
     async fn get_all_account_balances(&self, address: Address)
         -> RpcResult<HashMap<Address, U256>>;
 
-    #[method(name = "getL2ToL1MsgProof")]
-    async fn get_l2_to_l1_msg_proof(
-        &self,
-        block: L2BlockNumber,
-        sender: Address,
-        msg: H256,
-        l2_log_position: Option<usize>,
-    ) -> RpcResult<Option<L2ToL1LogProof>>;
-
     #[method(name = "getL2ToL1LogProof")]
     async fn get_l2_to_l1_log_proof(
         &self,

--- a/core/node/api_server/src/web3/backend_jsonrpsee/namespaces/zks.rs
+++ b/core/node/api_server/src/web3/backend_jsonrpsee/namespaces/zks.rs
@@ -79,18 +79,6 @@ impl ZksNamespaceServer for ZksNamespace {
             .map_err(|err| self.current_method().map_err(err))
     }
 
-    async fn get_l2_to_l1_msg_proof(
-        &self,
-        block: L2BlockNumber,
-        sender: Address,
-        msg: H256,
-        l2_log_position: Option<usize>,
-    ) -> RpcResult<Option<L2ToL1LogProof>> {
-        self.get_l2_to_l1_msg_proof_impl(block, sender, msg, l2_log_position)
-            .await
-            .map_err(|err| self.current_method().map_err(err))
-    }
-
     async fn get_l2_to_l1_log_proof(
         &self,
         tx_hash: H256,

--- a/core/node/api_server/src/web3/namespaces/zks.rs
+++ b/core/node/api_server/src/web3/namespaces/zks.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use anyhow::Context as _;
 use zksync_crypto_primitives::hasher::{keccak::KeccakHasher, Hasher};
 use zksync_dal::{Connection, Core, CoreDal, DalError};
 use zksync_metadata_calculator::api_server::TreeApiError;
@@ -8,11 +7,10 @@ use zksync_mini_merkle_tree::MiniMerkleTree;
 use zksync_multivm::interface::VmEvent;
 use zksync_system_constants::DEFAULT_L2_TX_GAS_PER_PUBDATA_BYTE;
 use zksync_types::{
-    address_to_h256,
     api::{
-        self, state_override::StateOverride, BlockDetails, BridgeAddresses, GetLogsFilter,
-        L1BatchDetails, L2ToL1LogProof, Proof, ProtocolVersion, StorageProof,
-        TransactionDetailedResult, TransactionDetails,
+        self, state_override::StateOverride, BlockDetails, BridgeAddresses, L1BatchDetails,
+        L2ToL1LogProof, Proof, ProtocolVersion, StorageProof, TransactionDetailedResult,
+        TransactionDetails,
     },
     fee::Fee,
     fee_model::{FeeParams, PubdataIndependentBatchFeeModelInput},
@@ -26,7 +24,7 @@ use zksync_types::{
     web3,
     web3::Bytes,
     AccountTreeId, L1BatchNumber, L2BlockNumber, ProtocolVersionId, StorageKey, Transaction,
-    L1_MESSENGER_ADDRESS, L2_BASE_TOKEN_ADDRESS, REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, U256, U64,
+    L2_BASE_TOKEN_ADDRESS, REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_BYTE, U256, U64,
 };
 use zksync_web3_decl::{
     error::{ClientRpcContext, Web3Error},
@@ -243,84 +241,6 @@ impl ZksNamespace {
             })
             .collect();
         Ok(balances)
-    }
-
-    pub async fn get_l2_to_l1_msg_proof_impl(
-        &self,
-        block_number: L2BlockNumber,
-        sender: Address,
-        msg: H256,
-        l2_log_position: Option<usize>,
-    ) -> Result<Option<L2ToL1LogProof>, Web3Error> {
-        if let Some(handler) = &self.state.l2_l1_log_proof_handler {
-            return handler
-                .get_l2_to_l1_msg_proof(block_number, sender, msg, l2_log_position)
-                .rpc_context("get_l2_to_l1_msg_proof")
-                .await
-                .map_err(Into::into);
-        }
-
-        let mut storage = self.state.acquire_connection().await?;
-        self.state
-            .start_info
-            .ensure_not_pruned(block_number, &mut storage)
-            .await?;
-
-        let Some(l1_batch_number) = storage
-            .blocks_web3_dal()
-            .get_l1_batch_number_of_l2_block(block_number)
-            .await
-            .map_err(DalError::generalize)?
-        else {
-            return Ok(None);
-        };
-        let (first_l2_block_of_l1_batch, _) = storage
-            .blocks_web3_dal()
-            .get_l2_block_range_of_l1_batch(l1_batch_number)
-            .await
-            .map_err(DalError::generalize)?
-            .context("L1 batch should contain at least one L2 block")?;
-
-        // Position of l1 log in L1 batch relative to logs with identical data
-        let l1_log_relative_position = if let Some(l2_log_position) = l2_log_position {
-            let logs = storage
-                .events_web3_dal()
-                .get_logs(
-                    GetLogsFilter {
-                        from_block: first_l2_block_of_l1_batch,
-                        to_block: block_number,
-                        addresses: vec![L1_MESSENGER_ADDRESS],
-                        topics: vec![(2, vec![address_to_h256(&sender)]), (3, vec![msg])],
-                    },
-                    self.state.api_config.req_entities_limit,
-                )
-                .await
-                .map_err(DalError::generalize)?;
-            let maybe_pos = logs.iter().position(|event| {
-                event.block_number == Some(block_number.0.into())
-                    && event.log_index == Some(l2_log_position.into())
-            });
-            match maybe_pos {
-                Some(pos) => pos,
-                None => return Ok(None),
-            }
-        } else {
-            0
-        };
-
-        let log_proof = self
-            .get_l2_to_l1_log_proof_inner(
-                &mut storage,
-                l1_batch_number,
-                l1_log_relative_position,
-                |log| {
-                    log.sender == L1_MESSENGER_ADDRESS
-                        && log.key == address_to_h256(&sender)
-                        && log.value == msg
-                },
-            )
-            .await?;
-        Ok(log_proof)
     }
 
     async fn get_l2_to_l1_log_proof_inner(


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Removes `zks_getL2ToL1MsgProof` from our JSON-RPC API. Greenlit by devex, devrel and protocol.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

* Has been deprecated for a long time
* Has a direct alternative in the form of `zks_getL2ToL1LogProof`
* No observable usage on any of the envs
* Unused in SDKs

## Is this a breaking change?
- [x] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

`zks_getL2ToL1MsgProof` can be removed from JSON-RPC whitelist

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
