### PR TITLE
fix: Prefix env vars for `zksync_server`

### DIFF
--- a/core/bin/block_reverter/src/main.rs
+++ b/core/bin/block_reverter/src/main.rs
@@ -126,7 +126,7 @@ async fn main() -> anyhow::Result<()> {
         ..ConfigFilePaths::default()
     };
     let config_sources =
-        tokio::task::spawn_blocking(|| config_file_paths.into_config_sources("")).await??;
+        tokio::task::spawn_blocking(|| config_file_paths.into_config_sources("ZKSYNC_")).await??;
 
     let _guard = config_sources
         .observability()?

--- a/core/bin/contract-verifier/src/main.rs
+++ b/core/bin/contract-verifier/src/main.rs
@@ -65,7 +65,7 @@ async fn main() -> anyhow::Result<()> {
         ..ConfigFilePaths::default()
     };
     let config_sources =
-        tokio::task::spawn_blocking(|| config_file_paths.into_config_sources("")).await??;
+        tokio::task::spawn_blocking(|| config_file_paths.into_config_sources("ZKSYNC_")).await??;
 
     let _observability_guard = config_sources.observability()?.install()?;
 

--- a/core/bin/genesis_generator/src/main.rs
+++ b/core/bin/genesis_generator/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
         ..ConfigFilePaths::default()
     };
     let config_sources =
-        tokio::task::spawn_blocking(|| config_file_paths.into_config_sources("")).await??;
+        tokio::task::spawn_blocking(|| config_file_paths.into_config_sources("ZKSYNC_")).await??;
 
     let schema = full_config_schema(false);
     let repo = config_sources.build_repository(&schema);

--- a/core/bin/merkle_tree_consistency_checker/src/main.rs
+++ b/core/bin/merkle_tree_consistency_checker/src/main.rs
@@ -51,7 +51,7 @@ impl Cli {
 }
 
 fn main() -> anyhow::Result<()> {
-    let config_sources = ConfigFilePaths::default().into_config_sources("")?;
+    let config_sources = ConfigFilePaths::default().into_config_sources("ZKSYNC_")?;
     let _observability_guard = config_sources.observability()?.install()?;
 
     let schema = full_config_schema(false);

--- a/core/bin/snapshots_creator/src/main.rs
+++ b/core/bin/snapshots_creator/src/main.rs
@@ -68,7 +68,7 @@ async fn main() -> anyhow::Result<()> {
         ..ConfigFilePaths::default()
     };
     let config_sources =
-        tokio::task::spawn_blocking(|| config_file_paths.into_config_sources("")).await??;
+        tokio::task::spawn_blocking(|| config_file_paths.into_config_sources("ZKSYNC_")).await??;
 
     let _observability_guard = config_sources.observability()?.install()?;
 

--- a/core/bin/verified_sources_fetcher/src/main.rs
+++ b/core/bin/verified_sources_fetcher/src/main.rs
@@ -6,7 +6,9 @@ use zksync_types::contract_verification::api::SourceCodeData;
 
 #[tokio::main]
 async fn main() {
-    let config_sources = ConfigFilePaths::default().into_config_sources("").unwrap();
+    let config_sources = ConfigFilePaths::default()
+        .into_config_sources("ZKSYNC_")
+        .unwrap();
 
     let schema = full_config_schema(false);
     let repo = config_sources.build_repository(&schema);

--- a/core/bin/zksync_server/src/main.rs
+++ b/core/bin/zksync_server/src/main.rs
@@ -91,7 +91,7 @@ fn main() -> anyhow::Result<()> {
         wallets: opt.wallets_path,
         ..ConfigFilePaths::default()
     };
-    let config_sources = config_file_paths.into_config_sources("")?;
+    let config_sources = config_file_paths.into_config_sources("ZKSYNC_")?;
 
     let runtime = Runtime::new().context("failed creating Tokio runtime")?;
     let observability_guard = {

--- a/prover/crates/bin/circuit_prover/src/main.rs
+++ b/prover/crates/bin/circuit_prover/src/main.rs
@@ -69,7 +69,7 @@ async fn main() -> anyhow::Result<()> {
         secrets: opt.secrets_path,
         ..ConfigFilePaths::default()
     };
-    let config_sources = config_file_paths.into_config_sources("")?;
+    let config_sources = config_file_paths.into_config_sources("ZKSYNC_")?;
 
     let _observability_guard = config_sources.observability()?.install()?;
 

--- a/prover/crates/bin/proof_fri_compressor/src/main.rs
+++ b/prover/crates/bin/proof_fri_compressor/src/main.rs
@@ -53,7 +53,7 @@ async fn main() -> anyhow::Result<()> {
         secrets: opt.secrets_path,
         ..ConfigFilePaths::default()
     };
-    let config_sources = config_file_paths.into_config_sources("")?;
+    let config_sources = config_file_paths.into_config_sources("ZKSYNC_")?;
 
     let _observability_guard = config_sources.observability()?.install()?;
 

--- a/prover/crates/bin/prover_fri_gateway/src/main.rs
+++ b/prover/crates/bin/prover_fri_gateway/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
         secrets: opt.secrets_path,
         ..ConfigFilePaths::default()
     };
-    let config_sources = config_file_paths.into_config_sources("")?;
+    let config_sources = config_file_paths.into_config_sources("ZKSYNC_")?;
 
     let _observability_guard = config_sources.observability()?.install()?;
 

--- a/prover/crates/bin/prover_job_monitor/src/main.rs
+++ b/prover/crates/bin/prover_job_monitor/src/main.rs
@@ -48,7 +48,7 @@ async fn main() -> anyhow::Result<()> {
         secrets: opt.secrets_path,
         ..ConfigFilePaths::default()
     };
-    let config_sources = config_file_paths.into_config_sources("")?;
+    let config_sources = config_file_paths.into_config_sources("ZKSYNC_")?;
 
     let _observability_guard = config_sources.observability()?.install()?;
 

--- a/prover/crates/bin/witness_generator/src/main.rs
+++ b/prover/crates/bin/witness_generator/src/main.rs
@@ -103,7 +103,7 @@ async fn main() -> anyhow::Result<()> {
         secrets: opt.secrets_path,
         ..ConfigFilePaths::default()
     };
-    let config_sources = config_file_paths.into_config_sources("")?;
+    let config_sources = config_file_paths.into_config_sources("ZKSYNC_")?;
 
     let _observability_guard = config_sources.observability()?.install()?;
 


### PR DESCRIPTION
## What ❔

Adds `ZKSYNC_` prefix for env vars read by the main node and other binaries (other than the external node).

## Why ❔

There may be a collision with non-prefixed vars and vars auto-defined by K8s (e.g., `CONTRACT_VERIFIER_PORT`).

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

If env-based config is used for the main node, it now needs to be prefixed with `ZKSYNC_`. (Note that we haven't *de facto* supported env-based configs for the main node for some time.)

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.