### PR TITLE
chore(nix): update development environment

### DIFF
--- a/etc/nix/devShell.nix
+++ b/etc/nix/devShell.nix
@@ -7,20 +7,19 @@
 let
   toolchain = pkgs.rust-bin.fromRustupToolchainFile (inputs.src + "/rust-toolchain");
 
-  toolchain_with_src = (toolchain.override {
+  toolchain_with_src = toolchain.override {
     extensions = [ "rustfmt" "clippy" "rust-src" ];
-  });
+  };
 in
 pkgs.mkShell {
   inputsFrom = [ tee_prover ];
   packages = [ ];
 
-  inherit (coreCommonArgs) env hardeningEnable;
+  inherit (coreCommonArgs) hardeningEnable;
 
   shellHook = ''
     export ZKSYNC_HOME=$PWD
     export PATH=$ZKSYNC_HOME/bin:$PATH
-
     if [ "x$NIX_LD" = "x" ]; then
       export NIX_LD=$(<${pkgs.clangStdenv.cc}/nix-support/dynamic-linker)
     fi
@@ -31,7 +30,9 @@ pkgs.mkShell {
     fi
   '';
 
-  RUST_SRC_PATH = "${toolchain_with_src}/lib/rustlib/src/rust/library";
-  ZK_NIX_LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ ];
+  env = coreCommonArgs.env // {
+    RUST_SRC_PATH = "${toolchain_with_src}/lib/rustlib/src/rust/library";
+    ZK_NIX_LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath coreCommonArgs.buildInputs;
+  };
 }
 

--- a/etc/nix/devShellAll.nix
+++ b/etc/nix/devShellAll.nix
@@ -3,6 +3,7 @@
 , zkstack
 , devShell
 , foundry-zksync
+, rustPlatform
 , ...
 }:
 let
