### PR TITLE
ci: update contract verifier era-vm-solc-version to 1.0.2

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -86,7 +86,7 @@ jobs:
           yarn calculate-hashes:check
 
       - name: Download compilers for contract verifier tests
-        run: ci_run zkstack contract-verifier init --zksolc-version=v1.5.10 --zkvyper-version=v1.5.4 --solc-version=0.8.26 --vyper-version=v0.3.10 --era-vm-solc-version=0.8.26-1.0.1 --only --chain era
+        run: ci_run zkstack contract-verifier init --zksolc-version=v1.5.10 --zkvyper-version=v1.5.4 --solc-version=0.8.26 --vyper-version=v0.3.10 --era-vm-solc-version=0.8.26-1.0.2 --only --chain era
 
       - name: Rust unit tests
         run: |
@@ -450,7 +450,7 @@ jobs:
 
       - name: Initialize Contract verifier
         run: |
-          ci_run zkstack contract-verifier init --zksolc-version=v1.5.10 --zkvyper-version=v1.5.4 --solc-version=0.8.26 --vyper-version=v0.3.10 --era-vm-solc-version=0.8.26-1.0.1 --only --chain era
+          ci_run zkstack contract-verifier init --zksolc-version=v1.5.10 --zkvyper-version=v1.5.4 --solc-version=0.8.26 --vyper-version=v0.3.10 --era-vm-solc-version=0.8.26-1.0.2 --only --chain era
           ci_run zkstack contract-verifier run --chain era &> ${{ env.SERVER_LOGS_DIR }}/contract-verifier-rollup.log &
           ci_run zkstack contract-verifier wait --chain era --verbose
 

--- a/core/lib/contract_verifier/src/tests/real.rs
+++ b/core/lib/contract_verifier/src/tests/real.rs
@@ -29,7 +29,7 @@ impl Toolchain {
 // The tests may expect specific compiler versions (e.g. contracts won't compile with Vyper 0.4.0),
 // so we hardcode versions.
 const ZKSOLC_VERSION: &str = "v1.5.10";
-const ERA_VM_SOLC_VERSION: &str = "0.8.26-1.0.1";
+const ERA_VM_SOLC_VERSION: &str = "0.8.26-1.0.2";
 const SOLC_VERSION: &str = "0.8.26";
 const VYPER_VERSION: &str = "v0.3.10";
 const ZKVYPER_VERSION: &str = "v1.5.4";

--- a/core/tests/ts-integration/tests/api/contract-verification.test.ts
+++ b/core/tests/ts-integration/tests/api/contract-verification.test.ts
@@ -12,7 +12,7 @@ const DATE_REGEX = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{6})?/;
 
 const ZKSOLC_VERSION = 'v1.5.10';
 const SOLC_VERSION = '0.8.26';
-const ZK_VM_SOLC_VERSION = 'zkVM-0.8.26-1.0.1';
+const ZK_VM_SOLC_VERSION = 'zkVM-0.8.26-1.0.2';
 
 const ZKVYPER_VERSION = 'v1.5.4';
 const VYPER_VERSION = '0.3.10';


### PR DESCRIPTION
## What ❔

* update contract verifier era-vm-solc-version to 1.0.2

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Contract verifier is unable to download 1.0.1 anymore due to paging issue with GH releases. Use the latest newly released 1.0.2 by default.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
