### PR TITLE
fix(zkstack): Use `latest` for prover component by default

### DIFF
--- a/zkstack_cli/crates/zkstack/src/commands/prover/args/run.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/args/run.rs
@@ -283,7 +283,7 @@ impl ProverRunArgs {
                 .ask()
         });
 
-        let tag = self.tag.unwrap_or("latest2.0".to_string());
+        let tag = self.tag.unwrap_or("latest".to_string());
 
         Ok(ProverRunArgs {
             component: Some(component),


### PR DESCRIPTION
## What ❔

Use `latest` for prover component by default.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Label `latest2.0` was deprecated last year.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.

ref ZKD-2769

