### PR TITLE
chore(api): Observe transaction submission errors

### DIFF
--- a/core/lib/vm_executor/src/shared.rs
+++ b/core/lib/vm_executor/src/shared.rs
@@ -46,6 +46,7 @@ impl RuntimeContextStorageMetrics {
         storage_metrics: &StorageViewStats,
     ) {
         const STORAGE_INVOCATIONS_DEBUG_THRESHOLD: usize = 1_000;
+        const TOTAL_VM_LATENCY_THRESHOLD: Duration = Duration::from_secs(5);
 
         let metrics = &STORAGE_METRICS[&GlobalStorageLabels { interrupted }];
         let total_storage_invocations = storage_metrics.get_value_storage_invocations
@@ -84,7 +85,10 @@ impl RuntimeContextStorageMetrics {
             .ratio
             .observe(total_time_spent_in_storage.as_secs_f64() / total_vm_latency.as_secs_f64());
 
-        if total_storage_invocations > STORAGE_INVOCATIONS_DEBUG_THRESHOLD || interrupted {
+        if total_storage_invocations > STORAGE_INVOCATIONS_DEBUG_THRESHOLD
+            || total_vm_latency > TOTAL_VM_LATENCY_THRESHOLD
+            || interrupted
+        {
             tracing::info!(
                 interrupted,
                 "{op} resulted in {total_storage_invocations} storage_invocations, {} new_storage_invocations, \

--- a/core/node/api_server/src/web3/backend_jsonrpsee/metadata.rs
+++ b/core/node/api_server/src/web3/backend_jsonrpsee/metadata.rs
@@ -10,6 +10,7 @@ use zksync_web3_decl::{error::Web3Error, jsonrpsee::MethodResponse};
 use super::testonly::RecordedMethodCalls;
 use crate::{
     execution_sandbox::SANDBOX_METRICS,
+    tx_sender::SubmitTxError,
     web3::metrics::{ObservedRpcParams, API_METRICS},
 };
 
@@ -114,6 +115,13 @@ impl MethodTracer {
         if let Some(metadata) = &mut *cell.borrow_mut() {
             API_METRICS.observe_web3_error(metadata.name, err);
             metadata.has_app_error = true;
+        }
+    }
+
+    pub(super) fn observe_submit_error(&self, err: &SubmitTxError) {
+        let cell = self.inner.get_or_default();
+        if let Some(metadata) = &*cell.borrow() {
+            API_METRICS.observe_submit_error(metadata.name, err);
         }
     }
 }

--- a/core/node/api_server/src/web3/backend_jsonrpsee/mod.rs
+++ b/core/node/api_server/src/web3/backend_jsonrpsee/mod.rs
@@ -57,15 +57,15 @@ impl MethodTracer {
 
         ErrorObjectOwned::owned(code, message, data)
     }
-}
 
-impl From<SubmitTxError> for Web3Error {
-    fn from(err: SubmitTxError) -> Self {
+    pub(crate) fn map_submit_err(&self, err: SubmitTxError) -> Web3Error {
+        self.observe_submit_error(&err);
+
         match err {
-            SubmitTxError::Internal(err) => Self::InternalError(err),
-            SubmitTxError::ProxyError(err) => Self::ProxyError(err),
-            SubmitTxError::ServerShuttingDown => Self::ServerShuttingDown,
-            _ => Self::SubmitTransactionError(err.to_string(), err.data()),
+            SubmitTxError::Internal(err) => Web3Error::InternalError(err),
+            SubmitTxError::ProxyError(err) => Web3Error::ProxyError(err),
+            SubmitTxError::ServerShuttingDown => Web3Error::ServerShuttingDown,
+            _ => Web3Error::SubmitTransactionError(err.to_string(), err.data()),
         }
     }
 }

--- a/core/node/api_server/src/web3/metrics.rs
+++ b/core/node/api_server/src/web3/metrics.rs
@@ -13,7 +13,7 @@ use super::{
     backend_jsonrpsee::MethodMetadata, ApiTransport, InternalApiConfig, OptionalApiParams,
     TypedFilter,
 };
-use crate::utils::ReportFilter;
+use crate::{tx_sender::SubmitTxError, utils::ReportFilter};
 
 /// Observed version of RPC parameters. Have a bounded upper-limit size (256 bytes), so that we don't over-allocate.
 #[derive(Debug)]
@@ -216,6 +216,12 @@ struct Web3ErrorLabels {
     kind: Web3ErrorKind,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelSet)]
+struct SubmitErrorLabels {
+    method: &'static str,
+    reason: &'static str,
+}
+
 #[derive(Debug, EncodeLabelSet)]
 struct Web3ConfigLabels {
     #[metrics(unit = Unit::Seconds)]
@@ -264,8 +270,7 @@ pub(crate) struct ApiMetrics {
     /// Number of protocol errors grouped by error code and method name. Method name is not set for "method not found" errors.
     web3_rpc_errors: Family<ProtocolErrorLabels, Counter>,
     /// Number of transaction submission errors for a specific submission error reason.
-    #[metrics(labels = ["reason"])]
-    pub submit_tx_error: LabeledFamily<&'static str, Counter>,
+    submit_tx_error: Family<SubmitErrorLabels, Counter>,
 
     #[metrics(buckets = Buckets::exponential(1.0..=128.0, 2.0))]
     pub web3_in_flight_requests: Family<ApiTransportLabel, Histogram<usize>>,
@@ -413,6 +418,21 @@ impl ApiMetrics {
                 labels.kind
             );
         }
+    }
+
+    pub(super) fn observe_submit_error(&self, method: &'static str, err: &SubmitTxError) {
+        static FILTER: ReportFilter = report_filter!(Duration::from_secs(5));
+
+        // All internal errors are reported anyway, so no need to log them here.
+        if !matches!(err, SubmitTxError::Internal(_)) && FILTER.should_report() {
+            tracing::info!("Observed submission error for method `{method}`: {err}");
+        }
+
+        let labels = SubmitErrorLabels {
+            method,
+            reason: err.prom_error_code(),
+        };
+        self.submit_tx_error[&labels].inc();
     }
 }
 

--- a/core/node/api_server/src/web3/namespaces/unstable/mod.rs
+++ b/core/node/api_server/src/web3/namespaces/unstable/mod.rs
@@ -23,7 +23,7 @@ use zksync_web3_decl::{error::Web3Error, types::H256};
 
 use crate::{
     execution_sandbox::BlockArgs,
-    web3::{backend_jsonrpsee::MethodTracer, metrics::API_METRICS, RpcState},
+    web3::{backend_jsonrpsee::MethodTracer, RpcState},
 };
 
 mod utils;
@@ -243,11 +243,7 @@ impl UnstableNamespace {
             .tx_sender
             .submit_tx(tx, block_args)
             .await
-            .map_err(|err| {
-                tracing::debug!("Send raw transaction error: {err}");
-                API_METRICS.submit_tx_error[&err.prom_error_code()].inc();
-                err
-            })?;
+            .map_err(|err| self.current_method().map_submit_err(err))?;
         Ok(TransactionDetailedResult {
             transaction_hash: tx_hash,
             storage_logs: submit_output

--- a/core/node/api_server/src/web3/namespaces/zks.rs
+++ b/core/node/api_server/src/web3/namespaces/zks.rs
@@ -129,8 +129,7 @@ impl ZksNamespace {
             self.state.api_config.estimate_gas_acceptable_overestimation;
         let search_kind = BinarySearchKind::new(self.state.api_config.estimate_gas_optimize_search);
 
-        Ok(self
-            .state
+        self.state
             .tx_sender
             .get_txs_fee_in_wei(
                 tx,
@@ -140,7 +139,8 @@ impl ZksNamespace {
                 state_override,
                 search_kind,
             )
-            .await?)
+            .await
+            .map_err(|err| self.current_method().map_submit_err(err))
     }
 
     pub fn get_bridgehub_contract_impl(&self) -> Option<Address> {


### PR DESCRIPTION
## What ❔

Adds more observability for tx submission errors (which also covers calls and gas estimation).

## Why ❔

These errors could be useful in debugging API server issues. RN, we only observe submission errors for tx submission. 

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.