### PR TITLE
fix(prover): Fix revert GPU prover table migration

### DIFF
--- a/prover/crates/lib/prover_dal/migrations/20250319105631_remove_gpu_prover_table.down.sql
+++ b/prover/crates/lib/prover_dal/migrations/20250319105631_remove_gpu_prover_table.down.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS gpu_prover_queue_fri (
     zone                        TEXT,
     created_at                  TIMESTAMP NOT NULL,
     updated_at                  TIMESTAMP NOT NULL,
-    processing_started_at       TIMESTAMP
+    processing_started_at       TIMESTAMP,
     protocol_version            INT,
     protocol_version_patch      INT NOT NULL DEFAULT 0
 );


### PR DESCRIPTION
The revert migration was incomplete and revert would not revert the state properly. This fixes the issue. This has been observed in chains that were not ready to upgrade and had to revert. Reverting didn't provide a quick fix and the chain owners had to manually intervene.

