### PR TITLE
feat: return `txHash` when tracing blocks with `CallTracer`

### DIFF
--- a/core/lib/types/src/api/mod.rs
+++ b/core/lib/types/src/api/mod.rs
@@ -655,6 +655,7 @@ pub struct GetLogsFilter {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ResultDebugCall {
+    pub tx_hash: H256,
     pub result: DebugCall,
 }
 

--- a/core/node/api_server/src/web3/namespaces/debug.rs
+++ b/core/node/api_server/src/web3/namespaces/debug.rs
@@ -202,6 +202,7 @@ impl DebugNamespace {
                 call_traces
                     .into_iter()
                     .map(|(call, meta)| ResultDebugCall {
+                        tx_hash: meta.tx_hash,
                         result: Self::map_default_call(
                             call,
                             options.tracer_config.only_top_call,


### PR DESCRIPTION
## What ❔

This PR adds `txHash` also to the response of `CallTracer`. This field is already returned by `FlatCallTracer` and by other popular EVM nodes.

## Why ❔

In some cases you might have only block hash / number and you wish to trace it. It's helpful to have the hash of each transaction in the trace for further lookups if needed, without having to fetch the block too.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
