### PR TITLE
feat(fee_model): scale the batch fee unconditionally

### DIFF
--- a/core/bin/zksync_server/src/node_builder.rs
+++ b/core/bin/zksync_server/src/node_builder.rs
@@ -218,7 +218,11 @@ impl MainNodeBuilder {
                 .add_layer(BaseTokenRatioProviderLayer::new(base_token_adjuster_config));
         }
         let state_keeper_config = try_load_config!(self.configs.state_keeper_config);
-        let l1_gas_layer = L1GasLayer::new(&state_keeper_config);
+        let api_config = try_load_config!(self.configs.api_config);
+        let l1_gas_layer = L1GasLayer::new(
+            &state_keeper_config,
+            api_config.web3_json_rpc.gas_price_scale_factor_open_batch,
+        );
         self.node.add_layer(l1_gas_layer);
         Ok(self)
     }

--- a/core/lib/config/src/configs/api.rs
+++ b/core/lib/config/src/configs/api.rs
@@ -164,8 +164,11 @@ pub struct Web3JsonRpcConfig {
     pub max_nonce_ahead: u32,
     /// The multiplier to use when suggesting gas price. Should be higher than one,
     /// otherwise if the L1 prices soar, the suggested gas price won't be sufficient to be included in block
+    /// This value is only used when there is no open batch.
     #[config(default_t = 1.5)]
     pub gas_price_scale_factor: f64,
+    /// The factor by which to scale the gas price when there is an open batch.
+    pub gas_price_scale_factor_open_batch: Option<f64>,
     /// The factor by which to scale the gasLimit
     #[config(default_t = 1.3)]
     pub estimate_gas_scale_factor: f64,
@@ -250,6 +253,7 @@ impl Web3JsonRpcConfig {
     pub fn for_tests() -> Self {
         Self {
             gas_price_scale_factor: 1.2,
+            gas_price_scale_factor_open_batch: Some(1.2),
             estimate_gas_scale_factor: 1.5,
             ..Self::default()
         }
@@ -381,6 +385,7 @@ mod tests {
                 ],
                 api_namespaces: Some(vec!["debug".to_string()]),
                 extended_api_tracing: true,
+                gas_price_scale_factor_open_batch: Some(1.3),
             },
             healthcheck: HealthCheckConfig {
                 port: 8081,
@@ -405,6 +410,7 @@ mod tests {
             API_WEB3_JSON_RPC_PUBSUB_POLLING_INTERVAL=200
             API_WEB3_JSON_RPC_MAX_NONCE_AHEAD=5
             API_WEB3_JSON_RPC_GAS_PRICE_SCALE_FACTOR=1.2
+            API_WEB3_JSON_RPC_GAS_PRICE_SCALE_FACTOR_OPEN_BATCH=1.3
             API_WEB3_JSON_RPC_ESTIMATE_GAS_OPTIMIZE_SEARCH=true
             API_WEB3_JSON_RPC_VM_EXECUTION_CACHE_MISSES_LIMIT=1000
             API_WEB3_JSON_RPC_API_NAMESPACES=debug
@@ -474,6 +480,7 @@ mod tests {
             pubsub_polling_interval: 200
             max_nonce_ahead: 5
             gas_price_scale_factor: 1.2
+            gas_price_scale_factor_open_batch: 1.3
             estimate_gas_scale_factor: 1
             estimate_gas_acceptable_overestimation: 1000
             max_tx_size: 1000000
@@ -534,6 +541,7 @@ mod tests {
             pubsub_polling_interval: 200ms
             max_nonce_ahead: 5
             gas_price_scale_factor: 1.2
+            gas_price_scale_factor_open_batch: 1.3
             estimate_gas_scale_factor: 1
             estimate_gas_acceptable_overestimation: 1000
             max_tx_size: 1000000 B

--- a/core/lib/types/src/fee_model.rs
+++ b/core/lib/types/src/fee_model.rs
@@ -289,7 +289,7 @@ pub struct FeeParamsV1 {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct FeeParamsV2 {
-    pub config: FeeModelConfigV2,
+    config: FeeModelConfigV2,
     l1_gas_price: u64,
     l1_pubdata_price: u64,
     conversion_ratio: BaseTokenConversionRatio,

--- a/core/node/api_server/src/tx_sender/mod.rs
+++ b/core/node/api_server/src/tx_sender/mod.rs
@@ -78,8 +78,11 @@ pub async fn build_tx_sender(
     let max_concurrency = web3_json_config.vm_concurrency_limit;
     let (vm_concurrency_limiter, vm_barrier) = VmConcurrencyLimiter::new(max_concurrency);
 
-    let batch_fee_input_provider =
-        ApiFeeInputProvider::new(batch_fee_model_input_provider, replica_pool);
+    let batch_fee_input_provider = ApiFeeInputProvider::new(
+        batch_fee_model_input_provider,
+        replica_pool,
+        web3_json_config.gas_price_scale_factor_open_batch,
+    );
     let executor_options = SandboxExecutorOptions::new(
         tx_sender_config.chain_id,
         AccountTreeId::new(tx_sender_config.fee_account_addr),

--- a/core/node/api_server/src/tx_sender/mod.rs
+++ b/core/node/api_server/src/tx_sender/mod.rs
@@ -78,8 +78,7 @@ pub async fn build_tx_sender(
     let max_concurrency = web3_json_config.vm_concurrency_limit;
     let (vm_concurrency_limiter, vm_barrier) = VmConcurrencyLimiter::new(max_concurrency);
 
-    let batch_fee_input_provider =
-        ApiFeeInputProvider::new(batch_fee_model_input_provider);
+    let batch_fee_input_provider = ApiFeeInputProvider::new(batch_fee_model_input_provider);
     let executor_options = SandboxExecutorOptions::new(
         tx_sender_config.chain_id,
         AccountTreeId::new(tx_sender_config.fee_account_addr),

--- a/core/node/api_server/src/tx_sender/mod.rs
+++ b/core/node/api_server/src/tx_sender/mod.rs
@@ -79,7 +79,7 @@ pub async fn build_tx_sender(
     let (vm_concurrency_limiter, vm_barrier) = VmConcurrencyLimiter::new(max_concurrency);
 
     let batch_fee_input_provider =
-        ApiFeeInputProvider::new(batch_fee_model_input_provider, replica_pool);
+        ApiFeeInputProvider::new(batch_fee_model_input_provider);
     let executor_options = SandboxExecutorOptions::new(
         tx_sender_config.chain_id,
         AccountTreeId::new(tx_sender_config.fee_account_addr),

--- a/core/node/api_server/src/tx_sender/mod.rs
+++ b/core/node/api_server/src/tx_sender/mod.rs
@@ -78,7 +78,8 @@ pub async fn build_tx_sender(
     let max_concurrency = web3_json_config.vm_concurrency_limit;
     let (vm_concurrency_limiter, vm_barrier) = VmConcurrencyLimiter::new(max_concurrency);
 
-    let batch_fee_input_provider = ApiFeeInputProvider::new(batch_fee_model_input_provider);
+    let batch_fee_input_provider =
+        ApiFeeInputProvider::new(batch_fee_model_input_provider, replica_pool);
     let executor_options = SandboxExecutorOptions::new(
         tx_sender_config.chain_id,
         AccountTreeId::new(tx_sender_config.fee_account_addr),

--- a/core/node/api_server/src/web3/tests/vm.rs
+++ b/core/node/api_server/src/web3/tests/vm.rs
@@ -47,10 +47,6 @@ impl ExpectedFeeInput {
         self.expect_for_block(api::BlockNumber::Pending, scale);
     }
 
-    fn expect_custom(&self, expected: BatchFeeInput) {
-        *self.0.lock().unwrap() = expected;
-    }
-
     fn assert_eq(&self, actual: BatchFeeInput) {
         let expected = *self.0.lock().unwrap();
         // We do relaxed comparisons to deal with the fact that the fee input provider may convert inputs to pubdata independent form.

--- a/core/node/api_server/src/web3/tests/vm.rs
+++ b/core/node/api_server/src/web3/tests/vm.rs
@@ -176,7 +176,11 @@ impl HttpTest for CallTest {
         )
         .await?;
         // Fee input is not scaled further as per `ApiFeeInputProvider` implementation
-        self.fee_input.expect_custom(batch_header.fee_input);
+        self.fee_input.expect_custom(
+            batch_header
+                .fee_input
+                .scale_fair_l2_gas_price(TraceCallTest::FEE_SCALE),
+        );
         let call_request = Self::call_request(b"block=2");
         let call_result = client.call(call_request.clone(), None, None).await?;
         assert_eq!(call_result.0, b"output");
@@ -804,7 +808,7 @@ impl HttpTest for TraceCallTest {
         self.fee_input.expect_custom(
             batch_header
                 .fee_input
-                .scale_linearly(Self::FEE_SCALE, Self::FEE_SCALE),
+                .scale_fair_l2_gas_price(Self::FEE_SCALE),
         );
         let call_request = CallTest::call_request(b"block=2");
         let call_result = client.trace_call(call_request.clone(), None, None).await?;

--- a/core/node/api_server/src/web3/tests/vm.rs
+++ b/core/node/api_server/src/web3/tests/vm.rs
@@ -169,14 +169,14 @@ impl HttpTest for CallTest {
         // Check that the method handler fetches fee input from the open batch. To do that, we open a new batch
         // with a large fee input; it should be loaded by `ApiFeeInputProvider` and used instead of the input
         // provided by the wrapped mock provider.
-        let batch_header = open_l1_batch(
+        open_l1_batch(
             &mut connection,
             L1BatchNumber(1),
             scaled_sensible_fee_input(3.0),
         )
         .await?;
         // Fee input is not scaled further as per `ApiFeeInputProvider` implementation
-        self.fee_input.expect_custom(batch_header.fee_input);
+        self.fee_input.expect_default(1.0);
         let call_request = Self::call_request(b"block=2");
         let call_result = client.call(call_request.clone(), None, None).await?;
         assert_eq!(call_result.0, b"output");
@@ -794,14 +794,14 @@ impl HttpTest for TraceCallTest {
         // Check that the method handler fetches fee input from the open batch. To do that, we open a new batch
         // with a large fee input; it should be loaded by `ApiFeeInputProvider` and used instead of the input
         // provided by the wrapped mock provider.
-        let batch_header = open_l1_batch(
+        open_l1_batch(
             &mut connection,
             L1BatchNumber(2),
             scaled_sensible_fee_input(3.0),
         )
         .await?;
         // Fee input is not scaled further as per `ApiFeeInputProvider` implementation
-        self.fee_input.expect_custom(batch_header.fee_input);
+        self.fee_input.expect_default(Self::FEE_SCALE);
         let call_request = CallTest::call_request(b"block=2");
         let call_result = client.trace_call(call_request.clone(), None, None).await?;
         Self::assert_debug_call(&call_request, &call_result.unwrap_default());

--- a/core/node/fee_model/src/lib.rs
+++ b/core/node/fee_model/src/lib.rs
@@ -376,27 +376,4 @@ mod tests {
         .await
         .expect("Failed to create GasAdjuster")
     }
-
-    #[tokio::test]
-    async fn test_take_fee_input_from_unsealed_batch() {
-        let sealed_batch_fee_input = BatchFeeInput::pubdata_independent(1, 2, 3);
-        let unsealed_batch_fee_input = BatchFeeInput::pubdata_independent(101, 102, 103);
-
-        let pool = ConnectionPool::<Core>::test_pool().await;
-        let mut conn = pool.connection().await.unwrap();
-        insert_genesis_batch(&mut conn, &GenesisParams::mock())
-            .await
-            .unwrap();
-
-        let mut l1_batch_header = create_l1_batch(1);
-        l1_batch_header.batch_fee_input = sealed_batch_fee_input;
-
-        let mut l1_batch_header = create_l1_batch(2);
-        l1_batch_header.batch_fee_input = unsealed_batch_fee_input;
-
-        let provider: &dyn BatchFeeModelInputProvider =
-            &ApiFeeInputProvider::new(Arc::new(MockBatchFeeParamsProvider::default()));
-        let fee_input = provider.get_batch_fee_input().await.unwrap();
-        assert_eq!(fee_input, unsealed_batch_fee_input);
-    }
 }

--- a/core/node/fee_model/src/lib.rs
+++ b/core/node/fee_model/src/lib.rs
@@ -101,12 +101,8 @@ pub struct ApiFeeInputProvider {
 }
 
 impl ApiFeeInputProvider {
-    pub fn new(
-        inner: Arc<dyn BatchFeeModelInputProvider>,
-    ) -> Self {
-        Self {
-            inner,
-        }
+    pub fn new(inner: Arc<dyn BatchFeeModelInputProvider>) -> Self {
+        Self { inner }
     }
 }
 

--- a/core/node/fee_model/src/lib.rs
+++ b/core/node/fee_model/src/lib.rs
@@ -2,6 +2,8 @@ use std::{fmt, sync::Arc};
 
 use anyhow::Context;
 use async_trait::async_trait;
+#[cfg(test)]
+use zksync_dal::{ConnectionPool, Core};
 use zksync_types::fee_model::{
     BaseTokenConversionRatio, BatchFeeInput, FeeModelConfig, FeeParams, FeeParamsV1, FeeParamsV2,
 };

--- a/core/node/fee_model/src/lib.rs
+++ b/core/node/fee_model/src/lib.rs
@@ -2,8 +2,6 @@ use std::{fmt, sync::Arc};
 
 use anyhow::Context;
 use async_trait::async_trait;
-#[cfg(test)]
-use zksync_dal::{ConnectionPool, Core};
 use zksync_types::fee_model::{
     BaseTokenConversionRatio, BatchFeeInput, FeeModelConfig, FeeParams, FeeParamsV1, FeeParamsV2,
 };
@@ -153,8 +151,6 @@ mod tests {
     use l1_gas_price::GasAdjusterClient;
     use zksync_config::GasAdjusterConfig;
     use zksync_eth_client::{clients::MockSettlementLayer, BaseFees};
-    use zksync_node_genesis::{insert_genesis_batch, GenesisParams};
-    use zksync_node_test_utils::create_l1_batch;
     use zksync_types::{
         commitment::L1BatchCommitmentMode,
         eth_sender::EthTxFinalityStatus,

--- a/core/node/fee_model/src/node/l1_gas.rs
+++ b/core/node/fee_model/src/node/l1_gas.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use zksync_config::configs::chain::{FeeModelVersion, StateKeeperConfig};
-use zksync_dal::node::{PoolResource, ReplicaPool};
 use zksync_node_framework::{
     wiring_layer::{WiringError, WiringLayer},
     FromContext, IntoContext,
@@ -26,7 +25,6 @@ pub struct L1GasLayer {
 #[derive(Debug, FromContext)]
 pub struct Input {
     gas_adjuster: Arc<GasAdjuster>,
-    replica_pool: PoolResource<ReplicaPool>,
     /// If not provided, the base token assumed to be ETH, and the ratio will be constant.
     base_token_ratio_provider: Option<Arc<dyn BaseTokenRatioProvider>>,
 }
@@ -82,10 +80,8 @@ impl WiringLayer for L1GasLayer {
             self.fee_model_config,
         ));
 
-        let replica_pool = input.replica_pool.get().await?;
         let api_fee_input_provider = Arc::new(ApiFeeInputProvider::new(
             main_fee_input_provider.clone(),
-            replica_pool,
         ));
 
         Ok(Output {

--- a/core/node/fee_model/src/node/l1_gas.rs
+++ b/core/node/fee_model/src/node/l1_gas.rs
@@ -21,6 +21,7 @@ use crate::{
 #[derive(Debug)]
 pub struct L1GasLayer {
     fee_model_config: FeeModelConfig,
+    gas_price_scale_factor_open_batch: Option<f64>,
 }
 
 #[derive(Debug, FromContext)]
@@ -39,9 +40,13 @@ pub struct Output {
 }
 
 impl L1GasLayer {
-    pub fn new(state_keeper_config: &StateKeeperConfig) -> Self {
+    pub fn new(
+        state_keeper_config: &StateKeeperConfig,
+        gas_price_scale_factor_open_batch: Option<f64>,
+    ) -> Self {
         Self {
             fee_model_config: Self::map_config(state_keeper_config),
+            gas_price_scale_factor_open_batch,
         }
     }
 
@@ -86,6 +91,7 @@ impl WiringLayer for L1GasLayer {
         let api_fee_input_provider = Arc::new(ApiFeeInputProvider::new(
             main_fee_input_provider.clone(),
             replica_pool,
+            self.gas_price_scale_factor_open_batch,
         ));
 
         Ok(Output {

--- a/core/node/fee_model/src/node/l1_gas.rs
+++ b/core/node/fee_model/src/node/l1_gas.rs
@@ -80,9 +80,8 @@ impl WiringLayer for L1GasLayer {
             self.fee_model_config,
         ));
 
-        let api_fee_input_provider = Arc::new(ApiFeeInputProvider::new(
-            main_fee_input_provider.clone(),
-        ));
+        let api_fee_input_provider =
+            Arc::new(ApiFeeInputProvider::new(main_fee_input_provider.clone()));
 
         Ok(Output {
             sequencer_fee_input: main_fee_input_provider.into(),


### PR DESCRIPTION
## What ❔

Apply scaling to the batch fee even if there is an open batch.

## Why ❔

When the transaction gas price is estimated at the end of the batch, there is a risk of transaction price being too low if the next batch has a higher gas price

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
