### PR TITLE
fix(prover): Use unified Prometheus initialization in gateway and job monitor

### DIFF
--- a/core/lib/config/src/configs/fri_prover_gateway.rs
+++ b/core/lib/config/src/configs/fri_prover_gateway.rs
@@ -15,8 +15,7 @@ pub struct FriProverGatewayConfig {
     pub api_mode: ApiMode,
     pub port: Option<u16>,
     // Configurations for prometheus
-    #[config(default_t = 3314)]
-    pub prometheus_listener_port: u16,
+    pub prometheus_listener_port: Option<u16>,
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
@@ -45,7 +44,7 @@ mod tests {
             api_poll_duration: Duration::from_secs(100),
             api_mode: ApiMode::ProverCluster,
             port: Some(8080),
-            prometheus_listener_port: 3316,
+            prometheus_listener_port: Some(3316),
         }
     }
 

--- a/core/lib/config/src/configs/prover_job_monitor.rs
+++ b/core/lib/config/src/configs/prover_job_monitor.rs
@@ -7,7 +7,7 @@ use smart_config::{metadata::TimeUnit, DescribeConfig, DeserializeConfig};
 #[derive(Debug, Clone, PartialEq, DescribeConfig, DeserializeConfig)]
 pub struct ProverJobMonitorConfig {
     /// Port for prometheus metrics connection.
-    pub prometheus_port: u16,
+    pub prometheus_port: Option<u16>,
     /// Maximum number of database connections per pool.
     /// In a balanced system it should match the number of Tasks ran by ProverJobMonitor.
     /// If lower, components will wait on one another for a connection.
@@ -62,7 +62,7 @@ mod tests {
 
     fn expected_config() -> ProverJobMonitorConfig {
         ProverJobMonitorConfig {
-            prometheus_port: 3317,
+            prometheus_port: Some(3317),
             max_db_connections: 9,
             graceful_shutdown_timeout: Duration::from_secs(5),
             gpu_prover_archiver_run_interval: Duration::from_secs(86400),

--- a/prover/crates/bin/prover_fri_gateway/src/main.rs
+++ b/prover/crates/bin/prover_fri_gateway/src/main.rs
@@ -14,7 +14,6 @@ use zksync_config::{
 use zksync_object_store::ObjectStoreFactory;
 use zksync_prover_dal::{ConnectionPool, Prover};
 use zksync_task_management::ManagedTasks;
-use zksync_vlog::prometheus::PrometheusExporterConfig;
 
 mod client;
 mod error;
@@ -69,8 +68,13 @@ async fn main() -> anyhow::Result<()> {
     })
     .context("Error setting Ctrl+C handler")?;
 
-    tracing::info!("Starting Fri Prover Gateway in mode {:?}", config.api_mode);
+    let prometheus_exporter_config = general_config
+        .prometheus_config
+        .build_exporter_config(config.prometheus_listener_port)
+        .context("Failed to build Prometheus exporter configuration")?;
+    tracing::info!("Using Prometheus exporter with {prometheus_exporter_config:?}");
 
+    tracing::info!("Starting Fri Prover Gateway in mode {:?}", config.api_mode);
     let tasks = match &config.api_mode {
         ApiMode::Legacy => {
             let proof_submitter = ProofSubmitter::new(
@@ -85,10 +89,7 @@ async fn main() -> anyhow::Result<()> {
             );
 
             vec![
-                tokio::spawn(
-                    PrometheusExporterConfig::pull(config.prometheus_listener_port)
-                        .run(stop_receiver.clone()),
-                ),
+                tokio::spawn(prometheus_exporter_config.run(stop_receiver.clone())),
                 tokio::spawn(
                     proof_gen_data_fetcher.run(config.api_poll_duration, stop_receiver.clone()),
                 ),
@@ -105,10 +106,7 @@ async fn main() -> anyhow::Result<()> {
             let api = server::Api::new(processor.clone(), port);
 
             vec![
-                tokio::spawn(
-                    PrometheusExporterConfig::pull(config.prometheus_listener_port)
-                        .run(stop_receiver.clone()),
-                ),
+                tokio::spawn(prometheus_exporter_config.run(stop_receiver.clone())),
                 tokio::spawn(api.run(stop_receiver)),
             ]
         }

--- a/prover/crates/bin/prover_job_monitor/src/main.rs
+++ b/prover/crates/bin/prover_job_monitor/src/main.rs
@@ -27,7 +27,6 @@ use zksync_prover_job_monitor::{
 };
 use zksync_prover_task::TaskRunner;
 use zksync_task_management::ManagedTasks;
-use zksync_vlog::prometheus::PrometheusExporterConfig;
 
 #[derive(Debug, Parser)]
 #[command(author = "Matter Labs", version)]
@@ -65,7 +64,11 @@ async fn main() -> anyhow::Result<()> {
     let witness_generator_config = general_config
         .witness_generator_config
         .context("witness_generator_config")?;
-    let exporter_config = PrometheusExporterConfig::pull(prover_job_monitor_config.prometheus_port);
+    let prometheus_exporter_config = general_config
+        .prometheus_config
+        .build_exporter_config(prover_job_monitor_config.prometheus_port)
+        .context("Failed to build Prometheus exporter configuration")?;
+    tracing::info!("Using Prometheus exporter with {prometheus_exporter_config:?}");
 
     let (stop_signal_sender, stop_signal_receiver) = oneshot::channel();
     let mut stop_signal_sender = Some(stop_signal_sender);
@@ -90,7 +93,9 @@ async fn main() -> anyhow::Result<()> {
 
     let graceful_shutdown_timeout = prover_job_monitor_config.graceful_shutdown_timeout;
 
-    let mut tasks = vec![tokio::spawn(exporter_config.run(stop_receiver.clone()))];
+    let mut tasks = vec![tokio::spawn(
+        prometheus_exporter_config.run(stop_receiver.clone()),
+    )];
 
     tasks.extend(get_tasks(
         connection_pool.clone(),


### PR DESCRIPTION

## What ❔

Use unified Prometheus initialization in prover gateway and prover job monitor.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To simplify and unify monitoring configuration.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.

ref ZKD-2794
