### PR TITLE
fix(consensus): Handle custom reverts on VM calls

### DIFF
--- a/core/node/consensus/src/registry/tests.rs
+++ b/core/node/consensus/src/registry/tests.rs
@@ -149,7 +149,16 @@ async fn test_pending_validator_committee() {
             .collect();
         let schedule = validator::Schedule::new(validator_infos, leader_selection).unwrap();
 
-        // *Change the activation delay so it's not immediate.*
+        // Read the *pending* validator schedule using the vm before doing anything.
+        // It should return `None`.
+        let block_num = node.last_block();
+        assert!(registry
+            .get_pending_validator_schedule(ctx, block_num)
+            .await
+            .unwrap()
+            .is_none());
+
+        // *Change the activation delay so it's not immediate*
         txs.push(testonly::make_tx(
             account,
             registry_addr,

--- a/core/node/consensus/src/vm.rs
+++ b/core/node/consensus/src/vm.rs
@@ -116,10 +116,23 @@ impl VM {
             }
             // If the execution was reverted by a general revert reason (i.e. the contract called revert()),
             // we can extract the revert reason from the output.
-            // We ignore the data from the revert reason, but we can decode it if necessary.
             ExecutionResult::Revert {
-                output: VmRevertReason::General { msg, .. },
-            } => Ok(VMResult::Revert { revert_reason: msg }),
+                output: VmRevertReason::General { msg, data },
+            } => Ok(VMResult::Revert {
+                revert_reason: format!("General revert:\nmsg: {msg}\ndata: {data:?}"),
+            }),
+            // If the execution was reverted with a custom revert reason, it will appear as Unknown.
+            ExecutionResult::Revert {
+                output:
+                    VmRevertReason::Unknown {
+                        function_selector,
+                        data,
+                    },
+            } => Ok(VMResult::Revert {
+                revert_reason: format!(
+                    "Custom revert:\nfunction_selector: {function_selector:?}\ndata: {data:?}"
+                ),
+            }),
             // In all other cases, we just return the error.
             other => Err(anyhow::format_err!("Unsuccessful execution: {other:?}").into()),
         }


### PR DESCRIPTION
## What ❔

VM calls from the consensus crate were erroring on reverts with custom Error types. This PR fixes that by handling them like general reverts.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

None

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
