### PR TITLE
feat(state-keeper): add `process_block` method

### DIFF
--- a/core/lib/multivm/src/versions/testonly/block_tip.rs
+++ b/core/lib/multivm/src/versions/testonly/block_tip.rs
@@ -171,7 +171,7 @@ fn execute_test<VM: TestedVm>(test_data: L1MessengerTestData) -> TestStatistics 
 
     // Now we count how much ergs were spent at the end of the batch
     // It is assumed that the top level frame is the bootloader
-    let gas_before = vm.vm.gas_remaining();
+    let gas_before = TestedVm::gas_remaining(&mut vm.vm);
     let result = vm
         .vm
         .finish_batch_with_state_diffs(test_data.state_diffs.clone(), default_pubdata_builder());
@@ -179,7 +179,7 @@ fn execute_test<VM: TestedVm>(test_data: L1MessengerTestData) -> TestStatistics 
         !result.result.is_failed(),
         "Batch wasn't successful for input: {test_data:?}"
     );
-    let gas_after = vm.vm.gas_remaining();
+    let gas_after = TestedVm::gas_remaining(&mut vm.vm);
     assert_eq!((gas_before - gas_after) as u64, result.statistics.gas_used);
 
     TestStatistics {

--- a/core/lib/multivm/src/versions/vm_1_3_2/vm.rs
+++ b/core/lib/multivm/src/versions/vm_1_3_2/vm.rs
@@ -189,6 +189,10 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
             )
             .glue_into()
     }
+
+    fn gas_remaining(&mut self) -> u32 {
+        self.vm.gas_remaining()
+    }
 }
 
 impl<S: WriteStorage, H: HistoryMode> VmFactory<S> for Vm<S, H> {

--- a/core/lib/multivm/src/versions/vm_1_4_1/vm.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_1/vm.rs
@@ -156,6 +156,10 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
             state_diffs: None,
         }
     }
+
+    fn gas_remaining(&mut self) -> u32 {
+        self.state.local_state.callstack.current.ergs_remaining
+    }
 }
 
 impl<S: WriteStorage, H: HistoryMode> VmFactory<S> for Vm<S, H> {

--- a/core/lib/multivm/src/versions/vm_1_4_2/vm.rs
+++ b/core/lib/multivm/src/versions/vm_1_4_2/vm.rs
@@ -157,6 +157,10 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
             ),
         }
     }
+
+    fn gas_remaining(&mut self) -> u32 {
+        self.state.local_state.callstack.current.ergs_remaining
+    }
 }
 
 impl<S: WriteStorage, H: HistoryMode> VmFactory<S> for Vm<S, H> {

--- a/core/lib/multivm/src/versions/vm_boojum_integration/vm.rs
+++ b/core/lib/multivm/src/versions/vm_boojum_integration/vm.rs
@@ -153,6 +153,10 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
             state_diffs: None,
         }
     }
+
+    fn gas_remaining(&mut self) -> u32 {
+        self.state.local_state.callstack.current.ergs_remaining
+    }
 }
 
 impl<S: WriteStorage, H: HistoryMode> VmFactory<S> for Vm<S, H> {

--- a/core/lib/multivm/src/versions/vm_fast/vm.rs
+++ b/core/lib/multivm/src/versions/vm_fast/vm.rs
@@ -855,6 +855,10 @@ where
             ),
         }
     }
+
+    fn gas_remaining(&mut self) -> u32 {
+        self.inner.current_frame().gas()
+    }
 }
 
 #[derive(Debug)]

--- a/core/lib/multivm/src/versions/vm_latest/vm.rs
+++ b/core/lib/multivm/src/versions/vm_latest/vm.rs
@@ -234,6 +234,10 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
             ),
         }
     }
+
+    fn gas_remaining(&mut self) -> u32 {
+        self.state.local_state.callstack.current.ergs_remaining
+    }
 }
 
 impl<S: WriteStorage, H: HistoryMode> VmFactory<S> for Vm<S, H> {

--- a/core/lib/multivm/src/versions/vm_m5/vm.rs
+++ b/core/lib/multivm/src/versions/vm_m5/vm.rs
@@ -121,6 +121,10 @@ impl<S: Storage, H: HistoryMode> VmInterface for Vm<S, H> {
             )
             .glue_into()
     }
+
+    fn gas_remaining(&mut self) -> u32 {
+        self.vm.gas_remaining()
+    }
 }
 
 impl<S: Storage, H: HistoryMode> VmFactory<S> for Vm<S, H> {

--- a/core/lib/multivm/src/versions/vm_m6/vm.rs
+++ b/core/lib/multivm/src/versions/vm_m6/vm.rs
@@ -213,6 +213,10 @@ impl<S: Storage, H: HistoryMode> VmInterface for Vm<S, H> {
             )
             .glue_into()
     }
