### PR TITLE
chore: Fixes to zk-env images CI

### DIFF
--- a/.github/workflows/zk-environment-publish.yml
+++ b/.github/workflows/zk-environment-publish.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files-yaml
-        uses: tj-actions/changed-files@48566bbcc22ceb7c5809ebdd27377309f2c3de8c # v39
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
           files_yaml: |
             zk_env:
@@ -92,7 +92,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Log in to Docker Hub
         if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch') }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
@@ -106,22 +106,28 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to US GAR
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch') }}
+        run: |
+          gcloud auth print-access-token --lifetime=7200 --impersonate-service-account=gha-ci-runners@matterlabs-infra.iam.gserviceaccount.com | docker login -u oauth2accesstoken --password-stdin https://us-docker.pkg.dev
       - name: Build and optionally push zk-environment lightweight
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           file: docker/zk-environment/Dockerfile
           target: rust-lightweight
           tags: |
+            us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/zk-environment:${{ needs.get_short_sha.outputs.short_sha }}-lightweight-${{ matrix.arch }}
             matterlabs/zk-environment:${{ needs.get_short_sha.outputs.short_sha }}-lightweight-${{ matrix.arch }}
             ghcr.io/${{ github.repository_owner }}/zk-environment:${{ needs.get_short_sha.outputs.short_sha }}-lightweight-${{ matrix.arch }}
           build-args: ARCH=${{ matrix.arch }}
           push: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch') }}
       - name: Build and optionally push zk-environment lightweight Rust nightly
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           file: docker/zk-environment/Dockerfile
           target: rust-lightweight-nightly
           tags: |
+            us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/zk-environment:${{ needs.get_short_sha.outputs.short_sha }}-lightweight-nightly-${{ matrix.arch }}
             matterlabs/zk-environment:${{ needs.get_short_sha.outputs.short_sha }}-lightweight-nightly-${{ matrix.arch }}
             ghcr.io/${{ github.repository_owner }}/zk-environment:${{ needs.get_short_sha.outputs.short_sha }}-lightweight-nightly-${{ matrix.arch }}
           build-args: ARCH=${{ matrix.arch }}
@@ -150,42 +156,43 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create and push multi-arch zk-environment lightweight manifests for Dockerhub
+      - name: Log in to US GAR
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch') }}
+        run: |
+          gcloud auth print-access-token --lifetime=7200 --impersonate-service-account=gha-ci-runners@matterlabs-infra.iam.gserviceaccount.com | docker login -u oauth2accesstoken --password-stdin https://us-docker.pkg.dev
+
+      - name: Create and push multi-arch manifests to all registries
         shell: bash
         run: |
           images=("lightweight" "lightweight-nightly")
           archs=("amd64" "arm64")
 
           for img in "${images[@]}"; do
-            multiarch_tag="matterlabs/zk-environment:latest2.0-${img}"
-            individual_images=()
+            # Pull images from each registry and create manifests
+            individual_images_dockerhub=()
+            individual_images_ghcr=()
+            individual_images_gar=()
 
             for arch in "${archs[@]}"; do
               TAG="${{ needs.get_short_sha.outputs.short_sha }}-${img}-${arch}"
+
+              # Pull from DockerHub
               docker pull matterlabs/zk-environment:${TAG} --platform linux/${arch}
-              individual_images+=("matterlabs/zk-environment:${TAG}")
-            done
+              individual_images_dockerhub+=("matterlabs/zk-environment:${TAG}")
 
-            docker buildx imagetools create --tag "${multiarch_tag}" "${individual_images[@]}"
-          done
-
-      - name: Create and push multi-arch zk-environment lightweight manifests for GitHub Container Registry
-        shell: bash
-        run: |
-          images=("lightweight" "lightweight-nightly")
-          archs=("amd64" "arm64")
-
-          for img in "${images[@]}"; do
-            multiarch_tag="ghcr.io/${{ github.repository_owner }}/zk-environment:latest2.0-${img}"
-            individual_images=()
-
-            for arch in "${archs[@]}"; do
-              TAG="${{ needs.get_short_sha.outputs.short_sha }}-${img}-${arch}"
+              # Pull from GHCR
               docker pull ghcr.io/${{ github.repository_owner }}/zk-environment:${TAG} --platform linux/${arch}
-              individual_images+=("ghcr.io/${{ github.repository_owner }}/zk-environment:${TAG}")
+              individual_images_ghcr+=("ghcr.io/${{ github.repository_owner }}/zk-environment:${TAG}")
+
+              # Pull from GAR
+              docker pull us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/zk-environment:${TAG} --platform linux/${arch}
+              individual_images_gar+=("us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/zk-environment:${TAG}")
             done
 
-            docker buildx imagetools create --tag "${multiarch_tag}" "${individual_images[@]}"
+            # Create manifests for all registries
+            docker buildx imagetools create --tag "matterlabs/zk-environment:latest2.0-${img}" "${individual_images_dockerhub[@]}"
+            docker buildx imagetools create --tag "ghcr.io/${{ github.repository_owner }}/zk-environment:latest2.0-${img}" "${individual_images_ghcr[@]}"
+            docker buildx imagetools create --tag "us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/zk-environment:latest2.0-${img}" "${individual_images_gar[@]}"
           done
 
   zk_environment_cuda:
@@ -213,7 +220,7 @@ jobs:
           submodules: "recursive"
 
       - name: Log in to US GAR
-        if: ${{ (steps.condition.outputs.should_run == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.build_cuda) }}
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch') }}
         run: |
           gcloud auth print-access-token --lifetime=7200 --impersonate-service-account=gha-ci-runners@matterlabs-infra.iam.gserviceaccount.com | docker login -u oauth2accesstoken --password-stdin https://us-docker.pkg.dev
 
@@ -238,11 +245,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: ${{ (steps.condition.outputs.should_run == 'true') || (github.event_name == 'workflow_dispatch' && inputs.build_cuda) }}
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build and optionally push
         if: ${{ (steps.condition.outputs.should_run == 'true') || (github.event_name == 'workflow_dispatch' && inputs.build_cuda) }}
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           file: docker/zk-environment/22.04_amd64_cuda_${{ matrix.cuda_version }}.Dockerfile
           push: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) || (github.event_name == 'workflow_dispatch' && inputs.build_cuda) }}

--- a/zkstack_cli/Cargo.lock
+++ b/zkstack_cli/Cargo.lock
@@ -7968,7 +7968,7 @@ dependencies = [
  "elliptic-curve",
  "hex",
  "k256",
- "rand",
+ "rand 0.8.5",
  "sha3",
  "thiserror 1.0.69",
  "zeroize",
@@ -7985,7 +7985,7 @@ dependencies = [
  "hex",
  "num-bigint",
  "prost",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "zksync_concurrency",
  "zksync_consensus_crypto",
@@ -8000,7 +8000,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0df57fdc2a2791ae0031e86931f2d08b31a54a46f5f28b0f833f2e4aa598bc59"
 dependencies = [
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "zksync_concurrency",
 ]


### PR DESCRIPTION
## What ❔

- Bumps Github Actions in zk-env CI workflow
- Pushes all zk-env images to all 3 registies we are using - ghcr, Dockerhub, GAR

## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
