### PR TITLE
docs: Fix [gas_adjuster] doc link

### DIFF
--- a/docs/src/guides/advanced/07_fee_model.md
+++ b/docs/src/guides/advanced/07_fee_model.md
@@ -239,9 +239,9 @@ There are a few reasons why refunds might be 'larger' on ZKsync (i.e., why we mi
 - We have to account for larger fluctuations in the L1 gas price (using gas_price_scale_factor mentioned earlier) - this
   might cause the estimation to be significantly higher, especially when the L1 gas price is already high, as it then
   impacts the amount of gas used by pubdata.
-
+  
 [gas_adjuster]:
-  https://github.com/matter-labs/zksync-era/blob/main/core/lib/zksync_core/src/l1_gas_price/gas_adjuster/mod.rs#L30
+  https://github.com/matter-labs/zksync-era/blob/main/core/node/fee_model/src/l1_gas_price/gas_adjuster/mod.rs#L50
   'gas_adjuster'
 [get_txs_fee_in_wei]:
   https://github.com/matter-labs/zksync-era/blob/714a8905d407de36a906a4b6d464ec2cab6eb3e8/core/lib/zksync_core/src/api_server/tx_sender/mod.rs#L656


### PR DESCRIPTION
## What ❔

This PR updates the `[gas_adjuster]` reference link in the documentation.  
The link now points to the correct file path and line number:  
`core/node/fee_model/src/l1_gas_price/gas_adjuster/mod.rs#L50`  
Previously, it pointed to an incorrect location in the old directory.

## Why ❔

The previous link was outdated and did not match the actual location of the `GasAdjuster` implementation.  
Updating this link improves the accuracy and usability of the documentation, making it easier for developers and external contributors to find the relevant code and understand the fee model logic.

## Is this a breaking change?
- [x] No

## Operational changes

No operational changes.  
This update only affects documentation and does not introduce any config changes, new flags, or script modifications.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.