+
+    fn gas_remaining(&mut self) -> u32 {
+        self.vm.gas_remaining()
+    }
 }
 
 impl<S: Storage, H: HistoryMode> VmFactory<S> for Vm<S, H> {

--- a/core/lib/multivm/src/versions/vm_refunds_enhancement/vm.rs
+++ b/core/lib/multivm/src/versions/vm_refunds_enhancement/vm.rs
@@ -142,6 +142,10 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
             state_diffs: None,
         }
     }
+
+    fn gas_remaining(&mut self) -> u32 {
+        self.state.local_state.callstack.current.ergs_remaining
+    }
 }
 
 impl<S: WriteStorage, H: HistoryMode> VmFactory<S> for Vm<S, H> {

--- a/core/lib/multivm/src/versions/vm_virtual_blocks/vm.rs
+++ b/core/lib/multivm/src/versions/vm_virtual_blocks/vm.rs
@@ -142,6 +142,10 @@ impl<S: WriteStorage, H: HistoryMode> VmInterface for Vm<S, H> {
             state_diffs: None,
         }
     }
+
+    fn gas_remaining(&mut self) -> u32 {
+        self.state.local_state.callstack.current.ergs_remaining
+    }
 }
 
 impl<S: WriteStorage, H: HistoryMode> VmFactory<S> for Vm<S, H> {

--- a/core/lib/multivm/src/vm_instance.rs
+++ b/core/lib/multivm/src/vm_instance.rs
@@ -92,6 +92,10 @@ impl<S: ReadStorage, H: HistoryMode> VmInterface for LegacyVmInstance<S, H> {
     fn finish_batch(&mut self, pubdata_builder: Rc<dyn PubdataBuilder>) -> FinishedL1Batch {
         dispatch_legacy_vm!(self.finish_batch(pubdata_builder))
     }
+
+    fn gas_remaining(&mut self) -> u32 {
+        dispatch_legacy_vm!(self.gas_remaining())
+    }
 }
 
 impl<S: ReadStorage, H: HistoryMode> VmFactory<StorageView<S>> for LegacyVmInstance<S, H> {
@@ -320,6 +324,10 @@ where
 
     fn finish_batch(&mut self, pubdata_builder: Rc<dyn PubdataBuilder>) -> FinishedL1Batch {
         dispatch_fast_vm!(self.finish_batch(pubdata_builder))
+    }
+
+    fn gas_remaining(&mut self) -> u32 {
+        dispatch_fast_vm!(self.gas_remaining())
     }
 }
 

--- a/core/lib/vm_executor/src/batch/factory.rs
+++ b/core/lib/vm_executor/src/batch/factory.rs
@@ -295,6 +295,10 @@ impl<S: ReadStorage, Tr: BatchTracer> BatchVm<S, Tr> {
             call_traces,
         }
     }
+
+    fn gas_remaining(&mut self) -> u32 {
+        dispatch_batch_vm!(self.gas_remaining())
+    }
 }
 
 /// Implementation of the "primary" (non-test) batch executor.
@@ -384,6 +388,12 @@ impl<S: ReadStorage + 'static, Tr: BatchTracer> CommandReceiver<S, Tr> {
                     }
                     batch_finished = true;
                     break;
+                }
+                Command::GasRemaining(resp) => {
+                    let gas_remaining = vm.gas_remaining();
+                    if resp.send(gas_remaining).is_err() {
+                        break;
+                    }
                 }
             }
         }

--- a/core/lib/vm_executor/src/batch/metrics.rs
+++ b/core/lib/vm_executor/src/batch/metrics.rs
@@ -15,6 +15,7 @@ pub(super) enum ExecutorCommand {
     StartNextL2Block,
     RollbackLastTx,
     FinishBatch,
+    GasRemaining,
 }
 
 const GAS_PER_NANOSECOND_BUCKETS: Buckets = Buckets::values(&[

--- a/core/lib/vm_interface/src/executor.rs
+++ b/core/lib/vm_interface/src/executor.rs
@@ -44,6 +44,9 @@ pub trait BatchExecutor<S>: 'static + Send + fmt::Debug {
 
     /// Finished the current L1 batch.
     async fn finish_batch(self: Box<Self>) -> anyhow::Result<(FinishedL1Batch, StorageView<S>)>;
+
+    /// Return gas remaining in VM instance.
+    async fn gas_remaining(&mut self) -> anyhow::Result<u32>;
 }
 
 /// VM executor capable of executing isolated transactions / calls (as opposed to [batch execution](BatchExecutor)).

--- a/core/lib/vm_interface/src/utils/dump.rs
+++ b/core/lib/vm_interface/src/utils/dump.rs
@@ -205,6 +205,10 @@ impl<S: ReadStorage, Vm: VmTrackingContracts> VmInterface for DumpingVm<S, Vm> {
     fn finish_batch(&mut self, pubdata_builder: Rc<dyn PubdataBuilder>) -> FinishedL1Batch {
         self.inner.finish_batch(pubdata_builder)
     }
+
+    fn gas_remaining(&mut self) -> u32 {
+        self.inner.gas_remaining()
+    }
 }
 
 impl<S, Vm> VmInterfaceHistoryEnabled for DumpingVm<S, Vm>

--- a/core/lib/vm_interface/src/utils/shadow.rs
+++ b/core/lib/vm_interface/src/utils/shadow.rs
@@ -605,6 +605,13 @@ where
         }
         main_batch
     }
