### PR TITLE
chore(nix): update foundry-zksync to 0.0.15

### DIFF
--- a/etc/nix/foundry-zksync.nix
+++ b/etc/nix/foundry-zksync.nix
@@ -5,21 +5,21 @@
 , ...
 }:
 let
-  version = "v0.0.14";
+  version = "v0.0.15";
 
   # use `nix-prefetch-url <URL>` to update the hashes
-
+  # or the script `./update-foundry-zksync.sh v0.0.15`
   linux_amd_bin_url = "https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-${version}/foundry_zksync_${version}_linux_amd64.tar.gz";
-  linux_amd_bin_sha = "108da9djxws30z7apr2p2dzzpr1ngi4nqx90lgmgrpsj5sf2pqmz";
+  linux_amd_bin_sha = "0ra6yab8jj9i002zxw2g49q4s17xcbmx417kb8h0gsxi10yn9i3r";
 
   linux_arm_bin_url = "https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-${version}/foundry_zksync_${version}_linux_arm64.tar.gz";
-  linux_arm_bin_sha = "1zdx72crr6mx835hzgmcm883qdf5j806nbcx6mh5afggxq3v645z";
+  linux_arm_bin_sha = "1x2v6gk0qv92wn8xd6f45j8f233hah1psks4pbcc14l97c9w9y6k";
 
   darwin_amd_bin_url = "https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-${version}/foundry_zksync_${version}_darwin_amd64.tar.gz";
-  darwin_amd_bin_sha = "07aw374hf31ix8vlyxkaw8iyq8i1dyi9hrs6wnrg3f31hp78bbwg";
+  darwin_amd_bin_sha = "0fnxn5jc6y5fl76q3jlpligh1876l0q6l5vcfpivjbdfvp03wcsp";
 
   darwin_arm_bin_url = "https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-${version}/foundry_zksync_${version}_darwin_arm64.tar.gz";
-  darwin_arm_bin_sha = "0x7w7ladfscnd2xpqj4l26606f3gy869nr8yrp0vvmbkh8awmi9b";
+  darwin_arm_bin_sha = "1yljrms7llwdbqwfsqmmr7brvkqnn43byxzb5sv38vaa8c65cpzv";
 
   # Map of system identifiers to their specific source URL and SHA256 hash
   sourcesBySystem = {

--- a/etc/nix/update-foundry-zksync.sh
+++ b/etc/nix/update-foundry-zksync.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Set the version
+VERSION="v0.0.15"
+
+# Function to update SHA in the nix file
+update_sha() {
+    local platform="$1"
+    local new_sha="$2"
+    local file="./foundry-zksync.nix"
+
+    case "$platform" in
+        "linux_amd64")
+            sed -i "s/linux_amd_bin_sha = \".*\"/linux_amd_bin_sha = \"$new_sha\"/" "$file"
+            ;;
+        "linux_arm64")
+            sed -i "s/linux_arm_bin_sha = \".*\"/linux_arm_bin_sha = \"$new_sha\"/" "$file"
+            ;;
+        "darwin_amd64")
+            sed -i "s/darwin_amd_bin_sha = \".*\"/darwin_amd_bin_sha = \"$new_sha\"/" "$file"
+            ;;
+        "darwin_arm64")
+            sed -i "s/darwin_arm_bin_sha = \".*\"/darwin_arm_bin_sha = \"$new_sha\"/" "$file"
+            ;;
+    esac
+}
+
+if ! [[ -f ./foundry-zksync.nix ]]; then
+    echo "Error: ./foundry-zksync.nix not found"
+    exit 1
+fi
+
+# Update version in the file if provided as argument
+if [ "$1" ]; then
+    VERSION="$1"
+    sed -i "s/version = \".*\"/version = \"$VERSION\"/" ./foundry-zksync.nix
+    sed -i "s/version=\".*\"/version=\"$VERSION\"/" ./foundry-zksync.nix
+fi
+
+echo "Updating foundry-zksync to version $VERSION..."
+
+# Fetch and update each platform
+echo "Fetching Linux AMD64..."
+SHA=$(nix-prefetch-url "https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-${VERSION}/foundry_zksync_${VERSION}_linux_amd64.tar.gz" 2>/dev/null)
+update_sha "linux_amd64" "$SHA"
+
+echo "Fetching Linux ARM64..."
+SHA=$(nix-prefetch-url "https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-${VERSION}/foundry_zksync_${VERSION}_linux_arm64.tar.gz" 2>/dev/null)
+update_sha "linux_arm64" "$SHA"
+
+echo "Fetching Darwin AMD64..."
+SHA=$(nix-prefetch-url "https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-${VERSION}/foundry_zksync_${VERSION}_darwin_amd64.tar.gz" 2>/dev/null)
+update_sha "darwin_amd64" "$SHA"
+
+echo "Fetching Darwin ARM64..."
+SHA=$(nix-prefetch-url "https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-${VERSION}/foundry_zksync_${VERSION}_darwin_arm64.tar.gz" 2>/dev/null)
+update_sha "darwin_arm64" "$SHA"
+
+echo "Update complete!"

--- a/etc/nix/update-foundry-zksync.sh
+++ b/etc/nix/update-foundry-zksync.sh
@@ -33,8 +33,7 @@ fi
 # Update version in the file if provided as argument
 if [ "$1" ]; then
     VERSION="$1"
-    sed -i "s/version = \".*\"/version = \"$VERSION\"/" ./foundry-zksync.nix
-    sed -i "s/version=\".*\"/version=\"$VERSION\"/" ./foundry-zksync.nix
+    sed -i "s/version *= *\".*\"/version = \"$VERSION\"/" ./foundry-zksync.nix
 fi
 
 echo "Updating foundry-zksync to version $VERSION..."

--- a/etc/nix/update-foundry-zksync.sh
+++ b/etc/nix/update-foundry-zksync.sh
@@ -11,16 +11,16 @@ update_sha() {
 
     case "$platform" in
         "linux_amd64")
-            sed -i "s/linux_amd_bin_sha = \".*\"/linux_amd_bin_sha = \"$new_sha\"/" "$file"
+            sed -i.bak "s/linux_amd_bin_sha = \".*\"/linux_amd_bin_sha = \"$new_sha\"/" "$file" && rm -f "$file.bak"
             ;;
         "linux_arm64")
-            sed -i "s/linux_arm_bin_sha = \".*\"/linux_arm_bin_sha = \"$new_sha\"/" "$file"
+            sed -i.bak "s/linux_arm_bin_sha = \".*\"/linux_arm_bin_sha = \"$new_sha\"/" "$file" && rm -f "$file.bak"
             ;;
         "darwin_amd64")
-            sed -i "s/darwin_amd_bin_sha = \".*\"/darwin_amd_bin_sha = \"$new_sha\"/" "$file"
+            sed -i.bak "s/darwin_amd_bin_sha = \".*\"/darwin_amd_bin_sha = \"$new_sha\"/" "$file" && rm -f "$file.bak"
             ;;
         "darwin_arm64")
-            sed -i "s/darwin_arm_bin_sha = \".*\"/darwin_arm_bin_sha = \"$new_sha\"/" "$file"
+            sed -i.bak "s/darwin_arm_bin_sha = \".*\"/darwin_arm_bin_sha = \"$new_sha\"/" "$file" && rm -f "$file.bak"
             ;;
     esac
 }


### PR DESCRIPTION
- added `update-foundry-zksync.sh` to update the hashes

## What ❔

- update foundry-zksync to 0.0.15 for the nix development environment

## Why ❔

- up2date nix environment

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
