### PR TITLE
feat(api): stabilize zks_gasPerPubdata

### DIFF
--- a/core/lib/web3_decl/src/namespaces/unstable.rs
+++ b/core/lib/web3_decl/src/namespaces/unstable.rs
@@ -7,7 +7,7 @@ use zksync_types::{
         TransactionDetailedResult, TransactionExecutionInfo,
     },
     tee_types::TeeType,
-    L1BatchNumber, L2ChainId, H256, U256,
+    L1BatchNumber, L2ChainId, H256,
 };
 
 use crate::{
@@ -68,7 +68,4 @@ pub trait UnstableNamespace {
         &self,
         tx_bytes: Bytes,
     ) -> RpcResult<TransactionDetailedResult>;
-
-    #[method(name = "gasPerPubdata")]
-    async fn gas_per_pubdata(&self) -> RpcResult<U256>;
 }

--- a/core/lib/web3_decl/src/namespaces/zks.rs
+++ b/core/lib/web3_decl/src/namespaces/zks.rs
@@ -120,4 +120,7 @@ pub trait ZksNamespace {
 
     #[method(name = "getBatchFeeInput")]
     async fn get_batch_fee_input(&self) -> RpcResult<PubdataIndependentBatchFeeModelInput>;
+
+    #[method(name = "gasPerPubdata")]
+    async fn gas_per_pubdata(&self) -> RpcResult<U256>;
 }

--- a/core/node/api_server/src/web3/backend_jsonrpsee/namespaces/unstable.rs
+++ b/core/node/api_server/src/web3/backend_jsonrpsee/namespaces/unstable.rs
@@ -1,4 +1,3 @@
-use zksync_multivm::zk_evm_latest::ethereum_types::U256;
 use zksync_types::{
     api::{
         ChainAggProof, DataAvailabilityDetails, GatewayMigrationStatus, L1ToL2TxsStatus, TeeProof,
@@ -81,12 +80,6 @@ impl UnstableNamespaceServer for UnstableNamespace {
         tx_bytes: web3::Bytes,
     ) -> RpcResult<TransactionDetailedResult> {
         self.send_raw_transaction_with_detailed_output_impl(tx_bytes)
-            .await
-            .map_err(|err| self.current_method().map_err(err))
-    }
-
-    async fn gas_per_pubdata(&self) -> RpcResult<U256> {
-        self.gas_per_pubdata_impl()
             .await
             .map_err(|err| self.current_method().map_err(err))
     }

--- a/core/node/api_server/src/web3/backend_jsonrpsee/namespaces/zks.rs
+++ b/core/node/api_server/src/web3/backend_jsonrpsee/namespaces/zks.rs
@@ -172,4 +172,10 @@ impl ZksNamespaceServer for ZksNamespace {
         self.get_l2_multicall3_impl()
             .map_err(|err| self.current_method().map_err(err))
     }
+
+    async fn gas_per_pubdata(&self) -> RpcResult<U256> {
+        self.gas_per_pubdata_impl()
+            .await
+            .map_err(|err| self.current_method().map_err(err))
+    }
 }

--- a/core/node/api_server/src/web3/namespaces/unstable/mod.rs
+++ b/core/node/api_server/src/web3/namespaces/unstable/mod.rs
@@ -6,10 +6,7 @@ use utils::{
 use zksync_crypto_primitives::hasher::keccak::KeccakHasher;
 use zksync_dal::{CoreDal, DalError};
 use zksync_mini_merkle_tree::MiniMerkleTree;
-use zksync_multivm::{
-    interface::VmEvent,
-    zk_evm_latest::ethereum_types::{U256, U64},
-};
+use zksync_multivm::{interface::VmEvent, zk_evm_latest::ethereum_types::U64};
 use zksync_types::{
     api,
     api::{
@@ -260,11 +257,6 @@ impl UnstableNamespace {
                 .map(|event| map_event(event, tx_hash))
                 .collect(),
         })
-    }
-
-    pub async fn gas_per_pubdata_impl(&self) -> Result<U256, Web3Error> {
-        let (_, gas_per_pubdata) = self.state.tx_sender.gas_price_and_gas_per_pubdata().await?;
-        Ok(gas_per_pubdata.into())
     }
 }
 

--- a/core/node/api_server/src/web3/namespaces/zks.rs
+++ b/core/node/api_server/src/web3/namespaces/zks.rs
@@ -553,6 +553,9 @@ impl ZksNamespace {
 
     pub async fn gas_per_pubdata_impl(&self) -> Result<U256, Web3Error> {
         let (_, gas_per_pubdata) = self.state.tx_sender.gas_price_and_gas_per_pubdata().await?;
+        // We don't accept transactions with `gas_per_pubdata=0` so API should always return 1 at the
+        // bare minimum.
+        let gas_per_pubdata = gas_per_pubdata.max(1);
         Ok(gas_per_pubdata.into())
     }
 }

--- a/core/node/api_server/src/web3/namespaces/zks.rs
+++ b/core/node/api_server/src/web3/namespaces/zks.rs
@@ -550,4 +550,9 @@ impl ZksNamespace {
             .await?
             .into_pubdata_independent())
     }