+
+    fn gas_remaining(&mut self) -> u32 {
+        self.get_mut("gas_remaining", |vm| match vm {
+            ShadowMut::Main(vm) => vm.gas_remaining(),
+            ShadowMut::Shadow(vm) => vm.gas_remaining(),
+        })
+    }
 }
 
 #[derive(Debug)]

--- a/core/lib/vm_interface/src/vm.rs
+++ b/core/lib/vm_interface/src/vm.rs
@@ -54,6 +54,8 @@ pub trait VmInterface {
     /// Execute batch till the end and return the result, with final execution state
     /// and bootloader memory.
     fn finish_batch(&mut self, pubdata_builder: Rc<dyn PubdataBuilder>) -> FinishedL1Batch;
+
+    fn gas_remaining(&mut self) -> u32;
 }
 
 /// Extension trait for [`VmInterface`] that provides some additional methods.

--- a/core/node/node_sync/src/tests.rs
+++ b/core/node/node_sync/src/tests.rs
@@ -16,7 +16,7 @@ use zksync_state_keeper::{
     io::{L1BatchParams, L2BlockParams},
     seal_criteria::NoopSealer,
     testonly::test_batch_executor::{MockReadStorageFactory, TestBatchExecutorBuilder},
-    OutputHandler, StateKeeperPersistence, TreeWritesPersistence, ZkSyncStateKeeper,
+    OutputHandler, StateKeeperInner, StateKeeperPersistence, TreeWritesPersistence,
 };
 use zksync_types::{
     api,
@@ -132,7 +132,7 @@ impl StateKeeperHandles {
             batch_executor.push_successful_transactions(tx_hashes_in_l1_batch);
         }
 
-        let state_keeper = ZkSyncStateKeeper::new(
+        let state_keeper_inner = StateKeeperInner::new(
             Box::new(io),
             Box::new(batch_executor),
             output_handler,
@@ -140,6 +140,7 @@ impl StateKeeperHandles {
             Arc::new(MockReadStorageFactory),
             None,
         );
+        let state_keeper = state_keeper_inner.initialize(&stop_receiver).await.unwrap();
 
         Self {
             stop_sender,

--- a/core/node/state_keeper/src/io/common/mod.rs
+++ b/core/node/state_keeper/src/io/common/mod.rs
@@ -20,7 +20,7 @@ pub(crate) fn poll_iters(delay_interval: Duration, max_wait: Duration) -> usize 
 }
 
 /// Cursor of the L2 block / L1 batch progress used by [`StateKeeperIO`](super::StateKeeperIO) implementations.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct IoCursor {
     pub next_l2_block: L2BlockNumber,
     pub prev_l2_block_hash: H256,

--- a/core/node/state_keeper/src/lib.rs
+++ b/core/node/state_keeper/src/lib.rs
@@ -3,7 +3,7 @@ pub use self::{
         mempool::MempoolIO, L2BlockParams, L2BlockSealerTask, OutputHandler, StateKeeperIO,
         StateKeeperOutputHandler, StateKeeperPersistence, TreeWritesPersistence,
     },
-    keeper::ZkSyncStateKeeper,
+    keeper::{StateKeeper, StateKeeperInner},
     mempool_actor::MempoolFetcher,
     seal_criteria::SequencerSealer,
     state_keeper_storage::AsyncRocksdbCache,

--- a/core/node/state_keeper/src/metrics.rs
+++ b/core/node/state_keeper/src/metrics.rs
@@ -97,6 +97,9 @@ pub struct StateKeeperMetrics {
     /// The time it takes for one iteration of the main loop in `process_l1_batch`.
     #[metrics(buckets = Buckets::LATENCIES)]
     pub process_l1_batch_loop_iteration: Histogram<Duration>,
+    /// The time it takes for one iteration of the main loop in `process_block`.
+    #[metrics(buckets = Buckets::LATENCIES)]
+    pub process_block_loop_iteration: Histogram<Duration>,
     /// The time it takes to wait for new L2 block parameters
     #[metrics(buckets = Buckets::LATENCIES)]
     pub wait_for_l2_block_params: Histogram<Duration>,

--- a/core/node/state_keeper/src/node/mempool_io.rs
+++ b/core/node/state_keeper/src/node/mempool_io.rs
@@ -11,7 +11,7 @@ use zksync_node_framework::{
     wiring_layer::{WiringError, WiringLayer},
     FromContext, IntoContext,
 };
-use zksync_shared_resources::contracts::{L2ContractsResource, SettlementLayerContractsResource};
+use zksync_shared_resources::contracts::L2ContractsResource;
 use zksync_types::{commitment::PubdataType, L2ChainId};
 
 use super::resources::{ConditionalSealerResource, StateKeeperIOResource};
@@ -45,7 +45,6 @@ pub struct MempoolIOLayer {
 pub struct Input {
     pub fee_input: SequencerFeeInputResource,
     pub master_pool: PoolResource<MasterPool>,
-    pub sl_contracts: SettlementLayerContractsResource,
     pub l2_contracts: L2ContractsResource,
 }
 

--- a/core/node/state_keeper/src/testonly/mod.rs
+++ b/core/node/state_keeper/src/testonly/mod.rs
@@ -74,6 +74,10 @@ impl BatchExecutor<OwnedStorage> for MockBatchExecutor {
         let storage = OwnedStorage::boxed(InMemoryStorage::default());
         Ok((FinishedL1Batch::mock(), StorageView::new(storage)))
     }
+
+    async fn gas_remaining(&mut self) -> anyhow::Result<u32> {
+        Ok(u32::MAX)
+    }
 }
 
 pub(crate) async fn apply_genesis_logs(storage: &mut Connection<'_, Core>, logs: &[StorageLog]) {

--- a/core/node/state_keeper/src/testonly/test_batch_executor.rs
+++ b/core/node/state_keeper/src/testonly/test_batch_executor.rs
@@ -37,7 +37,7 @@ use crate::{
     seal_criteria::{IoSealCriteria, SequencerSealer, UnexecutableReason},
     testonly::{successful_exec, BASE_SYSTEM_CONTRACTS},
     updates::UpdatesManager,
-    OutputHandler, StateKeeperOutputHandler, ZkSyncStateKeeper,
+    OutputHandler, StateKeeperInner, StateKeeperOutputHandler,
 };
 
 pub const FEE_ACCOUNT: Address = Address::repeat_byte(0x11);
@@ -215,7 +215,7 @@ impl TestScenario {
         let batch_executor = TestBatchExecutorBuilder::new(&self);
         let (stop_sender, stop_receiver) = watch::channel(false);
         let (io, output_handler) = TestIO::new(stop_sender, self);
-        let state_keeper = ZkSyncStateKeeper::new(
+        let state_keeper_inner = StateKeeperInner::new(
             Box::new(io),
             Box::new(batch_executor),
             output_handler,
@@ -223,6 +223,7 @@ impl TestScenario {
             Arc::new(MockReadStorageFactory),
             None,
         );
+        let state_keeper = state_keeper_inner.initialize(&stop_receiver).await.unwrap();
         let sk_thread = tokio::spawn(state_keeper.run(stop_receiver));
 
         // We must assume that *theoretically* state keeper may ignore the stop request from IO once scenario is
@@ -518,6 +519,10 @@ impl BatchExecutor<OwnedStorage> for TestBatchExecutor {
     ) -> anyhow::Result<(FinishedL1Batch, StorageView<OwnedStorage>)> {
         let storage = OwnedStorage::boxed(InMemoryStorage::default());
         Ok((FinishedL1Batch::mock(), StorageView::new(storage)))
+    }
+
+    async fn gas_remaining(&mut self) -> anyhow::Result<u32> {
+        Ok(u32::MAX)
     }
 }
 

--- a/core/node/state_keeper/src/tests/mod.rs
+++ b/core/node/state_keeper/src/tests/mod.rs
@@ -36,7 +36,7 @@ use crate::{
         BASE_SYSTEM_CONTRACTS,
     },
     updates::UpdatesManager,
-    ZkSyncStateKeeper,
+    StateKeeperInner,
 };
 
 pub(crate) fn seconds_since_epoch() -> u64 {
@@ -305,7 +305,7 @@ async fn load_upgrade_tx() {
     io.add_upgrade_tx(ProtocolVersionId::latest(), random_upgrade_tx(1));
     io.add_upgrade_tx(ProtocolVersionId::next(), random_upgrade_tx(2));
 
-    let mut sk = ZkSyncStateKeeper::new(
+    let mut sk = StateKeeperInner::new(
         Box::new(io),
         Box::new(batch_executor),
         output_handler,


### PR DESCRIPTION
## What ❔

Reworks state keeper so it's possible to process single L2 block with `process_block` method.

## Why ❔

Prerequisite for leader rotation.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

None

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
