### PR TITLE
feat(api): Support combined HTTP / WS server

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -524,7 +524,10 @@ jobs:
           # Override config for part of chains to test the default config as well
           ci_run zkstack dev config-writer --path etc/env/file_based/overrides/tests/integration.yaml --chain era
           ci_run zkstack dev config-writer --path etc/env/file_based/overrides/tests/integration.yaml --chain validium
-          
+          # Run the combined HTTP / WS server for some chains
+          sudo yq -i '.api.web3_json_rpc.ws_port = .api.web3_json_rpc.http_port' ./chains/era/configs/general.yaml
+          sudo yq -i '.api.web3_json_rpc.ws_url = "ws://127.0.0.1:\(.api.web3_json_rpc.http_port)/"' ./chains/era/configs/general.yaml
+
           ci_run zkstack server --ignore-prerequisites --chain era &> ${{ env.SERVER_LOGS_DIR }}/rollup.log &
           ci_run zkstack server --ignore-prerequisites --chain validium &> ${{ env.SERVER_LOGS_DIR }}/validium.log &
           ci_run zkstack server --ignore-prerequisites --chain custom_token &> ${{ env.SERVER_LOGS_DIR }}/custom_token.log &
@@ -677,6 +680,10 @@ jobs:
 
       - name: Run external nodes
         run: |
+          # Run the combined HTTP / WS server on the EN for some chains
+          sudo yq -i '.api.web3_json_rpc.ws_port = .api.web3_json_rpc.http_port' ./chains/validium/configs/external_node/general.yaml
+          sudo yq -i '.api.web3_json_rpc.ws_url = "ws://127.0.0.1:\(.api.web3_json_rpc.http_port)/"' ./chains/validium/configs/external_node/general.yaml
+
           ci_run zkstack external-node run --ignore-prerequisites --chain era &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/rollup.log &
           ci_run zkstack external-node run --ignore-prerequisites --chain validium --components all,da_fetcher &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/validium.log &
           ci_run zkstack external-node run --ignore-prerequisites --chain custom_token &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/custom_token.log &

--- a/core/bin/external_node/src/config/tests/config.yaml
+++ b/core/bin/external_node/src/config/tests/config.yaml
@@ -63,6 +63,9 @@ api:
     api_namespaces:
       - zks
       - eth
+    ws_api_namespaces:
+      - eth
+      - pubsub
     latest_values_max_block_lag: 30
     mempool_cache_update_interval_ms: 75
     max_response_body_size_mb: 5

