### PR TITLE
perf(state-keeper): Reduce retained data in updates manager

### DIFF
--- a/core/lib/dal/src/transactions_dal.rs
+++ b/core/lib/dal/src/transactions_dal.rs
@@ -524,10 +524,10 @@ impl TransactionsDal<'_, '_> {
     pub async fn mark_txs_as_executed_in_l1_batch(
         &mut self,
         l1_batch_number: L1BatchNumber,
-        transactions: &[TransactionExecutionResult],
+        tx_hashes: &[H256],
     ) -> DalResult<()> {
-        let hashes: Vec<_> = transactions.iter().map(|tx| tx.hash.as_bytes()).collect();
-        let l1_batch_tx_indexes: Vec<_> = (0..transactions.len() as i32).collect();
+        let hashes: Vec<_> = tx_hashes.iter().map(H256::as_bytes).collect();
+        let l1_batch_tx_indexes: Vec<_> = (0..tx_hashes.len() as i32).collect();
         sqlx::query!(
             r#"
             UPDATE transactions
@@ -550,7 +550,7 @@ impl TransactionsDal<'_, '_> {
         )
         .instrument("mark_txs_as_executed_in_l1_batch")
         .with_arg("l1_batch_number", &l1_batch_number)
-        .with_arg("transactions.len", &transactions.len())
+        .with_arg("transactions.len", &tx_hashes.len())
         .execute(self.storage)
         .await?;
         Ok(())

--- a/core/node/state_keeper/src/io/seal_logic/mod.rs
+++ b/core/node/state_keeper/src/io/seal_logic/mod.rs
@@ -83,7 +83,8 @@ impl UpdatesManager {
                 .len(),
         );
 
-        let (l1_tx_count, l2_tx_count) = l1_l2_tx_count(&self.l1_batch.executed_transactions);
+        let l1_tx_count = self.l1_batch.l1_tx_count;
+        let l2_tx_count = self.l1_batch.executed_transaction_hashes.len() - l1_tx_count;
         let (dedup_writes_count, dedup_reads_count) = log_query_write_read_counts(
             finished_batch
                 .final_execution_state
@@ -162,7 +163,7 @@ impl UpdatesManager {
             .transactions_dal()
             .mark_txs_as_executed_in_l1_batch(
                 self.l1_batch.number,
-                &self.l1_batch.executed_transactions,
+                &self.l1_batch.executed_transaction_hashes,
             )
             .await?;
         progress.observe(None);
@@ -262,7 +263,7 @@ impl UpdatesManager {
             .observe(writes_metrics.repeated_storage_writes);
         L1_BATCH_METRICS
             .transactions_in_l1_batch
-            .observe(self.l1_batch.executed_transactions.len());
+            .observe(self.l1_batch.executed_transaction_hashes.len());
 
         let batch_timestamp = self.batch_timestamp();
         let l1_batch_latency =

--- a/core/node/state_keeper/src/io/tests/mod.rs
+++ b/core/node/state_keeper/src/io/tests/mod.rs
@@ -70,7 +70,7 @@ async fn test_filter_with_pending_batch(commitment_mode: L1BatchCommitmentMode) 
         .insert_l2_block(&connection_pool, 1, 5, BatchFeeInput::l1_pegged(55, 555))
         .await;
     tester
-        .insert_sealed_batch(&connection_pool, 1, &[tx_result])
+        .insert_sealed_batch(&connection_pool, 1, &[tx_result.hash])
         .await;
 
     // Inserting a pending L2 block that isn't included in a sealed batch means there is a pending batch.
@@ -115,7 +115,7 @@ async fn test_filter_with_no_pending_batch(commitment_mode: L1BatchCommitmentMod
         .insert_l2_block(&connection_pool, 1, 5, BatchFeeInput::l1_pegged(55, 555))
         .await;
     tester
-        .insert_sealed_batch(&connection_pool, 1, &[tx_result])
+        .insert_sealed_batch(&connection_pool, 1, &[tx_result.hash])
         .await;
 
     // Create a copy of the tx filter that the mempool will use.
@@ -164,7 +164,7 @@ async fn test_timestamps_are_distinct(
         tester.set_timestamp(prev_l2_block_timestamp - 1);
     }
     tester
-        .insert_sealed_batch(&connection_pool, 1, &[tx_result])
+        .insert_sealed_batch(&connection_pool, 1, &[tx_result.hash])
         .await;
 
     let (mut mempool, mut guard) = tester.create_test_mempool_io(connection_pool).await;
@@ -724,7 +724,7 @@ async fn insert_unsealed_batch_on_init(commitment_mode: L1BatchCommitmentMode) {
         .insert_l2_block(&connection_pool, 1, 5, fee_input)
         .await;
     tester
-        .insert_sealed_batch(&connection_pool, 1, &[tx_result])
+        .insert_sealed_batch(&connection_pool, 1, &[tx_result.hash])
         .await;
     // Pre-insert L2 block without its unsealed L1 batch counterpart
     tester.set_timestamp(2);
@@ -762,7 +762,7 @@ async fn test_mempool_with_timestamp_assertion() {
         .insert_l2_block(&connection_pool, 1, 5, BatchFeeInput::l1_pegged(55, 555))
         .await;
     tester
-        .insert_sealed_batch(&connection_pool, 1, &[tx_result])
+        .insert_sealed_batch(&connection_pool, 1, &[tx_result.hash])
         .await;
 
     // Create a copy of the tx filter that the mempool will use.

--- a/core/node/state_keeper/src/io/tests/tester.rs
+++ b/core/node/state_keeper/src/io/tests/tester.rs
@@ -231,7 +231,7 @@ impl Tester {
         &self,
         pool: &ConnectionPool<Core>,
         number: u32,
-        tx_results: &[TransactionExecutionResult],
+        tx_hashes: &[H256],
     ) {
         let batch_header = create_l1_batch(number);
         let mut storage = pool.connection_tagged("state_keeper").await.unwrap();
@@ -247,7 +247,7 @@ impl Tester {
             .unwrap();
         storage
             .transactions_dal()
-            .mark_txs_as_executed_in_l1_batch(batch_header.number, tx_results)
+            .mark_txs_as_executed_in_l1_batch(batch_header.number, tx_hashes)
             .await
             .unwrap();
         storage

--- a/core/node/state_keeper/src/tests/mod.rs
+++ b/core/node/state_keeper/src/tests/mod.rs
@@ -284,7 +284,7 @@ async fn pending_batch_is_applied() {
         })
         .batch_sealed_with("Batch sealed with all 3 txs", |updates| {
             assert_eq!(
-                updates.l1_batch.executed_transactions.len(),
+                updates.l1_batch.executed_transaction_hashes.len(),
                 3,
                 "There should be 3 transactions in the batch"
             );

--- a/core/node/state_keeper/src/updates/l1_batch_updates.rs
+++ b/core/node/state_keeper/src/updates/l1_batch_updates.rs
@@ -1,6 +1,6 @@
-use zksync_multivm::interface::{FinishedL1Batch, TransactionExecutionResult, VmExecutionMetrics};
+use zksync_multivm::interface::{FinishedL1Batch, VmExecutionMetrics};
 use zksync_types::{
-    priority_op_onchain_data::PriorityOpOnchainData, ExecuteTransactionCommon, L1BatchNumber,
+    priority_op_onchain_data::PriorityOpOnchainData, ExecuteTransactionCommon, L1BatchNumber, H256,
 };
 
 use crate::updates::l2_block_updates::L2BlockUpdates;
@@ -8,7 +8,7 @@ use crate::updates::l2_block_updates::L2BlockUpdates;
 #[derive(Debug)]
 pub struct L1BatchUpdates {
     pub number: L1BatchNumber,
-    pub executed_transactions: Vec<TransactionExecutionResult>,
+    pub executed_transaction_hashes: Vec<H256>,
     pub priority_ops_onchain_data: Vec<PriorityOpOnchainData>,
     pub block_execution_metrics: VmExecutionMetrics,
     pub txs_encoding_size: usize,
@@ -20,9 +20,9 @@ impl L1BatchUpdates {
     pub(crate) fn new(number: L1BatchNumber) -> Self {
         Self {
             number,
-            executed_transactions: Default::default(),
-            priority_ops_onchain_data: Default::default(),
-            block_execution_metrics: Default::default(),
+            executed_transaction_hashes: vec![],
+            priority_ops_onchain_data: vec![],
+            block_execution_metrics: VmExecutionMetrics::default(),
             txs_encoding_size: 0,
             l1_tx_count: 0,
             finished: None,
@@ -30,14 +30,23 @@ impl L1BatchUpdates {
     }
 
     pub(crate) fn extend_from_sealed_l2_block(&mut self, l2_block_updates: L2BlockUpdates) {
-        for tx in &l2_block_updates.executed_transactions {
-            if let ExecuteTransactionCommon::L1(data) = &tx.transaction.common_data {
-                let onchain_metadata = data.onchain_metadata().onchain_data;
-                self.priority_ops_onchain_data.push(onchain_metadata);
-            }
-        }
-        self.executed_transactions
-            .extend(l2_block_updates.executed_transactions);
+        let priority_ops = l2_block_updates
+            .executed_transactions
+            .iter()
+            .filter_map(|tx| {
+                if let ExecuteTransactionCommon::L1(data) = &tx.transaction.common_data {
+                    Some(data.onchain_metadata().onchain_data)
+                } else {
+                    None
+                }
+            });
+        self.priority_ops_onchain_data.extend(priority_ops);
+
+        let tx_hashes = l2_block_updates
+            .executed_transactions
+            .iter()
+            .map(|tx| tx.hash);
+        self.executed_transaction_hashes.extend(tx_hashes);
 
         self.block_execution_metrics += l2_block_updates.block_execution_metrics;
         self.txs_encoding_size += l2_block_updates.txs_encoding_size;
@@ -75,7 +84,7 @@ mod tests {
         let mut l1_batch_accumulator = L1BatchUpdates::new(L1BatchNumber(1));
         l1_batch_accumulator.extend_from_sealed_l2_block(l2_block_accumulator);
 
-        assert_eq!(l1_batch_accumulator.executed_transactions.len(), 1);
+        assert_eq!(l1_batch_accumulator.executed_transaction_hashes.len(), 1);
         assert_eq!(l1_batch_accumulator.priority_ops_onchain_data.len(), 0);
         assert_eq!(
             l1_batch_accumulator.block_execution_metrics.l2_to_l1_logs,

--- a/core/node/state_keeper/src/updates/mod.rs
+++ b/core/node/state_keeper/src/updates/mod.rs
@@ -120,7 +120,7 @@ impl UpdatesManager {
         L2BlockSealCommand {
             l1_batch_number: self.l1_batch.number,
             l2_block: self.l2_block.clone(),
-            first_tx_index: self.l1_batch.executed_transactions.len(),
+            first_tx_index: self.l1_batch.executed_transaction_hashes.len(),
             fee_account_address: self.fee_account_address,
             fee_input: self.batch_fee_input,
             base_fee_per_gas: self.base_fee_per_gas,
@@ -225,7 +225,7 @@ impl UpdatesManager {
     }
 
     pub(crate) fn pending_executed_transactions_len(&self) -> usize {
-        self.l1_batch.executed_transactions.len() + self.l2_block.executed_transactions.len()
+        self.l1_batch.executed_transaction_hashes.len() + self.l2_block.executed_transactions.len()
     }
 
     pub(crate) fn pending_l1_transactions_len(&self) -> usize {
@@ -283,7 +283,10 @@ mod tests {
         // Check that only pending state is updated.
         assert_eq!(updates_manager.pending_executed_transactions_len(), 1);
         assert_eq!(updates_manager.l2_block.executed_transactions.len(), 1);
-        assert_eq!(updates_manager.l1_batch.executed_transactions.len(), 0);
+        assert_eq!(
+            updates_manager.l1_batch.executed_transaction_hashes.len(),
+            0
+        );
 
         // Seal an L2 block.
         updates_manager.set_next_l2_block_params(L2BlockParams {
@@ -296,6 +299,9 @@ mod tests {
         // and L2 block updates are empty.
         assert_eq!(updates_manager.pending_executed_transactions_len(), 1);
         assert_eq!(updates_manager.l2_block.executed_transactions.len(), 0);
-        assert_eq!(updates_manager.l1_batch.executed_transactions.len(), 1);
+        assert_eq!(
+            updates_manager.l1_batch.executed_transaction_hashes.len(),
+            1
+        );
     }
 }

--- a/core/node/state_keeper/src/updates/mod.rs
+++ b/core/node/state_keeper/src/updates/mod.rs
@@ -1,8 +1,7 @@
 use zksync_contracts::BaseSystemContractsHashes;
 use zksync_multivm::{
     interface::{
-        storage::StorageViewCache, Call, FinishedL1Batch, L1BatchEnv, SystemEnv,
-        VmExecutionMetrics, VmExecutionResultAndLogs,
+        Call, FinishedL1Batch, L1BatchEnv, SystemEnv, VmExecutionMetrics, VmExecutionResultAndLogs,
     },
     utils::{get_batch_base_fee, StorageWritesDeduplicator},
 };
@@ -35,7 +34,6 @@ pub struct UpdatesManager {
     base_fee_per_gas: u64,
     base_system_contract_hashes: BaseSystemContractsHashes,
     protocol_version: ProtocolVersionId,
-    storage_view_cache: Option<StorageViewCache>,
     pub l1_batch: L1BatchUpdates,
     pub l2_block: L2BlockUpdates,
     pub storage_writes_deduplicator: StorageWritesDeduplicator,
@@ -68,7 +66,6 @@ impl UpdatesManager {
                 protocol_version,
             ),
             storage_writes_deduplicator: StorageWritesDeduplicator::new(),
-            storage_view_cache: None,
             pubdata_params,
             next_l2_block_params: None,
             previous_batch_protocol_version,
@@ -183,14 +180,6 @@ impl UpdatesManager {
         self.l1_batch.finished = Some(finished_batch);
 
         latency.observe();
-    }
-
-    pub fn update_storage_view_cache(&mut self, storage_view_cache: StorageViewCache) {
-        self.storage_view_cache = Some(storage_view_cache);
-    }
-
-    pub fn storage_view_cache(&self) -> Option<StorageViewCache> {
-        self.storage_view_cache.clone()
     }
 
     /// Pushes a new L2 block with the specified timestamp into this manager. The previously

--- a/core/node/vm_runner/src/tests/mod.rs
+++ b/core/node/vm_runner/src/tests/mod.rs
@@ -338,7 +338,7 @@ async fn store_l1_batches(
             .mark_l2_blocks_as_executed_in_l1_batch(l1_batch_number)
             .await?;
         conn.transactions_dal()
-            .mark_txs_as_executed_in_l1_batch(l1_batch_number, &[tx_result])
+            .mark_txs_as_executed_in_l1_batch(l1_batch_number, &[tx_result.hash])
             .await?;
 
         let metadata = create_l1_batch_metadata(l1_batch_number.0);


### PR DESCRIPTION
## What ❔

Replaces transaction execution results currently retained for the entire L1 batch in `UpdatesManager`, with transaction hashes.

## Why ❔

Storing tx execution results is unnecessary and can contribute to high RAM usage; only tx hashes are used.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.