### PR TITLE
fix(proof_data_handler): get L1BatchCommitmentMode from database instead of config

### DIFF
--- a/core/bin/zksync_server/src/node_builder.rs
+++ b/core/bin/zksync_server/src/node_builder.rs
@@ -332,7 +332,6 @@ impl MainNodeBuilder {
         let gateway_config = try_load_config!(self.configs.prover_gateway);
         self.node.add_layer(ProofDataHandlerLayer::new(
             try_load_config!(self.configs.proof_data_handler_config),
-            self.genesis_config.l1_batch_commit_data_generator_mode,
             self.genesis_config.l2_chain_id,
             gateway_config.api_mode,
         ));
@@ -691,7 +690,6 @@ impl MainNodeBuilder {
         self.node.add_layer(ExternalProofIntegrationApiLayer::new(
             config,
             proof_data_handler_config,
-            self.genesis_config.l1_batch_commit_data_generator_mode,
             self.genesis_config.l2_chain_id,
         ));
 

--- a/core/node/external_proof_integration_api/src/node.rs
+++ b/core/node/external_proof_integration_api/src/node.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use zksync_basic_types::{commitment::L1BatchCommitmentMode, L2ChainId};
+use zksync_basic_types::L2ChainId;
 use zksync_config::configs::{
     external_proof_integration_api::ExternalProofIntegrationApiConfig, ProofDataHandlerConfig,
 };
@@ -21,7 +21,6 @@ use crate::Api;
 pub struct ExternalProofIntegrationApiLayer {
     external_proof_integration_api_config: ExternalProofIntegrationApiConfig,
     proof_data_handler_config: ProofDataHandlerConfig,
-    commitment_mode: L1BatchCommitmentMode,
     l2_chain_id: L2ChainId,
 }
 
@@ -41,13 +40,11 @@ impl ExternalProofIntegrationApiLayer {
     pub fn new(
         external_proof_integration_api_config: ExternalProofIntegrationApiConfig,
         proof_data_handler_config: ProofDataHandlerConfig,
-        commitment_mode: L1BatchCommitmentMode,
         l2_chain_id: L2ChainId,
     ) -> Self {
         Self {
             external_proof_integration_api_config,
             proof_data_handler_config,
-            commitment_mode,
             l2_chain_id,
         }
     }
@@ -70,7 +67,6 @@ impl WiringLayer for ExternalProofIntegrationApiLayer {
             blob_store,
             replica_pool,
             self.proof_data_handler_config,
-            self.commitment_mode,
             self.l2_chain_id,
         );
         let task = Api::new(

--- a/core/node/proof_data_handler/src/client/mod.rs
+++ b/core/node/proof_data_handler/src/client/mod.rs
@@ -6,7 +6,7 @@ use tokio::sync::watch;
 use zksync_config::configs::ProofDataHandlerConfig;
 use zksync_dal::{ConnectionPool, Core};
 use zksync_object_store::ObjectStore;
-use zksync_types::{commitment::L1BatchCommitmentMode, L2ChainId};
+use zksync_types::L2ChainId;
 
 mod http_client;
 mod proof_fetcher;
@@ -16,7 +16,6 @@ pub struct ProofDataHandlerClient {
     pub blob_store: Arc<dyn ObjectStore>,
     pub pool: ConnectionPool<Core>,
     pub config: ProofDataHandlerConfig,
-    pub batch_commitment_mode: L1BatchCommitmentMode,
     pub l2_chain_id: L2ChainId,
 }
 
@@ -25,14 +24,12 @@ impl ProofDataHandlerClient {
         blob_store: Arc<dyn ObjectStore>,
         pool: ConnectionPool<Core>,
         config: ProofDataHandlerConfig,
-        batch_commitment_mode: L1BatchCommitmentMode,
         l2_chain_id: L2ChainId,
     ) -> Self {
         Self {
             blob_store,
             pool,
             config,
-            batch_commitment_mode,
             l2_chain_id,
         }
     }
@@ -44,18 +41,12 @@ impl ProofDataHandlerClient {
             self.blob_store.clone(),
             self.pool.clone(),
             self.config.clone(),
-            self.batch_commitment_mode,
             self.l2_chain_id,
         )
         .run(stop_receiver.clone());
-        let proof_fetcher = ProofFetcher::new(
-            self.blob_store,
-            self.pool,
-            self.config,
-            self.batch_commitment_mode,
-            self.l2_chain_id,
-        )
-        .run(stop_receiver);
+        let proof_fetcher =
+            ProofFetcher::new(self.blob_store, self.pool, self.config, self.l2_chain_id)
+                .run(stop_receiver);
 
         tracing::info!("Started proof data submitter and proof fetcher");
 

--- a/core/node/proof_data_handler/src/client/proof_fetcher.rs
+++ b/core/node/proof_data_handler/src/client/proof_fetcher.rs
@@ -4,7 +4,7 @@ use tokio::sync::watch;
 use zksync_config::configs::ProofDataHandlerConfig;
 use zksync_dal::{ConnectionPool, Core};
 use zksync_object_store::ObjectStore;
-use zksync_types::{commitment::L1BatchCommitmentMode, L1BatchId, L2ChainId};
+use zksync_types::{L1BatchId, L2ChainId};
 
 use super::http_client::HttpClient;
 use crate::processor::{Locking, Processor};
@@ -20,14 +20,12 @@ impl ProofFetcher {
         blob_store: Arc<dyn ObjectStore>,
         pool: ConnectionPool<Core>,
         config: ProofDataHandlerConfig,
-        commitment_mode: L1BatchCommitmentMode,
         l2_chain_id: L2ChainId,
     ) -> Self {
         let processor = Processor::new(
             blob_store.clone(),
             pool.clone(),
             config.clone(),
-            commitment_mode,
             l2_chain_id,
         );
 

--- a/core/node/proof_data_handler/src/client/proof_gen_data_submitter.rs
+++ b/core/node/proof_data_handler/src/client/proof_gen_data_submitter.rs
@@ -4,7 +4,7 @@ use tokio::sync::watch;
 use zksync_config::configs::ProofDataHandlerConfig;
 use zksync_dal::{ConnectionPool, Core};
 use zksync_object_store::ObjectStore;
-use zksync_types::{commitment::L1BatchCommitmentMode, L2ChainId};
+use zksync_types::L2ChainId;
 
 use super::http_client::HttpClient;
 use crate::processor::{Locking, Processor};
@@ -20,14 +20,12 @@ impl ProofGenDataSubmitter {
         blob_store: Arc<dyn ObjectStore>,
         pool: ConnectionPool<Core>,
         config: ProofDataHandlerConfig,
-        commitment_mode: L1BatchCommitmentMode,
         l2_chain_id: L2ChainId,
     ) -> Self {
         let processor = Processor::new(
             blob_store.clone(),
             pool.clone(),
             config.clone(),
-            commitment_mode,
             l2_chain_id,
         );
 

--- a/core/node/proof_data_handler/src/lib.rs
+++ b/core/node/proof_data_handler/src/lib.rs
@@ -11,7 +11,7 @@ use zksync_prover_interface::api::{
     ProofGenerationDataRequest, ProofGenerationDataResponse, SubmitProofRequest,
     SubmitProofResponse,
 };
-use zksync_types::{commitment::L1BatchCommitmentMode, L1BatchId, L1BatchNumber, L2ChainId};
+use zksync_types::{L1BatchId, L1BatchNumber, L2ChainId};
 
 pub use crate::{
     client::ProofDataHandlerClient,
@@ -29,21 +29,14 @@ pub async fn run_server(
     config: ProofDataHandlerConfig,
     blob_store: Arc<dyn ObjectStore>,
     connection_pool: ConnectionPool<Core>,
-    commitment_mode: L1BatchCommitmentMode,
     l2_chain_id: L2ChainId,
     api_mode: ApiMode,
     mut stop_receiver: watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
     let bind_address = SocketAddr::from(([0, 0, 0, 0], config.http_port));
     tracing::info!("Starting proof data handler server on {bind_address}");
-    let app = create_proof_processing_router(
-        blob_store,
-        connection_pool,
-        config,
-        api_mode,
-        commitment_mode,
-        l2_chain_id,
-    );
+    let app =
+        create_proof_processing_router(blob_store, connection_pool, config, api_mode, l2_chain_id);
 
     let listener = tokio::net::TcpListener::bind(bind_address)
         .await
@@ -66,7 +59,6 @@ fn create_proof_processing_router(
     connection_pool: ConnectionPool<Core>,
     config: ProofDataHandlerConfig,
     api_mode: ApiMode,
-    commitment_mode: L1BatchCommitmentMode,
     l2_chain_id: L2ChainId,
 ) -> Router {
     let mut router = Router::new();
@@ -76,7 +68,6 @@ fn create_proof_processing_router(
             blob_store.clone(),
             connection_pool.clone(),
             config.clone(),
-            commitment_mode,
             l2_chain_id,
         );
         let submit_proof_processor = get_proof_gen_processor.clone();

--- a/core/node/proof_data_handler/src/node.rs
+++ b/core/node/proof_data_handler/src/node.rs
@@ -12,7 +12,7 @@ use zksync_node_framework::{
     FromContext, IntoContext,
 };
 use zksync_object_store::ObjectStore;
-use zksync_types::{commitment::L1BatchCommitmentMode, L2ChainId};
+use zksync_types::L2ChainId;
 
 use crate::ProofDataHandlerClient;
 
@@ -20,7 +20,6 @@ use crate::ProofDataHandlerClient;
 #[derive(Debug)]
 pub struct ProofDataHandlerLayer {
     proof_data_handler_config: ProofDataHandlerConfig,
-    commitment_mode: L1BatchCommitmentMode,
     l2_chain_id: L2ChainId,
     api_mode: ApiMode,
 }
@@ -40,13 +39,11 @@ pub struct Output {
 impl ProofDataHandlerLayer {
     pub fn new(
         proof_data_handler_config: ProofDataHandlerConfig,
-        commitment_mode: L1BatchCommitmentMode,
         l2_chain_id: L2ChainId,
         api_mode: ApiMode,
     ) -> Self {
         Self {
             proof_data_handler_config,
-            commitment_mode,
             l2_chain_id,
             api_mode,
         }
@@ -70,7 +67,6 @@ impl WiringLayer for ProofDataHandlerLayer {
             proof_data_handler_config: self.proof_data_handler_config,
             blob_store,
             main_pool,
-            commitment_mode: self.commitment_mode,
             l2_chain_id: self.l2_chain_id,
             api_mode: self.api_mode,
         };
@@ -85,7 +81,6 @@ pub struct ProofDataHandlerTask {
     blob_store: Arc<dyn ObjectStore>,
     main_pool: ConnectionPool<Core>,
     api_mode: ApiMode,
-    commitment_mode: L1BatchCommitmentMode,
     l2_chain_id: L2ChainId,
 }
 
@@ -100,7 +95,6 @@ impl Task for ProofDataHandlerTask {
             self.proof_data_handler_config.clone(),
             self.blob_store.clone(),
             self.main_pool.clone(),
-            self.commitment_mode,
             self.l2_chain_id,
             self.api_mode.clone(),
             stop_receiver.clone().0,
@@ -113,7 +107,6 @@ impl Task for ProofDataHandlerTask {
                 self.blob_store,
                 self.main_pool,
                 self.proof_data_handler_config,
-                self.commitment_mode,
                 self.l2_chain_id,
             );
 

--- a/core/node/proof_data_handler/src/processor.rs
+++ b/core/node/proof_data_handler/src/processor.rs
@@ -41,7 +41,6 @@ pub struct Processor<PM: ProcessorMode> {
     blob_store: Arc<dyn ObjectStore>,
     pool: ConnectionPool<Core>,
     config: ProofDataHandlerConfig,
-    commitment_mode: L1BatchCommitmentMode,
     chain_id: L2ChainId,
     _marker: std::marker::PhantomData<PM>,
 }
@@ -51,14 +50,12 @@ impl<PM: ProcessorMode> Processor<PM> {
         blob_store: Arc<dyn ObjectStore>,
         pool: ConnectionPool<Core>,
         config: ProofDataHandlerConfig,
-        commitment_mode: L1BatchCommitmentMode,
         chain_id: L2ChainId,
     ) -> Self {
         Self {
             blob_store,
             pool,
             config,
-            commitment_mode,
             chain_id,
             _marker: std::marker::PhantomData,
         }
@@ -126,6 +123,12 @@ impl<PM: ProcessorMode> Processor<PM> {
             .await?
             .unwrap_or_else(|| panic!("Missing header for {}", l1_batch_number));
 
+        let pubdata_params = conn
+            .blocks_dal()
+            .get_l1_batch_pubdata_params(l1_batch_number)
+            .await?
+            .unwrap_or_else(|| panic!("Missing pubdata params for {l1_batch_number}"));
+
         let minor_version = header.protocol_version.unwrap();
         let protocol_version = conn
             .protocol_versions_dal()
@@ -141,7 +144,7 @@ impl<PM: ProcessorMode> Processor<PM> {
             .await?
             .unwrap_or_else(|| panic!("Missing header for {}", l1_batch_number));
 
-        let eip_4844_blobs = match self.commitment_mode {
+        let eip_4844_blobs = match pubdata_params.pubdata_type.into() {
             L1BatchCommitmentMode::Validium => Eip4844Blobs::empty(),
             L1BatchCommitmentMode::Rollup => {
                 let blobs = batch_header.pubdata_input.as_deref().unwrap_or_else(|| {


### PR DESCRIPTION
## What ❔

Get the L1BatchCommitmentMode from the database instead of the config.
This is important during Rollup<->Validium switches, as the config may not correspond to the commitment mode of the specific batch.

## Why ❔

To eliminate the issues with blobs not being in the witness input for Rollup batches in case of Rollup->Validium migration or being in the witness input for Validium batches in case of Validium->Rollup migration.
When the config change happens during the migration - there might still be unprocessed batches (or even the unsealed ones) and we need them to be processed accordingly.

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
