### PR TITLE
fix: Fix prefix for `TeeProofDataHandlerConfig`

### DIFF
--- a/core/lib/config/src/configs/general.rs
+++ b/core/lib/config/src/configs/general.rs
@@ -57,7 +57,7 @@ pub struct GeneralConfig {
     pub prometheus_config: PrometheusConfig,
     #[config(nest, rename = "data_handler")]
     pub proof_data_handler_config: Option<ProofDataHandlerConfig>,
-    #[config(nest, rename = "tee_data_handler")]
+    #[config(nest, rename = "tee_proof_data_handler")]
     pub tee_proof_data_handler_config: Option<TeeProofDataHandlerConfig>,
     #[config(nest, rename = "db", alias = "database")]
     pub db_config: DBConfig,

--- a/core/lib/config/src/configs/tee_proof_data_handler.rs
+++ b/core/lib/config/src/configs/tee_proof_data_handler.rs
@@ -18,3 +18,34 @@ pub struct TeeProofDataHandlerConfig {
     #[config(default_t = 10 * TimeUnit::Days, with = TimeUnit::Hours)]
     pub batch_permanently_ignored_timeout_in_hours: Duration,
 }
+
+#[cfg(test)]
+mod tests {
+    use smart_config::{testing::test_complete, Yaml};
+
+    use super::*;
+
+    fn expected_config() -> TeeProofDataHandlerConfig {
+        TeeProofDataHandlerConfig {
+            http_port: 4320,
+            first_processed_batch: L1BatchNumber(123),
+            proof_generation_timeout_in_secs: Duration::from_secs(90),
+            batch_permanently_ignored_timeout_in_hours: 5 * TimeUnit::Days,
+        }
+    }
+
+    #[test]
+    fn tee_proof_data_handler_config_from_yaml() {
+        let yaml = r#"
+          http_port: 4320
+          first_processed_batch: 123
+          proof_generation_timeout_in_secs: 90
+          batch_permanently_ignored_timeout_in_hours: 120
+        "#;
+        let yaml = serde_yaml::from_str(yaml).unwrap();
+        let yaml = Yaml::new("test.yml", yaml).unwrap();
+
+        let config: TeeProofDataHandlerConfig = test_complete(yaml).unwrap();
+        assert_eq!(config, expected_config());
+    }
+}


### PR DESCRIPTION
## What ❔

Fixes the prefix for TEE proof data handler config.

## Why ❔

The prefix was changed while the config integration PR was in progress, and the change was missed during merge.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.