### PR TITLE
fix(da): gas relay check_finality

### DIFF
--- a/core/node/da_clients/src/avail/sdk.rs
+++ b/core/node/da_clients/src/avail/sdk.rs
@@ -4,7 +4,6 @@
 use std::{fmt::Debug, sync::Arc, time};
 
 use anyhow::{bail, Context};
-use backon::{ConstantBuilder, Retryable};
 use bip39::Mnemonic;
 use bytes::Bytes;
 use jsonrpsee::{


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->
Refactor the `check_finality` function in Avail GasRelay.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->
The previous approach to retrying GasRelay requests was invalid, which led to valid requests being dropped before they reached finality.

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
