### PR TITLE
fix(en): Update snapshot applier health during storage logs recovery

### DIFF
--- a/core/lib/snapshots_applier/src/lib.rs
+++ b/core/lib/snapshots_applier/src/lib.rs
@@ -971,6 +971,7 @@ impl<'a> SnapshotsApplier<'a> {
         let chunks_left = METRICS.storage_logs_chunks_left_to_process.dec_by(1) - 1;
         let latency = latency.observe();
         tracing::info!("Saved storage logs for chunk {chunk_id} in {latency:?}, there are {chunks_left} left to process");
+        self.update_health();
 
         Ok(())
     }


### PR DESCRIPTION
## What ❔

Updates snapshot applier health during storage logs recovery.

## Why ❔

The snapshot applier health is only updated before and after snapshot logs are recovered, but not during their recovery. This is misleading and can give off impression that recovery got stuck.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.