+
+    pub async fn gas_per_pubdata_impl(&self) -> Result<U256, Web3Error> {
+        let (_, gas_per_pubdata) = self.state.tx_sender.gas_price_and_gas_per_pubdata().await?;
+        Ok(gas_per_pubdata.into())
+    }
 }

--- a/core/tests/gateway-migration-test/package.json
+++ b/core/tests/gateway-migration-test/package.json
@@ -26,7 +26,7 @@
     "node-fetch": "^2.6.1",
     "ts-node": "^10.1.0",
     "typescript": "^4.3.5",
-    "zksync-ethers": "^6.18.0"
+    "zksync-ethers": "https://github.com/zksync-sdk/zksync-ethers#di/avoid-zks-estimate-fee-build"
   },
   "dependencies": {
     "prettier": "^2.3.2"

--- a/core/tests/recovery-test/package.json
+++ b/core/tests/recovery-test/package.json
@@ -31,6 +31,6 @@
     "ts-node": "^10.1.0",
     "typescript": "^4.3.5",
     "yaml": "^2.4.2",
-    "zksync-ethers": "^6.18.0"
+    "zksync-ethers": "https://github.com/zksync-sdk/zksync-ethers#di/avoid-zks-estimate-fee-build"
   }
 }

--- a/core/tests/revert-test/package.json
+++ b/core/tests/revert-test/package.json
@@ -30,6 +30,6 @@
     "node-fetch": "^2.6.1",
     "ts-node": "^10.1.0",
     "typescript": "^4.3.5",
-    "zksync-ethers": "^6.18.0"
+    "zksync-ethers": "https://github.com/zksync-sdk/zksync-ethers#di/avoid-zks-estimate-fee-build"
   }
 }

--- a/core/tests/ts-integration/package.json
+++ b/core/tests/ts-integration/package.json
@@ -38,6 +38,6 @@
     "typescript": "^4.3.5",
     "yaml": "^2.4.2",
     "js-yaml": "^4.0.9",
-    "zksync-ethers": "^6.18.0"
+    "zksync-ethers": "https://github.com/zksync-sdk/zksync-ethers#di/avoid-zks-estimate-fee-build"
   }
 }

