### PR TITLE
fix(config): Fix parsing null values with units + other config fixes

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -8998,8 +8998,9 @@ dependencies = [
 
 [[package]]
 name = "smart-config"
-version = "0.1.0-pre"
-source = "git+https://github.com/matter-labs/smart-config.git?rev=992f72e6540a116bf91bdc03151bf0067834dff0#992f72e6540a116bf91bdc03151bf0067834dff0"
+version = "0.2.0-pre"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "720d0d1a5fad745fb5e8ac665631528556c9b9cea35433b4949d50cd0cfc8bbb"
 dependencies = [
  "anyhow",
  "compile-fmt",
@@ -9014,8 +9015,9 @@ dependencies = [
 
 [[package]]
 name = "smart-config-commands"
-version = "0.1.0-pre"
-source = "git+https://github.com/matter-labs/smart-config.git?rev=992f72e6540a116bf91bdc03151bf0067834dff0#992f72e6540a116bf91bdc03151bf0067834dff0"
+version = "0.2.0-pre"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaa22d9fa376e806f965985b63025a81d78f536e2c934e80903ee8b5b1603f52"
 dependencies = [
  "anstream",
  "anstyle",
@@ -9026,8 +9028,9 @@ dependencies = [
 
 [[package]]
 name = "smart-config-derive"
-version = "0.1.0-pre"
-source = "git+https://github.com/matter-labs/smart-config.git?rev=992f72e6540a116bf91bdc03151bf0067834dff0#992f72e6540a116bf91bdc03151bf0067834dff0"
+version = "0.2.0-pre"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5fede39e20d50047e6eb1aee008bd44db17e6a851b1e1b00bce117bdf74d50"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -217,8 +217,8 @@ trybuild = "1.0"
 # "Internal" dependencies
 vise = "0.3.1"
 vise-exporter = "0.3.1"
-smart-config = { version = "=0.1.0-pre", git = "https://github.com/matter-labs/smart-config.git", rev = "992f72e6540a116bf91bdc03151bf0067834dff0" }
-smart-config-commands = { version = "=0.1.0-pre", git = "https://github.com/matter-labs/smart-config.git", rev = "992f72e6540a116bf91bdc03151bf0067834dff0" }
+smart-config = "=0.2.0-pre"
+smart-config-commands = "=0.2.0-pre"
 foundry-compilers = { version = "0.11.6", git = "https://github.com/Moonsong-Labs/compilers.git", rev = "7c69695e5c75451f158dd2456bf8c94a7492ea0b" }
 
 # DA clients' dependencies

--- a/core/lib/config/src/configs/api.rs
+++ b/core/lib/config/src/configs/api.rs
@@ -582,6 +582,20 @@ mod tests {
     }
 
     #[test]
+    fn parsing_null_time_limits() {
+        let yaml = r#"
+          port: 3071
+          slow_time_limit_ms: null
+          hard_time_limit_ms: null
+        "#;
+        let yaml = Yaml::new("test.yml", serde_yaml::from_str(yaml).unwrap()).unwrap();
+
+        let config = test::<HealthCheckConfig>(yaml).unwrap();
+        assert_eq!(config.slow_time_limit, None);
+        assert_eq!(config.hard_time_limit, None);
+    }
+
+    #[test]
     fn parsing_max_response_overrides() {
         let yaml = r#"
           max_response_body_size_overrides:

--- a/core/lib/config/src/configs/consensus.rs
+++ b/core/lib/config/src/configs/consensus.rs
@@ -7,7 +7,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 use smart_config::{
     de,
-    de::{DeserializeContext, Entries, Qualified, Serde, WellKnown},
+    de::{DeserializeContext, Entries, Qualified, Serde, WellKnown, WellKnownOption},
     metadata::{BasicTypes, ParamMetadata, SizeUnit, TypeDescription},
     value::SecretString,
     ByteSize, DescribeConfig, DeserializeConfig, ErrorWithOrigin,
@@ -27,6 +27,8 @@ impl WellKnown for ValidatorPublicKey {
     const DE: Self::Deserializer =
         Qualified::new(Serde![str], "has `validator:public:bls12_381:` prefix");
 }
+
+impl WellKnownOption for ValidatorPublicKey {}
 
 /// `zksync_consensus_crypto::TextFmt` representation of `zksync_consensus_roles::node::PublicKey`.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]

--- a/core/lib/config/src/configs/contracts/chain.rs
+++ b/core/lib/config/src/configs/contracts/chain.rs
@@ -1,8 +1,4 @@
-use serde::{Deserialize, Serialize};
-use smart_config::{
-    de::{Serde, WellKnown},
-    ConfigSchema, DescribeConfig, DeserializeConfig,
-};
+use smart_config::{ConfigSchema, DescribeConfig, DeserializeConfig};
 use zksync_basic_types::{Address, H256};
 
 use super::{
@@ -101,26 +97,25 @@ impl L2ContractsConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, DescribeConfig, DeserializeConfig)]
+#[config(derive(Default))]
 pub struct Bridge {
-    #[serde(alias = "proxy_addr")]
+    /// Address of the bridge on L1.
+    #[config(alias = "proxy_addr")]
     pub l1_address: Option<Address>,
-    #[serde(alias = "addr")]
+    /// Address of the bridge on L2.
+    #[config(alias = "addr")]
     pub l2_address: Option<Address>,
 }
 
-impl WellKnown for Bridge {
-    type Deserializer = Serde![object];
-    const DE: Self::Deserializer = Serde![object];
-}
-
 #[derive(Debug, Clone, PartialEq, DescribeConfig, DeserializeConfig)]
+#[config(derive(Default))]
 pub struct BridgesConfig {
-    #[config(default, alias = "shared_bridge")]
+    #[config(nest, alias = "shared_bridge")]
     pub shared: Bridge,
-    #[config(default, alias = "erc20_bridge")]
+    #[config(nest, alias = "erc20_bridge")]
     pub erc20: Bridge,
-    #[config(default, alias = "weth_bridge")]
+    #[config(nest, alias = "weth_bridge")]
     pub weth: Bridge,
 }
 

--- a/core/lib/config/src/configs/da_client/avail.rs
+++ b/core/lib/config/src/configs/da_client/avail.rs
@@ -34,12 +34,17 @@ pub struct AvailDefaultConfig {
     #[serde(default = "AvailDefaultConfig::default_dispatch_timeout")]
     pub dispatch_timeout: Duration,
     #[config(default_t = 5)]
+    #[serde(default = "AvailDefaultConfig::default_max_blocks_to_look_back")]
     pub max_blocks_to_look_back: usize,
 }
 
 impl AvailDefaultConfig {
     const fn default_dispatch_timeout() -> Duration {
         Duration::from_secs(180)
+    }
+
+    const fn default_max_blocks_to_look_back() -> usize {
+        5
     }
 }
 

--- a/core/lib/config/src/configs/genesis.rs
+++ b/core/lib/config/src/configs/genesis.rs
@@ -10,7 +10,7 @@ use serde::{
     Deserialize, Serialize,
 };
 use smart_config::{
-    de::{DeserializeContext, DeserializeParam, WellKnown},
+    de::{DeserializeContext, DeserializeParam, WellKnown, WellKnownOption},
     metadata::{BasicTypes, ParamMetadata},
     DescribeConfig, DeserializeConfig, ErrorWithOrigin,
 };
@@ -219,6 +219,8 @@ impl WellKnown for GenesisConfig {
     type Deserializer = GenesisConfigDeserializer;
     const DE: Self::Deserializer = GenesisConfigDeserializer;
 }
+
+impl WellKnownOption for GenesisConfig {}
 
 #[derive(Debug, Clone, PartialEq, DescribeConfig, DeserializeConfig)]
 pub struct GenesisConfigWrapper {

--- a/core/lib/config/src/utils.rs
+++ b/core/lib/config/src/utils.rs
@@ -18,7 +18,7 @@ where
     const EXPECTING: BasicTypes = <T::Deserializer>::EXPECTING.or(De::EXPECTING);
 
     fn describe(&self, description: &mut TypeDescription) {
-        self.0.describe(description);
+        T::DE.describe(description);
         description.set_fallback(&self.0);
     }
 

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -6474,8 +6474,9 @@ dependencies = [
 
 [[package]]
 name = "smart-config"
-version = "0.1.0-pre"
-source = "git+https://github.com/matter-labs/smart-config.git?rev=992f72e6540a116bf91bdc03151bf0067834dff0#992f72e6540a116bf91bdc03151bf0067834dff0"
+version = "0.2.0-pre"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "720d0d1a5fad745fb5e8ac665631528556c9b9cea35433b4949d50cd0cfc8bbb"
 dependencies = [
  "anyhow",
  "compile-fmt",
@@ -6490,8 +6491,9 @@ dependencies = [
 
 [[package]]
 name = "smart-config-derive"
-version = "0.1.0-pre"
-source = "git+https://github.com/matter-labs/smart-config.git?rev=992f72e6540a116bf91bdc03151bf0067834dff0#992f72e6540a116bf91bdc03151bf0067834dff0"
+version = "0.2.0-pre"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5fede39e20d50047e6eb1aee008bd44db17e6a851b1e1b00bce117bdf74d50"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -65,7 +65,7 @@ tracing-subscriber = "0.3"
 tracing-test = "0.2.5"
 url = "2.5.2"
 vise = "0.3.1"
-smart-config = { version = "=0.1.0-pre", git = "https://github.com/matter-labs/smart-config.git", rev = "992f72e6540a116bf91bdc03151bf0067834dff0" }
+smart-config = "=0.2.0-pre"
 
 circuit_definitions = "=0.152.3"
 circuit_sequencer_api = "=0.152.3"

--- a/prover/crates/bin/prover_autoscaler/src/config.rs
+++ b/prover/crates/bin/prover_autoscaler/src/config.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, hash::Hash, time::Duration};
 
 use serde::{Deserialize, Serialize};
 use smart_config::{
-    de::{Serde, WellKnown},
+    de::{Serde, WellKnown, WellKnownOption},
     metadata::TimeUnit,
     DescribeConfig, DeserializeConfig,
 };
@@ -18,6 +18,8 @@ impl WellKnown for NamespaceName {
     type Deserializer = Serde![str];
     const DE: Self::Deserializer = Serde![str];
 }
+
+impl WellKnownOption for NamespaceName {}
 
 impl WellKnown for ClusterName {
     type Deserializer = Serde![str];


### PR DESCRIPTION
## What ❔

- Fixes parsing null values with units, such as `slow_time_limit_ms: null`.
- Updates `smart-config` to a published version (0.2.0-pre).
- Adds a missing default for the `max_blocks_to_look_back` param.

## Why ❔

We want existing Era configs to be parseable.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.