### PR TITLE
perf: deallocate all heaps that don't need to be kept

### DIFF
--- a/core/lib/multivm/src/versions/vm_latest/old_vm/memory.rs
+++ b/core/lib/multivm/src/versions/vm_latest/old_vm/memory.rs
@@ -287,7 +287,7 @@ impl<H: HistoryMode> Memory for SimpleMemory<H> {
 
         // When the code oracle decommits a bytecode for the first time,
         // it needs to keep that heap alive forever.
-        // We keep all heaps of that contract just to be safe.
+        // We keep all pages of that contract just to be safe.
         if last_callstack_this != CODE_ORACLE_ADDRESS {
             for &page in self.observable_pages.inner().current_frame() {
                 // If the page's number is greater than or equal to the `base_page`,


### PR DESCRIPTION
Only keep heaps containing decommitted code forever.

(A quick bugfix resulted in us keeping all heaps for the duration of a batch. This wastes memory.)