--- a/core/tests/ts-integration/tests/contracts.test.ts
+++ b/core/tests/ts-integration/tests/contracts.test.ts
@@ -145,10 +145,7 @@ describe('Smart contract behavior checks', () => {
         // TODO: provide a proper error for transactions that consume too much gas.
         // await expect(infiniteLoop.callStatic.infiniteLoop()).toBeRejected('cannot estimate transaction: out of gas');
         // ...and then an actual transaction
-        // FIXME: passing gasPerPubdata on purpose to avoid calling zks_estimateFee; to be removed after zksync-ethers stops using it
-        await expect(
-            infiniteLoop.infiniteLoop({ gasLimit: 1_000_000, gasPrice, customData: { gasPerPubdata: 50_000n } })
-        ).toBeReverted([]);
+        await expect(infiniteLoop.infiniteLoop({ gasLimit: 1_000_000, gasPrice })).toBeReverted([]);
     });
 
     test('Should test reverting storage logs', async () => {
@@ -158,12 +155,10 @@ describe('Smart contract behavior checks', () => {
 
         // We manually provide a gas limit and gas price, since otherwise the exception would be thrown
         // while querying zks_estimateFee.
-        // FIXME: passing gasPerPubdata on purpose to avoid calling zks_estimateFee; to be removed after zksync-ethers stops using it
         await expect(
             counterContract.incrementWithRevert(5, true, {
                 gasLimit: 5000000,
-                gasPrice,
-                customData: { gasPerPubdata: 50_000n }
+                gasPrice
             })
         ).toBeReverted();
 

--- a/core/tests/ts-integration/tests/erc20.test.ts
+++ b/core/tests/ts-integration/tests/erc20.test.ts
@@ -112,10 +112,10 @@ describe('L1 ERC20 contract checks', () => {
         const feeTaken = await shouldOnlyTakeFee(alice);
 
         // Send transfer, it should revert due to lack of balance.
-        // FIXME: passing gasPerPubdata on purpose to avoid calling zks_estimateFee; to be removed after zksync-ethers stops using it
-        await expect(
-            aliceErc20.transfer(bob.address, value, { gasLimit, gasPrice, customData: { gasPerPubdata: 50_000n } })
-        ).toBeReverted([noBalanceChange, feeTaken]);
+        await expect(aliceErc20.transfer(bob.address, value, { gasLimit, gasPrice })).toBeReverted([
+            noBalanceChange,
+            feeTaken
+        ]);
     });
 
     test('Transfer to zero address should revert', async () => {
@@ -134,10 +134,10 @@ describe('L1 ERC20 contract checks', () => {
         const feeTaken = await shouldOnlyTakeFee(alice);
 
         // Send transfer, it should revert because transfers to zero address are not allowed.
-        // FIXME: passing gasPerPubdata on purpose to avoid calling zks_estimateFee; to be removed after zksync-ethers stops using it
-        await expect(
-            aliceErc20.transfer(zeroAddress, value, { gasLimit, gasPrice, customData: { gasPerPubdata: 50_000n } })
-        ).toBeReverted([noBalanceChange, feeTaken]);
+        await expect(aliceErc20.transfer(zeroAddress, value, { gasLimit, gasPrice })).toBeReverted([
+            noBalanceChange,
+            feeTaken
+        ]);
     });
 
     test('Approve and transferFrom should work', async () => {

--- a/core/tests/ts-integration/tests/prividium.test.ts
+++ b/core/tests/ts-integration/tests/prividium.test.ts
@@ -162,12 +162,10 @@ describe('Tests for the private rpc', () => {
         const absurdly_high_value = ethers.parseEther('1000000.0');
         const gasPrice = await scaledGasPrice(alice);
         const gasLimit = await aliceErc20.transfer.estimateGas(bob.address, 1);
-        // FIXME: passing gasPerPubdata on purpose to avoid calling zks_estimateFee; to be removed after zksync-ethers stops using it
         await expect(
             aliceErc20.transfer(bob.address, absurdly_high_value, {
                 gasLimit,
-                gasPrice,
-                customData: { gasPerPubdata: 50_000n }
+                gasPrice
             })
         ).toBeReverted([noBalanceChange, feeTaken]);
     });

--- a/core/tests/upgrade-test/package.json
+++ b/core/tests/upgrade-test/package.json
@@ -29,7 +29,7 @@
     "node-fetch": "^2.6.1",
     "ts-node": "^10.1.0",
     "typescript": "^4.3.5",
-    "zksync-ethers": "^6.18.0"
+    "zksync-ethers": "https://github.com/zksync-sdk/zksync-ethers#di/avoid-zks-estimate-fee-build"
   },
   "dependencies": {
     "prettier": "^2.3.2"

--- a/etc/utils/package.json
+++ b/etc/utils/package.json
@@ -13,6 +13,6 @@
     },
     "devDependencies": {
         "ethers": "^6.13.5",
-        "zksync-ethers": "^6.18.0"
+        "zksync-ethers": "https://github.com/zksync-sdk/zksync-ethers#di/avoid-zks-estimate-fee-build"
     }
 }

--- a/private-rpc/src/rpc/rpc-method-handlers.ts
+++ b/private-rpc/src/rpc/rpc-method-handlers.ts
@@ -84,6 +84,7 @@ export const allHandlers = [
     forbiddenMethod('zks_getProof'),
     unrestricted('zks_getBatchFeeInput'),
     zks_sendRawTransactionWithDetailedOutput,
+    unrestricted('zks_gasPerPubdata'),
 
     whoAmI
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -11994,7 +11994,6 @@ zksync-ethers@^5.0.0, zksync-ethers@^5.9.0:
   dependencies:
     ethers "~5.7.0"
 
-zksync-ethers@^6.18.0:
+"zksync-ethers@https://github.com/zksync-sdk/zksync-ethers#di/avoid-zks-estimate-fee-build":
   version "6.18.0"
-  resolved "https://registry.yarnpkg.com/zksync-ethers/-/zksync-ethers-6.18.0.tgz#f2fee53afadb048903da778baecf6f1874e19441"
-  integrity sha512-ScBZNlgYGppmq775mK36d44G5zS+PM4inzwlcKD1vFM2AleV9VvZmCOr7CSZGWTLofNraE4l7bhpwj8WAM/Osw==
+  resolved "https://github.com/zksync-sdk/zksync-ethers#b64fd27144356938c8876185add4cfdd537c15ef"


### PR DESCRIPTION
## What ❔

This PR:
* Stabilizes `unstable_gasPerPubdata` as `zks_gasPerPubdata`
* Makes it never return less than `1` gas per pubdata as such transactions are considered invalid
* Upgrades zksync-ethers to use a [WIP branch](https://github.com/zksync-sdk/zksync-ethers/pull/252) that stops calling `zks_estimateFee` in favour of `zks_gasPerPubdata` (if available)

## Why ❔

`zks_estimateFee` is scheduled for deprecation and this is the last missing piece

## Is this a breaking change?
- [x] Yes
- [ ] No

## Operational changes

This is technically a breaking change but realistically `unstable_gasPerPubdata` is unused by the public

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
