### PR TITLE
feat: SIGTERM handling in circuit-prover & compressor

### DIFF
--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -8860,6 +8860,7 @@ version = "21.1.0"
 dependencies = [
  "anyhow",
  "clap 4.5.37",
+ "ctrlc",
  "shivini",
  "tokio",
  "tokio-util",
@@ -9290,6 +9291,7 @@ version = "21.1.0"
 dependencies = [
  "anyhow",
  "clap 4.5.37",
+ "ctrlc",
  "proof-compression",
  "reqwest 0.12.9",
  "tokio",

--- a/prover/crates/bin/circuit_prover/Cargo.toml
+++ b/prover/crates/bin/circuit_prover/Cargo.toml
@@ -17,6 +17,7 @@ tokio-util.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
 clap = { workspace = true, features = ["derive"] }
+ctrlc = { workspace = true, features = ["termination"] }
 
 zksync_config = { workspace = true, features = ["observability_ext"] }
 zksync_object_store.workspace = true

--- a/prover/crates/bin/proof_fri_compressor/Cargo.toml
+++ b/prover/crates/bin/proof_fri_compressor/Cargo.toml
@@ -30,3 +30,4 @@ tokio = { workspace = true, features = ["time", "macros"] }
 tokio-util.workspace = true
 clap = { workspace = true, features = ["derive"] }
 reqwest = { workspace = true, features = ["blocking"] }
+ctrlc = { workspace = true, features = ["termination"] }


### PR DESCRIPTION
## What ❔
tokio::signal::ctrl_c() doesn't handle SIGTERM. It's replaced with ctrlc crate functionality. 

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔
SIGTERM is not handled in circuit-prover & compressor resulting in immediate killing of binary without graceful shutdown and further requeuing of stuck jobs.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
