### PR TITLE
chore(prover): Improve logging

### DIFF
--- a/core/lib/basic_types/src/lib.rs
+++ b/core/lib/basic_types/src/lib.rs
@@ -249,8 +249,7 @@ impl std::fmt::Display for L1BatchId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "L1BatchId
-        (chain_id: {}, batch_number: {})",
+            "L1BatchId(chain_id: {}, batch_number: {})",
             self.chain_id.as_u64(),
             self.batch_number.0
         )


### PR DESCRIPTION
Currently, all logs related to L1BatchId is broken on 2 lines. This is super hard to work with, especially if you grep for data (because you'll get the identification data, but not the line that caused it).

This PR makes troubleshooting easier.
