### PR TITLE
feat(private-rpc): add migrations to Dockerfile

### DIFF
--- a/private-rpc/Dockerfile
+++ b/private-rpc/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY src src/
 COPY package.json .
 COPY drizzle.config.ts .
+COPY drizzle drizzle
 COPY esbuild.ts .
 COPY tsconfig.json .
 


### PR DESCRIPTION
## What ❔

Add migrations to private-rpc Dockerfile

## Why ❔

This migrations are really small, they have no impact in the final image size. Adding them allows to do everything needed to run the private rpc in a single image.

## Is this a breaking change?
- [ ] Yes
- [ x ] No

## Operational changes

None

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ x ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ x ] Tests for the changes have been added / updated.
- [ x ] Documentation comments have been added / updated.
- [ x ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
