### PR TITLE
fix(en): Fix statement timeout errors during cache recovery

### DIFF
--- a/core/node/state_keeper/src/node/state_keeper.rs
+++ b/core/node/state_keeper/src/node/state_keeper.rs
@@ -87,7 +87,13 @@ impl WiringLayer for StateKeeperLayer {
             self.rocksdb_options,
         );
         // The number of connections in the recovery DB pool (~recovery concurrency) is based on the Era mainnet recovery runs.
-        let recovery_pool = input.replica_pool.get_custom(10).await?;
+        let recovery_pool = input
+            .replica_pool
+            .build(|builder| {
+                // Disable the statement timeout since there are potential long-living queries inside recovery logic.
+                builder.set_statement_timeout(None).set_max_size(10);
+            })
+            .await?;
         rocksdb_catchup = rocksdb_catchup.with_recovery_pool(recovery_pool);
 
         let state_keeper_builder = StateKeeperBuilder::new(


### PR DESCRIPTION
## What ❔

Disables statement timeouts for the connection pool used for state keeper cache recovery.

## Why ❔

Cache recovery logic incorporates potentially long-running queries, so having the default timeout for it is bogus.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.