--- a/core/bin/external_node/src/config/tests/mod.rs
+++ b/core/bin/external_node/src/config/tests/mod.rs
@@ -229,6 +229,7 @@ fn parsing_from_full_env() {
         EN_WHITELISTED_TOKENS_FOR_AA=0x0000000000000000000000000000000000000001
         EN_REQUEST_TIMEOUT_SEC=20
         EN_GAS_PRICE_SCALE_FACTOR_OPEN_BATCH=1.35
+        EN_WS_API_NAMESPACES=eth,pubsub
         # NEW PARAMS: From HealthcheckConfig
         EN_HEALTHCHECK_EXPOSE_CONFIG=true
 
@@ -358,6 +359,10 @@ fn test_parsing_general_config(source: impl ConfigSource + Clone) {
     assert_eq!(
         config.api_namespaces,
         HashSet::from([Namespace::Zks, Namespace::Eth])
+    );
+    assert_eq!(
+        config.ws_api_namespaces,
+        Some(HashSet::from([Namespace::Pubsub, Namespace::Eth]))
     );
     assert!(config.filters_disabled);
     assert_eq!(

--- a/core/bin/external_node/src/node_builder.rs
+++ b/core/bin/external_node/src/node_builder.rs
@@ -491,12 +491,18 @@ impl<R> ExternalNodeBuilder<R> {
 impl ExternalNodeBuilder {
     fn web3_api_optional_config(&self) -> anyhow::Result<Web3ServerOptionalConfig> {
         let config = &self.config.local.api.web3_json_rpc;
+        let http_namespaces = config.api_namespaces.clone();
+        let ws_namespaces = config
+            .ws_api_namespaces
+            .clone()
+            .unwrap_or_else(|| http_namespaces.clone());
         // The refresh interval should be several times lower than the pruning removal delay, so that
         // soft-pruning will timely propagate to the API server.
         let pruning_info_refresh_interval = self.config.local.pruning.removal_delay / 5;
 
         Ok(Web3ServerOptionalConfig {
-            namespaces: config.api_namespaces.clone(),
+            http_namespaces,
+            ws_namespaces,
             filters_limit: config.filters_limit,
             subscriptions_limit: config.subscriptions_limit,
             batch_request_size_limit: config.max_batch_request_size.get(),

--- a/core/bin/external_node/src/node_builder.rs
+++ b/core/bin/external_node/src/node_builder.rs
@@ -492,10 +492,7 @@ impl ExternalNodeBuilder {
     fn web3_api_optional_config(&self) -> anyhow::Result<Web3ServerOptionalConfig> {
         let config = &self.config.local.api.web3_json_rpc;
         let http_namespaces = config.api_namespaces.clone();
-        let ws_namespaces = config
-            .ws_api_namespaces
-            .clone()
-            .unwrap_or_else(|| http_namespaces.clone());
+        let ws_namespaces = config.ws_namespaces().clone();
         // The refresh interval should be several times lower than the pruning removal delay, so that
         // soft-pruning will timely propagate to the API server.
         let pruning_info_refresh_interval = self.config.local.pruning.removal_delay / 5;

--- a/core/bin/external_node/src/node_builder.rs
+++ b/core/bin/external_node/src/node_builder.rs
@@ -544,28 +544,15 @@ impl ExternalNodeBuilder {
         Ok(self)
     }
 
-    fn add_http_web3_api_layer(mut self) -> anyhow::Result<Self> {
-        let mut optional_config = self.web3_api_optional_config()?;
-        // Not relevant for HTTP server, so we reset to prevent a logged warning.
-        optional_config.websocket_requests_per_minute_limit = None;
-        let internal_api_config_base: InternalApiConfigBase = (&self.config).into();
-
-        self.node.add_layer(Web3ServerLayer::http(
-            self.config.local.api.web3_json_rpc.http_port,
-            internal_api_config_base,
-            optional_config,
-        ));
-
-        Ok(self)
-    }
-
-    fn add_ws_web3_api_layer(mut self) -> anyhow::Result<Self> {
+    fn add_web3_api_layer(mut self, enable_http: bool, enable_ws: bool) -> anyhow::Result<Self> {
         // TODO: Support websocket requests per minute limit
         let optional_config = self.web3_api_optional_config()?;
         let internal_api_config_base: InternalApiConfigBase = (&self.config).into();
+        let api = &self.config.local.api;
 
-        self.node.add_layer(Web3ServerLayer::ws(
-            self.config.local.api.web3_json_rpc.ws_port,
+        self.node.add_layer(Web3ServerLayer::new(
+            enable_http.then_some(api.web3_json_rpc.http_port),
+            enable_ws.then_some(api.web3_json_rpc.ws_port),
             internal_api_config_base,
             optional_config,
         ));
@@ -620,7 +607,9 @@ impl ExternalNodeBuilder {
 
         for component in &components {
             match component {
-                Component::HttpApi => {
+                Component::HttpApi | Component::WsApi => {
+                    let enable_http = components.contains(&Component::HttpApi);
+                    let enable_ws = components.contains(&Component::WsApi);
                     self = self
                         .add_sync_state_updater_layer()?
                         .add_bridge_addresses_updater_layer()?
@@ -628,17 +617,7 @@ impl ExternalNodeBuilder {
                         .add_tree_api_client_layer()?
                         .add_main_node_fee_params_fetcher_layer()?
                         .add_tx_sender_layer()?
-                        .add_http_web3_api_layer()?;
-                }
-                Component::WsApi => {
-                    self = self
-                        .add_sync_state_updater_layer()?
-                        .add_bridge_addresses_updater_layer()?
-                        .add_mempool_cache_layer()?
-                        .add_tree_api_client_layer()?
-                        .add_main_node_fee_params_fetcher_layer()?
-                        .add_tx_sender_layer()?
-                        .add_ws_web3_api_layer()?;
+                        .add_web3_api_layer(enable_http, enable_ws)?;
                 }
                 Component::Tree => {
                     // Right now, distributed mode for EN is not fully supported, e.g. there are some

--- a/core/bin/zksync_server/src/node_builder.rs
+++ b/core/bin/zksync_server/src/node_builder.rs
@@ -420,14 +420,19 @@ impl MainNodeBuilder {
         let state_keeper_config = try_load_config!(self.configs.state_keeper_config);
 
         // TODO(PLA-1153): Make the node do what the config says
-        let mut namespaces = rpc_config.api_namespaces.clone();
+        let mut http_namespaces = rpc_config.api_namespaces.clone();
         if state_keeper_config.shared.save_call_traces {
-            namespaces.insert(Namespace::Debug);
+            http_namespaces.insert(Namespace::Debug);
         }
-        namespaces.insert(Namespace::Snapshots);
+        http_namespaces.insert(Namespace::Snapshots);
+        let ws_namespaces = rpc_config
+            .ws_api_namespaces
+            .clone()
+            .unwrap_or_else(|| http_namespaces.clone());
 
         let optional_config = Web3ServerOptionalConfig {
-            namespaces,
+            http_namespaces,
+            ws_namespaces,
             filters_limit: rpc_config.filters_limit,
             subscriptions_limit: rpc_config.subscriptions_limit,
             batch_request_size_limit: rpc_config.max_batch_request_size.get(),

--- a/core/bin/zksync_server/src/node_builder.rs
+++ b/core/bin/zksync_server/src/node_builder.rs
@@ -425,10 +425,7 @@ impl MainNodeBuilder {
             http_namespaces.insert(Namespace::Debug);
         }
         http_namespaces.insert(Namespace::Snapshots);
-        let ws_namespaces = rpc_config
-            .ws_api_namespaces
-            .clone()
-            .unwrap_or_else(|| http_namespaces.clone());
+        let ws_namespaces = rpc_config.ws_namespaces().clone();
 
         let optional_config = Web3ServerOptionalConfig {
             http_namespaces,

--- a/core/lib/config/src/configs/api.rs
+++ b/core/lib/config/src/configs/api.rs
@@ -9,7 +9,7 @@ use std::{
 use anyhow::Context as _;
 use serde::{Deserialize, Serialize};
 use smart_config::{
-    de::{Delimited, Entries, NamedEntries, OrString, Serde, ToEntries, WellKnown},
+    de::{Delimited, Entries, NamedEntries, Optional, OrString, Serde, ToEntries, WellKnown},
     metadata::{SizeUnit, TimeUnit},
     ByteSize, DescribeConfig, DeserializeConfig,
 };
@@ -290,9 +290,12 @@ pub struct Web3JsonRpcConfig {
     /// (additionally to natively bridged tokens).
     #[config(default, with = Delimited(","))]
     pub whitelisted_tokens_for_aa: Vec<Address>,
-    /// Enabled JSON RPC API namespaces.
+    /// Enabled JSON-RPC API namespaces. Applies to the HTTP server, and to the WS server unless `ws_api_namespaces` param is set.
     #[config(with = Delimited(","), default_t = Namespace::DEFAULT.into())]
     pub api_namespaces: HashSet<Namespace>,
+    /// JSON-RPC API namespaces for the WS server. If `null`, the WS server will use `api_namespaces`.
+    #[config(with = Optional(Delimited(",")))]
+    pub ws_api_namespaces: Option<HashSet<Namespace>>,
     /// Enables extended tracing of RPC calls. This is useful for debugging, but may negatively impact performance for nodes under high load
     /// (hundreds or thousands RPS).
     #[config(default, alias = "extended_rpc_tracing")]
@@ -443,6 +446,7 @@ mod tests {
                     Address::from_low_u64_be(2),
                 ],
                 api_namespaces: HashSet::from([Namespace::Debug]),
+                ws_api_namespaces: Some(HashSet::from([Namespace::Pubsub])), // FIXME: update fixtures
                 extended_api_tracing: true,
                 gas_price_scale_factor_open_batch: Some(1.3),
             },

--- a/core/lib/config/src/configs/api.rs
+++ b/core/lib/config/src/configs/api.rs
@@ -171,7 +171,7 @@ impl WellKnown for MaxResponseSizeOverrides {
 }
 
 /// Response size limits for JSON-RPC servers.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MaxResponseSize {
     /// Global limit applied to all RPC methods. Measured in bytes.
     pub global: usize,

--- a/core/lib/config/src/configs/api.rs
+++ b/core/lib/config/src/configs/api.rs
@@ -330,6 +330,13 @@ impl Web3JsonRpcConfig {
             overrides: self.max_response_body_size_overrides.scale(scale),
         }
     }
+
+    /// Returns enabled RPC namespaces for the WS server.
+    pub fn ws_namespaces(&self) -> &HashSet<Namespace> {
+        self.ws_api_namespaces
+            .as_ref()
+            .unwrap_or(&self.api_namespaces)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, DescribeConfig, DeserializeConfig)]

--- a/core/lib/config/src/configs/api.rs
+++ b/core/lib/config/src/configs/api.rs
@@ -446,7 +446,7 @@ mod tests {
                     Address::from_low_u64_be(2),
                 ],
                 api_namespaces: HashSet::from([Namespace::Debug]),
-                ws_api_namespaces: Some(HashSet::from([Namespace::Pubsub])), // FIXME: update fixtures
+                ws_api_namespaces: Some(HashSet::from([Namespace::Eth, Namespace::Pubsub])),
                 extended_api_tracing: true,
                 gas_price_scale_factor_open_batch: Some(1.3),
             },
@@ -478,6 +478,7 @@ mod tests {
             API_WEB3_JSON_RPC_ESTIMATE_GAS_OPTIMIZE_SEARCH=true
             API_WEB3_JSON_RPC_VM_EXECUTION_CACHE_MISSES_LIMIT=1000
             API_WEB3_JSON_RPC_API_NAMESPACES=debug
+            API_WEB3_JSON_RPC_WS_API_NAMESPACES=eth,pubsub
             API_WEB3_JSON_RPC_EXTENDED_API_TRACING=true
             API_WEB3_JSON_RPC_WHITELISTED_TOKENS_FOR_AA="0x0000000000000000000000000000000000000001,0x0000000000000000000000000000000000000002"
             API_WEB3_JSON_RPC_ESTIMATE_GAS_SCALE_FACTOR=1.0
@@ -552,6 +553,9 @@ mod tests {
             filters_disabled: false
             api_namespaces:
             - debug
+            ws_api_namespaces:
+            - eth
+            - pubsub
             whitelisted_tokens_for_aa:
             - "0x0000000000000000000000000000000000000001"
             - "0x0000000000000000000000000000000000000002"
@@ -614,6 +618,9 @@ mod tests {
             filters_disabled: false
             api_namespaces:
             - debug
+            ws_api_namespaces:
+            - eth
+            - pubsub
             whitelisted_tokens_for_aa:
             - "0x0000000000000000000000000000000000000001"
             - "0x0000000000000000000000000000000000000002"

--- a/core/lib/health_check/src/lib.rs
+++ b/core/lib/health_check/src/lib.rs
@@ -412,6 +412,15 @@ impl ReactiveHealthCheck {
             Err(_) => future::pending().await,
         }
     }
+
+    /// Switches the name for this healthcheck, while still reporting health from the same [`HealthUpdater`].
+    /// This can be used to report a single component with multiple health checks.
+    pub fn renamed(self, other_name: &'static str) -> Self {
+        Self {
+            name: other_name,
+            health_receiver: self.health_receiver,
+        }
+    }
 }
 
 #[async_trait]

--- a/core/node/api_server/src/node/server/mod.rs
+++ b/core/node/api_server/src/node/server/mod.rs
@@ -249,21 +249,25 @@ impl WiringLayer for Web3ServerLayer {
 
         // Insert healthchecks.
         if let Some(server) = &http_server {
-            input
-                .app_health
-                .insert_component(server.health_check())
-                .map_err(WiringError::internal)?;
+            for health_check in server.health_checks() {
+                input
+                    .app_health
+                    .insert_component(health_check)
+                    .map_err(WiringError::internal)?;
+            }
         }
         let http_server_task = http_server.map(|server| Web3ApiTask {
             server,
-            pub_sub: pub_sub.clone(), // FIXME: double-check
+            pub_sub: pub_sub.clone(),
         });
 
         if let Some(server) = &ws_server {
-            input
-                .app_health
-                .insert_component(server.health_check())
-                .map_err(WiringError::internal)?;
+            for health_check in server.health_checks() {
+                input
+                    .app_health
+                    .insert_component(health_check)
+                    .map_err(WiringError::internal)?;
+            }
         }
         let ws_server_task = ws_server.map(|server| Web3ApiTask { server, pub_sub });
 

--- a/core/node/api_server/src/web3/backend_jsonrpsee/mod.rs
+++ b/core/node/api_server/src/web3/backend_jsonrpsee/mod.rs
@@ -11,7 +11,7 @@ pub(crate) use self::{
     metadata::{MethodMetadata, MethodTracer},
     middleware::{
         CorrelationMiddleware, LimitMiddleware, MetadataLayer, RpcMethodFilter,
-        ServerTimeoutMiddleware, ShutdownMiddleware, TrafficTracker,
+        RpcMethodFilterConfig, ServerTimeoutMiddleware, ShutdownMiddleware, TrafficTracker,
     },
 };
 use crate::tx_sender::SubmitTxError;

--- a/core/node/api_server/src/web3/backend_jsonrpsee/mod.rs
+++ b/core/node/api_server/src/web3/backend_jsonrpsee/mod.rs
@@ -10,8 +10,8 @@ use zksync_web3_decl::{
 pub(crate) use self::{
     metadata::{MethodMetadata, MethodTracer},
     middleware::{
-        CorrelationMiddleware, LimitMiddleware, MetadataLayer, ServerTimeoutMiddleware,
-        ShutdownMiddleware, TrafficTracker,
+        CorrelationMiddleware, LimitMiddleware, MetadataLayer, RpcMethodFilter,
+        ServerTimeoutMiddleware, ShutdownMiddleware, TrafficTracker,
     },
 };
 use crate::tx_sender::SubmitTxError;

--- a/core/node/api_server/src/web3/http_middleware.rs
+++ b/core/node/api_server/src/web3/http_middleware.rs
@@ -1,0 +1,85 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::future::Either;
+use http::{Request, Response};
+use pin_project_lite::pin_project;
+use tower::Service;
+use tower_http::cors::{self, Cors, CorsLayer};
+use zksync_web3_decl::jsonrpsee::server;
+
+use super::metrics::{ApiTransportLabel, API_METRICS};
+
+/// Middleware applying CORS to HTTP requests and adding the transport label to the request extensions.
+#[derive(Debug)]
+pub(super) struct TransportLayer {
+    pub cors: CorsLayer,
+}
+
+impl<Svc> tower::Layer<Svc> for TransportLayer {
+    type Service = WithTransport<Svc>;
+
+    fn layer(&self, inner: Svc) -> Self::Service {
+        WithTransport {
+            cors: self.cors.layer(inner),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct WithTransport<Svc> {
+    cors: Cors<Svc>,
+}
+
+impl<Svc, ReqBody, ResBody> Service<Request<ReqBody>> for WithTransport<Svc>
+where
+    Svc: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    ResBody: Default,
+{
+    type Response = Svc::Response;
+    type Error = Svc::Error;
+    type Future = Either<WsSession<Svc::Future>, cors::ResponseFuture<Svc::Future>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.cors.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        let transport = if server::ws::is_upgrade_request(&req) {
+            ApiTransportLabel::Ws
+        } else {
+            ApiTransportLabel::Http
+        };
+        req.extensions_mut().insert(transport);
+
+        if matches!(transport, ApiTransportLabel::Http) {
+            // CORS is not applied to WS requests.
+            Either::Right(self.cors.call(req))
+        } else {
+            Either::Left(WsSession {
+                inner: self.cors.get_mut().call(req),
+                _guard: API_METRICS.ws_open_sessions.inc_guard(1),
+            })
+        }
+    }
+}
+
+pin_project! {
+    #[derive(Debug)]
+    pub(super) struct WsSession<Fut> {
+        #[pin]
+        inner: Fut,
+        _guard: vise::GaugeGuard,
+    }
+}
+
+impl<Fut: Future> Future for WsSession<Fut> {
+    type Output = Fut::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().inner.poll(cx)
+    }
+}

--- a/core/node/api_server/src/web3/metrics.rs
+++ b/core/node/api_server/src/web3/metrics.rs
@@ -500,6 +500,16 @@ pub(super) struct TxReceiptMetrics {
 #[vise::register]
 pub(super) static TX_RECEIPT_METRICS: vise::Global<TxReceiptMetrics> = vise::Global::new();
 
+#[derive(Debug, Metrics)]
+#[metrics(prefix = "api_jsonrpc_backend_batch")] // FIXME: prefix is bogus; there's no `jsonrpc_backend`
+pub(super) struct LimitMiddlewareMetrics {
+    /// Number of rate-limited requests.
+    pub rate_limited: Family<ApiTransportLabel, Counter>,
+}
+
+#[vise::register]
+pub(super) static LIMIT_METRICS: vise::Global<LimitMiddlewareMetrics> = vise::Global::new();
+
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;

--- a/core/node/api_server/src/web3/metrics.rs
+++ b/core/node/api_server/src/web3/metrics.rs
@@ -10,7 +10,7 @@ use zksync_instrument::filter::{report_filter, ReportFilter};
 use zksync_types::api;
 use zksync_web3_decl::error::Web3Error;
 
-use super::{backend_jsonrpsee::MethodMetadata, ApiTransport, TypedFilter};
+use super::{backend_jsonrpsee::MethodMetadata, TypedFilter};
 use crate::tx_sender::SubmitTxError;
 
 /// Observed version of RPC parameters. Have a bounded upper-limit size (256 bytes), so that we don't over-allocate.
@@ -82,15 +82,6 @@ impl<'a> ObservedRpcParams<'a> {
 pub(crate) enum ApiTransportLabel {
     Http,
     Ws,
-}
-
-impl From<&ApiTransport> for ApiTransportLabel {
-    fn from(transport: &ApiTransport) -> Self {
-        match transport {
-            ApiTransport::Http(_) => Self::Http,
-            ApiTransport::WebSocket(_) => Self::Ws,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue)]

--- a/core/node/api_server/src/web3/namespaces/debug.rs
+++ b/core/node/api_server/src/web3/namespaces/debug.rs
@@ -28,8 +28,8 @@ pub(crate) struct DebugNamespace {
 }
 
 impl DebugNamespace {
-    pub async fn new(state: RpcState) -> anyhow::Result<Self> {
-        Ok(Self { state })
+    pub fn new(state: RpcState) -> Self {
+        Self { state }
     }
 
     pub(crate) fn map_call(

--- a/core/node/api_server/src/web3/namespaces/eth.rs
+++ b/core/node/api_server/src/web3/namespaces/eth.rs
@@ -216,8 +216,7 @@ impl EthNamespace {
     pub async fn get_filter_logs_impl(&self, idx: U256) -> Result<FilterChanges, Web3Error> {
         let installed_filters = self
             .state
-            .installed_filters
-            .as_ref()
+            .installed_filters()
             .ok_or(Web3Error::MethodNotImplemented)?;
         // We clone the filter to not hold the filter lock for an extended period of time.
         let maybe_filter = installed_filters.lock().await.get_and_update_stats(idx);
@@ -565,8 +564,7 @@ impl EthNamespace {
     pub async fn new_block_filter_impl(&self) -> Result<U256, Web3Error> {
         let installed_filters = self
             .state
-            .installed_filters
-            .as_ref()
+            .installed_filters()
             .ok_or(Web3Error::MethodNotImplemented)?;
         let mut storage = self.state.acquire_connection().await?;
         let last_block_number = storage
@@ -587,8 +585,7 @@ impl EthNamespace {
     pub async fn new_filter_impl(&self, mut filter: Filter) -> Result<U256, Web3Error> {
         let installed_filters = self
             .state
-            .installed_filters
-            .as_ref()
+            .installed_filters()
             .ok_or(Web3Error::MethodNotImplemented)?;
         if let Some(topics) = filter.topics.as_ref() {
             if topics.len() > EVENT_TOPIC_NUMBER_LIMIT {
@@ -607,8 +604,7 @@ impl EthNamespace {
     pub async fn new_pending_transaction_filter_impl(&self) -> Result<U256, Web3Error> {
         let installed_filters = self
             .state
-            .installed_filters
-            .as_ref()
+            .installed_filters()
             .ok_or(Web3Error::MethodNotImplemented)?;
         Ok(installed_filters
             .lock()
@@ -621,8 +617,7 @@ impl EthNamespace {
     pub async fn get_filter_changes_impl(&self, idx: U256) -> Result<FilterChanges, Web3Error> {
         let installed_filters = self
             .state
-            .installed_filters
-            .as_ref()
+            .installed_filters()
             .ok_or(Web3Error::MethodNotImplemented)?;
         let mut filter = installed_filters
             .lock()
@@ -647,8 +642,7 @@ impl EthNamespace {
     pub async fn uninstall_filter_impl(&self, idx: U256) -> Result<bool, Web3Error> {
         let installed_filters = self
             .state
-            .installed_filters
-            .as_ref()
+            .installed_filters()
             .ok_or(Web3Error::MethodNotImplemented)?;
         Ok(installed_filters.lock().await.remove(idx))
     }

--- a/core/node/api_server/src/web3/pubsub.rs
+++ b/core/node/api_server/src/web3/pubsub.rs
@@ -472,7 +472,7 @@ impl EthSubscribe {
     /// Test-only helper spawning all 3 notifier tasks.
     pub(crate) fn spawn_notifiers(
         &self,
-        connection_pool: ConnectionPool<Core>,
+        connection_pool: &ConnectionPool<Core>,
         stop_receiver: &watch::Receiver<bool>,
     ) -> Vec<JoinHandle<anyhow::Result<()>>> {
         [

--- a/core/node/api_server/src/web3/pubsub.rs
+++ b/core/node/api_server/src/web3/pubsub.rs
@@ -254,7 +254,7 @@ impl PubSubNotifier {
 }
 
 /// Subscription support for Web3 APIs.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct EthSubscribe {
     polling_interval: Duration,
     blocks: broadcast::Sender<Vec<PubSubResult>>,

--- a/core/node/api_server/src/web3/testonly.rs
+++ b/core/node/api_server/src/web3/testonly.rs
@@ -136,8 +136,9 @@ impl TestServerBuilder {
     }
 
     /// Sets an RPC method tracer for this builder.
+    #[cfg(test)]
     #[must_use]
-    pub fn with_method_tracer(mut self, tracer: Arc<MethodTracer>) -> Self {
+    pub(crate) fn with_method_tracer(mut self, tracer: Arc<MethodTracer>) -> Self {
         self.method_tracer = tracer;
         self
     }

--- a/core/node/api_server/src/web3/testonly.rs
+++ b/core/node/api_server/src/web3/testonly.rs
@@ -232,7 +232,8 @@ impl TestServerBuilder {
             .with_tx_sender(tx_sender)
             .with_vm_barrier(vm_barrier)
             .with_method_tracer(method_tracer)
-            .enable_api_namespaces(namespaces)
+            .enable_http_namespaces(namespaces.clone())
+            .enable_ws_namespaces(namespaces)
             .with_sealed_l2_block_handle(sealed_l2_block_handle)
             .with_bridge_addresses_handle(bridge_addresses_handle);
         if let Some(timeout) = request_timeout {

--- a/core/node/api_server/src/web3/testonly.rs
+++ b/core/node/api_server/src/web3/testonly.rs
@@ -241,7 +241,7 @@ impl TestServerBuilder {
         }
 
         let server = server_builder.build().expect("Unable to build API server");
-        let health_check = server.health_check();
+        let health_check = server.health_checks().pop().unwrap();
         server_tasks.push(tokio::spawn(server.run(pub_sub, stop_receiver)));
         let handles = ApiServerHandles {
             tasks: server_tasks,

--- a/core/node/api_server/src/web3/tests/combined.rs
+++ b/core/node/api_server/src/web3/tests/combined.rs
@@ -1,12 +1,7 @@
 //! Tests for combined HTTP / WS server.
 
-use std::fmt;
-
 use zksync_types::web3::BlockHeader;
-use zksync_web3_decl::{
-    client::WsClient,
-    jsonrpsee::core::client::{Error, SubscriptionClientT},
-};
+use zksync_web3_decl::{client::WsClient, jsonrpsee::core::client::SubscriptionClientT};
 
 use super::{ws::WsTest, *};
 use crate::web3::metrics::SubscriptionType;
@@ -47,13 +42,6 @@ async fn test_combined_server(test: impl CombinedTest) {
 
     stop_sender.send_replace(true);
     server_handles.shutdown().await;
-}
-
-fn assert_not_found<T: fmt::Debug>(result: Result<T, Error>) {
-    assert_matches!(result, Err(Error::Call(e)) => {
-        assert_eq!(e.code(), ErrorCode::MethodNotFound.code());
-        assert_eq!(e.message(), ErrorCode::MethodNotFound.message());
-    });
 }
 
 #[derive(Debug)]

--- a/core/node/api_server/src/web3/tests/combined.rs
+++ b/core/node/api_server/src/web3/tests/combined.rs
@@ -1,0 +1,142 @@
+//! Tests for combined HTTP / WS server.
+
+use std::fmt;
+
+use zksync_types::web3::BlockHeader;
+use zksync_web3_decl::{
+    client::WsClient,
+    jsonrpsee::core::client::{Error, SubscriptionClientT},
+};
+
+use super::{ws::WsTest, *};
+use crate::web3::metrics::SubscriptionType;
+
+#[async_trait]
+trait CombinedTest: TestInit {
+    async fn test(
+        &self,
+        http_client: &DynClient<L2>,
+        ws_client: &WsClient<L2>,
+        pool: &ConnectionPool<Core>,
+        pub_sub_events: &mut mpsc::UnboundedReceiver<PubSubEvent>,
+    ) -> anyhow::Result<()>;
+}
+
+async fn test_combined_server(test: impl CombinedTest) {
+    let pool = ConnectionPool::<Core>::test_pool().await;
+    let (stop_sender, stop_receiver) = watch::channel(false);
+    let transport = ApiTransport::HttpAndWs((Ipv4Addr::LOCALHOST, 0).into());
+    let (local_addr, mut server_handles) =
+        prepare_server(transport, &pool, &test, stop_receiver).await;
+
+    let http_client = Client::http(format!("http://{local_addr}/").parse().unwrap())
+        .unwrap()
+        .build();
+    let ws_client = Client::ws(format!("ws://{local_addr}").parse().unwrap())
+        .await
+        .unwrap()
+        .build();
+    test.test(
+        &http_client,
+        &ws_client,
+        &pool,
+        &mut server_handles.pub_sub_events,
+    )
+    .await
+    .unwrap();
+
+    stop_sender.send_replace(true);
+    server_handles.shutdown().await;
+}
+
+fn assert_not_found<T: fmt::Debug>(result: Result<T, Error>) {
+    assert_matches!(result, Err(Error::Call(e)) => {
+        assert_eq!(e.code(), ErrorCode::MethodNotFound.code());
+        assert_eq!(e.message(), ErrorCode::MethodNotFound.message());
+    });
+}
+
+#[derive(Debug)]
+struct CombinedServerBasicTest;
+
+impl TestInit for CombinedServerBasicTest {}
+
+#[async_trait]
+impl CombinedTest for CombinedServerBasicTest {
+    async fn test(
+        &self,
+        http_client: &DynClient<L2>,
+        ws_client: &WsClient<L2>,
+        pool: &ConnectionPool<Core>,
+        pub_sub_events: &mut mpsc::UnboundedReceiver<PubSubEvent>,
+    ) -> anyhow::Result<()> {
+        // Just delegate to already defined basic HTTP / WS tests.
+        HttpServerBasicsTest.test(http_client, pool).await?;
+        ws::WsServerCanStartTest
+            .test(ws_client, pool, pub_sub_events)
+            .await?;
+        ws::BasicSubscriptionsTest::default()
+            .test(ws_client, pool, pub_sub_events)
+            .await?;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn combined_server_basics() {
+    test_combined_server(CombinedServerBasicTest).await;
+}
+
+#[derive(Debug)]
+struct NamespaceFilteringTest;
+
+impl TestInit for NamespaceFilteringTest {
+    fn web3_config(&self) -> Web3JsonRpcConfig {
+        Web3JsonRpcConfig {
+            api_namespaces: HashSet::from([Namespace::Eth]),
+            ws_api_namespaces: Some(HashSet::from([Namespace::Zks, Namespace::Pubsub])),
+            ..Web3JsonRpcConfig::for_tests()
+        }
+    }
+}
+
+#[async_trait]
+impl CombinedTest for NamespaceFilteringTest {
+    async fn test(
+        &self,
+        http_client: &DynClient<L2>,
+        ws_client: &WsClient<L2>,
+        _pool: &ConnectionPool<Core>,
+        pub_sub_events: &mut mpsc::UnboundedReceiver<PubSubEvent>,
+    ) -> anyhow::Result<()> {
+        let block_number = http_client.get_block_number().await?;
+        assert_eq!(block_number, U64::from(0));
+        let l1_batch_number = ws_client.get_l1_batch_number().await?;
+        assert_eq!(l1_batch_number, U64::from(0));
+
+        assert_not_found(ws_client.get_block_number().await);
+        assert_not_found(http_client.get_l1_batch_number().await);
+
+        // The HTTP server must not support subscriptions.
+        assert_not_found(
+            http_client
+                .request::<String, _>("eth_subscribe", rpc_params!["newHeads"])
+                .await,
+        );
+
+        // Subscriptions must work for the WS server.
+        let params = rpc_params!["newHeads"];
+        let blocks_subscription = ws_client
+            .subscribe::<BlockHeader, _>("eth_subscribe", params, "eth_unsubscribe")
+            .await?;
+        ws::wait_for_subscription(pub_sub_events, SubscriptionType::Blocks).await;
+
+        blocks_subscription.unsubscribe().await?;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn namespace_filtering() {
+    test_combined_server(NamespaceFilteringTest).await;
+}

--- a/core/node/api_server/src/web3/tests/debug.rs
+++ b/core/node/api_server/src/web3/tests/debug.rs
@@ -39,6 +39,8 @@ fn execute_l2_transaction_with_traces(index_in_block: u8) -> TransactionExecutio
 #[derive(Debug)]
 struct TraceBlockTest(L2BlockNumber);
 
+impl TestInit for TraceBlockTest {}
+
 #[async_trait]
 impl HttpTest for TraceBlockTest {
     async fn test(
@@ -106,6 +108,8 @@ async fn tracing_block() {
 
 #[derive(Debug)]
 struct TraceBlockFlatTest(L2BlockNumber);
+
+impl TestInit for TraceBlockFlatTest {}
 
 #[async_trait]
 impl HttpTest for TraceBlockFlatTest {
@@ -201,6 +205,8 @@ async fn tracing_block_flat() {
 #[derive(Debug)]
 struct TraceTransactionTest;
 
+impl TestInit for TraceTransactionTest {}
+
 #[async_trait]
 impl HttpTest for TraceTransactionTest {
     async fn test(
@@ -241,12 +247,14 @@ async fn tracing_transaction() {
 #[derive(Debug)]
 struct TraceBlockTestWithSnapshotRecovery;
 
-#[async_trait]
-impl HttpTest for TraceBlockTestWithSnapshotRecovery {
+impl TestInit for TraceBlockTestWithSnapshotRecovery {
     fn storage_initialization(&self) -> StorageInitialization {
         StorageInitialization::empty_recovery()
     }
+}
 
+#[async_trait]
+impl HttpTest for TraceBlockTestWithSnapshotRecovery {
     async fn test(
         &self,
         client: &DynClient<L2>,
@@ -282,6 +290,8 @@ async fn tracing_block_after_snapshot_recovery() {
 #[derive(Debug)]
 struct GetRawTransactionTest;
 
+impl TestInit for GetRawTransactionTest {}
+
 #[async_trait]
 impl HttpTest for GetRawTransactionTest {
     async fn test(
@@ -315,6 +325,8 @@ async fn get_raw_transaction() {
 
 #[derive(Debug)]
 struct GetRawTransactionsTest(L2BlockNumber);
+
+impl TestInit for GetRawTransactionsTest {}
 
 #[async_trait]
 impl HttpTest for GetRawTransactionsTest {

--- a/core/node/api_server/src/web3/tests/filters.rs
+++ b/core/node/api_server/src/web3/tests/filters.rs
@@ -17,8 +17,7 @@ struct BasicFilterChangesTest {
     snapshot_recovery: bool,
 }
 
-#[async_trait]
-impl HttpTest for BasicFilterChangesTest {
+impl TestInit for BasicFilterChangesTest {
     fn storage_initialization(&self) -> StorageInitialization {
         if self.snapshot_recovery {
             StorageInitialization::empty_recovery()
@@ -26,7 +25,10 @@ impl HttpTest for BasicFilterChangesTest {
             StorageInitialization::genesis()
         }
     }
+}
 
+#[async_trait]
+impl HttpTest for BasicFilterChangesTest {
     async fn test(
         &self,
         client: &DynClient<L2>,
@@ -103,8 +105,7 @@ struct LogFilterChangesTest {
     snapshot_recovery: bool,
 }
 
-#[async_trait]
-impl HttpTest for LogFilterChangesTest {
+impl TestInit for LogFilterChangesTest {
     fn storage_initialization(&self) -> StorageInitialization {
         if self.snapshot_recovery {
             StorageInitialization::empty_recovery()
@@ -112,7 +113,10 @@ impl HttpTest for LogFilterChangesTest {
             StorageInitialization::genesis()
         }
     }
+}
 
+#[async_trait]
+impl HttpTest for LogFilterChangesTest {
     async fn test(
         &self,
         client: &DynClient<L2>,
@@ -185,6 +189,8 @@ async fn log_filter_changes_after_snapshot_recovery() {
 
 #[derive(Debug)]
 struct LogFilterChangesWithBlockBoundariesTest;
+
+impl TestInit for LogFilterChangesWithBlockBoundariesTest {}
 
 #[async_trait]
 impl HttpTest for LogFilterChangesWithBlockBoundariesTest {
@@ -294,6 +300,15 @@ fn assert_not_implemented<T: fmt::Debug>(result: Result<T, Error>) {
 #[derive(Debug)]
 struct DisableFiltersTest;
 
+impl TestInit for DisableFiltersTest {
+    fn web3_config(&self) -> Web3JsonRpcConfig {
+        Web3JsonRpcConfig {
+            filters_disabled: true,
+            ..Web3JsonRpcConfig::for_tests()
+        }
+    }
+}
+
 #[async_trait]
 impl HttpTest for DisableFiltersTest {
     async fn test(
@@ -313,13 +328,6 @@ impl HttpTest for DisableFiltersTest {
         assert_not_implemented(client.get_filter_changes(1.into()).await);
 
         Ok(())
-    }
-
-    fn web3_config(&self) -> Web3JsonRpcConfig {
-        Web3JsonRpcConfig {
-            filters_disabled: true,
-            ..Web3JsonRpcConfig::for_tests()
-        }
     }
 }
 

--- a/core/node/api_server/src/web3/tests/snapshots.rs
+++ b/core/node/api_server/src/web3/tests/snapshots.rs
@@ -26,6 +26,8 @@ impl SnapshotBasicsTest {
     }
 }
 
+impl TestInit for SnapshotBasicsTest {}
+
 #[async_trait]
 impl HttpTest for SnapshotBasicsTest {
     async fn test(

--- a/core/node/api_server/src/web3/tests/unstable.rs
+++ b/core/node/api_server/src/web3/tests/unstable.rs
@@ -6,13 +6,9 @@ use zksync_web3_decl::namespaces::UnstableNamespaceClient;
 use super::*;
 
 #[derive(Debug)]
-struct GetTeeProofsTest {}
+struct GetTeeProofsTest;
 
-impl GetTeeProofsTest {
-    fn new() -> Self {
-        Self {}
-    }
-}
+impl TestInit for GetTeeProofsTest {}
 
 #[async_trait]
 impl HttpTest for GetTeeProofsTest {
@@ -60,5 +56,5 @@ impl HttpTest for GetTeeProofsTest {
 
 #[tokio::test]
 async fn get_tee_proofs() {
-    test_http_server(GetTeeProofsTest::new()).await;
+    test_http_server(GetTeeProofsTest).await;
 }

--- a/core/node/api_server/src/web3/tests/vm.rs
+++ b/core/node/api_server/src/web3/tests/vm.rs
@@ -120,12 +120,14 @@ impl CallTest {
     }
 }
 
-#[async_trait]
-impl HttpTest for CallTest {
+impl TestInit for CallTest {
     fn transaction_executor(&self) -> MockOneshotExecutor {
         Self::create_executor(L2BlockNumber(1), self.fee_input.clone())
     }
+}
 
+#[async_trait]
+impl HttpTest for CallTest {
     async fn test(
         &self,
         client: &DynClient<L2>,
@@ -252,8 +254,7 @@ fn evm_emulator_responses(tx: &Transaction, env: &OneshotEnv) -> ExecutionResult
 #[derive(Debug)]
 struct CallTestWithEvmEmulator;
 
-#[async_trait]
-impl HttpTest for CallTestWithEvmEmulator {
+impl TestInit for CallTestWithEvmEmulator {
     fn storage_initialization(&self) -> StorageInitialization {
         StorageInitialization::genesis_with_evm()
     }
@@ -263,7 +264,10 @@ impl HttpTest for CallTestWithEvmEmulator {
         executor.set_call_responses(evm_emulator_responses);
         executor
     }
+}
 
+#[async_trait]
+impl HttpTest for CallTestWithEvmEmulator {
     async fn test(
         &self,
         client: &DynClient<L2>,
@@ -300,8 +304,7 @@ struct CallTestAfterSnapshotRecovery {
     fee_input: ExpectedFeeInput,
 }
 
-#[async_trait]
-impl HttpTest for CallTestAfterSnapshotRecovery {
+impl TestInit for CallTestAfterSnapshotRecovery {
     fn storage_initialization(&self) -> StorageInitialization {
         StorageInitialization::empty_recovery()
     }
@@ -310,7 +313,10 @@ impl HttpTest for CallTestAfterSnapshotRecovery {
         let first_local_l2_block = StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 1;
         CallTest::create_executor(first_local_l2_block, self.fee_input.clone())
     }
+}
 
+#[async_trait]
+impl HttpTest for CallTestAfterSnapshotRecovery {
     async fn test(
         &self,
         client: &DynClient<L2>,
@@ -362,8 +368,7 @@ async fn call_method_after_snapshot_recovery() {
 #[derive(Debug)]
 struct CallTestWithSlowVm;
 
-#[async_trait]
-impl HttpTest for CallTestWithSlowVm {
+impl TestInit for CallTestWithSlowVm {
     fn transaction_executor(&self) -> MockOneshotExecutor {
         let mut tx_executor = MockOneshotExecutor::default();
         tx_executor.set_vm_delay(Duration::from_secs(3_600));
@@ -377,7 +382,10 @@ impl HttpTest for CallTestWithSlowVm {
             ..Web3JsonRpcConfig::for_tests()
         }
     }
+}
 
+#[async_trait]
+impl HttpTest for CallTestWithSlowVm {
     async fn test(
         &self,
         client: &DynClient<L2>,
@@ -446,8 +454,7 @@ impl SendRawTransactionTest {
     }
 }
 
-#[async_trait]
-impl HttpTest for SendRawTransactionTest {
+impl TestInit for SendRawTransactionTest {
     fn storage_initialization(&self) -> StorageInitialization {
         if self.snapshot_recovery {
             let logs = vec![Self::balance_storage_log()];
@@ -474,7 +481,10 @@ impl HttpTest for SendRawTransactionTest {
         });
         tx_executor
     }
+}
 
+#[async_trait]
+impl HttpTest for SendRawTransactionTest {
     async fn test(
         &self,
         client: &DynClient<L2>,
@@ -515,6 +525,8 @@ async fn send_raw_transaction_after_snapshot_recovery() {
 #[derive(Debug)]
 struct SendRawTransactionWithoutToAddressTest;
 
+impl TestInit for SendRawTransactionWithoutToAddressTest {}
+
 #[async_trait]
 impl HttpTest for SendRawTransactionWithoutToAddressTest {
     async fn test(
@@ -549,8 +561,7 @@ async fn send_raw_transaction_fails_without_to_address() {
 #[derive(Debug)]
 struct SendRawTransactionTestWithEvmEmulator;
 
-#[async_trait]
-impl HttpTest for SendRawTransactionTestWithEvmEmulator {
+impl TestInit for SendRawTransactionTestWithEvmEmulator {
     fn storage_initialization(&self) -> StorageInitialization {
         StorageInitialization::genesis_with_evm()
     }
@@ -560,7 +571,10 @@ impl HttpTest for SendRawTransactionTestWithEvmEmulator {
         executor.set_tx_responses(evm_emulator_responses);
         executor
     }
+}
 
+#[async_trait]
+impl HttpTest for SendRawTransactionTestWithEvmEmulator {
     async fn test(
         &self,
         client: &DynClient<L2>,
@@ -636,8 +650,8 @@ impl SendTransactionWithDetailedOutputTest {
         }]
     }
 }
-#[async_trait]
-impl HttpTest for SendTransactionWithDetailedOutputTest {
+
+impl TestInit for SendTransactionWithDetailedOutputTest {
     fn transaction_executor(&self) -> MockOneshotExecutor {
         let mut tx_executor = MockOneshotExecutor::default();
         let tx_bytes_and_hash = SendRawTransactionTest::transaction_bytes_and_hash(true);
@@ -660,7 +674,10 @@ impl HttpTest for SendTransactionWithDetailedOutputTest {
         });
         tx_executor
     }
+}
 
+#[async_trait]
+impl HttpTest for SendTransactionWithDetailedOutputTest {
     async fn test(
         &self,
         client: &DynClient<L2>,
@@ -733,12 +750,14 @@ impl TraceCallTest {
     }
 }
 
-#[async_trait]
-impl HttpTest for TraceCallTest {
+impl TestInit for TraceCallTest {
     fn transaction_executor(&self) -> MockOneshotExecutor {
         CallTest::create_executor(L2BlockNumber(1), self.fee_input.clone())
     }
+}
 
+#[async_trait]
+impl HttpTest for TraceCallTest {
     async fn test(
         &self,
         client: &DynClient<L2>,
@@ -858,8 +877,7 @@ struct TraceCallTestAfterSnapshotRecovery {
     fee_input: ExpectedFeeInput,
 }
 
-#[async_trait]
-impl HttpTest for TraceCallTestAfterSnapshotRecovery {
+impl TestInit for TraceCallTestAfterSnapshotRecovery {
     fn storage_initialization(&self) -> StorageInitialization {
         StorageInitialization::empty_recovery()
     }
@@ -868,7 +886,10 @@ impl HttpTest for TraceCallTestAfterSnapshotRecovery {
         let number = StorageInitialization::SNAPSHOT_RECOVERY_BLOCK + 1;
         CallTest::create_executor(number, self.fee_input.clone())
     }
+}
 
+#[async_trait]
+impl HttpTest for TraceCallTestAfterSnapshotRecovery {
     async fn test(
         &self,
         client: &DynClient<L2>,
@@ -923,8 +944,7 @@ async fn trace_call_after_snapshot_recovery() {
 #[derive(Debug)]
 struct TraceCallTestWithEvmEmulator;
 
-#[async_trait]
-impl HttpTest for TraceCallTestWithEvmEmulator {
+impl TestInit for TraceCallTestWithEvmEmulator {
     fn storage_initialization(&self) -> StorageInitialization {
         StorageInitialization::genesis_with_evm()
     }
@@ -934,7 +954,10 @@ impl HttpTest for TraceCallTestWithEvmEmulator {
         executor.set_call_responses(evm_emulator_responses);
         executor
     }
+}
 
+#[async_trait]
+impl HttpTest for TraceCallTestWithEvmEmulator {
     async fn test(
         &self,
         client: &DynClient<L2>,
@@ -1014,8 +1037,7 @@ impl EstimateGasTest {
     }
 }
 
-#[async_trait]
-impl HttpTest for EstimateGasTest {
+impl TestInit for EstimateGasTest {
     fn storage_initialization(&self) -> StorageInitialization {
         let snapshot_recovery = self.snapshot_recovery;
         SendRawTransactionTest { snapshot_recovery }.storage_initialization()
@@ -1048,7 +1070,10 @@ impl HttpTest for EstimateGasTest {
         });
         tx_executor
     }
+}
 
+#[async_trait]
+impl HttpTest for EstimateGasTest {
     async fn test(
         &self,
         client: &DynClient<L2>,
@@ -1121,8 +1146,7 @@ struct EstimateGasWithStateOverrideTest {
     inner: EstimateGasTest,
 }
 
-#[async_trait]
-impl HttpTest for EstimateGasWithStateOverrideTest {
+impl TestInit for EstimateGasWithStateOverrideTest {
     fn storage_initialization(&self) -> StorageInitialization {
         self.inner.storage_initialization()
     }
@@ -1130,7 +1154,10 @@ impl HttpTest for EstimateGasWithStateOverrideTest {
     fn transaction_executor(&self) -> MockOneshotExecutor {
         self.inner.transaction_executor()
     }
+}
 
+#[async_trait]
+impl HttpTest for EstimateGasWithStateOverrideTest {
     async fn test(
         &self,
         client: &DynClient<L2>,
@@ -1191,6 +1218,8 @@ struct EstimateGasWithoutToAddressTest {
     method: EstimateMethod,
 }
 
+impl TestInit for EstimateGasWithoutToAddressTest {}
+
 #[async_trait]
 impl HttpTest for EstimateGasWithoutToAddressTest {
     async fn test(
@@ -1222,8 +1251,7 @@ struct EstimateGasTestWithEvmEmulator {
     method: EstimateMethod,
 }
 
-#[async_trait]
-impl HttpTest for EstimateGasTestWithEvmEmulator {
+impl TestInit for EstimateGasTestWithEvmEmulator {
     fn storage_initialization(&self) -> StorageInitialization {
         StorageInitialization::genesis_with_evm()
     }
@@ -1233,7 +1261,10 @@ impl HttpTest for EstimateGasTestWithEvmEmulator {
         executor.set_tx_responses(evm_emulator_responses);
         executor
     }
+}
 
+#[async_trait]
+impl HttpTest for EstimateGasTestWithEvmEmulator {
     async fn test(
         &self,
         client: &DynClient<L2>,

--- a/core/node/api_server/src/web3/tests/ws.rs
+++ b/core/node/api_server/src/web3/tests/ws.rs
@@ -7,9 +7,7 @@ use async_trait::async_trait;
 use http::StatusCode;
 use tokio::sync::watch;
 use zksync_dal::ConnectionPool;
-use zksync_types::{
-    api, settlement::SettlementLayer, Address, Bloom, L1BatchNumber, H160, H256, U64,
-};
+use zksync_types::{api, Address, Bloom, L1BatchNumber, H160, H256, U64};
 use zksync_web3_decl::{
     client::{WsClient, L2},
     jsonrpsee::{
@@ -112,7 +110,7 @@ async fn notifiers_start_after_snapshot_recovery() {
     let (events_sender, mut events_receiver) = mpsc::unbounded_channel();
     let mut subscribe_logic = EthSubscribe::new(POLL_INTERVAL);
     subscribe_logic.set_events_sender(events_sender);
-    let notifier_handles = subscribe_logic.spawn_notifiers(pool.clone(), &stop_receiver);
+    let notifier_handles = subscribe_logic.spawn_notifiers(&pool, &stop_receiver);
     assert!(!notifier_handles.is_empty());
 
     // Wait a little doing nothing and check that notifier tasks are still active (i.e., have not panicked).
@@ -144,63 +142,38 @@ async fn notifiers_start_after_snapshot_recovery() {
 }
 
 #[async_trait]
-trait WsTest: Send + Sync {
-    /// Prepares the storage before the server is started. The default implementation performs genesis.
-    fn storage_initialization(&self) -> StorageInitialization {
-        StorageInitialization::genesis()
-    }
-
+pub(super) trait WsTest: TestInit {
     async fn test(
         &self,
         client: &WsClient<L2>,
         pool: &ConnectionPool<Core>,
-        pub_sub_events: mpsc::UnboundedReceiver<PubSubEvent>,
+        pub_sub_events: &mut mpsc::UnboundedReceiver<PubSubEvent>,
     ) -> anyhow::Result<()>;
-
-    fn websocket_requests_per_minute_limit(&self) -> Option<NonZeroU32> {
-        None
-    }
 }
 
 async fn test_ws_server(test: impl WsTest) {
     let pool = ConnectionPool::<Core>::test_pool().await;
-    let contracts_config = ContractsConfig::for_tests();
-    let web3_config = Web3JsonRpcConfig::for_tests();
-    let genesis_config = GenesisConfig::for_tests();
-    let api_config = InternalApiConfig::new(
-        &web3_config,
-        &contracts_config.settlement_layer_specific_contracts(),
-        &contracts_config.l1_specific_contracts(),
-        &contracts_config.l2_contracts(),
-        &genesis_config,
-        false,
-        SettlementLayer::for_tests(),
-    );
-    let mut storage = pool.connection().await.unwrap();
-    test.storage_initialization()
-        .prepare_storage(&mut storage)
-        .await
-        .expect("Failed preparing storage for test");
-    drop(storage);
-
     let (stop_sender, stop_receiver) = watch::channel(false);
-    let (mut server_handles, pub_sub_events) = TestServerBuilder::new(pool.clone(), api_config)
-        .build_ws(test.websocket_requests_per_minute_limit(), stop_receiver)
-        .await;
+    let transport = ApiTransport::Ws((Ipv4Addr::LOCALHOST, 0).into());
+    let (local_addr, mut server_handles) =
+        prepare_server(transport, &pool, &test, stop_receiver).await;
 
-    let local_addr = server_handles.wait_until_ready().await;
     let client = Client::ws(format!("ws://{local_addr}").parse().unwrap())
         .await
         .unwrap()
         .build();
-    test.test(&client, &pool, pub_sub_events).await.unwrap();
+    test.test(&client, &pool, &mut server_handles.pub_sub_events)
+        .await
+        .unwrap();
 
     stop_sender.send_replace(true);
     server_handles.shutdown().await;
 }
 
 #[derive(Debug)]
-struct WsServerCanStartTest;
+pub(super) struct WsServerCanStartTest;
+
+impl TestInit for WsServerCanStartTest {}
 
 #[async_trait]
 impl WsTest for WsServerCanStartTest {
@@ -208,7 +181,7 @@ impl WsTest for WsServerCanStartTest {
         &self,
         client: &WsClient<L2>,
         _pool: &ConnectionPool<Core>,
-        _pub_sub_events: mpsc::UnboundedReceiver<PubSubEvent>,
+        _pub_sub_events: &mut mpsc::UnboundedReceiver<PubSubEvent>,
     ) -> anyhow::Result<()> {
         let block_number = client.get_block_number().await?;
         assert_eq!(block_number, U64::from(0));
@@ -235,8 +208,7 @@ struct BasicSubscriptionsTest {
     snapshot_recovery: bool,
 }
 
-#[async_trait]
-impl WsTest for BasicSubscriptionsTest {
+impl TestInit for BasicSubscriptionsTest {
     fn storage_initialization(&self) -> StorageInitialization {
         if self.snapshot_recovery {
             StorageInitialization::empty_recovery()
@@ -244,17 +216,20 @@ impl WsTest for BasicSubscriptionsTest {
             StorageInitialization::genesis()
         }
     }
+}
 
+#[async_trait]
+impl WsTest for BasicSubscriptionsTest {
     async fn test(
         &self,
         client: &WsClient<L2>,
         pool: &ConnectionPool<Core>,
-        mut pub_sub_events: mpsc::UnboundedReceiver<PubSubEvent>,
+        pub_sub_events: &mut mpsc::UnboundedReceiver<PubSubEvent>,
     ) -> anyhow::Result<()> {
         // Wait for the notifiers to get initialized so that they don't skip notifications
         // for the created subscriptions.
         wait_for_notifiers(
-            &mut pub_sub_events,
+            pub_sub_events,
             &[SubscriptionType::Blocks, SubscriptionType::Txs],
         )
         .await;
@@ -263,13 +238,13 @@ impl WsTest for BasicSubscriptionsTest {
         let mut blocks_subscription = client
             .subscribe::<BlockHeader, _>("eth_subscribe", params, "eth_unsubscribe")
             .await?;
-        wait_for_subscription(&mut pub_sub_events, SubscriptionType::Blocks).await;
+        wait_for_subscription(pub_sub_events, SubscriptionType::Blocks).await;
 
         let params = rpc_params!["newPendingTransactions"];
         let mut txs_subscription = client
             .subscribe::<H256, _>("eth_subscribe", params, "eth_unsubscribe")
             .await?;
-        wait_for_subscription(&mut pub_sub_events, SubscriptionType::Txs).await;
+        wait_for_subscription(pub_sub_events, SubscriptionType::Txs).await;
 
         let mut storage = pool.connection().await?;
         let tx_result = mock_execute_transaction(create_l2_transaction(1, 2).into());
@@ -404,8 +379,7 @@ impl LogSubscriptions {
     }
 }
 
-#[async_trait]
-impl WsTest for LogSubscriptionsTest {
+impl TestInit for LogSubscriptionsTest {
     fn storage_initialization(&self) -> StorageInitialization {
         if self.snapshot_recovery {
             StorageInitialization::empty_recovery()
@@ -413,18 +387,21 @@ impl WsTest for LogSubscriptionsTest {
             StorageInitialization::genesis()
         }
     }
+}
 
+#[async_trait]
+impl WsTest for LogSubscriptionsTest {
     async fn test(
         &self,
         client: &WsClient<L2>,
         pool: &ConnectionPool<Core>,
-        mut pub_sub_events: mpsc::UnboundedReceiver<PubSubEvent>,
+        pub_sub_events: &mut mpsc::UnboundedReceiver<PubSubEvent>,
     ) -> anyhow::Result<()> {
         let LogSubscriptions {
             mut all_logs_subscription,
             mut address_subscription,
             mut topic_subscription,
-        } = LogSubscriptions::new(client, &mut pub_sub_events).await?;
+        } = LogSubscriptions::new(client, pub_sub_events).await?;
 
         let mut storage = pool.connection().await?;
         let next_l2_block_number = if self.snapshot_recovery {
@@ -451,7 +428,7 @@ impl WsTest for LogSubscriptionsTest {
         let topic_logs = collect_logs(&mut topic_subscription, 2).await?;
         assert_logs_match(&topic_logs, &[events[1], events[3]]);
 
-        wait_for_notifiers(&mut pub_sub_events, &[SubscriptionType::Logs]).await;
+        wait_for_notifiers(pub_sub_events, &[SubscriptionType::Logs]).await;
 
         // Check that no new notifications were sent to subscribers.
         tokio::time::timeout(POLL_INTERVAL, all_logs_subscription.next())
@@ -501,19 +478,21 @@ async fn log_subscriptions_after_snapshot_recovery() {
 #[derive(Debug)]
 struct LogSubscriptionsWithNewBlockTest;
 
+impl TestInit for LogSubscriptionsWithNewBlockTest {}
+
 #[async_trait]
 impl WsTest for LogSubscriptionsWithNewBlockTest {
     async fn test(
         &self,
         client: &WsClient<L2>,
         pool: &ConnectionPool<Core>,
-        mut pub_sub_events: mpsc::UnboundedReceiver<PubSubEvent>,
+        pub_sub_events: &mut mpsc::UnboundedReceiver<PubSubEvent>,
     ) -> anyhow::Result<()> {
         let LogSubscriptions {
             mut all_logs_subscription,
             mut address_subscription,
             ..
-        } = LogSubscriptions::new(client, &mut pub_sub_events).await?;
+        } = LogSubscriptions::new(client, pub_sub_events).await?;
 
         let mut storage = pool.connection().await?;
         let (_, events) = store_events(&mut storage, 1, 0).await?;
@@ -549,19 +528,21 @@ async fn log_subscriptions_with_new_block() {
 #[derive(Debug)]
 struct LogSubscriptionsWithManyBlocksTest;
 
+impl TestInit for LogSubscriptionsWithManyBlocksTest {}
+
 #[async_trait]
 impl WsTest for LogSubscriptionsWithManyBlocksTest {
     async fn test(
         &self,
         client: &WsClient<L2>,
         pool: &ConnectionPool<Core>,
-        mut pub_sub_events: mpsc::UnboundedReceiver<PubSubEvent>,
+        pub_sub_events: &mut mpsc::UnboundedReceiver<PubSubEvent>,
     ) -> anyhow::Result<()> {
         let LogSubscriptions {
             mut all_logs_subscription,
             mut address_subscription,
             ..
-        } = LogSubscriptions::new(client, &mut pub_sub_events).await?;
+        } = LogSubscriptions::new(client, pub_sub_events).await?;
 
         // Add two blocks in the storage atomically.
         let mut storage = pool.connection().await?;
@@ -595,16 +576,18 @@ async fn log_subscriptions_with_many_new_blocks_at_once() {
 #[derive(Debug)]
 struct LogSubscriptionsWithDelayTest;
 
+impl TestInit for LogSubscriptionsWithDelayTest {}
+
 #[async_trait]
 impl WsTest for LogSubscriptionsWithDelayTest {
     async fn test(
         &self,
         client: &WsClient<L2>,
         pool: &ConnectionPool<Core>,
-        mut pub_sub_events: mpsc::UnboundedReceiver<PubSubEvent>,
+        pub_sub_events: &mut mpsc::UnboundedReceiver<PubSubEvent>,
     ) -> anyhow::Result<()> {
         // Wait until notifiers are initialized.
-        wait_for_notifiers(&mut pub_sub_events, &[SubscriptionType::Logs]).await;
+        wait_for_notifiers(pub_sub_events, &[SubscriptionType::Logs]).await;
 
         // Store an L2 block w/o subscriptions being present.
         let mut storage = pool.connection().await?;
@@ -612,12 +595,7 @@ impl WsTest for LogSubscriptionsWithDelayTest {
         drop(storage);
 
         // Wait for the log notifier to process the new L2 block.
-        wait_for_notifier_l2_block(
-            &mut pub_sub_events,
-            SubscriptionType::Logs,
-            L2BlockNumber(1),
-        )
-        .await;
+        wait_for_notifier_l2_block(pub_sub_events, SubscriptionType::Logs, L2BlockNumber(1)).await;
 
         let params = rpc_params!["logs"];
         let mut all_logs_subscription = client
@@ -632,7 +610,7 @@ impl WsTest for LogSubscriptionsWithDelayTest {
             .subscribe::<api::Log, _>("eth_subscribe", params, "eth_unsubscribe")
             .await?;
         for _ in 0..2 {
-            wait_for_subscription(&mut pub_sub_events, SubscriptionType::Logs).await;
+            wait_for_subscription(pub_sub_events, SubscriptionType::Logs).await;
         }
 
         let mut storage = pool.connection().await?;
@@ -665,13 +643,22 @@ async fn log_subscriptions_with_delay() {
 #[derive(Debug)]
 struct RateLimitingTest;
 
+impl TestInit for RateLimitingTest {
+    fn web3_config(&self) -> Web3JsonRpcConfig {
+        Web3JsonRpcConfig {
+            websocket_requests_per_minute_limit: NonZeroU32::new(3).unwrap(),
+            ..Web3JsonRpcConfig::for_tests()
+        }
+    }
+}
+
 #[async_trait]
 impl WsTest for RateLimitingTest {
     async fn test(
         &self,
         client: &WsClient<L2>,
         _pool: &ConnectionPool<Core>,
-        _pub_sub_events: mpsc::UnboundedReceiver<PubSubEvent>,
+        _pub_sub_events: &mut mpsc::UnboundedReceiver<PubSubEvent>,
     ) -> anyhow::Result<()> {
         client.chain_id().await.unwrap();
         client.chain_id().await.unwrap();
@@ -688,10 +675,6 @@ impl WsTest for RateLimitingTest {
 
         Ok(())
     }
-
-    fn websocket_requests_per_minute_limit(&self) -> Option<NonZeroU32> {
-        Some(NonZeroU32::new(3).unwrap())
-    }
 }
 
 #[tokio::test]
@@ -702,13 +685,22 @@ async fn rate_limiting() {
 #[derive(Debug)]
 struct BatchGetsRateLimitedTest;
 
+impl TestInit for BatchGetsRateLimitedTest {
+    fn web3_config(&self) -> Web3JsonRpcConfig {
+        Web3JsonRpcConfig {
+            websocket_requests_per_minute_limit: NonZeroU32::new(3).unwrap(),
+            ..Web3JsonRpcConfig::for_tests()
+        }
+    }
+}
+
 #[async_trait]
 impl WsTest for BatchGetsRateLimitedTest {
     async fn test(
         &self,
         client: &WsClient<L2>,
         _pool: &ConnectionPool<Core>,
-        _pub_sub_events: mpsc::UnboundedReceiver<PubSubEvent>,
+        _pub_sub_events: &mut mpsc::UnboundedReceiver<PubSubEvent>,
     ) -> anyhow::Result<()> {
         client.chain_id().await.unwrap();
         client.chain_id().await.unwrap();
@@ -731,10 +723,6 @@ impl WsTest for BatchGetsRateLimitedTest {
         assert!(error.data().is_none());
 
         Ok(())
-    }
-
-    fn websocket_requests_per_minute_limit(&self) -> Option<NonZeroU32> {
-        Some(NonZeroU32::new(3).unwrap())
     }
 }
 

--- a/core/node/api_server/src/web3/tests/ws.rs
+++ b/core/node/api_server/src/web3/tests/ws.rs
@@ -25,7 +25,7 @@ use zksync_web3_decl::{
 use super::*;
 use crate::web3::metrics::SubscriptionType;
 
-async fn wait_for_subscription(
+pub(super) async fn wait_for_subscription(
     events: &mut mpsc::UnboundedReceiver<PubSubEvent>,
     sub_type: SubscriptionType,
 ) {
@@ -203,8 +203,8 @@ async fn ws_server_can_start() {
     test_ws_server(WsServerCanStartTest).await;
 }
 
-#[derive(Debug)]
-struct BasicSubscriptionsTest {
+#[derive(Debug, Default)]
+pub(super) struct BasicSubscriptionsTest {
     snapshot_recovery: bool,
 }
 

--- a/zkstack_cli/Cargo.lock
+++ b/zkstack_cli/Cargo.lock
@@ -7968,7 +7968,7 @@ dependencies = [
  "elliptic-curve",
  "hex",
  "k256",
- "rand",
+ "rand 0.8.5",
  "sha3",
  "thiserror 1.0.69",
  "zeroize",
@@ -7985,7 +7985,7 @@ dependencies = [
  "hex",
  "num-bigint",
  "prost",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "zksync_concurrency",
  "zksync_consensus_crypto",
@@ -8000,7 +8000,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0df57fdc2a2791ae0031e86931f2d08b31a54a46f5f28b0f833f2e4aa598bc59"
 dependencies = [
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "zksync_concurrency",
 ]

--- a/zkstack_cli/crates/zkstack/src/commands/chain/init/configs.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/init/configs.rs
@@ -23,7 +23,7 @@ use crate::{
         MSG_CHAIN_CONFIGS_INITIALIZED, MSG_CHAIN_NOT_FOUND_ERR,
         MSG_PORTAL_FAILED_TO_CREATE_CONFIG_ERR,
     },
-    utils::ports::EcosystemPortsScanner,
+    utils::ports::{AddressPortMap, EcosystemPortsScanner},
 };
 
 pub async fn run(args: InitConfigsArgs, shell: &Shell) -> anyhow::Result<()> {
@@ -54,6 +54,7 @@ pub async fn init_configs(
             shell,
             &chain_config.path_to_general_config(),
             chain_config.id,
+            &AddressPortMap::general(),
         )?;
     }
 

--- a/zkstack_cli/crates/zkstack/src/commands/external_node/prepare_configs.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/external_node/prepare_configs.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     utils::{
         consensus::node_public_key,
-        ports::EcosystemPortsScanner,
+        ports::{AddressPortMap, EcosystemPortsScanner},
         rocks_db::{recreate_rocksdb_dirs, RocksDBDirOption},
     },
 };
@@ -107,8 +107,18 @@ async fn prepare_configs(
     general_en.save().await?;
 
     let offset = 0; // This is zero because general_en ports already have a chain offset
-    ports.allocate_ports_in_yaml(shell, &general_config_path, offset)?;
-    ports.allocate_ports_in_yaml(shell, &en_configs_path.join(CONSENSUS_CONFIG_FILE), offset)?;
+    ports.allocate_ports_in_yaml(
+        shell,
+        &general_config_path,
+        offset,
+        &AddressPortMap::general(),
+    )?;
+    ports.allocate_ports_in_yaml(
+        shell,
+        &en_configs_path.join(CONSENSUS_CONFIG_FILE),
+        offset,
+        &AddressPortMap::consensus(),
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
## What ❔

- Supports combined HTTP / WS server bound to a single port.
- Allows configuring RPC namespaces for WS.

## Why ❔

Improves UX for node operators.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

- HTTP / WS server is combined automatically if `api.web3_json_rpc.{http_port, ws_port}` are equal.
- RPC namespaces for WS are represented via new `api.web3_json_rpc.ws_api_namespaces` param. `api.web3_json_rpc.api_namespaces` is still used if the new param is not set.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.