### PR TITLE
docs(en): Better config docs for node – public docs

### DIFF
--- a/docs/src/announcements/config_format_changes.md
+++ b/docs/src/announcements/config_format_changes.md
@@ -33,11 +33,17 @@ The env-based format is *de facto* currently deprecated for the main node (the `
 Potential breaking changes in it are not exhaustively tested and will be fixed at best-effort basis.
 ```
 
-The initial stage will also not touch env-based config for non-validator / external nodes (`zksync_external_node`
-binary); it will be migrated separately.
-
 Migration is only necessary for _existing_ configurations; config files newly created via (updated) `zkstack` will have
 the necessary changes applied automatically.
+
+## Migrating EN env configuration
+
+Env-based config logic is migrated starting from the EN release v${FIXME_VERSION}. No breaking changes are expected.
+However, multiple previously used env variables are now considered deprecated, and the corresponding warnings will be
+logged on the `WARN` level with the `smart_config` target during node initialization. It is recommended to move
+deprecated env variables to canonical locations as suggested by these warnings.
+
+## Migrating file-based configuration
 
 ### Tagged enumerations
 
@@ -211,6 +217,4 @@ state_keeper:
 
 ## Debugging configuration
 
-To debug configuration parameters, launch the node with the `config` command, e.g. `zksync_server config` or
-`zkstack server -- config` if using `zkstack`. By default, the `config` command will output help on configuration
-params, optionally filtered by the param name. If the `--debug` flag is specified, param values will be output instead.
+See [_Node Configuration_](../guides/external-node/02_configuration.md#debugging-configuration).

--- a/docs/src/guides/external-node/02_configuration.md
+++ b/docs/src/guides/external-node/02_configuration.md
@@ -1,14 +1,137 @@
 # Node Configuration
 
-This document outlines various configuration options for the EN. Currently, the Node requires the definition of numerous
-environment variables. To streamline this process, we provide prepared configs for the ZKsync Era - for both
+This document outlines various configuration options for the EN. Currently, the Node reads configuration from
+environment variables (generally prefixed with `EN_`), and/or from YAML files. To use YAML-based config params, it must
+be specified by providing `--config-path` command-line argument provided to the node binary. If both env vars and YAML
+are used, environment variables have higher priority.
+
+In the docs, we use env variable names for config params (e.g., `EN_MERKLE_TREE_PATH`), or its dot-separated paths in
+YAML like `database.merkle_tree.path`. A path always maps to an env variable obtained by replacing dots `.` with
+underscores `_`, capitalizing and prepending the `EN_` prefix. For example, `db.merkle_tree.path` is transformed to
+`EN_DB_MERKLE_TREE_PATH`. Some params have aliases or fallbacks (generally, non-prefixed env variables); these are
+exhaustively documented [in the config help](#getting-help-on-configuration-params). For example, the
+`EN_MERKLE_TREE_PATH` env var (or `merkle_tree.path`) is a deprecated alias for the aforementioned `db.merkle_tree.path`
+param.
+
+To streamline the config setup, we provide prepared configs for ZKsync Era – for both
 [mainnet](prepared_configs/mainnet-config.env) and [testnet](prepared_configs/testnet-sepolia-config.env). You can use
 these files as a starting point and modify only the necessary sections.
 
-**You can also see directory docker-compose-examples if you want to run external-node on your machine with recommended
-default settings.**
+```admonish tip
+You can see [Docker Compose examples](docker-compose-examples) if you want to run external-node on your machine with recommended
+default settings.
+```
 
-## Database
+## Getting help on configuration params
+
+```admonish note
+The functionality described in this section is only present in releases v${FIXME_VERSION}+. It works identically for the main node
+binary (`zksync_server`).
+```
+
+The node binary comes with a builtin help on all configuration parameters. This help can be triggered by launching the
+node binary with the `config help` command-line args:
+
+```shell
+zksync_external_node config help
+# ...or, if using zkstack:
+zkstack external-node -- config help
+```
+
+By providing an argument after `help`, it's possible to filter params by name; e.g., `config help port` will output help
+for all params containing "port" in their path.
+
+## Parameter format
+
+Formats for specific params are mentioned in their [help](#getting-help-on-configuration-params). One of the more
+flexible formats are parameters with units (durations or byte sizes).
+
+- The canonical format for such params is a string consisting of an integer number + the unit, e.g. `5sec`, `1 day`, or
+  `100 MB`.
+- Besides that, it can be an object with a single field corresponding to the unit, and an integer value. For example,
+  `{ "sec": 5 }`. The unit may be prefixed with `in_`; e.g. `{ "in_sec": 5 }`.
+- As a part of the general coercion rules, the object format can be flattened into the parent. E.g., instead of
+  specifying `timeout: 5 sec`, one can use `timeout_sec: 5` or `timeout_in_sec: 5`. This applies to env variables; e.g.,
+  the `db.merkle_tree.block_cache_size` param (a byte size) can be specified as either of
+  `EN_DB_MERKLE_TREE_BLOCK_CACHE_SIZE=128 MB` or `EN_DB_MERKLE_TREE_BLOCK_CACHE_SIZE_MB=128`.
+
+If it's necessary to pass a value with a complex structure (a JSON array or object) as an env variable, this can be
+accomplished by suffixing the parameter with `__JSON`:
+
+```shell
+# Sets the `api.web3_json_rpc.api_namespaces` param
+EN_API_WEB3_JSON_RPC_API_NAMESPACES__JSON='["zks", "eth"]'
+```
+
+## Debugging configuration
+
+```admonish note
+The functionality described in this section is only present in releases v${FIXME_VERSION}+. It works identically for the main node
+binary (`zksync_server`).
+```
+
+The node provides info on params as `DEBUG` logs with the `zksync_config` target at the node start, like this:
+
+```text
+2025-06-04T09:17:21.615338Z DEBUG zksync_config::observability_ext: parsed config param
+  param="http_port"
+  path="api.web3_json_rpc.http_port"
+  config="Web3JsonRpcConfig"
+  origin=YAML file './chains/era/configs/general.yaml' -> path 'api.web3_json_rpc.http_port'
+  value=3050
+  is_secret=false
+  is_default=true
+```
+
+Naturally, value for the secret params are not exposed; instead, `is_secret` is set to `true`.
+
+If configuration parsing fails, the node will print exhaustive failure reason(s) with rich context:
+
+```text
+Error: failed parsing config param(s): 3 error(s) in total
+1. error parsing param `filters_limit` in `Web3JsonRpcConfig` at `api.web3_json_rpc.filters_limit`
+  [origin: YAML file './chains/era/configs/general.yaml' -> path 'api.web3_json_rpc.filters_limit']:
+  invalid value: integer `-10000`, expected usize
+2. error parsing param `port` in `MerkleTreeApiConfig` at `api.merkle_tree.port`
+  [origin: YAML file './chains/era/configs/general.yaml' -> path 'api.merkle_tree.port']:
+  invalid digit found in string while parsing u16 value '3072?'
+3. error parsing param `block_cache_size` in `MerkleTreeConfig` at `db.merkle_tree.block_cache_size`
+  [origin: env variable 'EN_DB_MERKLE_TREE_BLOCK_CACHE_SIZE']:
+  invalid type: string "what", expected value with unit, like '32 MB'
+```
+
+Other than logs, config params are exposed as INFO metrics named `server_config_params`:
+
+```text
+server_config_params{default="false",path="api.healthcheck.port",secret="false",value="3071"} 1
+```
+
+If the `api.healthcheck.expose_config` param is set, config params are also output as a part of the `config` component
+in [the healthcheck endpoint](#exposed-ports). In this case, they can be accessed like this:
+
+```shell
+$ curl -s http://127.0.0.1:3081/health | jq '.components.config.details."api.merkle_tree.port"'
+{
+  "origin": "YAML file './chains/era/configs/general.yaml' -> path 'api.merkle_tree.port'",
+  "value": 3072
+}
+```
+
+There are a couple of node CLI commands for debugging as well:
+
+- `config debug` outputs param values with debugging info (e.g., the value origin), optionally filtered by the param
+  name.
+- `config print` outputs the entire merged configuration in a single YAML file or env variables list.
+
+See command help using `config debug --help` / `config print --help` for details.
+
+```admonish tip
+Besides debugging, `config print` is also useful to migrate all config params to their canonical locations / formats.
+```
+
+## Params overview
+
+### Database
 
 The Node uses two databases: PostgreSQL and RocksDB.
 
@@ -24,7 +147,7 @@ exclusive to a node; i.e., they **must not** be shared among nodes concurrently 
 Failing to adhere to this rule may result in RocksDB corruption or
 [the Node crashing on start](05_troubleshooting.md#rocksdb-issues).
 
-## L1 Web3 client
+### L1 Web3 client
 
 Node requires a connection to an Ethereum node. The corresponding env variable is `EN_ETH_CLIENT_URL`. Make sure to set
 the URL corresponding to the correct L1 network (L1 mainnet for L2 mainnet and L1 sepolia for L2 testnet).
@@ -33,7 +156,7 @@ Note: Currently, the Node makes 2 requests to the L1 per L1 batch, so the Web3 c
 be high. However, during the synchronization phase the new batches would be persisted on the Node quickly, so make sure
 that the L1 client won't exceed any limits (e.g. in case you use Infura).
 
-## Exposed ports
+### Exposed ports
 
 The dockerized version of the server exposes the following ports:
 
@@ -45,7 +168,7 @@ The dockerized version of the server exposes the following ports:
 While the configuration variables for them exist, you are not expected to change them unless you want to use the Node
 outside provided Docker environment (not supported at the time of writing).
 
-## API limits
+### API limits
 
 There are variables that allow you to fine-tune the limits of the RPC servers, such as limits on the number of returned
 entries or the limit for the accepted transaction size. Provided files contain sane defaults that are recommended for
@@ -61,14 +184,14 @@ use, but these can be edited, e.g. to make the Node more/less restrictive.
 - `EN_REQ_ENTITIES_LIMIT` (default 10,000) controls max possible limit of entities to be requested at once. Hitting the
   limit will result in errors similar to: "Query returned more than 10000 results (...)"
 
-## JSON-RPC API namespaces
+### JSON-RPC API namespaces
 
 There are 7 total supported API namespaces: `eth`, `net`, `web3`, `debug` - standard ones; `zks` - rollup-specific one;
 `pubsub` - a.k.a. `eth_subscribe`; `en` - used by Nodes while syncing. You can configure what namespaces you want to
 enable using `EN_API_NAMESPACES` and specifying namespace names in a comma-separated list. By default, all but the
 `debug` namespace are enabled.
 
-## API caching
+### API caching
 
 The API server performs in-memory caching of data used for VM invocations (i.e., `eth_call`, `eth_estimateGas`,
 `eth_sendRawTransaction` methods), such as state values and bytecodes. Cache sizes have reasonable defaults, but can be
@@ -81,7 +204,7 @@ adjusted to tradeoff between performance and RAM consumption of the node.
 - `EN_INITIAL_WRITES_CACHE_SIZE_MB` is the size of the initial writes caches. Initial write info is used as a part of
   the gas pricing model.
 
-## Optimizing RAM consumption
+### Optimizing RAM consumption
 
 With the default config options, a node may consume large amounts of RAM (order of 32–64 GB for larger networks). This
 consumption can be reduced with a moderate performance tradeoff as follows.
@@ -110,7 +233,7 @@ These options can be used together with pruning / snapshot recovery as well, but
 consumption is expected to be fairly small. The options can be changed or removed at any time; they do not require a
 long-term commitment or irreversible decisions, unlike enabling pruning for a node.
 
-## Logging and observability
+### Logging and observability
 
 - `MISC_LOG_FORMAT` defines the format in which logs are shown: `plain` corresponds to the human-readable format, while
   the other option is `json` (recommended for deployments).

--- a/docs/src/guides/external-node/02_configuration.md
+++ b/docs/src/guides/external-node/02_configuration.md
@@ -11,7 +11,14 @@ underscores `_`, capitalizing and prepending the `EN_` prefix. For example, `db.
 `EN_DB_MERKLE_TREE_PATH`. Some params have aliases or fallbacks (generally, non-prefixed env variables); these are
 exhaustively documented [in the config help](#getting-help-on-configuration-params). For example, the
 `EN_MERKLE_TREE_PATH` env var (or `merkle_tree.path`) is a deprecated alias for the aforementioned `db.merkle_tree.path`
-param.
+param. If a deprecated alias is used, a warning is logged with the `smart_config` target. It is recommended (but not
+immediately required) to convert config sources to use a canonical param path, which is output as a part of the warning.
+
+```admonish tip
+To output all config params in canonical formats / locations with node v${FIXME_VERSION}+, run the node binary
+with `config print` command-line args, or `config print --diff` to only output non-default param valuess.
+See the `config print --help` docs for more options.
+```
 
 To streamline the config setup, we provide prepared configs for ZKsync Era – for both
 [mainnet](prepared_configs/mainnet-config.env) and [testnet](prepared_configs/testnet-sepolia-config.env). You can use
@@ -83,7 +90,8 @@ The node provides info on params as `DEBUG` logs with the `zksync_config` target
   is_default=true
 ```
 
-Naturally, value for the secret params are not exposed; instead, `is_secret` is set to `true`.
+Naturally, value for the secret params are not exposed; instead, `is_secret` is set to `true`. Some additional logging
+happens inside the config library (i.e., with `smart_config::*` targets).
 
 If configuration parsing fails, the node will print exhaustive failure reason(s) with rich context:
 
@@ -235,10 +243,11 @@ long-term commitment or irreversible decisions, unlike enabling pruning for a no
 
 ### Logging and observability
 
-- `MISC_LOG_FORMAT` defines the format in which logs are shown: `plain` corresponds to the human-readable format, while
-  the other option is `json` (recommended for deployments).
-- `RUST_LOG` variable allows you to set up the logs granularity (e.g. make the Node emit fewer logs). You can read about
-  the format [here](https://docs.rs/env_logger/0.10.0/env_logger/#enabling-logging).
-- `MISC_SENTRY_URL` and `MISC_OTLP_URL` variables can be configured to set up Sentry and OpenTelemetry exporters.
+- `EN_LOG_FORMAT` env var (deprecated alias `MISC_LOG_FORMAT`) defines the format in which logs are shown. `plain`
+  corresponds to the human-readable format, while the other option is `json` (recommended for deployments).
+- `EN_LOG_DIRECTIVES` env var (also read from `RUST_LOG`) allows you to set up the logs granularity (e.g. make the Node
+  emit fewer logs). You can read about the format
+  [here](https://docs.rs/env_logger/0.10.0/env_logger/#enabling-logging).
+- `EN_SENTRY_URL` env var (deprecated alias `MISC_SENTRY_URL`) can be configured to set up a Sentry exporter.
 - If Sentry is configured, you also have to set `EN_SENTRY_ENVIRONMENT` variable to configure the environment in events
-  reported to sentry.
+  reported to Sentry.

--- a/docs/src/guides/external-node/04_observability.md
+++ b/docs/src/guides/external-node/04_observability.md
@@ -19,8 +19,7 @@ By default, latency histograms are distributed in the following buckets (in seco
 Node exposes a lot of metrics, a significant amount of which aren't interesting outside the development flow. This
 section's purpose is to highlight metrics that may be worth observing in the external setup.
 
-If you are not planning to scrape Prometheus metrics, please unset `EN_PROMETHEUS_PORT` environment variable to prevent
-memory leaking.
+If you are not planning to scrape Prometheus metrics, you can unset the `EN_PROMETHEUS_PORT` environment variable.
 
 | Metric name                                    | Type      | Labels                                | Description                                                        |
 | ---------------------------------------------- | --------- | ------------------------------------- | ------------------------------------------------------------------ |
@@ -39,4 +38,4 @@ memory leaking.
 | `sql_connection_acquire`                       | Histogram | -                                     | Time to get an SQL connection from the connection pool             |
 
 Metrics can be used to detect anomalies in configuration, which is described in more detail in the
-[next section](05_troubleshooting.md).
+[_Troubleshooting_ section](05_troubleshooting.md).

--- a/docs/src/guides/external-node/05_troubleshooting.md
+++ b/docs/src/guides/external-node/05_troubleshooting.md
@@ -56,7 +56,7 @@ Node.
 
 ## Logs
 
-_Note: logs with the `error` level are reported to Sentry if it's configured. If you notice unneeded alerts there that
+_Note: logs with the `error` level are reported to Sentry if it is configured. If you notice unneeded alerts there that
 you don't consider actionable, you may disable logs for a component by tweaking the configuration._
 
 | Level | Log substring                                         | Interpretation                                                                                           |
@@ -96,8 +96,9 @@ the last L1 batch to be retained by the node after the revert. The node will exe
 can be started normally.
 
 ```admonish warning
-Do not revert the node state by manually removing rows from Postgres. The node uses RocksDB instances (for the Merkle tree and state keeper cache)
+Do not revert the node state by manually removing rows from Postgres. The node uses RocksDB instances
+(for [the Merkle tree](06_components.md#merkle-tree) and [state keeper](06_components.md#state-keeper--vm) cache)
 besides Postgres, which are expected to be in sync with Postgres at all times.
-If this invariant breaks, the RocksDB instances may become irreperably broken, which would require rebuilding the Merkle tree / state keeper cache
+If this invariant breaks, the RocksDB instances may become irreparably broken, which would require rebuilding the Merkle tree / state keeper cache
 from scratch. This would result in significant performance degradation (for the cache) / delays in block processing (for the Merkle tree).
 ```

--- a/docs/src/guides/external-node/10_decentralization.md
+++ b/docs/src/guides/external-node/10_decentralization.md
@@ -46,9 +46,7 @@ gossipnet to other nodes, so that they can establish connections to your node. I
 to the public internet, you can use IP in your local network.
 ```
 
-Currently the config contains the following fields (refer to config
-[schema](https://github.com/matter-labs/zksync-era/blob/990676c5f84afd2ff8cd337f495c82e8d1f305a4/core/lib/protobuf_config/src/proto/core/consensus.proto#L66)
-for more details):
+Currently, the config contains the following fields:
 
 - `server_addr` - local TCP socket address that the node should listen on for incoming connections. Note that this is an
   additional TCP port that will be opened by the node.
@@ -60,7 +58,7 @@ for more details):
 
 ### Setting environment variables
 
-Uncomment (or add) the following lines in your `.env` config:
+Uncomment or add the following lines in your `.env` config:
 
 ```
 EN_CONSENSUS_CONFIG_PATH=...

--- a/docs/src/guides/external-node/11_setup_for_other_chains.md
+++ b/docs/src/guides/external-node/11_setup_for_other_chains.md
@@ -7,44 +7,45 @@ than ZKsync Era.
 If you want to run Node for a given chain, you can first ask the company hosting the chains for the Dockerfiles.
 ```
 
-## 1. Update `EN_L2_CHAIN_ID`
+## 1. Update L2 chain ID
 
 The `EN_L2_CHAIN_ID` environment variable specifies the Layer 2 chain ID of the blockchain.
 
 You can get it using main node rpc call `eth_chainId` or by asking the company hosting the chain. For example:
 
-```
+```shell
 curl -X POST https://mainnet.era.zksync.io \
--H "Content-Type: application/json" \
--d '{"jsonrpc": "2.0", "method": "eth_chainId", "params": [], "id": 1}'
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "method": "eth_chainId", "params": [], "id": 1}'
 ```
 
 returns
 
-```
-{ "jsonrpc": "2.0", "result": "0x144", "id": 1}
+```json
+{ "jsonrpc": "2.0", "result": "0x144", "id": 1 }
 ```
 
 where `0x144` is the chain ID (324 in decimal)
 
-## 2. Update `EN_MAIN_NODE_URL`
+## 2. Update main node URL
 
-The `EN_MAIN_NODE_URL` The EN_MAIN_NODE_URL environment variable should point to the main node URL of the target chain
+The `EN_MAIN_NODE_URL` environment variable should point to the main node URL of the target chain.
 
 ## 3. Update snapshots recovery settings
 
-Snapshots recovery is a feature that allows faster Node startup at the cost of no transaction history. By default the
+Snapshots recovery is a feature that allows faster Node startup at the cost of no transaction history. By default, the
 ZKsync Era docker-compose file has this feature enabled, but it's only recommended to use if the Node first startup time
-is too slow. It can be disabled by changing `EN_SNAPSHOTS_RECOVERY_ENABLED` to `false`
+is too slow. It can be disabled by changing `EN_SNAPSHOTS_RECOVERY_ENABLED=false`.
 
 If you want to keep this feature enabled for a Node, ask the company hosting the chain for the bucket name where the
-snapshots are stored and update the value of `EN_SNAPSHOTS_OBJECT_STORE_BUCKET_BASE_URL`
+snapshots are stored and update the value of `EN_SNAPSHOTS_OBJECT_STORE_BUCKET_BASE_URL`.
 
 ## 5. (Validium chains only) Enable and configure DA fetcher
 
-For Validium ENs to function properly, the Data Availability fetcher must be enabled and configured. It has to be added
-to the components list, e.g. for a standard list of components and DA fetcher it would be `--components=all,da_fetcher`.
+For Validium ENs to function properly, [the Data Availability fetcher](06_components.md#data-availability-fetcher) must
+be enabled and configured. It has to be added to the components list, e.g. for a standard list of components and DA
+fetcher it would be `--components=all,da_fetcher`.
 
-To configure the DA fetcher, you need to add the `da_client` config if the file-based config is used or configure in via
-the environment variables, they need to have an `EN_` prefix. If the DA client in use needs a secret to be configured -
+To configure the DA fetcher, you need to add the `da_client` config if the YAML-based config is used or configure in via
+the environment variables, they need to have an `EN_` prefix. If the DA client in use needs a secret to be configured,
 you need to set it in your secrets config or a corresponding environment variable.


### PR DESCRIPTION
## What ❔

Documents changes in EN configuration.

## Why ❔

To keep EN operators up to date.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

Described in the changed docs.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.