@@ -10,6 +11,7 @@ let
     inputsFrom = [ zksync zkstack ];
 
     packages = with pkgs; [
+      (cargo-nextest.override { rustPlatform = rustPlatform; })
       docker-compose
       nodejs
       yarn

--- a/etc/nix/foundry-zksync.nix
+++ b/etc/nix/foundry-zksync.nix
@@ -1,63 +1,58 @@
 { pkgs
+, system
 , lib
-, fetchFromGitHub
-, inputs
+, stdenv
 , ...
 }:
 let
-  src = fetchFromGitHub {
-    owner = "matter-labs";
-    repo = "foundry-zksync";
-    tag = "foundry-zksync-v0.0.11";
-    hash = "sha256-NSVzqv4UsAfW6i4b+Rj7ccFM66fbGlpsTJ1qPIgn8F0=";
+  version = "v0.0.14";
+
+  # use `nix-prefetch-url <URL>` to update the hashes
+
+  linux_amd_bin_url = "https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-${version}/foundry_zksync_${version}_linux_amd64.tar.gz";
+  linux_amd_bin_sha = "108da9djxws30z7apr2p2dzzpr1ngi4nqx90lgmgrpsj5sf2pqmz";
+
+  linux_arm_bin_url = "https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-${version}/foundry_zksync_${version}_linux_arm64.tar.gz";
+  linux_arm_bin_sha = "1zdx72crr6mx835hzgmcm883qdf5j806nbcx6mh5afggxq3v645z";
+
+  darwin_amd_bin_url = "https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-${version}/foundry_zksync_${version}_darwin_amd64.tar.gz";
+  darwin_amd_bin_sha = "07aw374hf31ix8vlyxkaw8iyq8i1dyi9hrs6wnrg3f31hp78bbwg";
+
+  darwin_arm_bin_url = "https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-${version}/foundry_zksync_${version}_darwin_arm64.tar.gz";
+  darwin_arm_bin_sha = "0x7w7ladfscnd2xpqj4l26606f3gy869nr8yrp0vvmbkh8awmi9b";
+
+  # Map of system identifiers to their specific source URL and SHA256 hash
+  sourcesBySystem = {
+    "x86_64-linux" = { url = linux_amd_bin_url; sha256 = linux_amd_bin_sha; };
+    "aarch64-linux" = { url = linux_arm_bin_url; sha256 = linux_arm_bin_sha; };
+    "x86_64-darwin" = { url = darwin_amd_bin_url; sha256 = darwin_amd_bin_sha; };
+    "aarch64-darwin" = { url = darwin_arm_bin_url; sha256 = darwin_arm_bin_sha; };
   };
 
-  toolchain = pkgs.rust-bin.fromRustupToolchainFile "${src}/rust-toolchain";
-
-  craneLib = (inputs.crane.mkLib pkgs).overrideToolchain toolchain;
-
-  rustPlatform = pkgs.makeRustPlatform {
-    cargo = toolchain;
-    rustc = toolchain;
-  };
+  # Get the attributes for the current target system
+  # The `system` argument (e.g., "x86_64-linux") is used directly as the key.
+  # If the system is not in our map, throw an error.
+  targetSystemAttrs = sourcesBySystem.${system} or
+    (lib.throw "Unsupported system: ${system}. Supported systems are: ${lib.concatStringsSep ", " (lib.attrNames sourcesBySystem)}");
 in
-craneLib.buildPackage {
-  # Some crates download stuff from the network while compiling!!!!
-  # Allows derivation to access network
-  #
-  # Users of this package must set options to indicate that the sandbox conditions can be relaxed for this package.
-  # These are:
-  # - When used in a flake, set the flake's config with this line: nixConfig.sandbox = false;
-  # - From the command line with nix <command>, add one of these options:
-  #   - --option sandbox false
-  #   - --no-sandbox
-  __noChroot = true;
-
-  pname = src.repo;
-  version = src.tag;
-  inherit src;
-
-  doCheck = false;
-
-  nativeBuildInputs = with pkgs;[
-    pkg-config
-    rustPlatform.bindgenHook
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.DarwinTools ];
-
-  buildInputs = with pkgs;[
-    libusb1.dev
-    libclang.dev
-    openssl.dev
-    lz4.dev
-    bzip2.dev
-    rocksdb_8_3
-    snappy.dev
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.apple_sdk.frameworks.AppKit ];
-
-  env = {
-    OPENSSL_NO_VENDOR = "1";
-    ROCKSDB_LIB_DIR = "${pkgs.rocksdb_8_3.out}/lib";
-    ROCKSDB_INCLUDE_DIR = "${pkgs.rocksdb_8_3.out}/include";
-    SNAPPY_LIB_DIR = "${pkgs.snappy.out}/lib";
+pkgs.stdenv.mkDerivation {
+  name = "foundry-zksync-${version}";
+  src = pkgs.fetchurl {
+    # Use the URL and SHA256 from the selected system attributes
+    url = targetSystemAttrs.url;
+    sha256 = targetSystemAttrs.sha256;
   };
+  phases = [ "installPhase" "patchPhase" ];
+  installPhase = ''
+    mkdir -p $out/bin
+    cd $out/bin
+    tar xvzf $src
+    chmod +x *
+  '';
+
+  prePatch = lib.optionalString stdenv.isDarwin ''
+    set -x
+    install_name_tool -change /opt/homebrew/opt/libusb/lib/libusb-1.0.0.dylib "${pkgs.libusb1}/lib/libusb-1.0.0.dylib" "$out/bin/forge"
+    install_name_tool -change /opt/homebrew/opt/libusb/lib/libusb-1.0.0.dylib "${pkgs.libusb1}/lib/libusb-1.0.0.dylib" "$out/bin/cast"
+  '';
 }

--- a/flake.nix
+++ b/flake.nix
@@ -129,6 +129,7 @@
                 inherit craneLib;
                 inherit coreCommonArgs;
                 inherit zkstackArgs;
+                inherit rustPlatform;
                 inputs = inputs // { src = ./.; };
               });
               directory = ./etc/nix;


### PR DESCRIPTION
## What ❔

- use foundry-zksync prebuilt binaries
- add `cargo-nextest` to devShellAll
- extend the ZK_LD_LIBRARY_PATH for live development with `cargo`

## Why ❔

extend the development capabilities in a nix environment 

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
