### PR TITLE
feat(eth-sender): use last value in gas adjuster for gateway txs

### DIFF
--- a/core/node/eth_sender/src/eth_fees_oracle.rs
+++ b/core/node/eth_sender/src/eth_fees_oracle.rs
@@ -200,7 +200,7 @@ impl GasAdjusterFeesOracle {
         );
         let base_fee_per_gas = self
             .gas_adjuster
-            .get_base_fee(capped_time_in_mempool_in_l1_blocks);
+            .gateway_get_base_fee(capped_time_in_mempool_in_l1_blocks);
         self.assert_fee_is_not_zero(base_fee_per_gas, "base");
         if self.is_base_fee_exceeding_limit(base_fee_per_gas) {
             return Err(EthSenderError::ExceedMaxBaseFee);

--- a/core/node/fee_model/src/l1_gas_price/gas_adjuster/mod.rs
+++ b/core/node/fee_model/src/l1_gas_price/gas_adjuster/mod.rs
@@ -323,6 +323,13 @@ impl TxParamsProvider for GasAdjuster {
         self.calculate_price_with_formula(time_in_mempool_in_l1_blocks, median)
     }
 
+    fn gateway_get_base_fee(&self, time_in_mempool_in_l1_blocks: u32) -> u64 {
+        // for gateway using median doesn't make sense since price doesn't change frequently (once per batch).
+        // to prevent tx from being stuck for a long time we are using last value instead.
+        let last = self.base_fee_statistics.last_added_value();
+        self.calculate_price_with_formula(time_in_mempool_in_l1_blocks, last)
+    }
+
     fn get_next_block_minimal_base_fee(&self) -> u64 {
         let last_block_base_fee = self.base_fee_statistics.last_added_value();
 
@@ -380,15 +387,13 @@ impl TxParamsProvider for GasAdjuster {
     }
 
     fn get_gateway_l2_pubdata_price(&self, time_in_mempool_in_l1_blocks: u32) -> u64 {
-        let median = self.l2_pubdata_price_statistics.median().as_u64();
-        METRICS.median_l2_pubdata_price.set(median);
-        self.calculate_price_with_formula(time_in_mempool_in_l1_blocks, median)
+        let last = self.l2_pubdata_price_statistics.last_added_value().as_u64();
+        self.calculate_price_with_formula(time_in_mempool_in_l1_blocks, last)
     }
 
     fn get_gateway_price_per_pubdata(&self, time_in_mempool_in_l1_blocks: u32) -> u64 {
-        let median = self.gas_per_pubdata_price_statistic.median();
-        METRICS.median_gas_per_pubdata_price.set(median);
-        self.calculate_price_with_formula(time_in_mempool_in_l1_blocks, median)
+        let last = self.gas_per_pubdata_price_statistic.last_added_value();
+        self.calculate_price_with_formula(time_in_mempool_in_l1_blocks, last)
     }
 
     fn get_parameter_b(&self) -> f64 {

--- a/core/node/fee_model/src/l1_gas_price/mod.rs
+++ b/core/node/fee_model/src/l1_gas_price/mod.rs
@@ -18,6 +18,9 @@ pub trait TxParamsProvider: fmt::Debug + 'static + Send + Sync {
     /// Returns the recommended `max_fee_per_gas` value (EIP1559).
     fn get_base_fee(&self, time_in_mempool_in_l1_blocks: u32) -> u64;
 
+    /// Returns the recommended `max_fee_per_gas` value if using gateway.
+    fn gateway_get_base_fee(&self, time_in_mempool_in_l1_blocks: u32) -> u64;
+
     /// Returns the recommended `max_priority_fee_per_gas` value (EIP1559).
     fn get_priority_fee(&self) -> u64;
 


### PR DESCRIPTION
## What ❔

For gateway using median doesn't make sense since price doesn't change frequently (once per batch).

## Why ❔

to prevent tx from being stuck for a long time we are using last value instead.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
