### PR TITLE
fix(eth-watcher): handle get_logs timeout in eth watch

### DIFF
--- a/core/lib/web3_decl/src/error.rs
+++ b/core/lib/web3_decl/src/error.rs
@@ -105,6 +105,10 @@ impl EnrichedClientError {
     pub fn is_retryable(&self) -> bool {
         is_retryable(&self.inner_error)
     }
+
+    pub fn is_timeout(&self) -> bool {
+        matches!(self.inner_error, ClientError::RequestTimeout)
+    }
 }
 
 impl AsRef<ClientError> for EnrichedClientError {

--- a/core/node/eth_watch/src/client.rs
+++ b/core/node/eth_watch/src/client.rs
@@ -224,6 +224,7 @@ where
                 || err_message.contains(TOO_BIG_RANGE_RETH)
                 || err_message.contains(TOO_MANY_RESULTS_CHAINSTACK)
                 || err_message.contains(REQUEST_REJECTED_503)
+                || err.is_timeout()
             {
                 // get the numeric block ids
                 let from_number = match from {


### PR DESCRIPTION
## What ❔

Handle get_logs timeout in eth watch

## Why ❔

In order to split request when timeout is received

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
