### PR TITLE
refactor: Introduce cancelation errors

### DIFF
--- a/core/bin/contract-verifier/src/main.rs
+++ b/core/bin/contract-verifier/src/main.rs
@@ -142,7 +142,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::select! {
         () = tasks.wait_single() => {},
         _ = tokio::signal::ctrl_c() => {
-            tracing::info!("Stop signal received, shutting down");
+            tracing::info!("Stop request received, shutting down");
         },
     };
     stop_sender.send_replace(true);

--- a/core/bin/external_node/src/tests/mod.rs
+++ b/core/bin/external_node/src/tests/mod.rs
@@ -135,7 +135,7 @@ async fn node_reacts_to_stop_signal_during_initial_reorg_detection() {
     let timeout_result = tokio::time::timeout(Duration::from_millis(50), &mut node_handle).await;
     assert_matches!(timeout_result, Err(tokio::time::error::Elapsed { .. }));
 
-    // Send a stop signal and check that the node reacts to it.
+    // Send a stop request and check that the node reacts to it.
     env_handles.sigint_sender.send(()).unwrap();
     node_handle.await.unwrap().unwrap();
 }

--- a/core/bin/zksync_tee_prover/src/tee_prover.rs
+++ b/core/bin/zksync_tee_prover/src/tee_prover.rs
@@ -151,7 +151,7 @@ impl Task for TeeProver {
 
         loop {
             if *stop_receiver.0.borrow() {
-                tracing::info!("Stop signal received, shutting down TEE Prover component");
+                tracing::info!("Stop request received, shutting down TEE Prover component");
                 return Ok(());
             }
             let result = self.step(&public_key).await;

--- a/core/lib/basic_types/src/errors.rs
+++ b/core/lib/basic_types/src/errors.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 /// Represents an error in a stoppable task: either an internal / fatal error, or a task getting stopped
-/// after receiving a stop signal.
+/// after receiving a stop request.
 ///
 /// The [`Error`](std::error::Error) trait is intentionally not implemented for this enum to force users
 /// to treat the `Stopped` variant with care. Depending on the application, it may not be an error.
@@ -10,7 +10,7 @@ use std::fmt;
 pub enum OrStopped<E = anyhow::Error> {
     /// Internal error.
     Internal(E),
-    /// Stop after receiving a signal.
+    /// Graceful stop after receiving the corresponding request.
     Stopped,
 }
 
@@ -18,7 +18,7 @@ impl fmt::Display for OrStopped {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Internal(err) => write!(formatter, "{err:#}"),
-            Self::Stopped => formatter.write_str("stopped by signal"),
+            Self::Stopped => formatter.write_str("gracefully stopped"),
         }
     }
 }

--- a/core/lib/basic_types/src/errors.rs
+++ b/core/lib/basic_types/src/errors.rs
@@ -1,0 +1,11 @@
+#[derive(Debug)]
+pub enum OrStopped<E = anyhow::Error> {
+    Internal(E),
+    Stopped,
+}
+
+impl<E> From<E> for OrStopped<E> {
+    fn from(err: E) -> Self {
+        Self::Internal(err)
+    }
+}

--- a/core/lib/basic_types/src/errors.rs
+++ b/core/lib/basic_types/src/errors.rs
@@ -1,8 +1,16 @@
 use std::fmt;
 
+/// Represents an error in a stoppable task: either an internal / fatal error, or a task getting stopped
+/// after receiving a stop signal.
+///
+/// The [`Error`](std::error::Error) trait is intentionally not implemented for this enum to force users
+/// to treat the `Stopped` variant with care. Depending on the application, it may not be an error.
+/// Use the [`try_stoppable!` macro](crate::try_stoppable) to handle this variant by early-returning `Ok(())`.
 #[derive(Debug)]
 pub enum OrStopped<E = anyhow::Error> {
+    /// Internal error.
     Internal(E),
+    /// Stop after receiving a signal.
     Stopped,
 }
 
@@ -21,7 +29,9 @@ impl<E> From<E> for OrStopped<E> {
     }
 }
 
+/// Extension trait for `Result<_, OrStopped>` similar to [`anyhow::Context`].
 pub trait StopContext<T>: Sized {
+    /// Adds context to the internal error, if any.
     fn stop_context(self, context: &'static str) -> Result<T, OrStopped>;
 }
 

--- a/core/lib/basic_types/src/errors.rs
+++ b/core/lib/basic_types/src/errors.rs
@@ -1,11 +1,35 @@
+use std::fmt;
+
 #[derive(Debug)]
 pub enum OrStopped<E = anyhow::Error> {
     Internal(E),
     Stopped,
 }
 
+impl fmt::Display for OrStopped {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Internal(err) => write!(formatter, "{err:#}"),
+            Self::Stopped => formatter.write_str("stopped by signal"),
+        }
+    }
+}
+
 impl<E> From<E> for OrStopped<E> {
     fn from(err: E) -> Self {
         Self::Internal(err)
+    }
+}
+
+pub trait StopContext<T>: Sized {
+    fn stop_context(self, context: &'static str) -> Result<T, OrStopped>;
+}
+
+impl<T> StopContext<T> for Result<T, OrStopped> {
+    fn stop_context(self, context: &'static str) -> Result<T, OrStopped> {
+        self.map_err(|err| match err {
+            OrStopped::Internal(err) => OrStopped::Internal(err.context(context)),
+            OrStopped::Stopped => OrStopped::Stopped,
+        })
     }
 }

--- a/core/lib/basic_types/src/lib.rs
+++ b/core/lib/basic_types/src/lib.rs
@@ -27,7 +27,7 @@ pub use self::{
         address_to_h256, address_to_u256, h256_to_address, h256_to_u256, u256_to_address,
         u256_to_h256,
     },
-    errors::OrStopped,
+    errors::{OrStopped, StopContext},
 };
 
 #[macro_use]

--- a/core/lib/basic_types/src/lib.rs
+++ b/core/lib/basic_types/src/lib.rs
@@ -22,8 +22,12 @@ pub use ethabi::{
 };
 use serde::{de, Deserialize, Deserializer, Serialize};
 
-pub use self::conversions::{
-    address_to_h256, address_to_u256, h256_to_address, h256_to_u256, u256_to_address, u256_to_h256,
+pub use self::{
+    conversions::{
+        address_to_h256, address_to_u256, h256_to_address, h256_to_u256, u256_to_address,
+        u256_to_h256,
+    },
+    errors::OrStopped,
 };
 
 #[macro_use]
@@ -32,6 +36,7 @@ pub mod basic_fri_types;
 pub mod bytecode;
 pub mod commitment;
 mod conversions;
+mod errors;
 pub mod network;
 pub mod protocol_version;
 pub mod prover_dal;

--- a/core/lib/basic_types/src/macros.rs
+++ b/core/lib/basic_types/src/macros.rs
@@ -89,7 +89,7 @@ macro_rules! try_stoppable {
         match $res {
             ::core::result::Result::Ok(value) => value,
             ::core::result::Result::Err($crate::OrStopped::Stopped) => {
-                ::tracing::info!("Stop signal was received");
+                ::tracing::info!("Stop request was received");
                 return Ok(());
             }
             ::core::result::Result::Err($crate::OrStopped::Internal(err)) => {

--- a/core/lib/basic_types/src/macros.rs
+++ b/core/lib/basic_types/src/macros.rs
@@ -76,3 +76,19 @@ macro_rules! basic_type {
         }
     };
 }
+
+#[macro_export]
+macro_rules! try_stoppable {
+    ($res:expr) => {
+        match $res {
+            ::core::result::Result::Ok(value) => value,
+            ::core::result::Result::Err($crate::OrStopped::Stopped) => {
+                ::tracing::info!("Stop signal was received");
+                return Ok(());
+            }
+            ::core::result::Result::Err($crate::OrStopped::Internal(err)) => {
+                return Err(err);
+            }
+        }
+    };
+}

--- a/core/lib/basic_types/src/macros.rs
+++ b/core/lib/basic_types/src/macros.rs
@@ -77,6 +77,12 @@ macro_rules! basic_type {
     };
 }
 
+/// Shortcuts both error variants in a `Result<_, OrStopped>`.
+///
+/// The [`Internal`](crate::OrStopped::Internal) variant is mapped to an error, and the [`Stopped`](crate::OrStopped::Stopped)
+/// variant is mapped to `Ok(())`. As such, a method / function where this macro is invoked must return `anyhow::Result<()>`.
+///
+/// This macro makes sense to call in higher-level tasks that compose lower-level code returning `Result<_, OrStopped>`.
 #[macro_export]
 macro_rules! try_stoppable {
     ($res:expr) => {

--- a/core/lib/basic_types/src/macros.rs
+++ b/core/lib/basic_types/src/macros.rs
@@ -93,7 +93,8 @@ macro_rules! try_stoppable {
                 return Ok(());
             }
             ::core::result::Result::Err($crate::OrStopped::Internal(err)) => {
-                return Err(err);
+                #[allow(clippy::useless_conversion)]
+                return Err(err.into());
             }
         }
     };

--- a/core/lib/circuit_breaker/src/lib.rs
+++ b/core/lib/circuit_breaker/src/lib.rs
@@ -86,7 +86,7 @@ impl CircuitBreakerChecker {
                 .await
                 .ok();
         }
-        tracing::info!("received a stop signal; circuit breaker is shut down");
+        tracing::info!("received a stop request; circuit breaker is shut down");
         Ok(())
     }
 }

--- a/core/lib/contract_verifier/src/etherscan/mod.rs
+++ b/core/lib/contract_verifier/src/etherscan/mod.rs
@@ -438,7 +438,7 @@ impl EtherscanVerifier {
     pub async fn run(mut self) -> anyhow::Result<()> {
         loop {
             if *self.stop_receiver.borrow() {
-                tracing::warn!("Stop signal received, shutting down etherscan verifier");
+                tracing::warn!("Stop request received, shutting down etherscan verifier");
                 return Ok(());
             }
 
@@ -448,7 +448,7 @@ impl EtherscanVerifier {
                 tracing::error!("Failed to update solc versions: {}", err);
             }
 
-            // VerifierError::Canceled happens when the stop signal is received. Other errors are handled internally so
+            // VerifierError::Canceled happens when a stop request is received. Other errors are handled internally so
             // it's safe to ignore them to keep the processing loop running.
             if let Err(VerifierError::Canceled) = self.process_next_request().await {
                 continue;

--- a/core/lib/dal/src/helpers.rs
+++ b/core/lib/dal/src/helpers.rs
@@ -3,23 +3,23 @@
 use std::time::Duration;
 
 use tokio::sync::watch;
-use zksync_types::L1BatchNumber;
+use zksync_types::{L1BatchNumber, OrStopped};
 
 use crate::{ConnectionPool, Core, CoreDal};
 
 /// Repeatedly polls the DB until there is an L1 batch. We may not have such a batch initially
 /// if the DB is recovered from an application-level snapshot.
 ///
-/// Returns the number of the *earliest* L1 batch, or `None` if the stop signal is received.
+/// Returns the number of the *earliest* L1 batch.
 pub async fn wait_for_l1_batch(
     pool: &ConnectionPool<Core>,
     poll_interval: Duration,
     stop_receiver: &mut watch::Receiver<bool>,
-) -> anyhow::Result<Option<L1BatchNumber>> {
+) -> Result<L1BatchNumber, OrStopped> {
     tracing::debug!("Waiting for at least one L1 batch in db in DB");
     loop {
         if *stop_receiver.borrow() {
-            return Ok(None);
+            return Err(OrStopped::Stopped);
         }
 
         let mut storage = pool.connection().await?;
@@ -27,7 +27,7 @@ pub async fn wait_for_l1_batch(
         drop(storage);
 
         if let Some(number) = sealed_l1_batch_number {
-            return Ok(Some(number));
+            return Ok(number);
         }
 
         // We don't check the result: if a stop signal is received, we'll return at the start
@@ -68,7 +68,7 @@ mod tests {
         let l1_batch = wait_for_l1_batch(&pool, Duration::from_millis(10), &mut stop_receiver)
             .await
             .unwrap();
-        assert_eq!(l1_batch, Some(L1BatchNumber(0)));
+        assert_eq!(l1_batch, L1BatchNumber(0));
     }
 
     #[tokio::test]
@@ -81,9 +81,9 @@ mod tests {
             stop_sender.send_replace(true);
         });
 
-        let l1_batch = wait_for_l1_batch(&pool, Duration::from_secs(30), &mut stop_receiver)
+        let err = wait_for_l1_batch(&pool, Duration::from_secs(30), &mut stop_receiver)
             .await
-            .unwrap();
-        assert_eq!(l1_batch, None);
+            .unwrap_err();
+        assert!(matches!(err, OrStopped::Stopped));
     }
 }

--- a/core/lib/dal/src/helpers.rs
+++ b/core/lib/dal/src/helpers.rs
@@ -30,7 +30,7 @@ pub async fn wait_for_l1_batch(
             return Ok(number);
         }
 
-        // We don't check the result: if a stop signal is received, we'll return at the start
+        // We don't check the result: if a stop request is received, we'll return at the start
         // of the next iteration.
         tokio::time::timeout(poll_interval, stop_receiver.changed())
             .await

--- a/core/lib/db_connection/src/error.rs
+++ b/core/lib/db_connection/src/error.rs
@@ -1,6 +1,7 @@
 use std::{fmt, panic::Location};
 
 use sqlx::error::BoxDynError;
+use zksync_basic_types::OrStopped;
 
 use crate::connection::ConnectionTags;
 
@@ -25,6 +26,12 @@ impl DalError {
     /// Wraps this error into an `anyhow` wrapper.
     pub fn generalize(self) -> anyhow::Error {
         anyhow::Error::from(self).context("Postgres error")
+    }
+}
+
+impl From<DalError> for OrStopped {
+    fn from(err: DalError) -> Self {
+        err.generalize().into()
     }
 }
 

--- a/core/lib/db_connection/src/error.rs
+++ b/core/lib/db_connection/src/error.rs
@@ -29,6 +29,8 @@ impl DalError {
     }
 }
 
+// `DalError` is somewhat frequently converted to `OrStopped` in tasks, so we allow it via `?` instead
+// of forcing users to use `.map_err(DalError::generalize)`.
 impl From<DalError> for OrStopped {
     fn from(err: DalError) -> Self {
         err.generalize().into()

--- a/core/lib/merkle_tree/src/pruning.rs
+++ b/core/lib/merkle_tree/src/pruning.rs
@@ -233,7 +233,7 @@ impl<DB: PruneDatabase> MerkleTreePruner<DB> {
                 self.poll_interval
             };
         }
-        tracing::info!("Stop signal received, tree pruning is shut down");
+        tracing::info!("Stop request received, tree pruning is shut down");
         Ok(())
     }
 }

--- a/core/lib/merkle_tree/src/repair.rs
+++ b/core/lib/merkle_tree/src/repair.rs
@@ -275,7 +275,7 @@ impl StaleKeysRepairTask {
                 self.poll_interval
             };
         }
-        tracing::info!("Stop signal received, stale keys repair is shut down");
+        tracing::info!("Stop request received, stale keys repair is shut down");
         Ok(())
     }
 }

