### PR TITLE
fix(en): Fix parsing consensus secrets

### DIFF
--- a/core/bin/external_node/src/config/tests/consensus-secrets.yaml
+++ b/core/bin/external_node/src/config/tests/consensus-secrets.yaml
@@ -1,0 +1,2 @@
+validator_key: 'validator:secret:bls12_381:3cf20d771450fcd0cbb3839b21cab41161af1554e35d8407a53b0a5d98ff04d4'
+node_key: 'node:secret:ed25519:9a40791b5a6b1627fc538b1ddecfa843bd7c4cd01fc0a4d0da186f9d3e740d7c'


### PR DESCRIPTION
## What ❔

Fix parsing consensus secrets on the EN if `EN_CONSENSUS_SECRETS_PATH` env var is set.

## Why ❔

https://github.com/matter-labs/zksync-era/pull/4104 has incorrectly set the secrets prefix (`secrets.consensus` instead of `consensus`). 

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.