### PR TITLE
fix(tee_proof_data_handler): handle fallback deserialization for blob store data

### DIFF
--- a/core/node/tee_proof_data_handler/src/errors.rs
+++ b/core/node/tee_proof_data_handler/src/errors.rs
@@ -9,8 +9,11 @@ use zksync_object_store::ObjectStoreError;
 pub enum TeeProcessorError {
     #[error("General error: {0}")]
     GeneralError(String),
-    #[error("GCS error: {0}")]
-    ObjectStore(#[from] ObjectStoreError),
+    #[error("GCS error: {context}: {source}")]
+    ObjectStore {
+        source: ObjectStoreError,
+        context: String,
+    },
     #[error("Failed fetching/saving from db: {0}")]
     Dal(#[from] DalError),
 }
@@ -19,7 +22,7 @@ impl TeeProcessorError {
     pub fn status_code(&self) -> StatusCode {
         match self {
             Self::GeneralError(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            Self::ObjectStore(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::ObjectStore { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::Dal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/core/node/tee_proof_data_handler/src/tee_request_processor.rs
+++ b/core/node/tee_proof_data_handler/src/tee_request_processor.rs
@@ -8,7 +8,10 @@ use zksync_dal::{
     ConnectionPool, Core, CoreDal,
 };
 use zksync_object_store::{ObjectStore, ObjectStoreError};
-use zksync_prover_interface::inputs::{VMRunWitnessInputData, WitnessInputMerklePaths};
+use zksync_prover_interface::{
+    inputs::{VMRunWitnessInputData, WitnessInputMerklePaths},
+    Bincode,
+};
 use zksync_tee_prover_interface::{
     api::{
         RegisterTeeAttestationRequest, RegisterTeeAttestationResponse, SubmitTeeProofRequest,
@@ -77,7 +80,10 @@ impl TeeRequestProcessor {
                 Ok(input) => {
                     break Ok(Some(Json(TeeProofGenerationDataResponse(Box::new(input)))));
                 }
-                Err(TeeProcessorError::ObjectStore(ObjectStoreError::KeyNotFound(_))) => {
+                Err(TeeProcessorError::ObjectStore {
+                    source: ObjectStoreError::KeyNotFound(_),
+                    context,
+                }) => {
                     let duration = Utc::now().signed_duration_since(locked_batch.created_at);
                     let status = if duration > batch_ignored_timeout {
                         TeeProofGenerationJobStatus::PermanentlyIgnored
@@ -87,7 +93,7 @@ impl TeeRequestProcessor {
                     self.unlock_batch(batch_number, request.tee_type, status)
                         .await?;
                     tracing::warn!(
-                        "Assigned status {} to batch {} created at {}",
+                        "Assigned status `{}` to batch {} created at {}: {context}",
                         status,
                         batch_number,
                         locked_batch.created_at
@@ -111,17 +117,32 @@ impl TeeRequestProcessor {
         &self,
         l1_batch_number: L1BatchNumber,
     ) -> Result<TeeVerifierInput, TeeProcessorError> {
-        let vm_run_data: VMRunWitnessInputData = self
-            .blob_store
-            .get(l1_batch_number)
-            .await
-            .map_err(TeeProcessorError::ObjectStore)?;
+        let vm_run_data: VMRunWitnessInputData = match self.blob_store.get(l1_batch_number).await {
+            Ok(data) => data,
+            Err(_) => self
+                .blob_store
+                .get::<VMRunWitnessInputData<Bincode>>(l1_batch_number)
+                .await
+                .map(Into::into)
+                .map_err(|source| TeeProcessorError::ObjectStore {
+                    source,
+                    context: "Failed to get VMRunWitnessInputData".into(),
+                })?,
+        };
 
-        let merkle_paths: WitnessInputMerklePaths = self
-            .blob_store
-            .get(l1_batch_number)
-            .await
-            .map_err(TeeProcessorError::ObjectStore)?;
+        let merkle_paths: WitnessInputMerklePaths = match self.blob_store.get(l1_batch_number).await
+        {
+            Ok(data) => data,
+            Err(_) => self
+                .blob_store
+                .get::<WitnessInputMerklePaths<Bincode>>(l1_batch_number)
+                .await
+                .map(Into::into)
+                .map_err(|source| TeeProcessorError::ObjectStore {
+                    source,
+                    context: "Failed to get WitnessInputMerklePaths".into(),
+                })?,
+        };
 
         let mut connection = self.pool.connection_tagged("tee_request_processor").await?;
 


### PR DESCRIPTION
## What ❔

- Added fallback logic to deserialize blob store data as `Bincode`.
- Adjusted error handling to accommodate multiple deserialization attempts.

## Why ❔

This ensures compatibility with mixed serialization formats in the blob store.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