--- a/core/lib/queued_job_processor/src/lib.rs
+++ b/core/lib/queued_job_processor/src/lib.rs
@@ -67,7 +67,7 @@ pub trait JobProcessor: Sync + Send {
         while iterations_left.map_or(true, |i| i > 0) {
             if *stop_receiver.borrow() {
                 tracing::warn!(
-                    "Stop signal received, shutting down {} component while waiting for a new job",
+                    "Stop request received, shutting down {} component while waiting for a new job",
                     Self::SERVICE_NAME
                 );
                 return Ok(());
@@ -141,7 +141,7 @@ pub trait JobProcessor: Sync + Send {
             .await
             .is_ok()
             {
-                // Stop signal received, return early.
+                // Stop request received, return early.
                 // Exit will be processed/reported by the main loop.
                 return Ok(());
             }

--- a/core/lib/state/src/catchup.rs
+++ b/core/lib/state/src/catchup.rs
@@ -1,13 +1,10 @@
-use std::{
-    error, fmt,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use tokio::sync::watch;
 use zksync_dal::{ConnectionPool, Core};
 use zksync_shared_metrics::{SnapshotRecoveryStage, APP_METRICS};
-use zksync_types::L1BatchNumber;
+use zksync_types::{try_stoppable, L1BatchNumber, OrStopped};
 
 use crate::{rocksdb::InitStrategy, RocksdbStorage, RocksdbStorageOptions};
 
@@ -19,19 +16,6 @@ pub struct InitialRocksdbState {
     /// `None` if the cache is empty (i.e., needs recovery).
     pub next_l1_batch_number: Option<L1BatchNumber>,
 }
-
-/// Error returned from [`RocksdbCell`] methods if the corresponding [`AsyncCatchupTask`] has failed
-/// or was canceled.
-#[derive(Debug)]
-pub struct AsyncCatchupFailed(());
-
-impl fmt::Display for AsyncCatchupFailed {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("Async RocksDB cache catchup failed or was canceled")
-    }
-}
-
-impl error::Error for AsyncCatchupFailed {}
 
 /// `OnceCell` equivalent that can be `.await`ed. Correspondingly, it has the following invariants:
 ///
@@ -57,14 +41,14 @@ impl RocksdbCell {
     ///
     /// Returns an error if the async catch-up task failed or was canceled before initialization.
     #[allow(clippy::missing_panics_doc)] // false positive
-    pub async fn wait(&self) -> Result<RocksdbStorage, AsyncCatchupFailed> {
+    pub async fn wait(&self) -> Result<RocksdbStorage, OrStopped> {
         self.db
             .clone()
             .wait_for(Option::is_some)
             .await
             // `unwrap` below is safe by construction
             .map(|db| db.clone().unwrap())
-            .map_err(|_| AsyncCatchupFailed(()))
+            .map_err(|_| OrStopped::Stopped)
     }
 
     /// Gets a RocksDB instance if it has been initialized.
@@ -79,14 +63,14 @@ impl RocksdbCell {
     ///
     /// Returns an error if the async catch-up task failed or was canceled.
     #[allow(clippy::missing_panics_doc)] // false positive
-    pub async fn ensure_initialized(&self) -> Result<InitialRocksdbState, AsyncCatchupFailed> {
+    pub async fn ensure_initialized(&self) -> Result<InitialRocksdbState, OrStopped> {
         self.initial_state
             .clone()
             .wait_for(Option::is_some)
             .await
             // `unwrap` below is safe by construction
             .map(|state| state.clone().unwrap())
-            .map_err(|_| AsyncCatchupFailed(()))
+            .map_err(|_| OrStopped::Stopped)
     }
 
     /// Creates a task that will keep storage updated after it has caught up.
@@ -176,14 +160,11 @@ impl AsyncCatchupTask {
         tracing::info!("Initialized RocksDB catchup from state: {initial_state:?}");
         self.initial_state_sender.send_replace(Some(initial_state));
 
-        let Some((storage, init_strategy)) = rocksdb_builder
-            .ensure_ready(&self.recovery_pool, &stop_receiver)
-            .await
-            .context("failed initializing state keeper RocksDB from snapshot or scratch")?
-        else {
-            tracing::info!("RocksDB cache recovery was interrupted");
-            return Ok(());
-        };
+        let (storage, init_strategy) = try_stoppable!(
+            rocksdb_builder
+                .ensure_ready(&self.recovery_pool, &stop_receiver)
+                .await
+        );
 
         if matches!(init_strategy, InitStrategy::Recovery) {
             let elapsed = started_at.elapsed();
@@ -193,18 +174,13 @@ impl AsyncCatchupTask {
         }
 
         let mut connection = self.pool.connection_tagged("state_keeper").await?;
-        let rocksdb = storage
-            .synchronize(&mut connection, &stop_receiver, self.to_l1_batch_number)
-            .await
-            .context("Failed to catch up RocksDB to Postgres")?;
+        let rocksdb = try_stoppable!(
+            storage
+                .synchronize(&mut connection, &stop_receiver, self.to_l1_batch_number)
+                .await
+        );
         drop(connection);
-
-        if let Some(rocksdb) = rocksdb {
-            self.db_sender.send_replace(Some(rocksdb));
-        } else {
-            tracing::info!("Synchronizing RocksDB interrupted");
-        }
-
+        self.db_sender.send_replace(Some(rocksdb));
         Ok(())
     }
 }
@@ -235,18 +211,12 @@ impl KeepUpdatedTask {
 
         loop {
             let mut connection = self.pool.connection_tagged("rocksdb_updater_task").await?;
-            storage = match storage
-                .synchronize(&mut connection, &stop_receiver, None)
-                .await
-            {
-                Ok(Some(storage)) => storage,
-                Ok(None) => return Ok(()), // synchronization was interrupted
-                Err(err) => {
-                    return Err(err).context("Failed to catch up RocksDB to Postgres");
-                }
-            };
+            storage = try_stoppable!(
+                storage
+                    .synchronize(&mut connection, &stop_receiver, None)
+                    .await
+            );
             drop(connection);
-
             tokio::time::sleep(SLEEP_INTERVAL).await;
         }
     }

--- a/core/lib/state/src/catchup.rs
+++ b/core/lib/state/src/catchup.rs
@@ -199,11 +199,11 @@ impl KeepUpdatedTask {
                 // `unwrap()` is safe by construction
                 db.clone().unwrap()
             } else {
-                tracing::info!("Stop signal received, shutting down rocksdb updater task");
+                tracing::info!("Stop request received, shutting down rocksdb updater task");
                 return Ok(());
             },
             _ = stop_receiver.changed() => {
-                tracing::info!("Stop signal received, shutting down rocksdb updater task");
+                tracing::info!("Stop request received, shutting down rocksdb updater task");
                 return Ok(());
             }
         };

--- a/core/lib/state/src/postgres/mod.rs
+++ b/core/lib/state/src/postgres/mod.rs
@@ -394,7 +394,7 @@ impl PostgresStorageCachesTask {
                     *self.command_receiver.borrow_and_update()
                 },
                 else => {
-                    // The command sender has been dropped, which means that we must receive the stop signal soon.
+                    // The command sender has been dropped, which means that we must receive the stop request soon.
                     stop_receiver.changed().await?;
                     break;
                 }

--- a/core/lib/state/src/rocksdb/mod.rs
+++ b/core/lib/state/src/rocksdb/mod.rs
@@ -277,6 +277,12 @@ impl RocksdbStorage {
     ///
     /// - Errors if the local L1 batch number is greater than the last sealed L1 batch number
     ///   in Postgres.
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        err,
+        fields(to_l1_batch_number = ?to_l1_batch_number)
+    )]
     pub async fn synchronize(
         mut self,
         storage: &mut Connection<'_, Core>,

--- a/core/lib/state/src/rocksdb/mod.rs
+++ b/core/lib/state/src/rocksdb/mod.rs
@@ -32,7 +32,7 @@ use itertools::{Either, Itertools};
 use tokio::sync::watch;
 use zksync_dal::{Connection, ConnectionPool, Core, CoreDal, DalError};
 use zksync_storage::{db::NamedColumnFamily, RocksDB, RocksDBOptions};
-use zksync_types::{L1BatchNumber, StorageKey, StorageValue, H256};
+use zksync_types::{L1BatchNumber, OrStopped, StorageKey, StorageValue, H256};
 use zksync_vm_interface::storage::ReadStorage;
 
 use self::metrics::METRICS;
@@ -117,25 +117,6 @@ impl StateValue {
     }
 }
 
-/// Error emitted when [`RocksdbStorage`] is being updated.
-#[derive(Debug)]
-pub(crate) enum RocksdbSyncError {
-    Internal(anyhow::Error),
-    Interrupted,
-}
-
-impl From<anyhow::Error> for RocksdbSyncError {
-    fn from(err: anyhow::Error) -> Self {
-        Self::Internal(err)
-    }
-}
-
-impl From<DalError> for RocksdbSyncError {
-    fn from(err: DalError) -> Self {
-        Self::Internal(err.generalize())
-    }
-}
-
 /// Options for [`RocksdbStorage`].
 #[derive(Debug, Clone, Copy)]
 pub struct RocksdbStorageOptions {
@@ -215,20 +196,16 @@ impl RocksdbStorageBuilder {
         mut self,
         recovery_pool: &ConnectionPool<Core>,
         stop_receiver: &watch::Receiver<bool>,
-    ) -> anyhow::Result<Option<(RocksdbStorage, InitStrategy)>> {
-        let ready_result = self
+    ) -> Result<(RocksdbStorage, InitStrategy), OrStopped> {
+        let init_strategy = self
             .0
             .ensure_ready(
                 recovery_pool,
                 RocksdbStorage::DESIRED_LOG_CHUNK_SIZE,
                 stop_receiver,
             )
-            .await;
-        match ready_result {
-            Ok((strategy, _)) => Ok(Some((self.0, strategy))),
-            Err(RocksdbSyncError::Interrupted) => Ok(None),
-            Err(RocksdbSyncError::Internal(err)) => Err(err),
-        }
+            .await?;
+        Ok((self.0, init_strategy))
     }
 
     /// Gets the underlying storage if it is initialized. Unlike [`Self::ensure_ready()`], this method
@@ -305,7 +282,7 @@ impl RocksdbStorage {
         storage: &mut Connection<'_, Core>,
         stop_receiver: &watch::Receiver<bool>,
         to_l1_batch_number: Option<L1BatchNumber>,
-    ) -> anyhow::Result<Option<Self>> {
+    ) -> Result<Self, OrStopped> {
         let mut current_l1_batch_number = self.next_l1_batch_number().await;
 
         let latency = METRICS.update.start();
@@ -313,15 +290,16 @@ impl RocksdbStorage {
             storage.blocks_dal().get_sealed_l1_batch_number().await?
         else {
             // No L1 batches are persisted in Postgres; update is not necessary.
-            return Ok(Some(self));
+            return Ok(self);
         };
 
         let to_l1_batch_number = if let Some(to_l1_batch_number) = to_l1_batch_number {
             if to_l1_batch_number > latest_l1_batch_number {
-                anyhow::bail!(
+                let err = anyhow::anyhow!(
                     "Requested to update RocksDB to L1 batch number ({to_l1_batch_number}) that \
                      is greater than the last sealed L1 batch number in Postgres ({latest_l1_batch_number})"
                 );
+                return Err(err.into());
             }
             to_l1_batch_number
         } else {
@@ -330,15 +308,16 @@ impl RocksdbStorage {
         tracing::debug!("Loading storage for l1 batch number {to_l1_batch_number}");
 
         if current_l1_batch_number > to_l1_batch_number + 1 {
-            anyhow::bail!(
+            let err = anyhow::anyhow!(
                 "L1 batch number in state keeper cache ({current_l1_batch_number}) is greater than \
                  the requested batch number ({to_l1_batch_number})"
             );
+            return Err(err.into());
         }
 
         while current_l1_batch_number <= to_l1_batch_number {
             if *stop_receiver.borrow() {
-                return Ok(None);
+                return Err(OrStopped::Stopped);
             }
             let current_lag = to_l1_batch_number.0 - current_l1_batch_number.0 + 1;
             METRICS.lag.set(current_lag.into());
@@ -380,7 +359,7 @@ impl RocksdbStorage {
             "Secondary storage for L1 batch #{to_l1_batch_number} initialized, size is {estimated_size}"
         );
 
-        Ok(Some(self))
+        Ok(self)
     }
 
     async fn apply_storage_logs(

--- a/core/lib/state/src/rocksdb/recovery.rs
+++ b/core/lib/state/src/rocksdb/recovery.rs
@@ -6,13 +6,15 @@ use anyhow::Context as _;
 use futures::future;
 use tokio::sync::{watch, Mutex, Semaphore};
 use zksync_dal::{
-    storage_logs_dal::StorageRecoveryLogEntry, Connection, ConnectionPool, Core, CoreDal, DalError,
+    storage_logs_dal::StorageRecoveryLogEntry, Connection, ConnectionPool, Core, CoreDal,
 };
-use zksync_types::{snapshots::uniform_hashed_keys_chunk, L1BatchNumber, L2BlockNumber, H256};
+use zksync_types::{
+    snapshots::uniform_hashed_keys_chunk, L1BatchNumber, L2BlockNumber, OrStopped, H256,
+};
 
 use super::{
     metrics::{ChunkRecoveryStage, RecoveryStage, RECOVERY_METRICS},
-    RocksdbStorage, RocksdbSyncError, StateValue,
+    RocksdbStorage, StateValue,
 };
 
 #[derive(Debug)]
@@ -129,16 +131,13 @@ impl RocksdbStorage {
         pool: &ConnectionPool<Core>,
         desired_log_chunk_size: u64,
         stop_receiver: &watch::Receiver<bool>,
-    ) -> Result<(InitStrategy, L1BatchNumber), RocksdbSyncError> {
+    ) -> Result<InitStrategy, OrStopped> {
         if let Some(l1_batch_number) = self.next_l1_batch_number_opt().await {
             tracing::info!(?l1_batch_number, "RocksDB storage is ready");
-            return Ok((InitStrategy::Complete, l1_batch_number));
+            return Ok(InitStrategy::Complete);
         }
 
-        let mut storage = pool
-            .connection_tagged("state_keeper")
-            .await
-            .map_err(DalError::generalize)?;
+        let mut storage = pool.connection_tagged("state_keeper").await?;
         let init_params = InitParameters::new(&mut storage, desired_log_chunk_size).await?;
         drop(storage);
 
@@ -159,11 +158,11 @@ impl RocksdbStorage {
         Ok(if let Some(init_params) = init_params {
             self.recover_from_snapshot(pool, &init_params, stop_receiver)
                 .await?;
-            (InitStrategy::Recovery, init_params.l1_batch + 1)
+            InitStrategy::Recovery
         } else {
             tracing::info!("Initializing RocksDB storage from genesis");
             self.set_l1_batch_number(L1BatchNumber(0), false).await?;
-            (InitStrategy::Genesis, L1BatchNumber(0))
+            InitStrategy::Genesis
         })
     }
 
@@ -176,9 +175,9 @@ impl RocksdbStorage {
         pool: &ConnectionPool<Core>,
         init_parameters: &InitParameters,
         stop_receiver: &watch::Receiver<bool>,
-    ) -> Result<(), RocksdbSyncError> {
+    ) -> Result<(), OrStopped> {
         if *stop_receiver.borrow() {
-            return Err(RocksdbSyncError::Interrupted);
+            return Err(OrStopped::Stopped);
         }
 
         tracing::info!(
@@ -194,7 +193,7 @@ impl RocksdbStorage {
             .await?;
 
         if *stop_receiver.borrow() {
-            return Err(RocksdbSyncError::Interrupted);
+            return Err(OrStopped::Stopped);
         }
         let key_chunks = Self::load_key_chunks(&mut storage, init_parameters).await?;
         drop(storage);
@@ -368,14 +367,14 @@ impl RocksdbStorage {
         key_chunk: KeyChunk,
         total_chunk_count: usize,
         stop_receiver: &watch::Receiver<bool>,
-    ) -> Result<(), RocksdbSyncError> {
+    ) -> Result<(), OrStopped> {
         let latency =
             RECOVERY_METRICS.chunk_latency[&ChunkRecoveryStage::AcquireConnection].start();
         let mut storage = pool.connection_tagged("state_keeper").await?;
         latency.observe();
 
         if *stop_receiver.borrow() {
-            return Err(RocksdbSyncError::Interrupted);
+            return Err(OrStopped::Stopped);
         }
 
         let latency = RECOVERY_METRICS.chunk_latency[&ChunkRecoveryStage::LoadEntries].start();
@@ -387,7 +386,7 @@ impl RocksdbStorage {
         tracing::debug!(?latency, len = all_entries.len(), "Loaded log entries");
 
         if *stop_receiver.borrow() {
-            return Err(RocksdbSyncError::Interrupted);
+            return Err(OrStopped::Stopped);
         }
 
         Self::check_pruning_info(&mut storage, init_parameters.l1_batch).await?;
@@ -399,7 +398,7 @@ impl RocksdbStorage {
         tracing::debug!(?latency, "Acquired RocksDB mutex");
 
         if *stop_receiver.borrow() {
-            return Err(RocksdbSyncError::Interrupted);
+            return Err(OrStopped::Stopped);
         }
 
         let latency = RECOVERY_METRICS.chunk_latency[&ChunkRecoveryStage::SaveEntries].start();

--- a/core/lib/state/src/rocksdb/recovery.rs
+++ b/core/lib/state/src/rocksdb/recovery.rs
@@ -125,7 +125,7 @@ impl RocksdbStorage {
     /// # Return value
     ///
     /// Returns the next L1 batch that should be fed to the storage.
-    #[tracing::instrument(skip_all, ret)]
+    #[tracing::instrument(skip_all, ret, err)]
     pub(super) async fn ensure_ready(
         &mut self,
         pool: &ConnectionPool<Core>,
@@ -359,7 +359,7 @@ impl RocksdbStorage {
         Ok(retained_chunks)
     }
 
-    #[tracing::instrument(skip_all, fields(id = key_chunk.id, range = ?key_chunk.key_range))]
+    #[tracing::instrument(skip_all, err, fields(id = key_chunk.id, range = ?key_chunk.key_range))]
     async fn recover_logs_chunk(
         this: &Mutex<Self>,
         pool: &ConnectionPool<Core>,

--- a/core/lib/state/src/storage_factory/mod.rs
+++ b/core/lib/state/src/storage_factory/mod.rs
@@ -335,8 +335,8 @@ pub trait ReadStorageFactory<S = OwnedStorage>: fmt::Debug + Send + Sync + 'stat
     /// Creates a storage instance, e.g. over a Postgres connection or a RocksDB instance.
     /// The specific criteria on which one are left up to the implementation.
     ///
-    /// Implementations may be cancel-aware and return `Ok(None)` iff `stop_receiver` receives
-    /// a stop signal; this is the only case in which `Ok(None)` should be returned.
+    /// Implementations may be stop-aware and return `Err(OrStopped::Stopped)` iff `stop_receiver` receives
+    /// a stop request.
     async fn access_storage(
         &self,
         stop_receiver: &watch::Receiver<bool>,

--- a/core/lib/vm_executor/src/batch/factory.rs
+++ b/core/lib/vm_executor/src/batch/factory.rs
@@ -398,7 +398,7 @@ impl<S: ReadStorage + 'static, Tr: BatchTracer> CommandReceiver<S, Tr> {
             EXECUTOR_METRICS.batch_storage_interaction_duration[&InteractionType::SetValue]
                 .observe(stats.time_spent_on_set_value);
         } else {
-            // State keeper can exit because of stop signal, so it's OK to exit mid-batch.
+            // State keeper can exit because of a stop request, so it's OK to exit mid-batch.
             tracing::info!("State keeper exited with an unfinished L1 batch");
         }
         Ok(storage_view)

--- a/core/node/api_server/src/healthcheck.rs
+++ b/core/node/api_server/src/healthcheck.rs
@@ -35,9 +35,9 @@ async fn run_server(
     axum::serve(listener, app)
         .with_graceful_shutdown(async move {
             if stop_receiver.changed().await.is_err() {
-                tracing::warn!("Stop signal sender for healthcheck server was dropped without sending a signal");
+                tracing::warn!("Stop request sender for healthcheck server was dropped without sending a request");
             }
-            tracing::info!("Stop signal received, healthcheck server is shutting down");
+            tracing::info!("Stop request received, healthcheck server is shutting down");
         })
         .await
         .expect("Healthcheck server failed");

--- a/core/node/api_server/src/tx_sender/proxy.rs
+++ b/core/node/api_server/src/tx_sender/proxy.rs
@@ -13,7 +13,7 @@ use zksync_dal::{
 };
 use zksync_multivm::interface::tracer::ValidationTraces;
 use zksync_shared_metrics::{TxStage, APP_METRICS};
-use zksync_types::{api, l2::L2Tx, Address, Nonce, H256, U256};
+use zksync_types::{api, l2::L2Tx, try_stoppable, Address, Nonce, StopContext, H256, U256};
 use zksync_web3_decl::{
     client::{DynClient, L2},
     error::{ClientRpcContext, EnrichedClientResult, Web3Error},
@@ -186,17 +186,12 @@ impl TxCache {
         // Starting the updater before L1 batches are present in Postgres can lead to some invariants the server logic
         // implicitly assumes not being upheld. The only case when we'll actually wait here is immediately after snapshot recovery.
         let earliest_l1_batch_number =
-            wait_for_l1_batch(&pool, UPDATE_INTERVAL, &mut stop_receiver)
-                .await
-                .context("error while waiting for L1 batch in Postgres")?;
-        if let Some(number) = earliest_l1_batch_number {
-            tracing::info!("Successfully waited for at least one L1 batch in Postgres; the earliest one is #{number}");
-        } else {
-            tracing::info!(
-                "Received shutdown signal before TxCache::run_updates is started; shutting down"
+            try_stoppable!(
+                wait_for_l1_batch(&pool, UPDATE_INTERVAL, &mut stop_receiver)
+                    .await
+                    .stop_context("error while waiting for L1 batch in Postgres")
             );
-            return Ok(());
-        }
+        tracing::info!("Successfully waited for at least one L1 batch in Postgres; the earliest one is #{earliest_l1_batch_number}");
 
         while !*stop_receiver.borrow() {
             self.step(&pool).await?;

--- a/core/node/api_server/src/tx_sender/whitelist.rs
+++ b/core/node/api_server/src/tx_sender/whitelist.rs
@@ -158,7 +158,7 @@ impl AllowListTask {
             let _ = tokio::time::timeout(self.refresh_interval(), stop_receiver.changed()).await;
         }
 
-        tracing::info!("received a stop signal; allow list task is shut down");
+        tracing::info!("received a stop request; allow list task is shut down");
 
         Ok(())
     }

--- a/core/node/api_server/src/web3/mod.rs
+++ b/core/node/api_server/src/web3/mod.rs
@@ -614,13 +614,11 @@ impl ApiServer {
         );
         // Starting the server before L1 batches are present in Postgres can lead to some invariants the server logic
         // implicitly assumes not being upheld. The only case when we'll actually wait here is immediately after snapshot recovery.
-        let earliest_l1_batch_number = try_stoppable!(wait_for_l1_batch(
-            &self.pool,
-            self.polling_interval,
-            &mut stop_receiver
-        )
-        .await
-        .stop_context("error while waiting for L1 batch in Postgres"));
+        let earliest_l1_batch_number =
+            wait_for_l1_batch(&self.pool, self.polling_interval, &mut stop_receiver).await;
+        let earliest_l1_batch_number =
+            try_stoppable!(earliest_l1_batch_number
+                .stop_context("error while waiting for L1 batch in Postgres"));
         tracing::info!("Successfully waited for at least one L1 batch in Postgres; the earliest one is #{earliest_l1_batch_number}");
 
         let batch_request_config = self

--- a/core/node/api_server/src/web3/mod.rs
+++ b/core/node/api_server/src/web3/mod.rs
@@ -749,7 +749,7 @@ impl ApiServer {
         tokio::spawn(async move {
             if stop_receiver.changed().await.is_err() {
                 tracing::warn!(
-                    "Stop signal sender for {transport_str} JSON-RPC server was dropped \
+                    "Stop request sender for {transport_str} JSON-RPC server was dropped \
                      without sending a signal"
                 );
             }
@@ -757,7 +757,7 @@ impl ApiServer {
                 health_updater.update(HealthStatus::ShuttingDown.into());
             }
             tracing::info!(
-                "Stop signal received, {transport_str} JSON-RPC server is shutting down"
+                "Stop request received, {transport_str} JSON-RPC server is shutting down"
             );
 
             // Wait some time until the traffic to the server stops. This may be necessary if the API server

--- a/core/node/api_server/src/web3/pubsub.rs
+++ b/core/node/api_server/src/web3/pubsub.rs
@@ -78,7 +78,7 @@ impl PubSubNotifier {
                 break;
             }
         }
-        Ok(None) // we can only break from the loop if we've received a stop signal
+        Ok(None) // we can only break from the loop if we've received a stop request
     }
 
     fn emit_event(&self, event: PubSubEvent) {
@@ -94,14 +94,14 @@ impl PubSubNotifier {
             .get_starting_l2_block_number(&mut stop_receiver)
             .await?
         else {
-            tracing::info!("Stop signal received, pubsub_block_notifier is shutting down");
+            tracing::info!("Stop request received, pubsub_block_notifier is shutting down");
             return Ok(());
         };
 
         let mut timer = interval(self.polling_interval);
         loop {
             if *stop_receiver.borrow() {
-                tracing::info!("Stop signal received, pubsub_block_notifier is shutting down");
+                tracing::info!("Stop request received, pubsub_block_notifier is shutting down");
                 break;
             }
             timer.tick().await;
@@ -154,7 +154,7 @@ impl PubSubNotifier {
         let mut timer = interval(self.polling_interval);
         loop {
             if *stop_receiver.borrow() {
-                tracing::info!("Stop signal received, pubsub_tx_notifier is shutting down");
+                tracing::info!("Stop request received, pubsub_tx_notifier is shutting down");
                 break;
             }
             timer.tick().await;
@@ -196,14 +196,14 @@ impl PubSubNotifier {
             .get_starting_l2_block_number(&mut stop_receiver)
             .await?
         else {
-            tracing::info!("Stop signal received, pubsub_logs_notifier is shutting down");
+            tracing::info!("Stop request received, pubsub_logs_notifier is shutting down");
             return Ok(());
         };
 
         let mut timer = interval(self.polling_interval);
         loop {
             if *stop_receiver.borrow() {
-                tracing::info!("Stop signal received, pubsub_logs_notifier is shutting down");
+                tracing::info!("Stop request received, pubsub_logs_notifier is shutting down");
                 break;
             }
             timer.tick().await;

--- a/core/node/base_token_adjuster/src/base_token_ratio_persister.rs
+++ b/core/node/base_token_adjuster/src/base_token_ratio_persister.rs
@@ -62,7 +62,7 @@ impl BaseTokenRatioPersister {
             }
         }
 
-        tracing::info!("Stop signal received, base_token_ratio_persister is shutting down");
+        tracing::info!("Stop request received, base_token_ratio_persister is shutting down");
         Ok(())
     }
 

--- a/core/node/base_token_adjuster/src/base_token_ratio_provider.rs
+++ b/core/node/base_token_adjuster/src/base_token_ratio_provider.rs
@@ -57,7 +57,7 @@ impl DBBaseTokenRatioProvider {
             self.update_latest_price().await?;
         }
 
-        tracing::info!("Stop signal received, base_token_ratio_provider is shutting down");
+        tracing::info!("Stop request received, base_token_ratio_provider is shutting down");
         Ok(())
     }
 

--- a/core/node/block_reverter/src/tests.rs
+++ b/core/node/block_reverter/src/tests.rs
@@ -143,11 +143,7 @@ async fn block_reverter_basics(sync_merkle_tree: bool) {
     let sk_cache_path = temp_dir.path().join("sk_cache");
     let sk_cache = RocksdbStorage::builder(&sk_cache_path).await.unwrap();
     let (_stop_sender, stop_receiver) = watch::channel(false);
-    let (sk_cache, _) = sk_cache
-        .ensure_ready(&pool, &stop_receiver)
-        .await
-        .unwrap()
-        .expect("initialization interrupted");
+    let (sk_cache, _) = sk_cache.ensure_ready(&pool, &stop_receiver).await.unwrap();
     sk_cache
         .synchronize(&mut storage, &stop_receiver, None)
         .await
@@ -204,8 +200,7 @@ async fn block_reverter_basics(sync_merkle_tree: bool) {
     let mut sk_cache = sk_cache
         .synchronize(&mut storage, &stop_receiver, None)
         .await
-        .unwrap()
-        .expect("sk_cache syncing unexpectedly stopped");
+        .unwrap();
     for (i, log) in storage_logs.iter().enumerate() {
         let expected_value = if i <= 5 { log.value } else { H256::zero() };
         assert_eq!(sk_cache.read_value(&log.key), expected_value);

--- a/core/node/commitment_generator/src/lib.rs
+++ b/core/node/commitment_generator/src/lib.rs
@@ -477,7 +477,7 @@ impl CommitmentGenerator {
 
         loop {
             if *stop_receiver.borrow() {
-                tracing::info!("Stop signal received, commitment generator is shutting down");
+                tracing::info!("Stop request received, commitment generator is shutting down");
                 break;
             }
 

--- a/core/node/commitment_generator/src/validation_task.rs
+++ b/core/node/commitment_generator/src/validation_task.rs
@@ -34,7 +34,7 @@ impl L1BatchCommitmentModeValidationTask {
     }
 
     /// Makes the task exit after the commitment mode was successfully verified. By default, the task
-    /// will only exit on error or after getting a stop signal.
+    /// will only exit on error or after getting a stop request.
     pub fn exit_on_success(mut self) -> Self {
         self.exit_on_success = true;
         self
@@ -101,7 +101,7 @@ impl L1BatchCommitmentModeValidationTask {
     }
 
     /// Runs this task. The task will exit on error (and on success if `exit_on_success` is set),
-    /// or when a stop signal is received.
+    /// or when a stop request is received.
     pub async fn run(self, mut stop_receiver: watch::Receiver<bool>) -> anyhow::Result<()> {
         let exit_on_success = self.exit_on_success;
         let validation = self.validate_commitment_mode();

--- a/core/node/consistency_checker/src/lib.rs
+++ b/core/node/consistency_checker/src/lib.rs
@@ -666,7 +666,7 @@ impl ConsistencyChecker {
                     .await
                     .is_ok()
                 {
-                    tracing::info!("Stop signal received, consistency_checker is shutting down");
+                    tracing::info!("Stop request received, consistency_checker is shutting down");
                     return Ok(());
                 }
             } else {
@@ -786,7 +786,7 @@ impl ConsistencyChecker {
             }
         }
 
-        tracing::info!("Stop signal received, consistency_checker is shutting down");
+        tracing::info!("Stop request received, consistency_checker is shutting down");
         Ok(())
     }
 }
@@ -794,7 +794,7 @@ impl ConsistencyChecker {
 /// Repeatedly polls the DB until there is an L1 batch with metadata. We may not have such a batch initially
 /// if the DB is recovered from an application-level snapshot.
 ///
-/// Returns the number of the *earliest* L1 batch with metadata, or `None` if the stop signal is received.
+/// Returns the number of the *earliest* L1 batch with metadata, or `None` if a stop request is received.
 async fn wait_for_l1_batch_with_metadata(
     pool: &ConnectionPool<Core>,
     poll_interval: Duration,

--- a/core/node/consistency_checker/src/tests/mod.rs
+++ b/core/node/consistency_checker/src/tests/mod.rs
@@ -548,7 +548,7 @@ async fn normal_checker_function(
         }
     }
 
-    // Send the stop signal to the checker and wait for it to stop.
+    // Send a stop request to the checker and wait for it to stop.
     stop_sender.send_replace(true);
     checker_task.await.unwrap().unwrap();
 }
@@ -646,7 +646,7 @@ async fn checker_processes_pre_boojum_batches(
         }
     }
 
-    // Send the stop signal to the checker and wait for it to stop.
+    // Send a stop request to the checker and wait for it to stop.
     stop_sender.send_replace(true);
     checker_task.await.unwrap().unwrap();
 }

--- a/core/node/contract_verification_server/src/lib.rs
+++ b/core/node/contract_verification_server/src/lib.rs
@@ -27,9 +27,9 @@ pub async fn start_server(
     axum::serve(listener, api)
         .with_graceful_shutdown(async move {
             if stop_receiver.changed().await.is_err() {
-                tracing::warn!("Stop signal sender for contract verification server was dropped without sending a signal");
+                tracing::warn!("Stop request sender for contract verification server was dropped without sending a signal");
             }
-            tracing::info!("Stop signal received, contract verification server is shutting down");
+            tracing::info!("Stop request received, contract verification server is shutting down");
         })
         .await
         .context("Contract verification handler server failed")?;

--- a/core/node/da_dispatcher/src/da_dispatcher.rs
+++ b/core/node/da_dispatcher/src/da_dispatcher.rs
@@ -121,7 +121,7 @@ impl DataAvailabilityDispatcher {
             _ = stop_receiver.changed() => {},
         }
 
-        tracing::info!("Stop signal received, da_dispatcher is shutting down");
+        tracing::info!("Stop request received, da_dispatcher is shutting down");
         Ok(())
     }
 

--- a/core/node/db_pruner/src/lib.rs
+++ b/core/node/db_pruner/src/lib.rs
@@ -13,7 +13,7 @@ use zksync_dal::{
     Connection, ConnectionPool, Core, CoreDal,
 };
 use zksync_health_check::{Health, HealthStatus, HealthUpdater, ReactiveHealthCheck};
-use zksync_types::{L1BatchNumber, L2BlockNumber};
+use zksync_types::{L1BatchNumber, L2BlockNumber, OrStopped};
 
 use self::{
     metrics::{ConditionOutcome, PruneType, METRICS},
@@ -71,8 +71,6 @@ enum PruningIterationOutcome {
     NoOp,
     /// Iteration resulted in pruning.
     Pruned,
-    /// Pruning was interrupted because of a stop request.
-    Interrupted, // FIXME: use OrStopped?
 }
 
 /// Postgres database pruning component.
@@ -230,7 +228,7 @@ impl DbPruner {
         &self,
         storage: &mut Connection<'_, Core>,
         stop_receiver: &mut watch::Receiver<bool>,
-    ) -> anyhow::Result<PruningIterationOutcome> {
+    ) -> Result<PruningIterationOutcome, OrStopped> {
         let latency = METRICS.pruning_chunk_duration[&PruneType::Hard].start();
         let mut transaction = storage.start_transaction().await?;
 
@@ -262,7 +260,7 @@ impl DbPruner {
                 // rather than waiting a node to force-exit after a timeout, which would interrupt the DB connection and will lead to an implicit rollback.
                 tracing::info!("Hard pruning interrupted; rolling back pruning transaction");
                 transaction.rollback().await?;
-                return Ok(PruningIterationOutcome::Interrupted);
+                return Err(OrStopped::Stopped);
             }
         };
         METRICS.observe_hard_pruning(stats);
@@ -290,7 +288,7 @@ impl DbPruner {
     async fn run_single_iteration(
         &self,
         stop_receiver: &mut watch::Receiver<bool>,
-    ) -> anyhow::Result<PruningIterationOutcome> {
+    ) -> Result<PruningIterationOutcome, OrStopped> {
         let mut storage = self.connection_pool.connection_tagged("db_pruner").await?;
         let current_pruning_info = storage.pruning_dal().get_pruning_info().await?;
         self.update_health(current_pruning_info);
@@ -308,7 +306,7 @@ impl DbPruner {
             .await
             .is_ok()
         {
-            return Ok(PruningIterationOutcome::Interrupted);
+            return Err(OrStopped::Stopped);
         }
 
         let mut storage = self.connection_pool.connection_tagged("db_pruner").await?;
@@ -332,7 +330,7 @@ impl DbPruner {
             }
 
             let should_sleep = match self.run_single_iteration(&mut stop_receiver).await {
-                Err(err) => {
+                Err(OrStopped::Internal(err)) => {
                     // As this component is not really mission-critical, all errors are generally ignored
                     tracing::warn!(
                         "Pruning error, retrying in {next_iteration_delay:?}, error was: {err:?}"
@@ -344,7 +342,7 @@ impl DbPruner {
                     self.health_updater.update(health);
                     true
                 }
-                Ok(PruningIterationOutcome::Interrupted) => break,
+                Err(OrStopped::Stopped) => break,
                 Ok(PruningIterationOutcome::Pruned) => false,
                 Ok(PruningIterationOutcome::NoOp) => true,
             };

--- a/core/node/db_pruner/src/lib.rs
+++ b/core/node/db_pruner/src/lib.rs
@@ -71,8 +71,8 @@ enum PruningIterationOutcome {
     NoOp,
     /// Iteration resulted in pruning.
     Pruned,
-    /// Pruning was interrupted because of a stop signal.
-    Interrupted,
+    /// Pruning was interrupted because of a stop request.
+    Interrupted, // FIXME: use OrStopped?
 }
 
 /// Postgres database pruning component.
@@ -354,12 +354,12 @@ impl DbPruner {
                     .await
                     .is_ok()
             {
-                // The pruner either received a stop signal, or the stop receiver was dropped. In any case,
+                // The pruner either received a stop request, or the stop receiver was dropped. In any case,
                 // the pruner should exit.
                 break;
             }
         }
-        tracing::info!("Stop signal received, shutting down DB pruning");
+        tracing::info!("Stop request received, shutting down DB pruning");
         Ok(())
     }
 }

--- a/core/node/db_pruner/src/tests.rs
+++ b/core/node/db_pruner/src/tests.rs
@@ -555,8 +555,8 @@ async fn pruning_iteration_timely_shuts_down() {
     assert!(!pruning_handle.is_finished());
 
     stop_sender.send_replace(true);
-    let outcome = pruning_handle.await.unwrap().unwrap();
-    assert_matches!(outcome, PruningIterationOutcome::Interrupted);
+    let err = pruning_handle.await.unwrap().unwrap_err();
+    assert_matches!(err, OrStopped::Stopped);
 }
 
 #[tokio::test]

--- a/core/node/eth_sender/src/eth_tx_aggregator.rs
+++ b/core/node/eth_sender/src/eth_tx_aggregator.rs
@@ -159,7 +159,7 @@ impl EthTxAggregator {
             let mut storage = pool.connection_tagged("eth_sender").await.unwrap();
 
             if *stop_receiver.borrow() {
-                tracing::info!("Stop signal received, eth_tx_aggregator is shutting down");
+                tracing::info!("Stop request received, eth_tx_aggregator is shutting down");
                 break;
             }
 

--- a/core/node/eth_sender/src/eth_tx_manager.rs
+++ b/core/node/eth_sender/src/eth_tx_manager.rs
@@ -616,7 +616,7 @@ impl EthTxManager {
             let mut storage = pool.connection_tagged("eth_sender").await.unwrap();
 
             if *stop_receiver.borrow() {
-                tracing::info!("Stop signal received, eth_tx_manager is shutting down");
+                tracing::info!("Stop request received, eth_tx_manager is shutting down");
                 break;
             }
             let operator_to_track = self.l1_interface.supported_operator_types()[0];

--- a/core/node/eth_watch/src/lib.rs
+++ b/core/node/eth_watch/src/lib.rs
@@ -171,7 +171,7 @@ impl EthWatch {
             }
         }
 
-        tracing::info!("Stop signal received, eth_watch is shutting down");
+        tracing::info!("Stop request received, eth_watch is shutting down");
         Ok(())
     }
 

--- a/core/node/external_proof_integration_api/src/lib.rs
+++ b/core/node/external_proof_integration_api/src/lib.rs
@@ -69,9 +69,9 @@ impl Api {
         axum::serve(listener, self.router)
         .with_graceful_shutdown(async move {
             if stop_receiver.changed().await.is_err() {
-                tracing::warn!("Stop signal sender for external prover API server was dropped without sending a signal");
+                tracing::warn!("Stop request sender for external prover API server was dropped without sending a signal");
             }
-            tracing::info!("Stop signal received, external prover API server is shutting down");
+            tracing::info!("Stop request received, external prover API server is shutting down");
         })
         .await
         .context("External prover API server failed")?;

--- a/core/node/fee_model/src/l1_gas_price/gas_adjuster/mod.rs
+++ b/core/node/fee_model/src/l1_gas_price/gas_adjuster/mod.rs
@@ -213,7 +213,7 @@ impl GasAdjuster {
     pub async fn run(self: Arc<Self>, stop_receiver: watch::Receiver<bool>) -> anyhow::Result<()> {
         loop {
             if *stop_receiver.borrow() {
-                tracing::info!("Stop signal received, gas_adjuster is shutting down");
+                tracing::info!("Stop request received, gas_adjuster is shutting down");
                 break;
             }
 

--- a/core/node/fee_model/src/l1_gas_price/main_node_fetcher.rs
+++ b/core/node/fee_model/src/l1_gas_price/main_node_fetcher.rs
@@ -80,7 +80,7 @@ impl MainNodeFeeParamsFetcher {
             }
         }
 
-        tracing::info!("Stop signal received, MainNodeFeeParamsFetcher is shutting down");
+        tracing::info!("Stop request received, MainNodeFeeParamsFetcher is shutting down");
         Ok(())
     }
 }

--- a/core/node/gateway_migrator/src/lib.rs
+++ b/core/node/gateway_migrator/src/lib.rs
@@ -57,7 +57,7 @@ impl GatewayMigrator {
         let gateway_client = self.gateway_client.as_deref();
         loop {
             if *stop_receiver.borrow() {
-                tracing::info!("Stop signal received, GatewayMigrator is shutting down");
+                tracing::info!("Stop request received, GatewayMigrator is shutting down");
                 return Ok(());
             }
             let current_settlement_layer = current_settlement_layer(

--- a/core/node/house_keeper/src/periodic_job.rs
+++ b/core/node/house_keeper/src/periodic_job.rs
@@ -35,7 +35,7 @@ pub trait PeriodicJob: Sync + Send {
                 .ok();
         }
         tracing::info!(
-            "Stop signal received; periodic job {} is shut down",
+            "Stop request received; periodic job {} is shut down",
             Self::SERVICE_NAME
         );
         Ok(())

--- a/core/node/logs_bloom_backfill/src/lib.rs
+++ b/core/node/logs_bloom_backfill/src/lib.rs
@@ -37,7 +37,7 @@ impl LogsBloomBackfill {
                 return Ok(BloomWaitOutcome::Ok);
             }
 
-            // We don't check the result: if a stop signal is received, we'll return at the start
+            // We don't check the result: if a stop request is received, we'll return at the start
             // of the next iteration.
             tokio::time::timeout(INTERVAL, stop_receiver.changed())
                 .await
@@ -54,7 +54,7 @@ impl LogsBloomBackfill {
         if Self::wait_for_l2_block_with_bloom(&mut connection, &mut stop_receiver).await?
             == BloomWaitOutcome::Canceled
         {
-            return Ok(()); // Stop signal received
+            return Ok(()); // Stop request received
         }
 
         let genesis_block_has_bloom = connection
@@ -87,7 +87,7 @@ impl LogsBloomBackfill {
             const WINDOW: u32 = 1000;
 
             if *stop_receiver.borrow_and_update() {
-                tracing::info!("received a stop signal; logs bloom backfill is shut down");
+                tracing::info!("received a stop request; logs bloom backfill is shut down");
             }
 
             let left_bound = right_bound.saturating_sub(WINDOW - 1).max(first_l2_block.0);

--- a/core/node/metadata_calculator/src/api_server/mod.rs
+++ b/core/node/metadata_calculator/src/api_server/mod.rs
@@ -527,10 +527,10 @@ impl AsyncTreeReader {
             server.with_graceful_shutdown(async move {
                 if stop_receiver.changed().await.is_err() {
                     tracing::warn!(
-                        "Stop signal sender for Merkle tree API server was dropped without sending a signal"
+                        "Stop request sender for Merkle tree API server was dropped without sending a signal"
                     );
                 }
-                tracing::info!("Stop signal received, Merkle tree API server is shutting down");
+                tracing::info!("Stop request received, Merkle tree API server is shutting down");
             })
             .await
             .context("Merkle tree API server failed")?;

--- a/core/node/metadata_calculator/src/lib.rs
+++ b/core/node/metadata_calculator/src/lib.rs
@@ -17,6 +17,7 @@ use zksync_dal::{ConnectionPool, Core};
 use zksync_health_check::{CheckHealth, HealthUpdater, ReactiveHealthCheck};
 use zksync_object_store::ObjectStore;
 use zksync_shared_metrics::tree::METRICS;
+use zksync_types::try_stoppable;
 
 use self::{
     helpers::{create_db, Delayer, GenericAsyncTree, MerkleTreeHealth, MerkleTreeHealthCheck},
@@ -232,24 +233,24 @@ impl MetadataCalculator {
 
     pub async fn run(self, mut stop_receiver: watch::Receiver<bool>) -> anyhow::Result<()> {
         let tree = self.create_tree().await?;
-        let tree = tree
-            .ensure_ready(
+        let mut tree = try_stoppable!(
+            tree.ensure_ready(
                 &self.config.recovery,
                 &self.pool,
                 self.recovery_pool,
                 &self.health_updater,
                 &stop_receiver,
             )
-            .await?;
-        let Some(mut tree) = tree else {
-            return Ok(()); // recovery was aborted because a stop signal was received
-        };
+            .await
+        );
         // Set a tree reader before the tree is fully initialized to not wait for the first L1 batch to appear in Postgres.
         let tree_reader = tree.reader();
         self.tree_reader.send_replace(Some(tree_reader));
 
-        tree.ensure_consistency(&self.delayer, &self.pool, &mut stop_receiver)
-            .await?;
+        try_stoppable!(
+            tree.ensure_consistency(&self.delayer, &self.pool, &mut stop_receiver)
+                .await
+        );
         if !self.pruning_handles_sender.is_closed() {
             // Unlike tree reader, we shouldn't initialize pruning (as a task modifying the tree) before the tree is guaranteed
             // to be consistent with Postgres.

--- a/core/node/metadata_calculator/src/pruning.rs
+++ b/core/node/metadata_calculator/src/pruning.rs
@@ -81,7 +81,7 @@ impl MerkleTreePruningTask {
                 }
             }
             _ = stop_receiver.changed() => {
-                tracing::info!("Stop signal received before Merkle tree is initialized; shutting down tree pruning");
+                tracing::info!("Stop request received before Merkle tree is initialized; shutting down tree pruning");
                 return Ok(());
             }
         }
@@ -134,7 +134,7 @@ impl MerkleTreePruningTask {
 
         self.health_updater
             .update(MerkleTreePruningTaskHealth::ShuttingDown.into());
-        tracing::info!("Stop signal received, Merkle tree pruning is shutting down");
+        tracing::info!("Stop request received, Merkle tree pruning is shutting down");
         drop(pruner_handle);
         pruner_task_handle
             .await

--- a/core/node/metadata_calculator/src/recovery/mod.rs
+++ b/core/node/metadata_calculator/src/recovery/mod.rs
@@ -360,7 +360,7 @@ impl AsyncTreeRecovery {
         let mut tree = tree.into_inner();
         if *stop_receiver.borrow() {
             // Waiting for persistence is mostly useful for tests. Normally, the tree database won't be used in the same process
-            // after a stop signal is received, so there's no risk of data races with the background persistence thread.
+            // after a stop request is received, so there's no risk of data races with the background persistence thread.
             tree.wait_for_persistence().await?;
             return Err(OrStopped::Stopped);
         }

--- a/core/node/metadata_calculator/src/recovery/mod.rs
+++ b/core/node/metadata_calculator/src/recovery/mod.rs
@@ -41,7 +41,9 @@ use zksync_dal::{Connection, ConnectionPool, Core, CoreDal};
 use zksync_health_check::HealthUpdater;
 use zksync_merkle_tree::TreeEntry;
 use zksync_shared_metrics::{SnapshotRecoveryStage, APP_METRICS};
-use zksync_types::{snapshots::uniform_hashed_keys_chunk, L1BatchNumber, L2BlockNumber, H256};
+use zksync_types::{
+    snapshots::uniform_hashed_keys_chunk, L1BatchNumber, L2BlockNumber, OrStopped, H256,
+};
 
 use super::{
     helpers::{AsyncTree, AsyncTreeRecovery, GenericAsyncTree, MerkleTreeHealth},
@@ -249,20 +251,24 @@ impl GenericAsyncTree {
         recovery_pool: ConnectionPool<Core>,
         health_updater: &HealthUpdater,
         stop_receiver: &watch::Receiver<bool>,
-    ) -> anyhow::Result<Option<AsyncTree>> {
+    ) -> Result<AsyncTree, OrStopped> {
         let started_at = Instant::now();
         let (tree, init_params) = match self {
-            Self::Ready(tree) => return Ok(Some(tree)),
+            Self::Ready(tree) => return Ok(tree),
             Self::Recovering(tree) => {
                 let params = InitParameters::new(main_pool, config).await?.context(
                     "Merkle tree is recovering, but Postgres doesn't contain snapshot recovery information",
                 )?;
+
                 let recovered_version = tree.recovered_version();
-                anyhow::ensure!(
-                    u64::from(params.l1_batch.0) == recovered_version,
-                    "Snapshot L1 batch in Postgres ({params:?}) differs from the recovered Merkle tree version \
-                     ({recovered_version})"
-                );
+                if u64::from(params.l1_batch.0) != recovered_version {
+                    let err = anyhow::anyhow!(
+                        "Snapshot L1 batch in Postgres ({params:?}) differs from the recovered Merkle tree version \
+                         ({recovered_version})"
+                    );
+                    return Err(err.into());
+                }
+
                 tracing::info!("Resuming tree recovery with status: {params:?}");
                 (tree, params)
             }
@@ -275,7 +281,7 @@ impl GenericAsyncTree {
                 } else {
                     // The genesis block will be filled in `TreeUpdater::loop_updating_tree()`.
                     tracing::info!("Starting Merkle tree from scratch");
-                    return Ok(Some(AsyncTree::new(db, mode)?));
+                    return Ok(AsyncTree::new(db, mode)?);
                 }
             }
         };
@@ -291,12 +297,10 @@ impl GenericAsyncTree {
         let tree = tree
             .recover(init_params, recovery_options, &recovery_pool, stop_receiver)
             .await?;
-        if tree.is_some() {
-            // Only report latency if recovery wasn't canceled
-            let elapsed = started_at.elapsed();
-            APP_METRICS.snapshot_recovery_latency[&SnapshotRecoveryStage::Tree].set(elapsed);
-            tracing::info!("Recovered Merkle tree from snapshot in {elapsed:?}");
-        }
+        // Only report latency if recovery wasn't canceled
+        let elapsed = started_at.elapsed();
+        APP_METRICS.snapshot_recovery_latency[&SnapshotRecoveryStage::Tree].set(elapsed);
+        tracing::info!("Recovered Merkle tree from snapshot in {elapsed:?}");
         Ok(tree)
     }
 }
@@ -308,7 +312,7 @@ impl AsyncTreeRecovery {
         mut options: RecoveryOptions<'_>,
         pool: &ConnectionPool<Core>,
         stop_receiver: &watch::Receiver<bool>,
-    ) -> anyhow::Result<Option<AsyncTree>> {
+    ) -> Result<AsyncTree, OrStopped> {
         self.ensure_desired_chunk_size(init_params.desired_chunk_size)
             .await?;
 
@@ -358,16 +362,18 @@ impl AsyncTreeRecovery {
             // Waiting for persistence is mostly useful for tests. Normally, the tree database won't be used in the same process
             // after a stop signal is received, so there's no risk of data races with the background persistence thread.
             tree.wait_for_persistence().await?;
-            return Ok(None);
+            return Err(OrStopped::Stopped);
         }
 
         let finalize_latency = RECOVERY_METRICS.latency[&RecoveryStage::Finalize].start();
         let actual_root_hash = tree.root_hash().await;
         if let Some(expected_root_hash) = init_params.expected_root_hash {
-            anyhow::ensure!(
-                actual_root_hash == expected_root_hash,
-                "Root hash of recovered tree {actual_root_hash:?} differs from expected root hash {expected_root_hash:?}"
-            );
+            if actual_root_hash != expected_root_hash {
+                let err = anyhow::anyhow!(
+                    "Root hash of recovered tree {actual_root_hash:?} differs from expected root hash {expected_root_hash:?}"
+                );
+                return Err(err.into());
+            }
         }
 
         // Check pruning info one last time before finalizing the tree.
@@ -381,7 +387,7 @@ impl AsyncTreeRecovery {
             "Tree recovery has finished, the recovery took {:?}! resuming normal tree operation",
             start_time.elapsed()
         );
-        Ok(Some(tree))
+        Ok(tree)
     }
 
     /// Filters out `key_chunks` for which recovery was successfully performed.

--- a/core/node/metadata_calculator/src/repair.rs
+++ b/core/node/metadata_calculator/src/repair.rs
@@ -93,7 +93,7 @@ impl StaleKeysRepairTask {
                 }
             }
             _ = stop_receiver.changed() => {
-                tracing::info!("Stop signal received before Merkle tree is initialized; shutting down stale keys repair");
+                tracing::info!("Stop request received before Merkle tree is initialized; shutting down stale keys repair");
                 return Ok(());
             }
         };
@@ -113,7 +113,7 @@ impl StaleKeysRepairTask {
                 res.context("repair task panicked")?
             },
             _ = stop_receiver.changed() => {
-                tracing::info!("Stop signal received, stale keys repair is shutting down");
+                tracing::info!("Stop request received, stale keys repair is shutting down");
                 // This is the only strong reference to the handle, so dropping it should signal the task to stop.
                 drop(handle);
                 task.await.context("stale keys repair task panicked")?

--- a/core/node/metadata_calculator/src/updater.rs
+++ b/core/node/metadata_calculator/src/updater.rs
@@ -12,7 +12,7 @@ use zksync_object_store::ObjectStore;
 use zksync_shared_metrics::tree::{update_tree_metrics, TreeUpdateStage, METRICS};
 use zksync_types::{
     block::{L1BatchStatistics, L1BatchTreeData},
-    L1BatchNumber,
+    L1BatchNumber, OrStopped,
 };
 
 use super::helpers::{AsyncTree, Delayer, L1BatchWithLogs};
@@ -409,12 +409,9 @@ impl AsyncTree {
         delayer: &Delayer,
         pool: &ConnectionPool<Core>,
         stop_receiver: &mut watch::Receiver<bool>,
-    ) -> anyhow::Result<()> {
-        let Some(earliest_l1_batch) =
-            wait_for_l1_batch(pool, delayer.delay_interval(), stop_receiver).await?
-        else {
-            return Ok(()); // Stop signal received
-        };
+    ) -> Result<(), OrStopped> {
+        let earliest_l1_batch =
+            wait_for_l1_batch(pool, delayer.delay_interval(), stop_receiver).await?;
         let mut storage = pool.connection_tagged("metadata_calculator").await?;
 
         self.ensure_genesis(&mut storage, earliest_l1_batch).await?;

--- a/core/node/metadata_calculator/src/updater.rs
+++ b/core/node/metadata_calculator/src/updater.rs
@@ -254,7 +254,7 @@ impl TreeUpdater {
 
         loop {
             if *stop_receiver.borrow_and_update() {
-                tracing::info!("Stop signal received, metadata_calculator is shutting down");
+                tracing::info!("Stop request received, metadata_calculator is shutting down");
                 break;
             }
 
@@ -277,7 +277,7 @@ impl TreeUpdater {
             // and the stop receiver still allows to be more responsive during shutdown.
             tokio::select! {
                 _ = stop_receiver.changed() => {
-                    tracing::info!("Stop signal received, metadata_calculator is shutting down");
+                    tracing::info!("Stop request received, metadata_calculator is shutting down");
                     break;
                 }
                 () = delay => { /* The delay has passed */ }

--- a/core/node/node_framework/examples/showcase.rs
+++ b/core/node/node_framework/examples/showcase.rs
@@ -105,7 +105,7 @@ impl Task for PutTask {
         tracing::info!("Starting the task {}", self.id());
 
         // We have to respect the stop receiver and should exit as soon as we receive
-        // a stop signal.
+        // a stop request.
         tokio::select! {
             _ = self.run_inner() => {},
             _ = stop_receiver.0.changed() => {},

--- a/core/node/node_framework/src/implementations/layers/consensus/external_node.rs
+++ b/core/node/node_framework/src/implementations/layers/consensus/external_node.rs
@@ -112,7 +112,7 @@ impl Task for ExternalNodeTask {
         // exclusive).
         // Note, however, that awaiting for the `stop_receiver` is related to the root context behavior,
         // not the consensus task itself. There may have been any number of tasks running in the root context,
-        // but we only need to wait for stop signal once, and it will be propagated to all child contexts.
+        // but we only need to wait for a stop request once, and it will be propagated to all child contexts.
         scope::run!(&ctx::root(), |ctx, s| async {
             s.spawn_bg(consensus::era::run_external_node(
                 ctx,

--- a/core/node/node_framework/src/implementations/layers/consensus/main_node.rs
+++ b/core/node/node_framework/src/implementations/layers/consensus/main_node.rs
@@ -73,7 +73,7 @@ impl Task for MainNodeConsensusTask {
         // exclusive).
         // Note, however, that awaiting for the `stop_receiver` is related to the root context behavior,
         // not the consensus task itself. There may have been any number of tasks running in the root context,
-        // but we only need to wait for stop signal once, and it will be propagated to all child contexts.
+        // but we only need to wait for a stop request once, and it will be propagated to all child contexts.
         scope::run!(&ctx::root(), |ctx, s| async move {
             s.spawn_bg(consensus::era::run_main_node(
                 ctx,

--- a/core/node/node_framework/src/implementations/layers/node_storage_init/mod.rs
+++ b/core/node/node_framework/src/implementations/layers/node_storage_init/mod.rs
@@ -1,4 +1,5 @@
 use zksync_node_storage_init::{NodeInitializationStrategy, NodeStorageInitializer};
+use zksync_types::try_stoppable;
 
 use crate::{
     implementations::resources::pools::{MasterPool, PoolResource},
@@ -135,9 +136,9 @@ impl Task for NodeStorageInitializerPrecondition {
 
     async fn run(self: Box<Self>, stop_receiver: StopReceiver) -> anyhow::Result<()> {
         tracing::info!("Waiting for node storage to be initialized");
-        let result = self.0.wait_for_initialized_storage(stop_receiver.0).await;
+        try_stoppable!(self.0.wait_for_initialized_storage(stop_receiver.0).await);
         tracing::info!("Node storage initialization precondition completed");
-        result
+        Ok(())
     }
 }
 

--- a/core/node/node_framework/src/implementations/layers/postgres.rs
+++ b/core/node/node_framework/src/implementations/layers/postgres.rs
@@ -93,7 +93,7 @@ impl Task for PostgresMetricsScrapingTask {
                 tracing::warn!("Postgres metrics scraping unexpectedly stopped");
             }
             _ = stop_receiver.0.changed() => {
-                tracing::info!("Stop signal received, Postgres metrics scraping is shutting down");
+                tracing::info!("Stop request received, Postgres metrics scraping is shutting down");
             }
         }
         Ok(())

--- a/core/node/node_framework/src/implementations/layers/reorg_detector.rs
+++ b/core/node/node_framework/src/implementations/layers/reorg_detector.rs
@@ -1,4 +1,5 @@
 use zksync_reorg_detector::{self, ReorgDetector};
+use zksync_types::try_stoppable;
 
 use crate::{
     implementations::resources::{
@@ -66,7 +67,7 @@ impl Task for ReorgDetector {
     }
 
     async fn run(mut self: Box<Self>, stop_receiver: StopReceiver) -> anyhow::Result<()> {
-        (*self).run(stop_receiver.0).await?;
+        try_stoppable!((*self).run(stop_receiver.0).await);
         Ok(())
     }
 }

--- a/core/node/node_framework/src/implementations/layers/sigint.rs
+++ b/core/node/node_framework/src/implementations/layers/sigint.rs
@@ -62,7 +62,7 @@ impl Task for SigintHandlerTask {
         })
         .expect("Error setting Ctrl+C handler");
 
-        // Wait for either SIGINT or stop signal.
+        // Wait for either SIGINT or a stop request.
         tokio::select! {
             _ = sigint_receiver => {
                 tracing::info!("Received SIGINT signal");

--- a/core/node/node_framework/src/implementations/layers/web3_api/server/mod.rs
+++ b/core/node/node_framework/src/implementations/layers/web3_api/server/mod.rs
@@ -368,7 +368,7 @@ impl Task for ApiTaskGarbageCollector {
     }
 
     async fn run(self: Box<Self>, _stop_receiver: StopReceiver) -> anyhow::Result<()> {
-        // We can ignore the stop signal here, since we're tied to the main API task through the channel:
+        // We can ignore a stop request here, since we're tied to the main API task through the channel:
         // it'll either get dropped if API cannot be built or will send something through the channel.
         // The tasks it sends are aware of the stop receiver themselves.
         let Ok(tasks) = self.task_receiver.await else {

--- a/core/node/node_framework/src/implementations/layers/web3_api/tx_sender.rs
+++ b/core/node/node_framework/src/implementations/layers/web3_api/tx_sender.rs
@@ -262,9 +262,9 @@ impl Task for VmConcurrencyBarrier {
     }
 
     async fn run(mut self: Box<Self>, mut stop_receiver: StopReceiver) -> anyhow::Result<()> {
-        // Wait for the stop signal.
+        // Wait for a stop request.
         stop_receiver.0.changed().await?;
-        // Stop signal was received: seal the barrier so that no new VM requests are accepted.
+        // Stop request was received: seal the barrier so that no new VM requests are accepted.
         self.close();
         // Wait until all the existing API requests are processed.
         // We don't have to synchronize this with API servers being stopped, as they can decide themselves how to handle

--- a/core/node/node_framework/src/service/mod.rs
+++ b/core/node/node_framework/src/service/mod.rs
@@ -257,9 +257,9 @@ impl ZkStackService {
         remaining
     }
 
-    /// Sends the stop signal and waits for the remaining tasks to finish.
+    /// Sends the stop request and waits for the remaining tasks to finish.
     fn shutdown_tasks(&mut self, remaining: Vec<TaskFuture>) {
-        // Send stop signal to remaining tasks and wait for them to finish.
+        // Send a stop request to remaining tasks and wait for them to finish.
         self.stop_sender.send(true).ok();
 
         // Collect names for remaining tasks for reporting purposes.

--- a/core/node/node_framework/src/service/runnables.rs
+++ b/core/node/node_framework/src/service/runnables.rs
@@ -95,7 +95,7 @@ impl Runnables {
 
         let only_oneshot_tasks = long_running_tasks.is_empty();
         // Create a system task that is cancellation-aware and will only exit on either oneshot task failure or
-        // stop signal.
+        // a stop request.
         let oneshot_runner_system_task =
             oneshot_runner_task(oneshot_tasks, stop_receiver, only_oneshot_tasks);
         long_running_tasks.push(oneshot_runner_system_task);
@@ -138,15 +138,15 @@ fn oneshot_runner_task(
                 Ok(())
             }
             Ok(_) => {
-                // All oneshot tasks have exited and we have at least one long-running task.
-                // Simply wait for the stop signal.
+                // All oneshot tasks have exited, and we have at least one long-running task.
+                // Simply wait for the stop request.
                 stop_receiver.0.changed().await.ok();
                 Ok(())
             }
         }
-        // Note that we don't have to `select` on the stop signal explicitly:
-        // Each prerequisite is given a stop signal, and if everyone respects it, this future
-        // will still resolve once the stop signal is received.
+        // Note that we don't have to `select` on the stop request explicitly:
+        // Each prerequisite is given a stop request, and if everyone respects it, this future
+        // will still resolve once the stop request is received.
     };
 
     NamedBoxFuture::new(future.boxed(), "oneshot_runner".into())

--- a/core/node/node_framework/src/service/stop_receiver.rs
+++ b/core/node/node_framework/src/service/stop_receiver.rs
@@ -1,6 +1,6 @@
 use tokio::sync::watch;
 
-/// Represents a receiver for the stop signal.
+/// Represents a receiver for the stop request.
 /// This signal is sent when the node is shutting down.
 /// Every task is expected to listen to this signal and stop its execution when it is received.
 ///

--- a/core/node/node_framework/src/service/tests.rs
+++ b/core/node/node_framework/src/service/tests.rs
@@ -210,7 +210,7 @@ impl Task for SuccessfulTask {
 }
 
 // `ZkStack` Service's `run()` method has to allow remaining tasks to finish,
-// after stop signal was send.
+// after a stop request was sent.
 #[derive(Debug)]
 struct RemainingTask(Arc<Barrier>, Arc<Mutex<bool>>);
 

--- a/core/node/node_framework/src/task/mod.rs
+++ b/core/node/node_framework/src/task/mod.rs
@@ -27,7 +27,7 @@ mod types;
 /// implementation that returns `TaskKind::Task`.
 ///
 /// Typically, the implementation of [`Task::run`] will be some form of loop that runs until either an
-/// irrecoverable error happens (then task should return an error), or stop signal is received (then task should
+/// irrecoverable error happens (then task should return an error), or a stop request is received (then task should
 /// return `Ok(())`).
 ///
 /// ### `OneshotTask`
@@ -100,7 +100,7 @@ impl dyn Task {
         mut stop_receiver: StopReceiver,
         preconditions_barrier: Arc<Barrier>,
     ) -> anyhow::Result<()> {
-        // Wait either for barrier to be lifted or for the stop signal to be received.
+        // Wait either for barrier to be lifted or for the stop request to be received.
         tokio::select! {
             _ = preconditions_barrier.wait() => {
                 self.run(stop_receiver).await

--- a/core/node/node_storage_init/src/external_node/genesis.rs
+++ b/core/node/node_storage_init/src/external_node/genesis.rs
@@ -1,7 +1,7 @@
 use anyhow::Context as _;
 use tokio::sync::watch;
 use zksync_dal::{ConnectionPool, Core};
-use zksync_types::L2ChainId;
+use zksync_types::{L2ChainId, OrStopped};
 use zksync_web3_decl::client::{DynClient, L2};
 
 use crate::InitializeStorage;
@@ -20,7 +20,7 @@ impl InitializeStorage for ExternalNodeGenesis {
     async fn initialize_storage(
         &self,
         _stop_receiver: watch::Receiver<bool>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), OrStopped> {
         let mut storage = self.pool.connection_tagged("en").await?;
 
         // Custom genesis state for external nodes is not supported. If the main node has a custom genesis,
@@ -32,7 +32,9 @@ impl InitializeStorage for ExternalNodeGenesis {
             None,
         )
         .await
-        .context("performing genesis failed")
+        .context("performing genesis failed")?;
+
+        Ok(())
     }
 
     async fn is_initialized(&self) -> anyhow::Result<bool> {

--- a/core/node/node_storage_init/src/external_node/revert.rs
+++ b/core/node/node_storage_init/src/external_node/revert.rs
@@ -1,9 +1,8 @@
-use anyhow::Context as _;
 use tokio::sync::watch;
 use zksync_block_reverter::BlockReverter;
 use zksync_dal::{ConnectionPool, Core};
-use zksync_reorg_detector::ReorgDetector;
-use zksync_types::L1BatchNumber;
+use zksync_reorg_detector::{Error as ReorgError, ReorgDetector};
+use zksync_types::{L1BatchNumber, OrStopped};
 use zksync_web3_decl::client::{DynClient, L2};
 
 use crate::RevertStorage;
@@ -17,11 +16,7 @@ pub struct ExternalNodeReverter {
 
 #[async_trait::async_trait]
 impl RevertStorage for ExternalNodeReverter {
-    async fn revert_storage(
-        &self,
-        to_batch: L1BatchNumber,
-        _stop_receiver: watch::Receiver<bool>,
-    ) -> anyhow::Result<()> {
+    async fn revert_storage(&self, to_batch: L1BatchNumber) -> anyhow::Result<()> {
         let Some(block_reverter) = self.reverter.as_ref() else {
             anyhow::bail!(
                 "Revert to block {to_batch} was requested, but the reverter was not provided."
@@ -34,7 +29,10 @@ impl RevertStorage for ExternalNodeReverter {
         Ok(())
     }
 
-    async fn is_reorg_needed(&self, stop_receiver: watch::Receiver<bool>) -> anyhow::Result<bool> {
+    async fn is_reorg_needed(
+        &self,
+        stop_receiver: watch::Receiver<bool>,
+    ) -> Result<bool, OrStopped> {
         ReorgDetector::new(self.client.clone(), self.pool.clone())
             .check_reorg_presence(stop_receiver)
             .await
@@ -43,20 +41,19 @@ impl RevertStorage for ExternalNodeReverter {
     async fn last_correct_batch_for_reorg(
         &self,
         stop_receiver: watch::Receiver<bool>,
-    ) -> anyhow::Result<Option<L1BatchNumber>> {
+    ) -> Result<Option<L1BatchNumber>, OrStopped> {
         let mut reorg_detector = ReorgDetector::new(self.client.clone(), self.pool.clone());
-        let batch = match reorg_detector.run_once(stop_receiver).await {
+        match reorg_detector.run_once(stop_receiver).await {
             Ok(()) => {
-                // Even if stop signal was received, the node will shut down without launching any tasks.
                 tracing::info!("No rollback was detected");
-                None
+                Ok(None)
             }
-            Err(zksync_reorg_detector::Error::ReorgDetected(last_correct_l1_batch)) => {
+            Err(OrStopped::Internal(ReorgError::ReorgDetected(last_correct_l1_batch))) => {
                 tracing::info!("Reverting to l1 batch number {last_correct_l1_batch}");
-                Some(last_correct_l1_batch)
+                Ok(Some(last_correct_l1_batch))
             }
-            Err(err) => return Err(err).context("reorg_detector.check_consistency()"),
-        };
-        Ok(batch)
+            Err(OrStopped::Internal(err)) => Err(OrStopped::Internal(err.into())),
+            Err(OrStopped::Stopped) => Err(OrStopped::Stopped),
+        }
     }
 }

--- a/core/node/node_storage_init/src/lib.rs
+++ b/core/node/node_storage_init/src/lib.rs
@@ -3,7 +3,7 @@ use std::{future::Future, sync::Arc, time::Duration};
 use tokio::sync::watch;
 use zksync_config::ObjectStoreConfig;
 use zksync_dal::{ConnectionPool, Core, CoreDal as _};
-use zksync_types::L1BatchNumber;
+use zksync_types::{try_stoppable, L1BatchNumber, OrStopped, StopContext};
 
 pub use crate::traits::{InitializeStorage, RevertStorage};
 
@@ -107,15 +107,17 @@ impl NodeStorageInitializer {
         match decision {
             InitDecision::Genesis => {
                 tracing::info!("Performing genesis initialization");
-                self.strategy
-                    .genesis
-                    .initialize_storage(stop_receiver.clone())
-                    .await?;
+                try_stoppable!(
+                    self.strategy
+                        .genesis
+                        .initialize_storage(stop_receiver.clone())
+                        .await
+                );
             }
             InitDecision::SnapshotRecovery => {
                 tracing::info!("Performing snapshot recovery initialization");
                 if let Some(recovery) = &self.strategy.snapshot_recovery {
-                    recovery.initialize_storage(stop_receiver.clone()).await?;
+                    try_stoppable!(recovery.initialize_storage(stop_receiver.clone()).await);
                 } else {
                     anyhow::bail!(
                         "Snapshot recovery should be performed, but the strategy is not provided. \
@@ -130,13 +132,12 @@ impl NodeStorageInitializer {
 
         // Now we may check whether we're in the invalid state and should perform a rollback.
         if let Some(reverter) = &self.strategy.block_reverter {
-            if let Some(to_batch) = reverter
-                .last_correct_batch_for_reorg(stop_receiver.clone())
-                .await?
+            if let Some(to_batch) =
+                try_stoppable!(reverter.last_correct_batch_for_reorg(stop_receiver).await)
             {
                 tracing::info!(l1_batch = %to_batch, "State must be rolled back to L1 batch");
                 tracing::info!("Performing the rollback");
-                reverter.revert_storage(to_batch, stop_receiver).await?;
+                reverter.revert_storage(to_batch).await?;
             }
         }
 
@@ -147,7 +148,7 @@ impl NodeStorageInitializer {
     pub async fn wait_for_initialized_storage(
         &self,
         stop_receiver: watch::Receiver<bool>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), OrStopped> {
         const POLLING_INTERVAL: Duration = Duration::from_secs(1);
 
         // Wait until data is added to the database.
@@ -155,17 +156,12 @@ impl NodeStorageInitializer {
             self.is_database_initialized()
         })
         .await?;
-        if *stop_receiver.borrow() {
-            return Ok(());
-        }
 
         // Wait until the rollback is no longer needed.
         poll(stop_receiver.clone(), POLLING_INTERVAL, || {
             self.is_chain_tip_correct(stop_receiver.clone())
         })
-        .await?;
-
-        Ok(())
+        .await
     }
 
     async fn is_database_initialized(&self) -> anyhow::Result<bool> {
@@ -186,7 +182,10 @@ impl NodeStorageInitializer {
     ) -> anyhow::Result<bool> {
         // May be `true` if stop signal is received, but the node will shut down without launching any tasks anyway.
         let initialized = if let Some(reverter) = &self.strategy.block_reverter {
-            !reverter.is_reorg_needed(stop_receiver).await?
+            !reverter
+                .is_reorg_needed(stop_receiver)
+                .await
+                .unwrap_stopped(false)?
         } else {
             true
         };
@@ -198,7 +197,7 @@ async fn poll<F, Fut>(
     mut stop_receiver: watch::Receiver<bool>,
     polling_interval: Duration,
     mut check: F,
-) -> anyhow::Result<()>
+) -> Result<(), OrStopped>
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = anyhow::Result<bool>>,
@@ -210,5 +209,9 @@ where
             .ok();
     }
 
-    Ok(())
+    if *stop_receiver.borrow() {
+        Err(OrStopped::Stopped)
+    } else {
+        Ok(())
+    }
 }

--- a/core/node/node_storage_init/src/lib.rs
+++ b/core/node/node_storage_init/src/lib.rs
@@ -180,7 +180,7 @@ impl NodeStorageInitializer {
         &self,
         stop_receiver: watch::Receiver<bool>,
     ) -> anyhow::Result<bool> {
-        // May be `true` if stop signal is received, but the node will shut down without launching any tasks anyway.
+        // May be `true` if stop request is received, but the node will shut down without launching any tasks anyway.
         let initialized = if let Some(reverter) = &self.strategy.block_reverter {
             !reverter
                 .is_reorg_needed(stop_receiver)

--- a/core/node/node_storage_init/src/main_node/genesis.rs
+++ b/core/node/node_storage_init/src/main_node/genesis.rs
@@ -6,6 +6,7 @@ use zksync_config::{configs::contracts::SettlementLayerSpecificContracts, Genesi
 use zksync_dal::{ConnectionPool, Core, CoreDal as _};
 use zksync_node_genesis::GenesisParams;
 use zksync_object_store::bincode;
+use zksync_types::OrStopped;
 use zksync_web3_decl::client::{DynClient, L1};
 
 use crate::traits::InitializeStorage;
@@ -18,14 +19,8 @@ pub struct MainNodeGenesis {
     pub pool: ConnectionPool<Core>,
 }
 
-#[async_trait::async_trait]
-impl InitializeStorage for MainNodeGenesis {
-    /// Will perform genesis initialization if it's required.
-    /// If genesis is already performed, this method will do nothing.
-    async fn initialize_storage(
-        &self,
-        _stop_receiver: watch::Receiver<bool>,
-    ) -> anyhow::Result<()> {
+impl MainNodeGenesis {
+    async fn initialize(&self) -> anyhow::Result<()> {
         let mut storage = self.pool.connection_tagged("genesis").await?;
 
         if !storage.blocks_dal().is_genesis_needed().await? {
@@ -62,8 +57,19 @@ impl InitializeStorage for MainNodeGenesis {
         )
         .await
         .context("Failed to save SetChainId upgrade transaction")?;
-
         Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl InitializeStorage for MainNodeGenesis {
+    /// Will perform genesis initialization if it's required.
+    /// If genesis is already performed, this method will do nothing.
+    async fn initialize_storage(
+        &self,
+        _stop_receiver: watch::Receiver<bool>,
+    ) -> Result<(), OrStopped> {
+        self.initialize().await.map_err(Into::into)
     }
 
     async fn is_initialized(&self) -> anyhow::Result<bool> {

--- a/core/node/node_storage_init/src/traits.rs
+++ b/core/node/node_storage_init/src/traits.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use tokio::sync::watch;
-use zksync_types::L1BatchNumber;
+use zksync_types::{L1BatchNumber, OrStopped};
 
 /// An abstract storage initialization strategy.
 #[async_trait::async_trait]
@@ -11,7 +11,10 @@ pub trait InitializeStorage: fmt::Debug + Send + Sync + 'static {
 
     /// Initializes the storage.
     /// Implementors of this method may assume that they have unique access to the storage.
-    async fn initialize_storage(&self, stop_receiver: watch::Receiver<bool>) -> anyhow::Result<()>;
+    async fn initialize_storage(
+        &self,
+        stop_receiver: watch::Receiver<bool>,
+    ) -> Result<(), OrStopped>;
 }
 
 /// An abstract storage revert strategy.
@@ -19,18 +22,17 @@ pub trait InitializeStorage: fmt::Debug + Send + Sync + 'static {
 #[async_trait::async_trait]
 pub trait RevertStorage: fmt::Debug + Send + Sync + 'static {
     /// Checks whether a reorg is needed for the storage.
-    async fn is_reorg_needed(&self, stop_receiver: watch::Receiver<bool>) -> anyhow::Result<bool>;
+    async fn is_reorg_needed(
+        &self,
+        stop_receiver: watch::Receiver<bool>,
+    ) -> Result<bool, OrStopped>;
 
     /// Checks if the storage is invalid state and has to be rolled back.
     async fn last_correct_batch_for_reorg(
         &self,
         stop_receiver: watch::Receiver<bool>,
-    ) -> anyhow::Result<Option<L1BatchNumber>>;
+    ) -> Result<Option<L1BatchNumber>, OrStopped>;
 
     /// Reverts the storage to the provided batch number.
-    async fn revert_storage(
-        &self,
-        to_batch: L1BatchNumber,
-        stop_receiver: watch::Receiver<bool>,
-    ) -> anyhow::Result<()>;
+    async fn revert_storage(&self, to_batch: L1BatchNumber) -> anyhow::Result<()>;
 }

--- a/core/node/node_sync/src/batch_status_updater/mod.rs
+++ b/core/node/node_sync/src/batch_status_updater/mod.rs
@@ -305,7 +305,7 @@ impl BatchStatusUpdater {
             }
         }
 
-        tracing::info!("Stop signal received, exiting the batch status updater routine");
+        tracing::info!("Stop request received, exiting the batch status updater routine");
         Ok(())
     }
 

--- a/core/node/node_sync/src/data_availability_fetcher/mod.rs
+++ b/core/node/node_sync/src/data_availability_fetcher/mod.rs
@@ -243,7 +243,7 @@ impl DataAvailabilityFetcher {
         self.health_updater.update(health.into());
     }
 
-    /// Runs this component until a fatal error occurs or a stop signal is received. Retriable errors
+    /// Runs this component until a fatal error occurs or a stop request is received. Retriable errors
     /// (e.g., no network connection) are handled gracefully by retrying after a delay.
     pub async fn run(mut self, mut stop_receiver: watch::Receiver<bool>) -> anyhow::Result<()> {
         self.health_updater
@@ -297,7 +297,7 @@ impl DataAvailabilityFetcher {
                 break;
             }
         }
-        tracing::info!("Stop signal received; data availability fetcher is shutting down");
+        tracing::info!("Stop request received; data availability fetcher is shutting down");
         Ok(())
     }
 

--- a/core/node/node_sync/src/tree_data_fetcher/mod.rs
+++ b/core/node/node_sync/src/tree_data_fetcher/mod.rs
@@ -266,7 +266,7 @@ impl TreeDataFetcher {
         self.health_updater.update(health.into());
     }
 
-    /// Runs this component until a fatal error occurs or a stop signal is received. Retriable errors
+    /// Runs this component until a fatal error occurs or a stop request is received. Retriable errors
     /// (e.g., no network connection) are handled gracefully by retrying after a delay.
     pub async fn run(mut self, mut stop_receiver: watch::Receiver<bool>) -> anyhow::Result<()> {
         self.metrics.observe_info(&self);
@@ -326,7 +326,7 @@ impl TreeDataFetcher {
                 break;
             }
         }
-        tracing::info!("Stop signal received; tree data fetcher is shutting down");
+        tracing::info!("Stop request received; tree data fetcher is shutting down");
         Ok(())
     }
 }

--- a/core/node/node_sync/src/validate_chain_ids_task.rs
+++ b/core/node/node_sync/src/validate_chain_ids_task.rs
@@ -133,7 +133,7 @@ impl ValidateChainIdsTask {
         }
     }
 
-    /// Runs the task once, exiting either when all the checks are performed or when the stop signal is received.
+    /// Runs the task once, exiting either when all the checks are performed or when the stop request is received.
     pub async fn run_once(self, mut stop_receiver: watch::Receiver<bool>) -> anyhow::Result<()> {
         let l1_client_check = Self::check_client(self.l1_client, self.l1_chain_id.0.into());
         let main_node_l1_check =
@@ -150,10 +150,10 @@ impl ValidateChainIdsTask {
         }
     }
 
-    /// Runs the task until the stop signal is received.
+    /// Runs the task until the stop request is received.
     pub async fn run(self, mut stop_receiver: watch::Receiver<bool>) -> anyhow::Result<()> {
         // Since check futures are fused, they are safe to poll after getting resolved; they will never resolve again,
-        // so we'll just wait for another check or a stop signal.
+        // so we'll just wait for another check or a stop request.
         let l1_client_check = Self::check_client(self.l1_client, self.l1_chain_id.0.into()).fuse();
         let main_node_l1_check =
             Self::check_l1_chain_using_main_node(self.main_node_client.clone(), self.l1_chain_id)

--- a/core/node/proof_data_handler/src/client/proof_fetcher.rs
+++ b/core/node/proof_data_handler/src/client/proof_fetcher.rs
@@ -49,7 +49,7 @@ impl ProofFetcher {
         loop {
             if *stop_receiver.borrow() {
                 tracing::info!(
-                    "Stop signal received, proof generation data submitter is shutting down"
+                    "Stop request received, proof generation data submitter is shutting down"
                 );
                 break;
             }

--- a/core/node/proof_data_handler/src/client/proof_gen_data_submitter.rs
+++ b/core/node/proof_data_handler/src/client/proof_gen_data_submitter.rs
@@ -49,7 +49,7 @@ impl ProofGenDataSubmitter {
         loop {
             if *stop_receiver.borrow() {
                 tracing::info!(
-                    "Stop signal received, proof generation data submitter is shutting down"
+                    "Stop request received, proof generation data submitter is shutting down"
                 );
                 break;
             }

--- a/core/node/proof_data_handler/src/lib.rs
+++ b/core/node/proof_data_handler/src/lib.rs
@@ -50,9 +50,9 @@ pub async fn run_server(
     axum::serve(listener, app)
         .with_graceful_shutdown(async move {
             if stop_receiver.changed().await.is_err() {
-                tracing::warn!("Stop signal sender for proof data handler server was dropped without sending a signal");
+                tracing::warn!("Stop request sender for proof data handler server was dropped without sending a signal");
             }
-            tracing::info!("Stop signal received, proof data handler server is shutting down");
+            tracing::info!("Stop request received, proof data handler server is shutting down");
         })
         .await
         .context("Proof data handler server failed")?;

--- a/core/node/reorg_detector/src/lib.rs
+++ b/core/node/reorg_detector/src/lib.rs
@@ -442,13 +442,9 @@ impl ReorgDetector {
         .map(L1BatchNumber)
     }
 
-    /// Runs this detector *once* checking whether there is a reorg. This method will return:
+    /// Runs this detector *once* checking whether there is a reorg.
     ///
-    /// - `Ok(())` if there is no reorg, or if a stop signal is received.
-    /// - `Err(ReorgDetected(_))` if a reorg was detected.
-    /// - `Err(_)` for fatal errors.
-    ///
-    /// Retriable errors are retried indefinitely accounting for a stop signal.
+    /// Only fatal errors are returned (incl. detected reorgs). Retriable errors are retried indefinitely accounting for a stop request.
     pub async fn run_once(
         &mut self,
         stop_receiver: watch::Receiver<bool>,
@@ -457,7 +453,7 @@ impl ReorgDetector {
     }
 
     /// Runs this detector continuously checking for a reorg until a fatal error occurs (including if a reorg is detected),
-    /// or a stop signal is received.
+    /// or a stop request is received.
     pub async fn run(
         mut self,
         stop_receiver: watch::Receiver<bool>,

--- a/core/node/reorg_detector/src/lib.rs
+++ b/core/node/reorg_detector/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{fmt, future::Future, time::Duration};
+use std::{convert::Infallible, fmt, future::Future, time::Duration};
 
 use anyhow::Context as _;
 use async_trait::async_trait;
@@ -6,7 +6,7 @@ use tokio::sync::watch;
 use zksync_dal::{ConnectionPool, Core, CoreDal, DalError};
 use zksync_health_check::{Health, HealthStatus, HealthUpdater, ReactiveHealthCheck};
 use zksync_shared_metrics::{CheckerComponent, EN_METRICS};
-use zksync_types::{L1BatchNumber, L2BlockNumber, H256};
+use zksync_types::{L1BatchNumber, L2BlockNumber, OrStopped, H256};
 use zksync_web3_decl::{
     client::{DynClient, L2},
     error::{ClientRpcContext, EnrichedClientError, EnrichedClientResult},
@@ -449,29 +449,40 @@ impl ReorgDetector {
     /// - `Err(_)` for fatal errors.
     ///
     /// Retriable errors are retried indefinitely accounting for a stop signal.
-    pub async fn run_once(&mut self, stop_receiver: watch::Receiver<bool>) -> Result<(), Error> {
+    pub async fn run_once(
+        &mut self,
+        stop_receiver: watch::Receiver<bool>,
+    ) -> Result<(), OrStopped<Error>> {
         self.run_inner(true, stop_receiver).await
     }
 
     /// Runs this detector continuously checking for a reorg until a fatal error occurs (including if a reorg is detected),
     /// or a stop signal is received.
-    pub async fn run(mut self, stop_receiver: watch::Receiver<bool>) -> Result<(), Error> {
+    pub async fn run(
+        mut self,
+        stop_receiver: watch::Receiver<bool>,
+    ) -> Result<Infallible, OrStopped<Error>> {
         self.event_handler.initialize();
-        self.run_inner(false, stop_receiver).await?;
-        self.event_handler.start_shutting_down();
-        tracing::info!("Shutting down reorg detector");
-        Ok(())
+        // `unwrap_err()` is safe: `run_inner()` can only return `Ok(())` if `stop_after_success` is set.
+        let err = self.run_inner(false, stop_receiver).await.unwrap_err();
+        if matches!(&err, OrStopped::Stopped) {
+            self.event_handler.start_shutting_down();
+            tracing::info!("Shutting down reorg detector");
+        }
+        Err(err)
     }
 
     async fn run_inner(
         &mut self,
         stop_after_success: bool,
         mut stop_receiver: watch::Receiver<bool>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), OrStopped<Error>> {
         while !*stop_receiver.borrow_and_update() {
             let sleep_interval = match self.check_consistency().await {
-                Err(Error::HashMatch(err)) => self.handle_hash_err(err)?,
-                Err(err) => return Err(err),
+                Err(Error::HashMatch(err)) => {
+                    self.handle_hash_err(err).map_err(OrStopped::internal)?
+                }
+                Err(err) => return Err(err.into()),
                 Ok(()) if stop_after_success => return Ok(()),
                 Ok(()) => self.sleep_interval,
             };
@@ -485,7 +496,7 @@ impl ReorgDetector {
                 break;
             }
         }
-        Ok(())
+        Err(OrStopped::Stopped)
     }
 
     /// Returns the sleep interval if the error is transient.
@@ -507,14 +518,14 @@ impl ReorgDetector {
     /// Checks whether a reorg is present. Unlike [`Self::run_once()`], this method doesn't pinpoint the first diverged L1 batch;
     /// it just checks whether diverged batches / blocks exist in general.
     ///
-    /// Internally retries transient errors. Returns `Ok(false)` if a stop signal is received.
+    /// Internally retries transient errors.
     pub async fn check_reorg_presence(
         &mut self,
         mut stop_receiver: watch::Receiver<bool>,
-    ) -> anyhow::Result<bool> {
+    ) -> Result<bool, OrStopped> {
         while !*stop_receiver.borrow_and_update() {
             let sleep_interval = match self.find_last_diverged_batch().await {
-                Err(err) => self.handle_hash_err(err)?,
+                Err(err) => self.handle_hash_err(err).map_err(OrStopped::internal)?,
                 Ok(maybe_diverged_batch) => return Ok(maybe_diverged_batch.is_some()),
             };
 
@@ -522,7 +533,7 @@ impl ReorgDetector {
                 .await
                 .is_ok()
             {
-                break;
+                return Err(OrStopped::Stopped);
             }
         }
         Ok(false)

--- a/core/node/state_keeper/src/executor/tests/read_storage_factory.rs
+++ b/core/node/state_keeper/src/executor/tests/read_storage_factory.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use tokio::sync::watch;
 use zksync_dal::{ConnectionPool, Core};
 use zksync_state::{OwnedStorage, ReadStorageFactory, RocksdbStorage};
-use zksync_types::L1BatchNumber;
+use zksync_types::{L1BatchNumber, OrStopped};
 
 #[derive(Debug, Clone)]
 pub struct RocksdbStorageFactory {
@@ -17,31 +17,21 @@ impl ReadStorageFactory for RocksdbStorageFactory {
         &self,
         stop_receiver: &watch::Receiver<bool>,
         _l1_batch_number: L1BatchNumber,
-    ) -> anyhow::Result<Option<OwnedStorage>> {
+    ) -> Result<OwnedStorage, OrStopped> {
         // Waiting for recovery here is not a good idea in the general case because of snapshot recovery taking potentially very long time.
         // Since this is a test implementation, it's OK here.
-        let Some((rocksdb, _)) = RocksdbStorage::builder(self.state_keeper_db_path.as_ref())
+        let (rocksdb, _) = RocksdbStorage::builder(self.state_keeper_db_path.as_ref())
             .await
             .context("Failed opening state keeper RocksDB")?
             .ensure_ready(&self.pool, stop_receiver)
-            .await
-            .context("RocksDB cache is not initialized")?
-        else {
-            return Ok(None); // initialization interrupted
-        };
+            .await?;
         let mut conn = self
             .pool
             .connection_tagged("state_keeper")
             .await
             .context("Failed getting a connection to Postgres")?;
-        let Some(rocksdb_storage) = rocksdb
-            .synchronize(&mut conn, stop_receiver, None)
-            .await
-            .context("Failed synchronizing state keeper's RocksDB to Postgres")?
-        else {
-            return Ok(None);
-        };
-        Ok(Some(OwnedStorage::Rocksdb(rocksdb_storage)))
+        let rocksdb_storage = rocksdb.synchronize(&mut conn, stop_receiver, None).await?;
+        Ok(OwnedStorage::Rocksdb(rocksdb_storage))
     }
 }
 

--- a/core/node/state_keeper/src/executor/tests/tester.rs
+++ b/core/node/state_keeper/src/executor/tests/tester.rs
@@ -179,8 +179,7 @@ impl Tester {
         let storage = storage_factory
             .access_storage(&stop_receiver, l1_batch_env.number - 1)
             .await
-            .expect("failed creating VM storage")
-            .unwrap();
+            .expect("failed creating VM storage");
         if self.config.trace_calls {
             let mut executor = MainBatchExecutorFactory::<TraceCalls>::new(false);
             executor.set_fast_vm_mode(self.config.fast_vm_mode);

--- a/core/node/state_keeper/src/keeper.rs
+++ b/core/node/state_keeper/src/keeper.rs
@@ -344,7 +344,7 @@ impl ZkSyncStateKeeper {
         stop_receiver: &mut watch::Receiver<bool>,
     ) -> Result<(SystemEnv, L1BatchEnv, PubdataParams), OrStopped> {
         // `io.wait_for_new_batch_params(..)` is not cancel-safe; once we get new batch params, we must hold onto them
-        // until we get the rest of parameters from I/O or receive a stop signal.
+        // until we get the rest of parameters from I/O or receive a stop request.
         let params = self
             .wait_for_new_batch_params(cursor, stop_receiver)
             .await?;

--- a/core/node/state_keeper/src/keeper.rs
+++ b/core/node/state_keeper/src/keeper.rs
@@ -19,8 +19,8 @@ use zksync_shared_metrics::{TxStage, APP_METRICS};
 use zksync_state::{OwnedStorage, ReadStorageFactory};
 use zksync_types::{
     block::L2BlockExecutionData, commitment::PubdataParams, l2::TransactionType,
-    protocol_upgrade::ProtocolUpgradeTx, protocol_version::ProtocolVersionId,
-    utils::display_timestamp, L1BatchNumber, Transaction,
+    protocol_upgrade::ProtocolUpgradeTx, protocol_version::ProtocolVersionId, try_stoppable,
+    utils::display_timestamp, L1BatchNumber, OrStopped, Transaction,
 };
 use zksync_vm_executor::whitelist::DeploymentTxFilter;
 
@@ -37,24 +37,6 @@ use crate::{
 /// Amount of time to block on waiting for some resource. The exact value is not really important,
 /// we only need it to not block on waiting indefinitely and be able to process cancellation requests.
 pub(super) const POLL_WAIT_DURATION: Duration = Duration::from_secs(1);
-
-/// Structure used to indicate that task cancellation was requested.
-#[derive(thiserror::Error, Debug)]
-pub(super) enum Error {
-    #[error("canceled")]
-    Canceled,
-    #[error(transparent)]
-    Fatal(#[from] anyhow::Error),
-}
-
-impl Error {
-    fn context(self, msg: &'static str) -> Self {
-        match self {
-            Self::Canceled => Self::Canceled,
-            Self::Fatal(err) => Self::Fatal(err.context(msg)),
-        }
-    }
-}
 
 /// State keeper represents a logic layer of L1 batch / L2 block processing flow.
 ///
@@ -98,20 +80,15 @@ impl ZkSyncStateKeeper {
     }
 
     pub async fn run(mut self, stop_receiver: watch::Receiver<bool>) -> anyhow::Result<()> {
-        match self.run_inner(stop_receiver).await {
-            Err(Error::Fatal(err)) => Err(err).context("state_keeper failed"),
-            Err(Error::Canceled) => {
-                tracing::info!("Stop signal received, state keeper is shutting down");
-                Ok(())
-            }
-        }
+        try_stoppable!(self.run_inner(stop_receiver).await);
+        Ok(())
     }
 
     /// Fallible version of `run` routine that allows to easily exit upon cancellation.
     async fn run_inner(
         &mut self,
         mut stop_receiver: watch::Receiver<bool>,
-    ) -> Result<Infallible, Error> {
+    ) -> Result<Infallible, OrStopped> {
         let (cursor, pending_batch_params) = self.io.initialize().await?;
         self.output_handler.initialize(&cursor).await?;
         self.health_updater
@@ -145,8 +122,7 @@ impl ZkSyncStateKeeper {
                 tracing::info!("There is no open pending batch, starting a new empty batch");
                 let (system_env, l1_batch_env, pubdata_params) = self
                     .wait_for_new_batch_env(&cursor, &mut stop_receiver)
-                    .await
-                    .map_err(|e| e.context("wait_for_new_batch_params()"))?;
+                    .await?;
                 PendingBatchData {
                     l1_batch_env,
                     pending_l2_blocks: Vec::new(),
@@ -253,7 +229,7 @@ impl ZkSyncStateKeeper {
                 None
             };
         }
-        Err(Error::Canceled)
+        Err(OrStopped::Stopped)
     }
 
     async fn create_batch_executor(
@@ -262,13 +238,11 @@ impl ZkSyncStateKeeper {
         system_env: SystemEnv,
         pubdata_params: PubdataParams,
         stop_receiver: &watch::Receiver<bool>,
-    ) -> Result<Box<dyn BatchExecutor<OwnedStorage>>, Error> {
+    ) -> Result<Box<dyn BatchExecutor<OwnedStorage>>, OrStopped> {
         let storage = self
             .storage_factory
             .access_storage(stop_receiver, l1_batch_env.number - 1)
-            .await
-            .context("failed creating VM storage")?
-            .ok_or(Error::Canceled)?;
+            .await?;
         Ok(self
             .batch_executor
             .init_batch(storage, l1_batch_env, system_env, pubdata_params))
@@ -282,7 +256,7 @@ impl ZkSyncStateKeeper {
         pending_l2_blocks: &[L2BlockExecutionData],
         protocol_version: ProtocolVersionId,
         l1_batch_number: L1BatchNumber,
-    ) -> Result<Option<ProtocolUpgradeTx>, Error> {
+    ) -> anyhow::Result<Option<ProtocolUpgradeTx>> {
         // After the Shared Bridge is integrated,
         // there has to be a GenesisUpgrade upgrade transaction after the chain genesis.
         // It has to be the first transaction of the first batch.
@@ -343,7 +317,7 @@ impl ZkSyncStateKeeper {
         &mut self,
         cursor: &IoCursor,
         stop_receiver: &watch::Receiver<bool>,
-    ) -> Result<L1BatchParams, Error> {
+    ) -> Result<L1BatchParams, OrStopped> {
         while !is_canceled(stop_receiver) {
             if let Some(params) = self
                 .io
@@ -353,7 +327,7 @@ impl ZkSyncStateKeeper {
                 return Ok(params);
             }
         }
-        Err(Error::Canceled)
+        Err(OrStopped::Stopped)
     }
 
     #[tracing::instrument(
@@ -366,7 +340,7 @@ impl ZkSyncStateKeeper {
         &mut self,
         cursor: &IoCursor,
         stop_receiver: &mut watch::Receiver<bool>,
-    ) -> Result<(SystemEnv, L1BatchEnv, PubdataParams), Error> {
+    ) -> Result<(SystemEnv, L1BatchEnv, PubdataParams), OrStopped> {
         // `io.wait_for_new_batch_params(..)` is not cancel-safe; once we get new batch params, we must hold onto them
         // until we get the rest of parameters from I/O or receive a stop signal.
         let params = self
@@ -389,7 +363,7 @@ impl ZkSyncStateKeeper {
                 let previous_batch_hash = hash_result.context("cannot load state hash for previous L1 batch")?;
                 Ok(params.into_env(self.io.chain_id(), contracts, cursor, previous_batch_hash))
             }
-            _ = stop_receiver.changed() => Err(Error::Canceled),
+            _ = stop_receiver.changed() => Err(OrStopped::Stopped),
         }
     }
 
@@ -404,7 +378,7 @@ impl ZkSyncStateKeeper {
         &mut self,
         updates: &UpdatesManager,
         stop_receiver: &watch::Receiver<bool>,
-    ) -> Result<L2BlockParams, Error> {
+    ) -> Result<L2BlockParams, OrStopped> {
         let latency = KEEPER_METRICS.wait_for_l2_block_params.start();
         let cursor = updates.io_cursor();
         while !is_canceled(stop_receiver) {
@@ -421,7 +395,7 @@ impl ZkSyncStateKeeper {
                 return Ok(params);
             }
         }
-        Err(Error::Canceled)
+        Err(OrStopped::Stopped)
     }
 
     fn set_l2_block_params(updates_manager: &mut UpdatesManager, l2_block_params: L2BlockParams) {
@@ -496,7 +470,7 @@ impl ZkSyncStateKeeper {
         updates_manager: &mut UpdatesManager,
         l2_blocks_to_reexecute: Vec<L2BlockExecutionData>,
         stop_receiver: &watch::Receiver<bool>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), OrStopped> {
         if l2_blocks_to_reexecute.is_empty() {
             return Ok(());
         }
@@ -578,8 +552,7 @@ impl ZkSyncStateKeeper {
         // The `wait_for_new_l2_block_params` call is used to initialize the StateKeeperIO with a correct new l2 block params
         let new_l2_block_params = self
             .wait_for_new_l2_block_params(updates_manager, stop_receiver)
-            .await
-            .map_err(|e| e.context("wait_for_new_l2_block_params"))?;
+            .await?;
         Self::set_l2_block_params(updates_manager, new_l2_block_params);
         Ok(())
     }
@@ -594,7 +567,7 @@ impl ZkSyncStateKeeper {
         updates_manager: &mut UpdatesManager,
         protocol_upgrade_tx: Option<ProtocolUpgradeTx>,
         stop_receiver: &watch::Receiver<bool>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), OrStopped> {
         if let Some(protocol_upgrade_tx) = protocol_upgrade_tx {
             self.process_upgrade_tx(batch_executor, updates_manager, protocol_upgrade_tx)
                 .await?;
@@ -640,8 +613,7 @@ impl ZkSyncStateKeeper {
                 // Get a tentative new l2 block parameters
                 let next_l2_block_params = self
                     .wait_for_new_l2_block_params(updates_manager, stop_receiver)
-                    .await
-                    .map_err(|e| e.context("wait_for_new_l2_block_params"))?;
+                    .await?;
                 Self::set_l2_block_params(updates_manager, next_l2_block_params);
             }
 
@@ -735,7 +707,7 @@ impl ZkSyncStateKeeper {
             }
             full_latency.observe();
         }
-        Err(Error::Canceled)
+        Err(OrStopped::Stopped)
     }
 
     async fn process_upgrade_tx(

--- a/core/node/state_keeper/src/mempool_actor.rs
+++ b/core/node/state_keeper/src/mempool_actor.rs
@@ -81,7 +81,7 @@ impl MempoolFetcher {
 
         loop {
             if *stop_receiver.borrow() {
-                tracing::info!("Stop signal received, mempool is shutting down");
+                tracing::info!("Stop request received, mempool is shutting down");
                 break;
             }
             let latency = KEEPER_METRICS.mempool_sync.start();

--- a/core/node/state_keeper/src/state_keeper_storage.rs
+++ b/core/node/state_keeper/src/state_keeper_storage.rs
@@ -7,7 +7,7 @@ use zksync_dal::{ConnectionPool, Core};
 use zksync_state::{
     AsyncCatchupTask, OwnedStorage, ReadStorageFactory, RocksdbCell, RocksdbStorageOptions,
 };
-use zksync_types::L1BatchNumber;
+use zksync_types::{L1BatchNumber, OrStopped};
 
 /// A [`ReadStorageFactory`] implementation that can produce short-lived [`ReadStorage`] handles
 /// backed by either Postgres or RocksDB (if it's caught up).
@@ -43,7 +43,7 @@ impl ReadStorageFactory for AsyncRocksdbCache {
         &self,
         stop_receiver: &watch::Receiver<bool>,
         l1_batch_number: L1BatchNumber,
-    ) -> anyhow::Result<Option<OwnedStorage>> {
+    ) -> Result<OwnedStorage, OrStopped> {
         let initial_state = self.rocksdb_cell.ensure_initialized().await?;
         let rocksdb = if initial_state.next_l1_batch_number >= Some(l1_batch_number) {
             tracing::info!(
@@ -65,17 +65,11 @@ impl ReadStorageFactory for AsyncRocksdbCache {
             .await
             .context("Failed getting a Postgres connection")?;
         if let Some(rocksdb) = rocksdb {
-            let storage =
-                OwnedStorage::rocksdb(&mut connection, rocksdb, stop_receiver, l1_batch_number)
-                    .await
-                    .context("Failed accessing RocksDB storage")?;
-            Ok(storage)
+            OwnedStorage::rocksdb(&mut connection, rocksdb, stop_receiver, l1_batch_number).await
         } else {
-            Ok(Some(
-                OwnedStorage::postgres(connection, l1_batch_number)
-                    .await?
-                    .into(),
-            ))
+            Ok(OwnedStorage::postgres(connection, l1_batch_number)
+                .await?
+                .into())
         }
     }
 }

--- a/core/node/state_keeper/src/testonly/test_batch_executor.rs
+++ b/core/node/state_keeper/src/testonly/test_batch_executor.rs
@@ -225,7 +225,7 @@ impl TestScenario {
         );
         let sk_thread = tokio::spawn(state_keeper.run(stop_receiver));
 
-        // We must assume that *theoretically* state keeper may ignore the stop signal from IO once scenario is
+        // We must assume that *theoretically* state keeper may ignore the stop request from IO once scenario is
         // completed, so we spawn it in a separate thread to not get test stuck.
         let hard_timeout = Duration::from_secs(60);
         let poll_interval = Duration::from_millis(50);

--- a/core/node/state_keeper/src/testonly/test_batch_executor.rs
+++ b/core/node/state_keeper/src/testonly/test_batch_executor.rs
@@ -29,7 +29,7 @@ use zksync_state::{interface::StorageView, OwnedStorage, ReadStorageFactory};
 use zksync_types::{
     commitment::PubdataParams, fee_model::BatchFeeInput, l2_to_l1_log::UserL2ToL1Log,
     protocol_upgrade::ProtocolUpgradeTx, Address, L1BatchNumber, L2BlockNumber, L2ChainId,
-    ProtocolVersionId, Transaction, H256,
+    OrStopped, ProtocolVersionId, Transaction, H256,
 };
 
 use crate::{
@@ -847,8 +847,8 @@ impl ReadStorageFactory<OwnedStorage> for MockReadStorageFactory {
         &self,
         _stop_receiver: &watch::Receiver<bool>,
         _l1_batch_number: L1BatchNumber,
-    ) -> anyhow::Result<Option<OwnedStorage>> {
+    ) -> Result<OwnedStorage, OrStopped> {
         let storage = InMemoryStorage::default();
-        Ok(Some(OwnedStorage::boxed(storage)))
+        Ok(OwnedStorage::boxed(storage))
     }
 }

--- a/core/node/tee_proof_data_handler/src/lib.rs
+++ b/core/node/tee_proof_data_handler/src/lib.rs
@@ -42,9 +42,9 @@ pub async fn run_server(
     axum::serve(listener, app)
         .with_graceful_shutdown(async move {
             if stop_receiver.changed().await.is_err() {
-                tracing::warn!("Stop signal sender for proof data handler server was dropped without sending a signal");
+                tracing::warn!("Stop request sender for proof data handler server was dropped without sending a signal");
             }
-            tracing::info!("Stop signal received, proof data handler server is shutting down");
+            tracing::info!("Stop request received, proof data handler server is shutting down");
         })
         .await
         .context("Proof data handler server failed")?;

--- a/core/node/vm_runner/src/impls/playground.rs
+++ b/core/node/vm_runner/src/impls/playground.rs
@@ -314,7 +314,7 @@ pub struct VmPlaygroundLoaderTask {
 }
 
 impl VmPlaygroundLoaderTask {
-    /// Runs a task until a stop signal is received.
+    /// Runs a task until a stop request is received.
     pub async fn run(self, mut stop_receiver: watch::Receiver<bool>) -> anyhow::Result<()> {
         let task = tokio::select! {
             biased;

--- a/core/node/vm_runner/src/storage.rs
+++ b/core/node/vm_runner/src/storage.rs
@@ -13,7 +13,7 @@ use zksync_state::{
     AsyncCatchupTask, BatchDiff, OwnedStorage, RocksdbCell, RocksdbStorage, RocksdbWithMemory,
 };
 use zksync_types::{
-    block::L2BlockExecutionData, commitment::PubdataParams, L1BatchNumber, L2ChainId,
+    block::L2BlockExecutionData, commitment::PubdataParams, try_stoppable, L1BatchNumber, L2ChainId,
 };
 use zksync_vm_executor::storage::L1BatchParamsProvider;
 use zksync_vm_interface::{L1BatchEnv, SystemEnv};
@@ -298,7 +298,7 @@ impl<Io: VmRunnerIo> StorageSyncTask<Io> {
         const SLEEP_INTERVAL: Duration = Duration::from_millis(50);
 
         self.catchup_task.run(stop_receiver.clone()).await?;
-        let mut rocksdb = self.rocksdb_cell.wait().await?;
+        let mut rocksdb = try_stoppable!(self.rocksdb_cell.wait().await);
         loop {
             if *stop_receiver.borrow() {
                 tracing::info!("`StorageSyncTask` was interrupted");
@@ -325,15 +325,11 @@ impl<Io: VmRunnerIo> StorageSyncTask<Io> {
             // number less than `latest_processed_batch`. If they do, RocksDB synchronization below
             // will cause them to have an inconsistent view on DB which we consider to be an
             // undefined behavior.
-            let Some(updated_rocksdb) = rocksdb
-                .synchronize(&mut conn, &stop_receiver, Some(latest_processed_batch))
-                .await
-                .context("Failed to catch up state keeper RocksDB storage to Postgres")?
-            else {
-                tracing::info!("`StorageSyncTask` was interrupted during RocksDB synchronization");
-                return Ok(());
-            };
-            rocksdb = updated_rocksdb;
+            rocksdb = try_stoppable!(
+                rocksdb
+                    .synchronize(&mut conn, &stop_receiver, Some(latest_processed_batch))
+                    .await
+            );
 
             let mut state = self.state.write().await;
             state.rocksdb = Some(rocksdb.clone());

--- a/core/node/zk_os_tree_manager/src/api/mod.rs
+++ b/core/node/zk_os_tree_manager/src/api/mod.rs
@@ -345,10 +345,10 @@ impl AsyncTreeReader {
             server.with_graceful_shutdown(async move {
                 if stop_receiver.changed().await.is_err() {
                     tracing::warn!(
-                        "Stop signal sender for Merkle tree API server was dropped without sending a signal"
+                        "Stop request sender for Merkle tree API server was dropped without sending a signal"
                     );
                 }
-                tracing::info!("Stop signal received, Merkle tree API server is shutting down");
+                tracing::info!("Stop request received, Merkle tree API server is shutting down");
             })
             .await
             .context("Merkle tree API server failed")?;

--- a/core/node/zk_os_tree_manager/src/api/tests.rs
+++ b/core/node/zk_os_tree_manager/src/api/tests.rs
@@ -125,7 +125,7 @@ async fn api_client_basics() {
     let internal_node = internal_node.internal.as_ref().unwrap();
     assert!(internal_node.0.len() > 1, "{internal_node:?}");
 
-    // Check that the server reacts to a stop signal.
+    // Check that the server reacts to a stop request.
     stop_sender.send_replace(true);
     server_task.await.unwrap().unwrap();
 }

--- a/core/node/zk_os_tree_manager/src/tests.rs
+++ b/core/node/zk_os_tree_manager/src/tests.rs
@@ -124,7 +124,7 @@ async fn genesis_creation() {
     assert_eq!(tree_info.next_version, 1);
     assert!(tree_info.leaf_count > 10);
 
-    // Check that the manager is responsive to stop signals.
+    // Check that the manager is responsive to stop requests.
     stop_sender.send_replace(true);
     manager_task.await.unwrap().unwrap();
 

--- a/core/node/zk_os_tree_manager/src/updater.rs
+++ b/core/node/zk_os_tree_manager/src/updater.rs
@@ -10,7 +10,7 @@ use zksync_dal::{helpers::wait_for_l1_batch, Connection, ConnectionPool, Core, C
 use zksync_shared_metrics::tree::{update_tree_metrics, TreeUpdateStage, METRICS};
 use zksync_types::{
     block::{L1BatchStatistics, L1BatchTreeData},
-    L1BatchNumber,
+    L1BatchNumber, OrStopped,
 };
 
 use crate::{batch::L1BatchWithLogs, helpers::AsyncMerkleTree};
@@ -335,12 +335,8 @@ impl AsyncMerkleTree {
         delay_interval: Duration,
         pool: &ConnectionPool<Core>,
         stop_receiver: &mut watch::Receiver<bool>,
-    ) -> anyhow::Result<()> {
-        let Some(earliest_l1_batch) =
-            wait_for_l1_batch(pool, delay_interval, stop_receiver).await?
-        else {
-            return Ok(()); // Stop signal received
-        };
+    ) -> Result<(), OrStopped> {
+        let earliest_l1_batch = wait_for_l1_batch(pool, delay_interval, stop_receiver).await?;
         let mut storage = pool.connection_tagged("tree_updater").await?;
 
         self.ensure_genesis(&mut storage, earliest_l1_batch).await?;

--- a/core/node/zk_os_tree_manager/src/updater.rs
+++ b/core/node/zk_os_tree_manager/src/updater.rs
@@ -175,7 +175,7 @@ impl TreeUpdater {
 
         loop {
             if *stop_receiver.borrow_and_update() {
-                tracing::info!("Stop signal received, metadata_calculator is shutting down");
+                tracing::info!("Stop request received, metadata_calculator is shutting down");
                 break;
             }
 
@@ -202,7 +202,7 @@ impl TreeUpdater {
             // and the stop receiver still allows to be more responsive during shutdown.
             tokio::select! {
                 _ = stop_receiver.changed() => {
-                    tracing::info!("Stop signal received, metadata_calculator is shutting down");
+                    tracing::info!("Stop request received, metadata_calculator is shutting down");
                     break;
                 }
                 () = delay => { /* The delay has passed */ }

--- a/core/tests/vm-benchmark/src/criterion.rs
+++ b/core/tests/vm-benchmark/src/criterion.rs
@@ -65,7 +65,7 @@ pub struct PrometheusRuntime {
 impl Drop for PrometheusRuntime {
     fn drop(&mut self) {
         self.stop_sender.send_replace(true);
-        // Metrics are pushed automatically on exit, so we wait *after* sending a stop signal
+        // Metrics are pushed automatically on exit, so we wait *after* sending a stop request
         println!("Waiting for Prometheus metrics to be pushed");
         thread::sleep(Duration::from_secs(1));
     }

--- a/prover/crates/bin/circuit_prover/src/main.rs
+++ b/prover/crates/bin/circuit_prover/src/main.rs
@@ -129,7 +129,7 @@ async fn main() -> anyhow::Result<()> {
         result = tokio::signal::ctrl_c() => {
             match result {
                 Ok(_) => {
-                    tracing::info!("Stop signal received, shutting down...");
+                    tracing::info!("Stop request received, shutting down...");
                     cancellation_token.cancel();
                 },
                 Err(_err) => {

--- a/prover/crates/bin/proof_fri_compressor/src/main.rs
+++ b/prover/crates/bin/proof_fri_compressor/src/main.rs
@@ -130,7 +130,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::select! {
         _ = tasks.wait_single() => {},
         _ = stop_signal_receiver => {
-            tracing::info!("Stop signal received, shutting down");
+            tracing::info!("Stop request received, shutting down");
         }
     };
     stop_sender.send_replace(true);

--- a/prover/crates/bin/prover_autoscaler/src/agent.rs
+++ b/prover/crates/bin/prover_autoscaler/src/agent.rs
@@ -46,10 +46,10 @@ pub async fn run_server(
         .with_graceful_shutdown(async move {
             if stop_receiver.changed().await.is_err() {
                 tracing::warn!(
-                    "Stop signal sender for Autoscaler agent was dropped without sending a signal"
+                    "Stop request sender for Autoscaler agent was dropped without sending a signal"
                 );
             }
-            tracing::info!("Stop signal received, Autoscaler agent is shutting down");
+            tracing::info!("Stop request received, Autoscaler agent is shutting down");
         })
         .await
         .context("Autoscaler agent failed")?;

--- a/prover/crates/bin/prover_autoscaler/src/main.rs
+++ b/prover/crates/bin/prover_autoscaler/src/main.rs
@@ -126,7 +126,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::select! {
         _ = tasks.wait_single() => {},
         _ = stop_signal_receiver => {
-            tracing::info!("Stop signal received, shutting down");
+            tracing::info!("Stop request received, shutting down");
         }
     }
     stop_sender.send(true).ok();

--- a/prover/crates/bin/prover_fri_gateway/src/main.rs
+++ b/prover/crates/bin/prover_fri_gateway/src/main.rs
@@ -114,7 +114,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::select! {
         _ = tasks.wait_single() => {},
          _ = stop_signal_receiver => {
-            tracing::info!("Stop signal received, shutting down");
+            tracing::info!("Stop request received, shutting down");
         }
     }
 

--- a/prover/crates/bin/prover_fri_gateway/src/server.rs
+++ b/prover/crates/bin/prover_fri_gateway/src/server.rs
@@ -46,9 +46,9 @@ impl Api {
         axum::serve(listener, self.router)
         .with_graceful_shutdown(async move {
             if stop_receiver.changed().await.is_err() {
-                tracing::warn!("Stop signal sender for prover gateway API server was dropped without sending a signal");
+                tracing::warn!("Stop request sender for prover gateway API server was dropped without sending a signal");
             }
-            tracing::info!("Stop signal received, prover gateway API server is shutting down");
+            tracing::info!("Stop request received, prover gateway API server is shutting down");
         })
         .await
         .context("Prover gateway API server failed")?;

--- a/prover/crates/bin/prover_fri_gateway/src/traits.rs
+++ b/prover/crates/bin/prover_fri_gateway/src/traits.rs
@@ -44,7 +44,10 @@ pub(crate) trait PeriodicApi: Sync + Send + 'static + Sized {
 
         loop {
             if *stop_receiver.borrow() {
-                tracing::warn!("Stop signal received, shutting down {}", Self::SERVICE_NAME);
+                tracing::warn!(
+                    "Stop request received, shutting down {}",
+                    Self::SERVICE_NAME
+                );
                 return Ok(());
             }
 

--- a/prover/crates/bin/prover_job_monitor/src/main.rs
+++ b/prover/crates/bin/prover_job_monitor/src/main.rs
@@ -107,17 +107,17 @@ async fn main() -> anyhow::Result<()> {
         .with_graceful_shutdown(async move {
             if receiver.changed().await.is_err() {
                 tracing::warn!(
-                    "Stop signal sender for PJM server was dropped without sending a signal"
+                    "Stop request sender for PJM server was dropped without sending a signal"
                 );
             }
-            tracing::info!("Stop signal received, PJM server is shutting down");
+            tracing::info!("Stop request received, PJM server is shutting down");
         })
         .into_future();
 
     tokio::select! {
         _ = tasks.wait_single() => {},
         _ = stop_signal_receiver => {
-            tracing::info!("Stop signal received, shutting down");
+            tracing::info!("Stop request received, shutting down");
         }
         _ = app => {}
     }

--- a/prover/crates/bin/witness_generator/src/main.rs
+++ b/prover/crates/bin/witness_generator/src/main.rs
@@ -261,7 +261,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::select! {
         _ = tasks.wait_single() => {},
         _ = stop_signal_receiver.next() => {
-            tracing::info!("Stop signal received, shutting down");
+            tracing::info!("Stop request received, shutting down");
         }
     }
 

--- a/prover/crates/lib/prover_job_processor/src/task_wiring/job_picker_task.rs
+++ b/prover/crates/lib/prover_job_processor/src/task_wiring/job_picker_task.rs
@@ -71,7 +71,7 @@ impl<P: JobPicker> Task for JobPickerTask<P> {
                 }
             }
         }
-        tracing::info!("Stop signal received, shutting down JobPickerTask...");
+        tracing::info!("Stop request received, shutting down JobPickerTask...");
         Ok(())
     }
 }

--- a/prover/crates/lib/prover_task/src/lib.rs
+++ b/prover/crates/lib/prover_task/src/lib.rs
@@ -36,7 +36,7 @@ impl PeriodicTask {
                 .await
                 .context("failed to invoke task")?;
         }
-        tracing::info!("Stop signal received; Task {} is shut down", self.name);
+        tracing::info!("Stop request received; Task {} is shut down", self.name);
         Ok(())
     }
 }


### PR DESCRIPTION
## What ❔

Introduces cancelation errors (i.e., a very lightweight form of structured concurrency). Uses these errors to improve control flow for some components (e.g., snapshot recovery).

## Why ❔

Improves DevEx.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.