### PR TITLE
chore: Add docker compose for prover stack

### DIFF
--- a/docker-compose-prover.yaml
+++ b/docker-compose-prover.yaml
@@ -1,0 +1,58 @@
+## To download setup keys:
+# zkstack prover setup-keys --region europe --mode download
+
+services:
+  prover-job-monitor:
+    image: matterlabs/prover-job-monitor:${PROVER_TAG}
+    network_mode: host
+    volumes:
+      - /zksync-era/./prover/data/keys:/prover/data/keys
+      - /zksync-era/./prover/artifacts:/artifacts
+      - /zksync-era/./chains/era/configs/:/configs
+    command: --config-path=/configs/general.yaml --secrets-path=/configs/secrets.yaml
+    expose:
+      - 3317 # metrics
+      - 3074 # queue
+
+  prover-fri-gateway:
+    image: matterlabs/prover-fri-gateway:${PROVER_TAG}
+    network_mode: host
+    volumes:
+      - /zksync-era/./prover/data/keys:/prover/data/keys
+      - /zksync-era/./prover/artifacts:/artifacts
+      - /zksync-era/./chains/era/configs/:/configs
+    command: --config-path=/configs/general.yaml --secrets-path=/configs/secrets.yaml
+    expose:
+      - 3310 # metrics
+      - 3324 # prover-cluster
+
+  witness-generator:
+    image: matterlabs/witness-generator:${PROVER_TAG}
+    network_mode: host
+    volumes:
+      - /zksync-era/./prover/data/keys:/prover/data/keys
+      - /zksync-era/./prover/artifacts:/artifacts
+      - /zksync-era/./chains/era/configs/:/configs
+    command: --config-path=/configs/general.yaml --secrets-path=/configs/secrets.yaml --all_rounds
+
+  circuit-prover-gpu:
+    image: matterlabs/circuit-prover-gpu:${PROVER_TAG}
+    network_mode: host
+    gpus: all
+    volumes:
+      - /zksync-era/./prover/data/keys:/prover/data/keys
+      - /zksync-era/./prover/artifacts:/artifacts
+      - /zksync-era/./chains/era/configs/:/configs
+    command: --config-path=/configs/general.yaml --secrets-path=/configs/secrets.yaml --light-wvg-count=16 --heavy-wvg-count=4 --max-allocation=25769803776
+    expose:
+      - 3315 # metrics
+
+  compressor:
+    image: matterlabs/proof-fri-gpu-compressor:${PROVER_TAG}
+    network_mode: host
+    gpus: all
+    volumes:
+      - /zksync-era/./prover/data/keys:/prover/data/keys
+      - /zksync-era/./prover/artifacts:/artifacts
+      - /zksync-era/./chains/era/configs/:/configs
+    command: --config-path=/configs/general.yaml --secrets-path=/configs/secrets.yaml


### PR DESCRIPTION


## What ❔

Add docker compose for prover stack to run full stack on a single machine.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

It could be used for local testing or running micro prover cluster.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.

ref ZKD-2769