### PR TITLE
fix(prover): Fixed loading setup for Compressor service 

### DIFF
--- a/prover/crates/lib/keystore/src/compressor.rs
+++ b/prover/crates/lib/keystore/src/compressor.rs
@@ -37,13 +37,18 @@ pub struct PlonkSetupData {
 }
 
 pub struct FflonkSetupData {
-    pub compression_mode1_setup_data: OnceLock<anyhow::Result<CompressionSetupData<CompressionMode1>>>,
-    pub compression_mode2_setup_data: OnceLock<anyhow::Result<CompressionSetupData<CompressionMode2>>>,
-    pub compression_mode3_setup_data: OnceLock<anyhow::Result<CompressionSetupData<CompressionMode3>>>,
-    pub compression_mode4_setup_data: OnceLock<anyhow::Result<CompressionSetupData<CompressionMode4>>>,
+    pub compression_mode1_setup_data:
+        OnceLock<anyhow::Result<CompressionSetupData<CompressionMode1>>>,
+    pub compression_mode2_setup_data:
+        OnceLock<anyhow::Result<CompressionSetupData<CompressionMode2>>>,
+    pub compression_mode3_setup_data:
+        OnceLock<anyhow::Result<CompressionSetupData<CompressionMode3>>>,
+    pub compression_mode4_setup_data:
+        OnceLock<anyhow::Result<CompressionSetupData<CompressionMode4>>>,
     pub compression_mode5_for_wrapper_setup_data:
         OnceLock<anyhow::Result<CompressionSetupData<CompressionMode5ForWrapper>>>,
-    pub fflonk_snark_wrapper_setup_data: OnceLock<anyhow::Result<SnarkWrapperSetupData<FflonkSnarkWrapper>>>,
+    pub fflonk_snark_wrapper_setup_data:
+        OnceLock<anyhow::Result<SnarkWrapperSetupData<FflonkSnarkWrapper>>>,
 }
 
 pub struct CompressorSetupData {
@@ -416,8 +421,7 @@ impl CompressorBlobStorage for Keystore {
     fn get_compression_mode1_setup_data(
         &self,
     ) -> anyhow::Result<&CompressionSetupData<CompressionMode1>> {
-        self
-            .setup_data_cache_proof_compressor
+        self.setup_data_cache_proof_compressor
             .fflonk_setup_data
             .compression_mode1_setup_data
             .get_or_init(|| {
@@ -431,8 +435,7 @@ impl CompressorBlobStorage for Keystore {
     fn get_compression_mode2_setup_data(
         &self,
     ) -> anyhow::Result<&CompressionSetupData<CompressionMode2>> {
-        self
-            .setup_data_cache_proof_compressor
+        self.setup_data_cache_proof_compressor
             .fflonk_setup_data
             .compression_mode2_setup_data
             .get_or_init(|| {
@@ -446,8 +449,7 @@ impl CompressorBlobStorage for Keystore {
     fn get_compression_mode3_setup_data(
         &self,
     ) -> anyhow::Result<&CompressionSetupData<CompressionMode3>> {
-        self
-            .setup_data_cache_proof_compressor
+        self.setup_data_cache_proof_compressor
             .fflonk_setup_data
             .compression_mode3_setup_data
             .get_or_init(|| {
@@ -461,8 +463,7 @@ impl CompressorBlobStorage for Keystore {
     fn get_compression_mode4_setup_data(
         &self,
     ) -> anyhow::Result<&CompressionSetupData<CompressionMode4>> {
-        self
-            .setup_data_cache_proof_compressor
+        self.setup_data_cache_proof_compressor
             .fflonk_setup_data
             .compression_mode4_setup_data
             .get_or_init(|| {
@@ -476,8 +477,7 @@ impl CompressorBlobStorage for Keystore {
     fn get_compression_mode5_for_wrapper_setup_data(
         &self,
     ) -> anyhow::Result<&CompressionSetupData<CompressionMode5ForWrapper>> {
-        self
-            .setup_data_cache_proof_compressor
+        self.setup_data_cache_proof_compressor
             .fflonk_setup_data
             .compression_mode5_for_wrapper_setup_data
             .get_or_init(|| {
@@ -486,15 +486,17 @@ impl CompressorBlobStorage for Keystore {
             })
             .as_ref()
             .map_err(|e| {
-                anyhow::anyhow!("Error loading compression mode 5 for wrapper setup data: {}", e)
+                anyhow::anyhow!(
+                    "Error loading compression mode 5 for wrapper setup data: {}",
+                    e
+                )
             })
     }
 
     fn get_compression_mode1_for_wrapper_setup_data(
         &self,
     ) -> anyhow::Result<&CompressionSetupData<CompressionMode1ForWrapper>> {
-        self
-            .setup_data_cache_proof_compressor
+        self.setup_data_cache_proof_compressor
             .plonk_setup_data
             .compression_mode1_for_wrapper_setup_data
             .get_or_init(|| {
@@ -503,7 +505,10 @@ impl CompressorBlobStorage for Keystore {
             })
             .as_ref()
             .map_err(|e| {
-                anyhow::anyhow!("Error loading compression mode 1 for wrapper setup data: {}", e)
+                anyhow::anyhow!(
+                    "Error loading compression mode 1 for wrapper setup data: {}",
+                    e
+                )
             })
     }
 
@@ -517,8 +522,7 @@ impl CompressorBlobStorage for Keystore {
     fn get_fflonk_snark_wrapper_setup_data(
         &self,
     ) -> anyhow::Result<&SnarkWrapperSetupData<FflonkSnarkWrapper>> {
-        self
-            .setup_data_cache_proof_compressor
+        self.setup_data_cache_proof_compressor
             .fflonk_setup_data
             .fflonk_snark_wrapper_setup_data
             .get_or_init(|| {
@@ -526,9 +530,7 @@ impl CompressorBlobStorage for Keystore {
                     .context("Failed to load Fflonk Snark Wrapper setup data")
             })
             .as_ref()
-            .map_err(|e| {
-                anyhow::anyhow!("Error loading Fflonk Snark Wrapper setup data: {}", e)
-            })
+            .map_err(|e| anyhow::anyhow!("Error loading Fflonk Snark Wrapper setup data: {}", e))
     }
 }
 

--- a/prover/crates/lib/keystore/src/compressor.rs
+++ b/prover/crates/lib/keystore/src/compressor.rs
@@ -420,6 +420,7 @@ impl CompressorBlobStorage for Keystore {
             .setup_data_cache_proof_compressor
             .fflonk_setup_data
             .compression_mode1_setup_data;
+        setup_data_cache.wait();
         if let Some(setup_data) = setup_data_cache.get() {
             Ok(setup_data)
         } else {
@@ -446,6 +447,7 @@ impl CompressorBlobStorage for Keystore {
             .setup_data_cache_proof_compressor
             .fflonk_setup_data
             .compression_mode2_setup_data;
+        setup_data_cache.wait();
         if let Some(setup_data) = setup_data_cache.get() {
             Ok(setup_data)
         } else {
@@ -472,6 +474,7 @@ impl CompressorBlobStorage for Keystore {
             .setup_data_cache_proof_compressor
             .fflonk_setup_data
             .compression_mode3_setup_data;
+        setup_data_cache.wait();
         if let Some(setup_data) = setup_data_cache.get() {
             Ok(setup_data)
         } else {
@@ -498,6 +501,7 @@ impl CompressorBlobStorage for Keystore {
             .setup_data_cache_proof_compressor
             .fflonk_setup_data
             .compression_mode4_setup_data;
+        setup_data_cache.wait();
         if let Some(setup_data) = setup_data_cache.get() {
             Ok(setup_data)
         } else {
@@ -524,6 +528,7 @@ impl CompressorBlobStorage for Keystore {
             .setup_data_cache_proof_compressor
             .fflonk_setup_data
             .compression_mode5_for_wrapper_setup_data;
+        setup_data_cache.wait();
         if let Some(setup_data) = setup_data_cache.get() {
             Ok(setup_data)
         } else {
@@ -552,6 +557,7 @@ impl CompressorBlobStorage for Keystore {
             .setup_data_cache_proof_compressor
             .plonk_setup_data
             .compression_mode1_for_wrapper_setup_data;
+        setup_data_cache.wait();
         if let Some(setup_data) = setup_data_cache.get() {
             Ok(setup_data)
         } else {
@@ -587,6 +593,7 @@ impl CompressorBlobStorage for Keystore {
             .setup_data_cache_proof_compressor
             .fflonk_setup_data
             .fflonk_snark_wrapper_setup_data;
+        setup_data_cache.wait();
         if let Some(setup_data) = setup_data_cache.get() {
             Ok(setup_data)
         } else {

--- a/prover/crates/lib/keystore/src/compressor.rs
+++ b/prover/crates/lib/keystore/src/compressor.rs
@@ -32,18 +32,18 @@ const COMPACT_CRS_ENV_VAR: &str = "COMPACT_CRS_FILE";
 
 pub struct PlonkSetupData {
     pub compression_mode1_for_wrapper_setup_data:
-        OnceLock<CompressionSetupData<CompressionMode1ForWrapper>>,
+        OnceLock<anyhow::Result<CompressionSetupData<CompressionMode1ForWrapper>>>,
     // We can't use cache for Plonk setup data so we load it in-place
 }
 
 pub struct FflonkSetupData {
-    pub compression_mode1_setup_data: OnceLock<CompressionSetupData<CompressionMode1>>,
-    pub compression_mode2_setup_data: OnceLock<CompressionSetupData<CompressionMode2>>,
-    pub compression_mode3_setup_data: OnceLock<CompressionSetupData<CompressionMode3>>,
-    pub compression_mode4_setup_data: OnceLock<CompressionSetupData<CompressionMode4>>,
+    pub compression_mode1_setup_data: OnceLock<anyhow::Result<CompressionSetupData<CompressionMode1>>>,
+    pub compression_mode2_setup_data: OnceLock<anyhow::Result<CompressionSetupData<CompressionMode2>>>,
+    pub compression_mode3_setup_data: OnceLock<anyhow::Result<CompressionSetupData<CompressionMode3>>>,
+    pub compression_mode4_setup_data: OnceLock<anyhow::Result<CompressionSetupData<CompressionMode4>>>,
     pub compression_mode5_for_wrapper_setup_data:
-        OnceLock<CompressionSetupData<CompressionMode5ForWrapper>>,
-    pub fflonk_snark_wrapper_setup_data: OnceLock<SnarkWrapperSetupData<FflonkSnarkWrapper>>,
+        OnceLock<anyhow::Result<CompressionSetupData<CompressionMode5ForWrapper>>>,
+    pub fflonk_snark_wrapper_setup_data: OnceLock<anyhow::Result<SnarkWrapperSetupData<FflonkSnarkWrapper>>>,
 }
 
 pub struct CompressorSetupData {
@@ -304,7 +304,7 @@ fn load_compression_mode1_setup_data(keystore: &Arc<Keystore>) {
             .get_or_init(|| {
                 keystore
                     .load_compression_setup_data::<CompressionMode1>()
-                    .expect("Failed to load compression mode 1 setup data")
+                    .context("Failed to load compression mode 1 setup data")
             });
     });
 }
@@ -319,7 +319,7 @@ fn load_compression_mode2_setup_data(keystore: &Arc<Keystore>) {
             .get_or_init(|| {
                 keystore
                     .load_compression_setup_data::<CompressionMode2>()
-                    .expect("Failed to load compression mode 2 setup data")
+                    .context("Failed to load compression mode 2 setup data")
             });
     });
 }
@@ -334,7 +334,7 @@ fn load_compression_mode3_setup_data(keystore: &Arc<Keystore>) {
             .get_or_init(|| {
                 keystore
                     .load_compression_setup_data::<CompressionMode3>()
-                    .expect("Failed to load compression mode 3 setup data")
+                    .context("Failed to load compression mode 3 setup data")
             });
     });
 }
@@ -349,7 +349,7 @@ fn load_compression_mode4_setup_data(keystore: &Arc<Keystore>) {
             .get_or_init(|| {
                 keystore
                     .load_compression_setup_data::<CompressionMode4>()
-                    .expect("Failed to load compression mode 4 setup data")
+                    .context("Failed to load compression mode 4 setup data")
             });
     });
 }
@@ -364,7 +364,7 @@ fn load_compression_mode5_for_wrapper_setup_data(keystore: &Arc<Keystore>) {
             .get_or_init(|| {
                 keystore
                     .load_compression_setup_data::<CompressionMode5ForWrapper>()
-                    .expect("Failed to load compression mode 5 for wrapper setup data")
+                    .context("Failed to load compression mode 5 for wrapper setup data")
             });
     });
 }
@@ -379,7 +379,7 @@ fn load_compression_mode1_for_wrapper_setup_data(keystore: &Arc<Keystore>) {
             .get_or_init(|| {
                 keystore
                     .load_compression_setup_data::<CompressionMode1ForWrapper>()
-                    .expect("Failed to load compression mode 1 for wrapper setup data")
+                    .context("Failed to load compression mode 1 for wrapper setup data")
             });
     });
 }
@@ -394,7 +394,7 @@ fn load_fflonk_snark_wrapper_setup_data(keystore: &Arc<Keystore>) {
             .get_or_init(|| {
                 keystore
                     .load_snark_wrapper_setup_data::<FflonkSnarkWrapper>()
-                    .expect("Failed to load Fflonk Snark Wrapper setup data")
+                    .context("Failed to load Fflonk Snark Wrapper setup data")
             });
     });
 }
@@ -416,167 +416,95 @@ impl CompressorBlobStorage for Keystore {
     fn get_compression_mode1_setup_data(
         &self,
     ) -> anyhow::Result<&CompressionSetupData<CompressionMode1>> {
-        let setup_data_cache = &self
+        self
             .setup_data_cache_proof_compressor
             .fflonk_setup_data
-            .compression_mode1_setup_data;
-        setup_data_cache.wait();
-        if let Some(setup_data) = setup_data_cache.get() {
-            Ok(setup_data)
-        } else {
-            let setup_data = self
-                .load_compression_setup_data::<CompressionMode1>()
-                .context("Failed to load compression mode 1 setup data")?;
-            setup_data_cache.set(setup_data).map_err(|_| {
-                anyhow::anyhow!("Compression mode 1 setup data is already initialized in cache")
-            })?;
-            if let Some(setup_data) = setup_data_cache.get() {
-                Ok(setup_data)
-            } else {
-                Err(anyhow::anyhow!(
-                    "Compression mode 1 setup data not found in cache"
-                ))
-            }
-        }
+            .compression_mode1_setup_data
+            .get_or_init(|| {
+                self.load_compression_setup_data::<CompressionMode1>()
+                    .context("Failed to load compression mode 1 setup data")
+            })
+            .as_ref()
+            .map_err(|e| anyhow::anyhow!("Error loading compression mode 1 setup data: {}", e))
     }
 
     fn get_compression_mode2_setup_data(
         &self,
     ) -> anyhow::Result<&CompressionSetupData<CompressionMode2>> {
-        let setup_data_cache = &self
+        self
             .setup_data_cache_proof_compressor
             .fflonk_setup_data
-            .compression_mode2_setup_data;
-        setup_data_cache.wait();
-        if let Some(setup_data) = setup_data_cache.get() {
-            Ok(setup_data)
-        } else {
-            let setup_data = self
-                .load_compression_setup_data::<CompressionMode2>()
-                .context("Failed to load compression mode 2 setup data")?;
-            setup_data_cache.set(setup_data).map_err(|_| {
-                anyhow::anyhow!("Compression mode 2 setup data is already initialized in cache")
-            })?;
-            if let Some(setup_data) = setup_data_cache.get() {
-                Ok(setup_data)
-            } else {
-                Err(anyhow::anyhow!(
-                    "Compression mode 2 setup data not found in cache"
-                ))
-            }
-        }
+            .compression_mode2_setup_data
+            .get_or_init(|| {
+                self.load_compression_setup_data::<CompressionMode2>()
+                    .context("Failed to load compression mode 2 setup data")
+            })
+            .as_ref()
+            .map_err(|e| anyhow::anyhow!("Error loading compression mode 2 setup data: {}", e))
     }
 
     fn get_compression_mode3_setup_data(
         &self,
     ) -> anyhow::Result<&CompressionSetupData<CompressionMode3>> {
-        let setup_data_cache = &self
+        self
             .setup_data_cache_proof_compressor
             .fflonk_setup_data
-            .compression_mode3_setup_data;
-        setup_data_cache.wait();
-        if let Some(setup_data) = setup_data_cache.get() {
-            Ok(setup_data)
-        } else {
-            let setup_data = self
-                .load_compression_setup_data::<CompressionMode3>()
-                .context("Failed to load compression mode 3 setup data")?;
-            setup_data_cache.set(setup_data).map_err(|_| {
-                anyhow::anyhow!("Compression mode 3 setup data is already initialized in cache")
-            })?;
-            if let Some(setup_data) = setup_data_cache.get() {
-                Ok(setup_data)
-            } else {
-                Err(anyhow::anyhow!(
-                    "Compression mode 3 setup data not found in cache"
-                ))
-            }
-        }
+            .compression_mode3_setup_data
+            .get_or_init(|| {
+                self.load_compression_setup_data::<CompressionMode3>()
+                    .context("Failed to load compression mode 3 setup data")
+            })
+            .as_ref()
+            .map_err(|e| anyhow::anyhow!("Error loading compression mode 3 setup data: {}", e))
     }
 
     fn get_compression_mode4_setup_data(
         &self,
     ) -> anyhow::Result<&CompressionSetupData<CompressionMode4>> {
-        let setup_data_cache = &self
+        self
             .setup_data_cache_proof_compressor
             .fflonk_setup_data
-            .compression_mode4_setup_data;
-        setup_data_cache.wait();
-        if let Some(setup_data) = setup_data_cache.get() {
-            Ok(setup_data)
-        } else {
-            let setup_data = self
-                .load_compression_setup_data::<CompressionMode4>()
-                .context("Failed to load compression mode 4 setup data")?;
-            setup_data_cache.set(setup_data).map_err(|_| {
-                anyhow::anyhow!("Compression mode 4 setup data is already initialized in cache")
-            })?;
-            if let Some(setup_data) = setup_data_cache.get() {
-                Ok(setup_data)
-            } else {
-                Err(anyhow::anyhow!(
-                    "Compression mode 4 setup data not found in cache"
-                ))
-            }
-        }
+            .compression_mode4_setup_data
+            .get_or_init(|| {
+                self.load_compression_setup_data::<CompressionMode4>()
+                    .context("Failed to load compression mode 4 setup data")
+            })
+            .as_ref()
+            .map_err(|e| anyhow::anyhow!("Error loading compression mode 4 setup data: {}", e))
     }
 
     fn get_compression_mode5_for_wrapper_setup_data(
         &self,
     ) -> anyhow::Result<&CompressionSetupData<CompressionMode5ForWrapper>> {
-        let setup_data_cache = &self
+        self
             .setup_data_cache_proof_compressor
             .fflonk_setup_data
-            .compression_mode5_for_wrapper_setup_data;
-        setup_data_cache.wait();
-        if let Some(setup_data) = setup_data_cache.get() {
-            Ok(setup_data)
-        } else {
-            let setup_data = self
-                .load_compression_setup_data::<CompressionMode5ForWrapper>()
-                .context("Failed to load compression mode 5 for wrapper setup data")?;
-            setup_data_cache.set(setup_data).map_err(|_| {
-                anyhow::anyhow!(
-                    "Compression mode 5 for wrapper setup data is already initialized in cache"
-                )
-            })?;
-            if let Some(setup_data) = setup_data_cache.get() {
-                Ok(setup_data)
-            } else {
-                Err(anyhow::anyhow!(
-                    "Compression mode 5 for wrapper setup data not found in cache"
-                ))
-            }
-        }
+            .compression_mode5_for_wrapper_setup_data
+            .get_or_init(|| {
+                self.load_compression_setup_data::<CompressionMode5ForWrapper>()
+                    .context("Failed to load compression mode 5 for wrapper setup data")
+            })
+            .as_ref()
+            .map_err(|e| {
+                anyhow::anyhow!("Error loading compression mode 5 for wrapper setup data: {}", e)
+            })
     }
 
     fn get_compression_mode1_for_wrapper_setup_data(
         &self,
     ) -> anyhow::Result<&CompressionSetupData<CompressionMode1ForWrapper>> {
-        let setup_data_cache = &self
+        self
             .setup_data_cache_proof_compressor
             .plonk_setup_data
-            .compression_mode1_for_wrapper_setup_data;
-        setup_data_cache.wait();
-        if let Some(setup_data) = setup_data_cache.get() {
-            Ok(setup_data)
-        } else {
-            let setup_data = self
-                .load_compression_setup_data::<CompressionMode1ForWrapper>()
-                .context("Failed to load compression mode 1 for wrapper setup data")?;
-            setup_data_cache.set(setup_data).map_err(|_| {
-                anyhow::anyhow!(
-                    "Compression mode 1 for wrapper setup data is already initialized in cache"
-                )
-            })?;
-            if let Some(setup_data) = setup_data_cache.get() {
-                Ok(setup_data)
-            } else {
-                Err(anyhow::anyhow!(
-                    "Compression mode 1 for wrapper setup data not found in cache"
-                ))
-            }
-        }
+            .compression_mode1_for_wrapper_setup_data
+            .get_or_init(|| {
+                self.load_compression_setup_data::<CompressionMode1ForWrapper>()
+                    .context("Failed to load compression mode 1 for wrapper setup data")
+            })
+            .as_ref()
+            .map_err(|e| {
+                anyhow::anyhow!("Error loading compression mode 1 for wrapper setup data: {}", e)
+            })
     }
 
     fn get_plonk_snark_wrapper_setup_data(
@@ -589,28 +517,18 @@ impl CompressorBlobStorage for Keystore {
     fn get_fflonk_snark_wrapper_setup_data(
         &self,
     ) -> anyhow::Result<&SnarkWrapperSetupData<FflonkSnarkWrapper>> {
-        let setup_data_cache = &self
+        self
             .setup_data_cache_proof_compressor
             .fflonk_setup_data
-            .fflonk_snark_wrapper_setup_data;
-        setup_data_cache.wait();
-        if let Some(setup_data) = setup_data_cache.get() {
-            Ok(setup_data)
-        } else {
-            let setup_data = self
-                .load_snark_wrapper_setup_data::<FflonkSnarkWrapper>()
-                .context("Failed to load Fflonk Snark Wrapper setup data")?;
-            setup_data_cache.set(setup_data).map_err(|_| {
-                anyhow::anyhow!("Fflonk Snark Wrapper setup data is already initialized in cache")
-            })?;
-            if let Some(setup_data) = setup_data_cache.get() {
-                Ok(setup_data)
-            } else {
-                Err(anyhow::anyhow!(
-                    "Fflonk Snark Wrapper setup data not found in cache"
-                ))
-            }
-        }
+            .fflonk_snark_wrapper_setup_data
+            .get_or_init(|| {
+                self.load_snark_wrapper_setup_data::<FflonkSnarkWrapper>()
+                    .context("Failed to load Fflonk Snark Wrapper setup data")
+            })
+            .as_ref()
+            .map_err(|e| {
+                anyhow::anyhow!("Error loading Fflonk Snark Wrapper setup data: {}", e)
+            })
     }
 }
 


### PR DESCRIPTION
## What ❔
Fixed issue with double initializing setup keys for Compressor.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
