### PR TITLE
fix(ci): Increase ulimits in compose for integrationg tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,10 @@ services:
   reth:
     restart: always
     image: "ghcr.io/paradigmxyz/reth:v1.3.7"
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576
     ports:
       - 127.0.0.1:8545:8545
     volumes:
@@ -17,6 +21,10 @@ services:
   postgres:
     image: "postgres:14"
     command: postgres -c 'max_connections=1000'
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576
     ports:
       - 127.0.0.1:5432:5432
     volumes:
@@ -33,6 +41,10 @@ services:
     security_opt:
       - seccomp:unconfined
     command: tail -f /dev/null
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576
     volumes:
       - .:/usr/src/zksync
       - /usr/src/cache:/usr/src/cache


### PR DESCRIPTION
## What ❔

Increasing ulimit for docker compose spawned containers, used in itegration tests

## Why ❔

On new faster runners we recieve error `Too many open files (os error 24)`

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
