### PR TITLE
fix: deprecate submission obj in favor of data obj

### DIFF
--- a/core/node/da_clients/src/avail/sdk.rs
+++ b/core/node/da_clients/src/avail/sdk.rs
@@ -435,13 +435,13 @@ pub struct GasRelayAPISubmissionResponse {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct GasRelayAPIStatusResponse {
-    submission: GasRelayAPISubmission,
+    data: GasRelayAPISubmission,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct GasRelayAPISubmission {
     block_hash: Option<H256>,
-    extrinsic_index: Option<u64>,
+    tx_index: Option<u64>,
 }
 
 impl GasRelayClient {
@@ -536,8 +536,8 @@ impl GasRelayClient {
                 };
 
             match (
-                status_response.submission.block_hash,
-                status_response.submission.extrinsic_index,
+                status_response.data.block_hash,
+                status_response.data.tx_index,
             ) {
                 (Some(block_hash), Some(ext_idx)) => return Ok(Some((block_hash, ext_idx))),
                 _ => tokio::time::sleep(Self::RETRY_DELAY).await,


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

This PR deprecates the use of `submission` object in favour of `data` object in Avail's TurboDA (GasRelay) API `GET /v1/get_submission_info`



## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

The TurboDA (GasRelay) API has been updated to no longer have the `submission` object as the relevant information was duplicated and already available in the `data` object when fetching submission info ([read API ref here](https://docs.availproject.org/api-reference/avail-turbo-da-api/get-submission-info#response))

Functionality remains the same when checking for DA finality.


## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->
use [updated GasRelay endpoint ](https://docs.availproject.org/api-reference/avail-turbo-da-api#turbo-da-endpoints) when using. 

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
