### PR TITLE
feat(en): remove JSON RPC syncing

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -439,16 +439,16 @@ jobs:
           ci_run zkstack dev config-writer --path etc/env/file_based/overrides/tests/integration.yaml --chain validium
           
           ci_run zkstack server --ignore-prerequisites --chain era \
-            --components==api,tree,eth,state_keeper,housekeeper,commitment_generator,da_dispatcher,vm_runner_protective_reads,consensus \
+            --components=api,tree,eth,state_keeper,housekeeper,commitment_generator,da_dispatcher,vm_runner_protective_reads,consensus \
             &> ${{ env.SERVER_LOGS_DIR }}/rollup.log &
           ci_run zkstack server --ignore-prerequisites --chain validium \
-            --components==api,tree,eth,state_keeper,housekeeper,commitment_generator,da_dispatcher,vm_runner_protective_reads,consensus \
+            --components=api,tree,eth,state_keeper,housekeeper,commitment_generator,da_dispatcher,vm_runner_protective_reads,consensus \
             &> ${{ env.SERVER_LOGS_DIR }}/validium.log &
           ci_run zkstack server --ignore-prerequisites --chain custom_token \
-            --components==api,tree,eth,state_keeper,housekeeper,commitment_generator,da_dispatcher,vm_runner_protective_reads,consensus \
+            --components=api,tree,eth,state_keeper,housekeeper,commitment_generator,da_dispatcher,vm_runner_protective_reads,consensus \
             &> ${{ env.SERVER_LOGS_DIR }}/custom_token.log &
           ci_run zkstack server --ignore-prerequisites --chain da_migration \
-            --components==api,tree,eth,state_keeper,housekeeper,commitment_generator,da_dispatcher,vm_runner_protective_reads,consensus \
+            --components=api,tree,eth,state_keeper,housekeeper,commitment_generator,da_dispatcher,vm_runner_protective_reads,consensus \
             &> ${{ env.SERVER_LOGS_DIR }}/da_migration.log &
 
           ci_run zkstack server wait --ignore-prerequisites --verbose --chain era

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -461,7 +461,9 @@ jobs:
           echo "Increasing L1 batch seal timeout and restarting server"
           sudo yq -i '.state_keeper.block_commit_deadline_ms = "10000"' ./chains/da_migration/configs/general.yaml
           ci_run pkill -f "zksync_server.*chains/da_migration/configs"
-          ci_run zkstack server --ignore-prerequisites --chain da_migration &>> ${{ env.SERVER_LOGS_DIR }}/da_migration.log &
+          ci_run zkstack server --ignore-prerequisites --chain da_migration \
+            --components=api,tree,eth,state_keeper,housekeeper,commitment_generator,da_dispatcher,vm_runner_protective_reads,consensus \
+            &>> ${{ env.SERVER_LOGS_DIR }}/da_migration.log &
           echo "Server restart initiated, waiting 30 seconds for startup"
           ci_run sleep 30
           
@@ -483,7 +485,9 @@ jobs:
           echo "Deploying L2 DA validator and restarting server"
           ci_run zkstack chain deploy-l2da-validator --chain da_migration
           ci_run pkill -f "zksync_server.*chains/da_migration/configs"
-          ci_run zkstack server --ignore-prerequisites --chain da_migration &>> ${{ env.SERVER_LOGS_DIR }}/da_migration.log &
+          ci_run zkstack server --ignore-prerequisites --chain da_migration \
+            --components=api,tree,eth,state_keeper,housekeeper,commitment_generator,da_dispatcher,vm_runner_protective_reads,consensus \
+            &>> ${{ env.SERVER_LOGS_DIR }}/da_migration.log &
           echo "Server restart initiated, waiting 30 seconds for startup"
           ci_run sleep 30
           echo "Server restart wait completed"
@@ -538,7 +542,9 @@ jobs:
           sudo yq -i '.state_keeper.pubdata_overhead_part = 0' ./chains/da_migration/configs/general.yaml
           sudo yq -i '.state_keeper.compute_overhead_part = 1' ./chains/da_migration/configs/general.yaml
           ci_run pkill -f "zksync_server.*chains/da_migration/configs"
-          ci_run zkstack server --ignore-prerequisites --chain da_migration &>> ${{ env.SERVER_LOGS_DIR }}/da_migration.log &
+          ci_run zkstack server --ignore-prerequisites --chain da_migration \
+            --components=api,tree,eth,state_keeper,housekeeper,commitment_generator,da_dispatcher,vm_runner_protective_reads,consensus \
+            &>> ${{ env.SERVER_LOGS_DIR }}/da_migration.log &
           echo "Server restart initiated, waiting 30 seconds for startup"
           ci_run sleep 30
           echo "Server restart wait completed"

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -596,10 +596,10 @@ jobs:
 
       - name: Run external nodes
         run: |
-          ci_run zkstack external-node run --ignore-prerequisites --chain era --enable-consensus &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/rollup.log &
-          ci_run zkstack external-node run --ignore-prerequisites --chain validium --enable-consensus --components all,da_fetcher &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/validium.log &
-          ci_run zkstack external-node run --ignore-prerequisites --chain custom_token --enable-consensus &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/custom_token.log &
-          ci_run zkstack external-node run --ignore-prerequisites --chain da_migration --enable-consensus --components all,da_fetcher &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/da_migration.log &
+          ci_run zkstack external-node run --ignore-prerequisites --chain era &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/rollup.log &
+          ci_run zkstack external-node run --ignore-prerequisites --chain validium --components all,da_fetcher &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/validium.log &
+          ci_run zkstack external-node run --ignore-prerequisites --chain custom_token &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/custom_token.log &
+          ci_run zkstack external-node run --ignore-prerequisites --chain da_migration --components all,da_fetcher &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/da_migration.log &
 
           ci_run zkstack external-node wait --ignore-prerequisites --verbose --chain era
           ci_run zkstack external-node wait --ignore-prerequisites --verbose --chain validium

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -365,32 +365,9 @@ jobs:
               exit 1
           fi
 
-      - name: Create and initialize Consensus chain
-        run: |
-          ci_run zkstack chain create \
-          --chain-name consensus \
-          --chain-id sequential \
-          --prover-mode no-proofs \
-          --wallet-creation localhost \
-          --l1-batch-commit-data-generator-mode validium \
-          --base-token-address ${{ env.CUSTOM_TOKEN_ADDRESS }} \
-          --base-token-price-nominator 314 \
-          --base-token-price-denominator 1000 \
-          --set-as-default false \
-          --ignore-prerequisites \
-          --evm-emulator false
-
-          ci_run zkstack chain init \
-          --deploy-paymaster \
-          --l1-rpc-url=http://localhost:8545 \
-          --server-db-url=postgres://postgres:notsecurepassword@localhost:5432 \
-          --server-db-name=zksync_server_localhost_consensus \
-          --chain consensus \
-          --validium-type no-da
-
       - name: Export chain list to environment variable
         run: |
-          CHAINS="era,validium,custom_token,da_migration,consensus"
+          CHAINS="era,validium,custom_token,da_migration"
           echo "CHAINS=$CHAINS" >> $GITHUB_ENV
 
       # ----------------------------------------------------------------
@@ -435,7 +412,6 @@ jobs:
           ci_run zkstack chain gateway migrate-to-gateway --chain validium --gateway-chain-name gateway
           ci_run zkstack chain gateway migrate-to-gateway --chain custom_token --gateway-chain-name gateway
           ci_run zkstack chain gateway migrate-to-gateway --chain da_migration --gateway-chain-name gateway
-          ci_run zkstack chain gateway migrate-to-gateway --chain consensus --gateway-chain-name gateway
 
       - name: Migrate back era
         if: matrix.use_gateway_chain == 'WITH_GATEWAY'
@@ -462,19 +438,23 @@ jobs:
           ci_run zkstack dev config-writer --path etc/env/file_based/overrides/tests/integration.yaml --chain era
           ci_run zkstack dev config-writer --path etc/env/file_based/overrides/tests/integration.yaml --chain validium
           
-          ci_run zkstack server --ignore-prerequisites --chain era &> ${{ env.SERVER_LOGS_DIR }}/rollup.log &
-          ci_run zkstack server --ignore-prerequisites --chain validium &> ${{ env.SERVER_LOGS_DIR }}/validium.log &
-          ci_run zkstack server --ignore-prerequisites --chain custom_token &> ${{ env.SERVER_LOGS_DIR }}/custom_token.log &
-          ci_run zkstack server --ignore-prerequisites --chain da_migration &> ${{ env.SERVER_LOGS_DIR }}/da_migration.log &
-          ci_run zkstack server --ignore-prerequisites --chain consensus \
-            --components=api,tree,eth,state_keeper,housekeeper,commitment_generator,vm_runner_protective_reads,vm_runner_bwip,vm_playground,da_dispatcher,consensus \
-            &> ${{ env.SERVER_LOGS_DIR }}/consensus.log &
+          ci_run zkstack server --ignore-prerequisites --chain era \
+            --components==api,tree,eth,state_keeper,housekeeper,commitment_generator,da_dispatcher,vm_runner_protective_reads,consensus \
+            &> ${{ env.SERVER_LOGS_DIR }}/rollup.log &
+          ci_run zkstack server --ignore-prerequisites --chain validium \
+            --components==api,tree,eth,state_keeper,housekeeper,commitment_generator,da_dispatcher,vm_runner_protective_reads,consensus \
+            &> ${{ env.SERVER_LOGS_DIR }}/validium.log &
+          ci_run zkstack server --ignore-prerequisites --chain custom_token \
+            --components==api,tree,eth,state_keeper,housekeeper,commitment_generator,da_dispatcher,vm_runner_protective_reads,consensus \
+            &> ${{ env.SERVER_LOGS_DIR }}/custom_token.log &
+          ci_run zkstack server --ignore-prerequisites --chain da_migration \
+            --components==api,tree,eth,state_keeper,housekeeper,commitment_generator,da_dispatcher,vm_runner_protective_reads,consensus \
+            &> ${{ env.SERVER_LOGS_DIR }}/da_migration.log &
 
           ci_run zkstack server wait --ignore-prerequisites --verbose --chain era
           ci_run zkstack server wait --ignore-prerequisites --verbose --chain validium
           ci_run zkstack server wait --ignore-prerequisites --verbose --chain custom_token
           ci_run zkstack server wait --ignore-prerequisites --verbose --chain da_migration
-          ci_run zkstack server wait --ignore-prerequisites --verbose --chain consensus
 
       - name: DA migration tests
         run: |
@@ -600,10 +580,6 @@ jobs:
           --db-name=zksync_en_localhost_era_da_migration --l1-rpc-url=http://localhost:8545 $GATEWAY_RPC_URL --chain da_migration
           ci_run zkstack external-node init --ignore-prerequisites --chain da_migration
 
-          ci_run zkstack external-node configs --db-url=postgres://postgres:notsecurepassword@localhost:5432 \
-          --db-name=zksync_en_localhost_era_consensus --l1-rpc-url=http://localhost:8545 $GATEWAY_RPC_URL --chain consensus
-          ci_run zkstack external-node init --ignore-prerequisites --chain consensus
-
       - name: Run recovery tests (from snapshot)
         run: |
           ci_run ./bin/run_on_all_chains.sh "zkstack dev test recovery --snapshot --no-deps --ignore-prerequisites --verbose" ${{ env.CHAINS }} ${{ env.SNAPSHOT_RECOVERY_LOGS_DIR }}
@@ -614,17 +590,15 @@ jobs:
 
       - name: Run external nodes
         run: |
-          ci_run zkstack external-node run --ignore-prerequisites --chain era &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/rollup.log &
-          ci_run zkstack external-node run --ignore-prerequisites --chain validium --components all,da_fetcher &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/validium.log &
-          ci_run zkstack external-node run --ignore-prerequisites --chain custom_token &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/custom_token.log &
-          ci_run zkstack external-node run --ignore-prerequisites --chain da_migration --components all,da_fetcher &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/da_migration.log &
-          ci_run zkstack external-node run --ignore-prerequisites --chain consensus --enable-consensus &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/consensus.log &
+          ci_run zkstack external-node run --ignore-prerequisites --chain era --enable-consensus &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/rollup.log &
+          ci_run zkstack external-node run --ignore-prerequisites --chain validium --enable-consensus --components all,da_fetcher &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/validium.log &
+          ci_run zkstack external-node run --ignore-prerequisites --chain custom_token --enable-consensus &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/custom_token.log &
+          ci_run zkstack external-node run --ignore-prerequisites --chain da_migration --enable-consensus --components all,da_fetcher &> ${{ env.EXTERNAL_NODE_LOGS_DIR }}/da_migration.log &
 
           ci_run zkstack external-node wait --ignore-prerequisites --verbose --chain era
           ci_run zkstack external-node wait --ignore-prerequisites --verbose --chain validium
           ci_run zkstack external-node wait --ignore-prerequisites --verbose --chain custom_token
           ci_run zkstack external-node wait --ignore-prerequisites --verbose --chain da_migration
-          ci_run zkstack external-node wait --ignore-prerequisites --verbose --chain consensus
 
       - name: Run integration tests en
         run: |

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -568,7 +568,7 @@ jobs:
 
       - name: Init external nodes
         run: |
-          GATEWAY_RPC_URL="${{ matrix.use_gateway_chain == 'WITH_GATEWAY' && '--gateway-rpc-url=http://localhost:3650' || '' }}"
+          GATEWAY_RPC_URL="${{ matrix.use_gateway_chain == 'WITH_GATEWAY' && '--gateway-rpc-url=http://localhost:3550' || '' }}"
           
           ci_run zkstack external-node configs --db-url=postgres://postgres:notsecurepassword@localhost:5432 \
           --db-name=zksync_en_localhost_era_rollup --l1-rpc-url=http://localhost:8545 $GATEWAY_RPC_URL --chain era

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -12604,6 +12604,7 @@ dependencies = [
  "zksync_node_storage_init",
  "zksync_node_sync",
  "zksync_object_store",
+ "zksync_protobuf",
  "zksync_reorg_detector",
  "zksync_snapshots_applier",
  "zksync_state",

--- a/core/bin/external_node/Cargo.toml
+++ b/core/bin/external_node/Cargo.toml
@@ -67,3 +67,5 @@ serde_yaml.workspace = true
 tempfile.workspace = true
 test-casing.workspace = true
 zksync_node_genesis.workspace = true
+zksync_protobuf.workspace = true
+

--- a/core/bin/external_node/src/config/mod.rs
+++ b/core/bin/external_node/src/config/mod.rs
@@ -360,15 +360,11 @@ impl ExternalNodeConfig<()> {
     /// Parses the local part of node configuration from the repo.
     ///
     /// **Important.** This method is blocking.
-    pub fn new(mut repo: ConfigRepository<'_>, has_consensus: bool) -> anyhow::Result<Self> {
+    pub fn new(mut repo: ConfigRepository<'_>) -> anyhow::Result<Self> {
         repo.capture_parsed_params();
         Ok(Self {
             local: repo.parse()?,
-            consensus: if has_consensus {
-                repo.parse_opt()?
-            } else {
-                None
-            },
+            consensus: repo.parse_opt()?,
             config_params: repo.into_captured_params(),
             remote: (),
         })

--- a/core/bin/external_node/src/config/tests/mod.rs
+++ b/core/bin/external_node/src/config/tests/mod.rs
@@ -721,7 +721,7 @@ fn parsing_consensus_from_env_vars() {
     let config_sources = cli.config_sources(None).unwrap();
     let schema = LocalConfig::schema().unwrap();
     let repo = config_sources.build_repository(&schema);
-    let config = ExternalNodeConfig::new(repo, true).unwrap();
+    let config = ExternalNodeConfig::new(repo).unwrap();
 
     assert_consensus_config(config.consensus.unwrap());
     let node_key = config.local.secrets.consensus.node_key.unwrap();

--- a/core/bin/external_node/src/main.rs
+++ b/core/bin/external_node/src/main.rs
@@ -45,8 +45,7 @@ struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
 
-    /// Enables consensus-based syncing instead of JSON-RPC based one. This is an experimental and incomplete feature;
-    /// do not use unless you know what you're doing.
+    /// Consensus is enabled unconditionally. This var is unused and kept for compatibility.
     #[arg(long)]
     enable_consensus: bool,
 
@@ -67,8 +66,7 @@ struct Cli {
         long,
         requires = "config_path",
         requires = "secrets_path",
-        requires = "external_node_config_path",
-        requires = "enable_consensus"
+        requires = "external_node_config_path"
     )]
     consensus_path: Option<std::path::PathBuf>,
 }
@@ -187,7 +185,7 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    let config = ExternalNodeConfig::new(repo, opt.enable_consensus)?;
+    let config = ExternalNodeConfig::new(repo)?;
 
     if let Some(l1_batch) = revert_to_l1_batch {
         let node = ExternalNodeBuilder::on_runtime(runtime, config).build_for_revert(l1_batch)?;

--- a/core/bin/external_node/src/tests/mod.rs
+++ b/core/bin/external_node/src/tests/mod.rs
@@ -19,15 +19,15 @@ mod utils;
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
-#[test_casing(4, ["all", "core", "api", "core,tree_api"])]
+#[test_casing(4, [("all", 0), ("core", 1), ("api", 2), ("core,tree_api", 3)])]
 #[tokio::test]
 #[tracing::instrument] // Add args to the test logs
-async fn external_node_basics(components_str: &'static str) {
+async fn external_node_basics(input: (&'static str, u16)) {
     let temp_dir = tempfile::TempDir::new().unwrap();
     let connection_pool = ConnectionPool::test_pool().await;
     let _guard = zksync_vlog::ObservabilityBuilder::new().try_build().ok(); // Enable logging to simplify debugging
     let (env, env_handles) =
-        utils::TestEnvironment::with_genesis_block(&temp_dir, &connection_pool, components_str)
+        utils::TestEnvironment::with_genesis_block(&temp_dir, &connection_pool, input.0, input.1)
             .await;
 
     let mut expected_health_components = utils::expected_health_components(&env.components);
@@ -91,7 +91,7 @@ async fn node_reacts_to_stop_signal_during_initial_reorg_detection() {
     let temp_dir = tempfile::TempDir::new().unwrap();
     let connection_pool = ConnectionPool::test_pool().await;
     let (env, env_handles) =
-        utils::TestEnvironment::with_genesis_block(&temp_dir, &connection_pool, "core").await;
+        utils::TestEnvironment::with_genesis_block(&temp_dir, &connection_pool, "core", 0).await;
 
     let l2_client = utils::mock_l2_client_hanging();
     let mut node_handle = env.spawn_node(l2_client);
@@ -111,7 +111,7 @@ async fn running_tree_without_core_is_not_allowed() {
     let temp_dir = tempfile::TempDir::new().unwrap();
     let connection_pool = ConnectionPool::test_pool().await;
     let (env, _env_handles) =
-        utils::TestEnvironment::with_genesis_block(&temp_dir, &connection_pool, "tree").await;
+        utils::TestEnvironment::with_genesis_block(&temp_dir, &connection_pool, "tree", 0).await;
 
     let l2_client = utils::mock_l2_client(&env);
     let eth_client = utils::mock_eth_client(
@@ -154,7 +154,7 @@ async fn reverting_node_state_no_op() {
     let temp_dir = tempfile::TempDir::new().unwrap();
     let connection_pool = ConnectionPool::test_pool().await;
     let (env, _env_handles) =
-        utils::TestEnvironment::with_genesis_block(&temp_dir, &connection_pool, "core").await;
+        utils::TestEnvironment::with_genesis_block(&temp_dir, &connection_pool, "core", 0).await;
 
     utils::spawn_node(move || {
         let node = ExternalNodeBuilder::new(env.config)?;

--- a/core/bin/external_node/src/tests/utils.rs
+++ b/core/bin/external_node/src/tests/utils.rs
@@ -2,14 +2,22 @@ use std::sync::Arc;
 
 use tempfile::TempDir;
 use tokio::sync::oneshot;
-use zksync_dal::{ConnectionPool, Core, CoreDal};
+use zksync_consensus_crypto::Text;
+use zksync_consensus_roles::validator::{
+    BlockNumber, ChainId, ForkNumber, GenesisRaw, LeaderSelection, LeaderSelectionMode,
+    ProtocolVersion, Schedule, SecretKey, ValidatorInfo,
+};
+use zksync_dal::{consensus::GlobalConfig, ConnectionPool, Core, CoreDal};
 use zksync_eth_client::clients::MockSettlementLayer;
 use zksync_health_check::AppHealthCheck;
 use zksync_node_genesis::{insert_genesis_batch, GenesisParams};
 use zksync_types::{
     api, block::L2BlockHeader, ethabi, Address, L2BlockNumber, ProtocolVersionId, H256,
 };
-use zksync_web3_decl::client::{MockClient, L1};
+use zksync_web3_decl::{
+    client::{MockClient, L1},
+    jsonrpsee::core::__reexports::serde_json,
+};
 
 use super::*;
 
@@ -60,6 +68,7 @@ impl TestEnvironment {
         temp_dir: &TempDir,
         connection_pool: &ConnectionPool<Core>,
         components_str: &str,
+        consensus_port_offset: u16,
     ) -> (Self, TestEnvironmentHandles) {
         // Simplest case to mock: the EN already has a genesis L1 batch / L2 block, and it's the only L1 batch / L2 block
         // in the network.
@@ -87,7 +96,7 @@ impl TestEnvironment {
         drop(storage);
 
         let components: ComponentsToRun = components_str.parse().unwrap();
-        let mut config = ExternalNodeConfig::mock(temp_dir, connection_pool);
+        let mut config = ExternalNodeConfig::mock(temp_dir, connection_pool, consensus_port_offset);
         if components.0.contains(&Component::TreeApi) {
             config.local.api.merkle_tree.port = 0;
         }
@@ -256,6 +265,38 @@ pub(super) fn mock_l2_client(env: &TestEnvironment) -> MockClient<L2> {
         )
         .method("zks_getFeeParams", || Ok(FeeParams::sensible_v1_default()))
         .method("en_whitelistedTokensForAA", || Ok([] as [Address; 0]))
+        .method("en_consensusGlobalConfig", || {
+            const VALIDATOR: &str = "validator:secret:bls12_381:3cf20d771450fcd0cbb3839b21cab41161af1554e35d8407a53b0a5d98ff04d4";
+            let key: SecretKey = Text::new(VALIDATOR).decode().unwrap();
+
+            let config = GlobalConfig {
+                genesis: GenesisRaw {
+                    chain_id: ChainId(9),
+                    fork_number: ForkNumber(0),
+                    protocol_version: ProtocolVersion(1),
+                    first_block: BlockNumber(0),
+                    validators_schedule: Some(
+                        Schedule::new(
+                            [ValidatorInfo {
+                                key: key.public(),
+                                weight: 1,
+                                leader: true,
+                            }],
+                            LeaderSelection {
+                                frequency: 1,
+                                mode: LeaderSelectionMode::RoundRobin,
+                            },
+                        )
+                            .unwrap()),
+                }.with_hash(),
+                registry_address: None,
+                seed_peers: Default::default(),
+            };
+            let serialized = zksync_protobuf::serde::Serialize
+                .proto_fmt(&config, serde_json::value::Serializer)
+                .unwrap();
+            Ok(api::en::ConsensusGlobalConfig(serialized))
+        })
         .build()
 }
 

--- a/core/lib/config/src/configs/consensus.rs
+++ b/core/lib/config/src/configs/consensus.rs
@@ -189,6 +189,44 @@ impl ConsensusConfig {
     pub fn rpc(&self) -> RpcConfig {
         self.rpc.clone()
     }
+
+    pub fn for_tests() -> Self {
+        const VALIDATOR: &str = "validator:public:bls12_381:80ee14e3a66e1324b9af2531054a823a1224b433\
+            6c6e46fa9491220bb94c887a66b14549060046537e17f831453d358d0b0662322437876622a2490246c0fe0a\
+            6a0b5013062d50a6411ddb745189da7e5d79ffd64903e899c8b5a3e7cd89be5a";
+
+        ConsensusConfig {
+            port: Some(0),
+            server_addr: "127.0.0.1:0".parse().unwrap(),
+            public_addr: Host("127.0.0.1:0".into()),
+            max_payload_size: ByteSize(2000000),
+            view_timeout: Duration::from_secs(3),
+            max_batch_size: ByteSize(125001024),
+            gossip_dynamic_inbound_limit: 10,
+            gossip_static_inbound: BTreeSet::from([
+                NodePublicKey("node:public:ed25519:5c270ee08cae1179a65845a62564ae5d216cbe2c97ed5083f512f2df353bb291".into())
+            ]),
+            gossip_static_outbound: BTreeMap::from([(
+                NodePublicKey("node:public:ed25519:5c270ee08cae1179a65845a62564ae5d216cbe2c97ed5083f512f2df353bb291".into()),
+                Host("127.0.0.1:3054".into())
+            )]),
+            genesis_spec: Some(GenesisSpec {
+                chain_id: L2ChainId::from(271),
+                protocol_version: ProtocolVersion(1),
+                validators: vec![(ValidatorPublicKey(VALIDATOR.into()), 1)],
+                leader: Some(ValidatorPublicKey(VALIDATOR.into())),
+                registry_address: Some("0x2469b58c37e02d53a65cdf248d4086beba17de85".parse().unwrap()),
+                seed_peers: BTreeMap::from([(
+                    NodePublicKey("node:public:ed25519:68d29127ab03408bf5c838553b19c32bdb3aaaae9bf293e5e078c3a0d265822a".into()),
+                    Host("example.com:3054".into())
+                )]),
+            }),
+            rpc: RpcConfig {
+                get_block_rps: NonZeroUsize::new(5).unwrap(),
+            },
+            debug_page_addr: Some("127.0.0.1:0".parse().unwrap()),
+        }
+    }
 }
 
 /// Secrets needed for consensus.

--- a/core/node/consensus/src/en.rs
+++ b/core/node/consensus/src/en.rs
@@ -1,46 +1,23 @@
 use std::sync::Arc;
 
 use anyhow::Context as _;
-use zksync_concurrency::{ctx, error::Wrap as _, scope, sync, time};
-use zksync_consensus_engine::{EngineInterface as _, EngineManager};
+use zksync_concurrency::{ctx, error::Wrap as _, scope, time};
+use zksync_consensus_engine::EngineManager;
 use zksync_consensus_executor::{self as executor};
-use zksync_consensus_roles::validator;
 use zksync_dal::consensus_dal;
-use zksync_node_sync::{fetcher::FetchedBlock, sync_action::ActionQueueSender};
+use zksync_node_sync::sync_action::ActionQueueSender;
 use zksync_shared_resources::api::SyncState;
 use zksync_types::L2BlockNumber;
 use zksync_web3_decl::{
     client::{DynClient, L2},
-    error::is_retryable,
     namespaces::{EnNamespaceClient as _, EthNamespaceClient as _},
 };
 
 use super::{config, storage::Store, ConsensusConfig, ConsensusSecrets};
 use crate::{
-    metrics::METRICS,
     registry::{Registry, RegistryAddress},
-    storage::{self, ConnectionPool},
+    storage::ConnectionPool,
 };
-
-/// Whenever more than FALLBACK_FETCHER_THRESHOLD certificates are missing,
-/// the fallback fetcher is active.
-pub(crate) const FALLBACK_FETCHER_THRESHOLD: u64 = 10;
-
-/// Waits until the main node block is greater or equal to the given block number.
-/// Returns the current main node block number.
-async fn wait_for_main_node_block(
-    ctx: &ctx::Ctx,
-    sync_state: &SyncState,
-    pred: impl Fn(validator::BlockNumber) -> bool,
-) -> ctx::OrCanceled<validator::BlockNumber> {
-    sync::wait_for_some(ctx, &mut sync_state.subscribe(), |inner| {
-        inner
-            .main_node_block()
-            .map(|n| validator::BlockNumber(n.0.into()))
-            .filter(|n| pred(*n))
-    })
-    .await
-}
 
 /// External node.
 pub(super) struct EN {
@@ -130,18 +107,6 @@ impl EN {
             .wrap("Store::new()")?;
             s.spawn_bg(async { Ok(runner.run(ctx).await.context("Store::runner()")?) });
 
-            // Run the temporary fetcher until the certificates are backfilled.
-            // Temporary fetcher should be removed once json RPC syncing is fully deprecated.
-            s.spawn_bg({
-                let store = store.clone();
-                async {
-                    let store = store;
-                    self.fallback_block_fetcher(ctx, &store)
-                        .await
-                        .wrap("fallback_block_fetcher()")
-                }
-            });
-
             let (engine_manager, engine_runner) = EngineManager::new(ctx, Box::new(store.clone()))
                 .await
                 .wrap("BlockStore::new()")?;
@@ -158,36 +123,6 @@ impl EN {
         })
         .await;
 
-        match res {
-            Ok(()) | Err(ctx::Error::Canceled(_)) => Ok(()),
-            Err(ctx::Error::Internal(err)) => Err(err),
-        }
-    }
-
-    /// Task fetching L2 blocks using JSON-RPC endpoint of the main node.
-    pub async fn run_fetcher(
-        self,
-        ctx: &ctx::Ctx,
-        actions: ActionQueueSender,
-    ) -> anyhow::Result<()> {
-        tracing::warn!("\
-            WARNING: this node is using ZKsync API synchronization, which will be deprecated soon. \
-            Please follow this instruction to switch to p2p synchronization: \
-            https://github.com/matter-labs/zksync-era/blob/main/docs/src/guides/external-node/10_decentralization.md");
-        let res: ctx::Result<()> = scope::run!(ctx, |ctx, s| async {
-            // Update sync state in the background.
-            s.spawn_bg(self.fetch_state_loop(ctx));
-            let mut payload_queue = self
-                .pool
-                .connection(ctx)
-                .await
-                .wrap("connection()")?
-                .new_payload_queue(ctx, actions, self.sync_state.clone())
-                .await
-                .wrap("new_fetcher_cursor()")?;
-            self.fetch_blocks(ctx, &mut payload_queue).await
-        })
-        .await;
         match res {
             Ok(()) | Err(ctx::Error::Canceled(_)) => Ok(()),
             Err(ctx::Error::Internal(err)) => Err(err),
@@ -230,88 +165,5 @@ impl EN {
         }
         .proto_fmt(&cfg.0)
         .context("deserialize()")?)
-    }
-
-    /// Fetches (with retries) the given block from the main node.
-    async fn fetch_block(
-        &self,
-        ctx: &ctx::Ctx,
-        n: validator::BlockNumber,
-    ) -> ctx::Result<FetchedBlock> {
-        const RETRY_INTERVAL: time::Duration = time::Duration::seconds(5);
-        let n = L2BlockNumber(n.0.try_into().context("overflow")?);
-        METRICS.fetch_block.inc();
-        loop {
-            match ctx.wait(self.client.sync_l2_block(n, true)).await? {
-                Ok(Some(block)) => return Ok(block.try_into()?),
-                Ok(None) => {}
-                Err(err) if is_retryable(&err) => {}
-                Err(err) => Err(err).with_context(|| format!("client.sync_l2_block({n})"))?,
-            }
-            ctx.sleep(RETRY_INTERVAL).await?;
-        }
-    }
-
-    /// Fetches blocks from the main node directly whenever the EN is lagging behind too much.
-    pub(crate) async fn fallback_block_fetcher(
-        &self,
-        ctx: &ctx::Ctx,
-        store: &Store,
-    ) -> ctx::Result<()> {
-        const MAX_CONCURRENT_REQUESTS: usize = 30;
-        scope::run!(ctx, |ctx, s| async {
-            let (send, mut recv) = ctx::channel::bounded(MAX_CONCURRENT_REQUESTS);
-            // TODO: metrics.
-            s.spawn::<()>(async {
-                let send = send;
-                let is_lagging =
-                    |main| main >= store.persisted().borrow().next() + FALLBACK_FETCHER_THRESHOLD;
-                let mut next = store.next_block(ctx).await.wrap("next_block()")?;
-                loop {
-                    // Wait until p2p syncing is lagging.
-                    wait_for_main_node_block(ctx, &self.sync_state, is_lagging).await?;
-                    // Determine the next block to fetch and wait for it to be available.
-                    next = next.max(store.next_block(ctx).await.wrap("next_block()")?);
-                    wait_for_main_node_block(ctx, &self.sync_state, |main| main >= next).await?;
-                    // Fetch the block asynchronously.
-                    send.send(ctx, s.spawn(self.fetch_block(ctx, next))).await?;
-                    next = next.next();
-                }
-            });
-            loop {
-                let block = recv.recv(ctx).await?;
-                store
-                    .queue_next_fetched_block(ctx, block.join(ctx).await?)
-                    .await
-                    .wrap("queue_next_fetched_block()")?;
-            }
-        })
-        .await
-    }
-
-    /// Fetches blocks starting with `queue.next()`.
-    async fn fetch_blocks(
-        &self,
-        ctx: &ctx::Ctx,
-        queue: &mut storage::PayloadQueue,
-    ) -> ctx::Result<()> {
-        const MAX_CONCURRENT_REQUESTS: usize = 30;
-        let mut next = queue.next();
-        scope::run!(ctx, |ctx, s| async {
-            let (send, mut recv) = ctx::channel::bounded(MAX_CONCURRENT_REQUESTS);
-            s.spawn::<()>(async {
-                let send = send;
-                loop {
-                    wait_for_main_node_block(ctx, &self.sync_state, |main| main >= next).await?;
-                    send.send(ctx, s.spawn(self.fetch_block(ctx, next))).await?;
-                    next = next.next();
-                }
-            });
-            loop {
-                let block = recv.recv(ctx).await?.join(ctx).await?;
-                queue.send(block).await.context("queue.send()")?;
-            }
-        })
-        .await
     }
 }

--- a/core/node/consensus/src/lib.rs
+++ b/core/node/consensus/src/lib.rs
@@ -51,7 +51,8 @@ pub async fn run_main_node(
 /// using JSON RPC, without starting the consensus node.
 pub async fn run_external_node(
     ctx: &ctx::Ctx,
-    cfg: Option<(ConsensusConfig, ConsensusSecrets)>,
+    config: ConsensusConfig,
+    secrets: ConsensusSecrets,
     pool: zksync_dal::ConnectionPool<Core>,
     sync_state: SyncState,
     main_node_client: Box<DynClient<L2>>,
@@ -63,20 +64,13 @@ pub async fn run_external_node(
         sync_state: sync_state.clone(),
         client: main_node_client.for_component("block_fetcher"),
     };
-    let res = match cfg {
-        Some((cfg, secrets)) => {
-            tracing::info!(
-                is_validator = secrets.validator_key.is_some(),
-                "running external node"
-            );
-            en.run(ctx, actions, cfg, secrets, Some(build_version))
-                .await
-        }
-        None => {
-            tracing::info!("running fetcher");
-            en.run_fetcher(ctx, actions).await
-        }
-    };
+    tracing::info!(
+        is_validator = secrets.validator_key.is_some(),
+        "running external node"
+    );
+    let res = en
+        .run(ctx, actions, config, secrets, Some(build_version))
+        .await;
     tracing::info!("Consensus actor stopped");
     res
 }

--- a/core/node/consensus/src/lib.rs
+++ b/core/node/consensus/src/lib.rs
@@ -51,14 +51,14 @@ pub async fn run_main_node(
 /// using JSON RPC, without starting the consensus node.
 pub async fn run_external_node(
     ctx: &ctx::Ctx,
-    config: ConsensusConfig,
-    secrets: ConsensusSecrets,
+    config: (ConsensusConfig, ConsensusSecrets),
     pool: zksync_dal::ConnectionPool<Core>,
     sync_state: SyncState,
     main_node_client: Box<DynClient<L2>>,
     actions: ActionQueueSender,
     build_version: semver::Version,
 ) -> anyhow::Result<()> {
+    let (cfg, secrets) = config;
     let en = en::EN {
         pool: storage::ConnectionPool(pool),
         sync_state: sync_state.clone(),
@@ -69,7 +69,7 @@ pub async fn run_external_node(
         "running external node"
     );
     let res = en
-        .run(ctx, actions, config, secrets, Some(build_version))
+        .run(ctx, actions, cfg, secrets, Some(build_version))
         .await;
     tracing::info!("Consensus actor stopped");
     res

--- a/core/node/consensus/src/node/external_node.rs
+++ b/core/node/consensus/src/node/external_node.rs
@@ -59,8 +59,7 @@ impl WiringLayer for ExternalNodeConsensusLayer {
 
         let consensus_task = ExternalNodeTask {
             build_version: self.build_version,
-            config: self.config,
-            secrets: self.secrets,
+            config: (self.config, self.secrets),
             pool,
             main_node_client,
             sync_state,
@@ -73,8 +72,7 @@ impl WiringLayer for ExternalNodeConsensusLayer {
 #[derive(Debug)]
 pub struct ExternalNodeTask {
     build_version: semver::Version,
-    config: ConsensusConfig,
-    secrets: ConsensusSecrets,
+    config: (ConsensusConfig, ConsensusSecrets),
     pool: ConnectionPool<Core>,
     main_node_client: Box<DynClient<L2>>,
     sync_state: SyncState,
@@ -98,7 +96,6 @@ impl Task for ExternalNodeTask {
             s.spawn_bg(crate::run_external_node(
                 ctx,
                 self.config,
-                self.secrets,
                 self.pool,
                 self.sync_state,
                 self.main_node_client,

--- a/core/node/consensus/src/storage/mod.rs
+++ b/core/node/consensus/src/storage/mod.rs
@@ -1,7 +1,6 @@
 //! Storage implementation based on DAL.
 
 use zksync_concurrency::ctx;
-use zksync_consensus_roles::validator;
 use zksync_dal::consensus_dal;
 use zksync_node_sync::{
     fetcher::{FetchedBlock, IoCursorExt as _},
@@ -44,10 +43,6 @@ pub(crate) struct PayloadQueue {
 }
 
 impl PayloadQueue {
-    pub(crate) fn next(&self) -> validator::BlockNumber {
-        validator::BlockNumber(self.inner.next_l2_block.0.into())
-    }
-
     /// Advances the cursor by converting the block into actions and pushing them
     /// to the actions queue.
     /// Does nothing and returns `Ok(())` if the block has been already processed.

--- a/core/node/consensus/src/storage/store.rs
+++ b/core/node/consensus/src/storage/store.rs
@@ -124,28 +124,6 @@ impl Store {
     async fn conn(&self, ctx: &ctx::Ctx) -> ctx::Result<Connection> {
         self.pool.connection(ctx).await.wrap("connection")
     }
-
-    /// Number of the next block to queue.
-    pub(crate) async fn next_block(&self, ctx: &ctx::Ctx) -> ctx::Result<validator::BlockNumber> {
-        Ok(sync::lock(ctx, &self.block_payloads)
-            .await?
-            .as_ref()
-            .context("payload_queue not set")?
-            .next())
-    }
-
-    /// Queues the next block.
-    pub(crate) async fn queue_next_fetched_block(
-        &self,
-        ctx: &ctx::Ctx,
-        block: FetchedBlock,
-    ) -> ctx::Result<()> {
-        let mut payloads = sync::lock(ctx, &self.block_payloads).await?.into_async();
-        if let Some(payloads) = &mut *payloads {
-            payloads.send(block).await.context("payloads.send()")?;
-        }
-        Ok(())
-    }
 }
 
 #[async_trait::async_trait]

--- a/core/node/consensus/src/testonly.rs
+++ b/core/node/consensus/src/testonly.rs
@@ -369,21 +369,6 @@ impl StateKeeper {
         }
     }
 
-    /// Runs the centralized fetcher.
-    pub async fn run_fetcher(
-        self,
-        ctx: &ctx::Ctx,
-        client: Box<DynClient<L2>>,
-    ) -> anyhow::Result<()> {
-        en::EN {
-            pool: self.pool,
-            client,
-            sync_state: self.sync_state.clone(),
-        }
-        .run_fetcher(ctx, self.actions_sender)
-        .await
-    }
-
     /// Runs consensus node for the external node.
     pub async fn run_consensus(
         self,

--- a/core/node/consensus/src/tests/mod.rs
+++ b/core/node/consensus/src/tests/mod.rs
@@ -15,10 +15,8 @@ use zksync_consensus_roles::{
 use zksync_dal::consensus_dal;
 use zksync_test_contracts::Account;
 use zksync_types::ProtocolVersionId;
-use zksync_web3_decl::namespaces::EnNamespaceClient as _;
 
 use crate::{
-    en::FALLBACK_FETCHER_THRESHOLD,
     mn::run_main_node,
     storage::{ConnectionPool, Store},
     testonly,
@@ -588,159 +586,6 @@ async fn test_en_validators(from_snapshot: bool, version: ProtocolVersionId) {
     .unwrap();
 }
 
-// Test fetcher back filling missing certs.
-#[test_casing(4, Product((FROM_SNAPSHOT,VERSIONS)))]
-#[tokio::test]
-async fn test_p2p_fetcher_backfill_certs(from_snapshot: bool, version: ProtocolVersionId) {
-    zksync_concurrency::testonly::abort_on_panic();
-    let ctx = &ctx::test_root(&ctx::AffineClock::new(10.));
-    let rng = &mut ctx.rng();
-    let setup = Setup::new(rng, 1);
-    let validator_cfg = testonly::new_configs(rng, &setup, 0)[0].clone();
-    let node_cfg = validator_cfg.new_fullnode(rng);
-    let account = &mut Account::random();
-
-    scope::run!(ctx, |ctx, s| async {
-        tracing::info!("Spawn validator.");
-        let validator_pool = ConnectionPool::test(from_snapshot, version).await;
-        let (mut validator, runner) =
-            testonly::StateKeeper::new(ctx, validator_pool.clone()).await?;
-        s.spawn_bg(runner.run(ctx));
-        s.spawn_bg(run_main_node(
-            ctx,
-            validator_cfg.config.clone(),
-            validator_cfg.secrets.clone(),
-            validator_pool.clone(),
-        ));
-        // API server needs at least 1 L1 batch to start.
-        validator.seal_batch().await;
-        let client = validator.connect(ctx).await?;
-
-        let node_pool = ConnectionPool::test(from_snapshot, version).await;
-
-        tracing::info!("Run p2p fetcher.");
-        scope::run!(ctx, |ctx, s| async {
-            let (node, runner) = testonly::StateKeeper::new(ctx, node_pool.clone()).await?;
-            s.spawn_bg(runner.run(ctx));
-            s.spawn_bg(node.run_consensus(ctx, client.clone(), node_cfg.clone()));
-            validator.push_random_blocks(rng, account, 3).await;
-            node_pool
-                .wait_for_block_certificate(ctx, validator.last_block())
-                .await?;
-            Ok(())
-        })
-        .await
-        .unwrap();
-
-        tracing::info!("Run centralized fetcher.");
-        scope::run!(ctx, |ctx, s| async {
-            let (node, runner) = testonly::StateKeeper::new(ctx, node_pool.clone()).await?;
-            s.spawn_bg(runner.run(ctx));
-            s.spawn_bg(node.run_fetcher(ctx, client.clone()));
-            validator.push_random_blocks(rng, account, 3).await;
-            node_pool
-                .wait_for_payload(ctx, validator.last_block())
-                .await?;
-            Ok(())
-        })
-        .await
-        .unwrap();
-
-        tracing::info!("Run p2p fetcher again.");
-        scope::run!(ctx, |ctx, s| async {
-            let (node, runner) = testonly::StateKeeper::new(ctx, node_pool.clone()).await?;
-            s.spawn_bg(runner.run(ctx));
-            s.spawn_bg(node.run_consensus(ctx, client.clone(), node_cfg));
-            validator.push_random_blocks(rng, account, 3).await;
-            let want = validator_pool
-                .wait_for_blocks_and_verify_certs(ctx, validator.last_block())
-                .await?;
-            let got = node_pool
-                .wait_for_blocks_and_verify_certs(ctx, validator.last_block())
-                .await?;
-            assert_eq!(want, got);
-            Ok(())
-        })
-        .await
-        .unwrap();
-        Ok(())
-    })
-    .await
-    .unwrap();
-}
-
-// Test temporary fetcher fetching blocks if a lot of certs are missing.
-#[test_casing(4, Product((FROM_SNAPSHOT,VERSIONS)))]
-#[tokio::test]
-async fn test_fallback_fetcher(from_snapshot: bool, version: ProtocolVersionId) {
-    zksync_concurrency::testonly::abort_on_panic();
-    let ctx = &ctx::test_root(&ctx::AffineClock::new(10.));
-    let rng = &mut ctx.rng();
-    // We force certs to be missing on EN by having 1 of the validators permanently offline.
-    // This way no blocks will be finalized at all, so no one will have certs.
-    let setup = Setup::new(rng, 2);
-    let validator_cfg = testonly::new_configs(rng, &setup, 0)[0].clone();
-    let node_cfg = validator_cfg.new_fullnode(rng);
-    let account = &mut Account::random();
-
-    scope::run!(ctx, |ctx, s| async {
-        tracing::info!("Spawn validator.");
-        let validator_pool = ConnectionPool::test(from_snapshot, version).await;
-        let (mut validator, runner) =
-            testonly::StateKeeper::new(ctx, validator_pool.clone()).await?;
-        s.spawn_bg(runner.run(ctx));
-        s.spawn_bg(run_main_node(
-            ctx,
-            validator_cfg.config.clone(),
-            validator_cfg.secrets.clone(),
-            validator_pool.clone(),
-        ));
-        // API server needs at least 1 L1 batch to start.
-        validator.seal_batch().await;
-        let client = validator.connect(ctx).await?;
-
-        // Wait for the consensus to be initialized.
-        while ctx.wait(client.consensus_global_config()).await??.is_none() {
-            ctx.sleep(time::Duration::milliseconds(100)).await?;
-        }
-
-        let node_pool = ConnectionPool::test(from_snapshot, version).await;
-
-        tracing::info!("Run centralized fetcher, so that there is a lot of certs missing.");
-        scope::run!(ctx, |ctx, s| async {
-            let (node, runner) = testonly::StateKeeper::new(ctx, node_pool.clone()).await?;
-            s.spawn_bg(runner.run(ctx));
-            s.spawn_bg(node.run_fetcher(ctx, client.clone()));
-            validator
-                .push_random_blocks(rng, account, FALLBACK_FETCHER_THRESHOLD as usize + 1)
-                .await;
-            node_pool
-                .wait_for_payload(ctx, validator.last_block())
-                .await?;
-            Ok(())
-        })
-        .await
-        .unwrap();
-
-        tracing::info!("Run p2p fetcher. Blocks should be fetched by the fallback fetcher anyway.");
-        scope::run!(ctx, |ctx, s| async {
-            let (node, runner) = testonly::StateKeeper::new(ctx, node_pool.clone()).await?;
-            s.spawn_bg(runner.run(ctx));
-            s.spawn_bg(node.run_consensus(ctx, client.clone(), node_cfg.clone()));
-            validator.push_random_blocks(rng, account, 5).await;
-            node_pool
-                .wait_for_payload(ctx, validator.last_block())
-                .await?;
-            Ok(())
-        })
-        .await
-        .unwrap();
-        Ok(())
-    })
-    .await
-    .unwrap();
-}
-
 #[test_casing(2, VERSIONS)]
 #[tokio::test]
 async fn test_with_pruning(version: ProtocolVersionId) {
@@ -833,46 +678,6 @@ async fn test_with_pruning(version: ProtocolVersionId) {
             .wait_for_blocks(ctx, validator.last_block())
             .await
             .wrap("wait_for_blocks()")?;
-        Ok(())
-    })
-    .await
-    .unwrap();
-}
-
-#[test_casing(4, Product((FROM_SNAPSHOT,VERSIONS)))]
-#[tokio::test]
-async fn test_centralized_fetcher(from_snapshot: bool, version: ProtocolVersionId) {
-    zksync_concurrency::testonly::abort_on_panic();
-    let ctx = &ctx::test_root(&ctx::RealClock);
-    let rng = &mut ctx.rng();
-    let account = &mut Account::random();
-
-    scope::run!(ctx, |ctx, s| async {
-        tracing::info!("Spawn a validator.");
-        let validator_pool = ConnectionPool::test(from_snapshot, version).await;
-        let (mut validator, runner) =
-            testonly::StateKeeper::new(ctx, validator_pool.clone()).await?;
-        s.spawn_bg(runner.run(ctx).instrument(tracing::info_span!("validator")));
-
-        tracing::info!("Produce a batch (to make api server start)");
-        // TODO: ensure at least L1 batch in `testonly::StateKeeper::new()` to make it fool proof.
-        validator.seal_batch().await;
-
-        tracing::info!("Spawn a node.");
-        let node_pool = ConnectionPool::test(from_snapshot, version).await;
-        let (node, runner) = testonly::StateKeeper::new(ctx, node_pool.clone()).await?;
-        s.spawn_bg(runner.run(ctx).instrument(tracing::info_span!("fetcher")));
-        s.spawn_bg(node.run_fetcher(ctx, validator.connect(ctx).await?));
-
-        tracing::info!("Produce some blocks and wait for node to fetch them");
-        validator.push_random_blocks(rng, account, 10).await;
-        let want = validator_pool
-            .wait_for_payload(ctx, validator.last_block())
-            .await?;
-        let got = node_pool
-            .wait_for_payload(ctx, validator.last_block())
-            .await?;
-        assert_eq!(want, got);
         Ok(())
     })
     .await

--- a/core/tests/gateway-migration-test/tests/migration.test.ts
+++ b/core/tests/gateway-migration-test/tests/migration.test.ts
@@ -76,7 +76,7 @@ describe('Migration From/To gateway test', function () {
         web3JsonRpc = generalConfig.api.web3_json_rpc.http_url;
 
         mainNodeSpawner = new utils.NodeSpawner(pathToHome, logs, fileConfig, {
-            enableConsensus: false,
+            enableConsensus: true,
             ethClientWeb3Url: ethProviderAddress!,
             apiWeb3JsonRpcHttpUrl: web3JsonRpc!,
             baseTokenAddress: contractsConfig.l1.base_token_addr

--- a/core/tests/revert-test/tests/revert-and-restart-en.test.ts
+++ b/core/tests/revert-test/tests/revert-and-restart-en.test.ts
@@ -95,19 +95,17 @@ describe('Block reverting test', function () {
         const extLogs = await fs.open(pathToEnLogs, 'a');
         utils.log(`Writing EN logs to ${pathToEnLogs}`);
 
-        const enableConsensus = process.env.ENABLE_CONSENSUS === 'true';
-        utils.log(`enableConsensus = ${enableConsensus}`);
         depositAmount = ethers.parseEther('0.001');
 
         const mainNodeSpawnOptions = {
-            enableConsensus,
+            enableConsensus: true,
             ethClientWeb3Url,
             apiWeb3JsonRpcHttpUrl,
             baseTokenAddress
         };
         mainNodeSpawner = new NodeSpawner(pathToHome, mainLogs, chainName, mainNodeSpawnOptions);
         const extNodeSpawnOptions = {
-            enableConsensus,
+            enableConsensus: true,
             ethClientWeb3Url,
             apiWeb3JsonRpcHttpUrl: enEthClientUrl,
             baseTokenAddress

--- a/core/tests/ts-integration/src/env.ts
+++ b/core/tests/ts-integration/src/env.ts
@@ -12,8 +12,6 @@ import { logsTestPath } from 'utils/build/logs';
 import * as nodefs from 'node:fs/promises';
 import { exec } from 'utils';
 
-const enableConsensus = process.env.ENABLE_CONSENSUS === 'true';
-
 async function logsPath(chain: string, name: string): Promise<string> {
     return await logsTestPath(chain, 'logs/server/', name);
 }
@@ -109,7 +107,7 @@ async function loadTestEnvironmentFromFile(fileConfig: FileConfig): Promise<Test
             }
         }
         let mainNodeSpawner = new NodeSpawner(pathToHome, mainLogs, fileConfig, {
-            enableConsensus,
+            enableConsensus: true,
             ethClientWeb3Url: l1NodeUrl,
             apiWeb3JsonRpcHttpUrl: l2NodeUrl,
             baseTokenAddress: contracts.l1.base_token_addr

--- a/core/tests/ts-integration/tests/fees.test.ts
+++ b/core/tests/ts-integration/tests/fees.test.ts
@@ -73,7 +73,6 @@ testFees('Test fees', function () {
 
     const fileConfig = shouldLoadConfigFromFile();
     const pathToHome = path.join(__dirname, '../../../..');
-    const enableConsensus = process.env.ENABLE_CONSENSUS == 'true';
 
     async function logsPath(chain: string | undefined, name: string): Promise<string> {
         chain = chain ? chain : 'default';
@@ -118,7 +117,7 @@ testFees('Test fees', function () {
         console.log(`Writing server logs to ${pathToMainLogs}`);
 
         mainNodeSpawner = new NodeSpawner(pathToHome, mainLogs, fileConfig, {
-            enableConsensus,
+            enableConsensus: true,
             ethClientWeb3Url,
             apiWeb3JsonRpcHttpUrl,
             baseTokenAddress

--- a/core/tests/upgrade-test/tests/upgrade.test.ts
+++ b/core/tests/upgrade-test/tests/upgrade.test.ts
@@ -128,7 +128,7 @@ describe('Upgrade test', function () {
         gatewayInfo = getGatewayInfo(pathToHome, fileConfig.chain);
 
         mainNodeSpawner = new utils.NodeSpawner(pathToHome, logs, fileConfig, {
-            enableConsensus: false,
+            enableConsensus: true,
             ethClientWeb3Url: ethProviderAddress!,
             apiWeb3JsonRpcHttpUrl: web3JsonRpc!,
             baseTokenAddress: contractsConfig.l1.base_token_addr

--- a/docs/src/guides/external-node/10_decentralization.md
+++ b/docs/src/guides/external-node/10_decentralization.md
@@ -1,9 +1,5 @@
 # Decentralization
 
-In the default setup, the Node will fetch data from the ZKsync API endpoint maintained by Matter Labs. To reduce the
-reliance on this centralized endpoint we have developed a decentralized p2p networking stack (aka gossipnet) which will
-eventually be used instead of ZKsync API for synchronizing data.
-
 On the gossipnet, the data integrity will be protected by the BFT (byzantine fault-tolerant) consensus algorithm
 (currently data is signed just by the main node though).
 
@@ -69,12 +65,3 @@ EN_CONSENSUS_SECRETS_PATH=...
 
 These variables should point to your consensus config and secrets files that we have just created. Tweak the paths to
 the files if you have placed them differently.
-
-### Add `--enable-consensus` flag to your entry point command
-
-For the consensus configuration to take effect you have to add `--enable-consensus` flag to the command line when
-running the node, for example:
-
-```
-docker run "matterlabs/external-node:2.0-v24.12.0" <all the other flags> --enable-consensus
-```

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/args/revert.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/args/revert.rs
@@ -1,13 +1,9 @@
 use clap::Parser;
 
-use crate::commands::dev::messages::{
-    MSG_NO_DEPS_HELP, MSG_NO_KILL_HELP, MSG_REVERT_TEST_ENABLE_CONSENSUS_HELP,
-};
+use crate::commands::dev::messages::{MSG_NO_DEPS_HELP, MSG_NO_KILL_HELP};
 
 #[derive(Debug, Parser)]
 pub struct RevertArgs {
-    #[clap(long, help = MSG_REVERT_TEST_ENABLE_CONSENSUS_HELP)]
-    pub enable_consensus: bool,
     #[clap(short, long, help = MSG_NO_DEPS_HELP)]
     pub no_deps: bool,
     #[clap(long, help = MSG_NO_KILL_HELP)]

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/revert.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/revert.rs
@@ -50,7 +50,7 @@ async fn run_test(
         .await?;
 
     let cmd = cmd!(shell, "yarn mocha tests/revert-and-restart-en.test.ts");
-    let mut cmd = Cmd::new(cmd)
+    let cmd = Cmd::new(cmd)
         .env("CHAIN_NAME", ecosystem_config.current_chain())
         .env("NO_KILL", args.no_kill.to_string())
         .env("MASTER_WALLET_PK", wallets.get_test_pk(&chain_config)?);

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/revert.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/revert.rs
@@ -54,9 +54,6 @@ async fn run_test(
         .env("CHAIN_NAME", ecosystem_config.current_chain())
         .env("NO_KILL", args.no_kill.to_string())
         .env("MASTER_WALLET_PK", wallets.get_test_pk(&chain_config)?);
-    if args.enable_consensus {
-        cmd = cmd.env("ENABLE_CONSENSUS", "true");
-    }
     cmd.with_force_run().run()?;
 
     Ok(())

--- a/zkstack_cli/crates/zkstack/src/commands/dev/messages.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/messages.rs
@@ -144,7 +144,6 @@ pub(super) const MSG_INTEGRATION_TESTS_BUILDING_DEPENDENCIES: &str =
 pub(super) const MSG_INTEGRATION_TESTS_BUILDING_CONTRACTS: &str = "Building test contracts...";
 
 // Revert tests related messages
-pub(super) const MSG_REVERT_TEST_ENABLE_CONSENSUS_HELP: &str = "Enable consensus";
 pub(super) const MSG_REVERT_TEST_RUN_INFO: &str = "Running revert and restart test";
 
 pub(super) const MSG_REVERT_TEST_RUN_SUCCESS: &str = "Revert and restart test ran successfully";

--- a/zkstack_cli/crates/zkstack/src/commands/external_node/args/run.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/external_node/args/run.rs
@@ -1,8 +1,6 @@
 use clap::Parser;
 
-use crate::messages::{
-    MSG_ENABLE_CONSENSUS_HELP, MSG_SERVER_ADDITIONAL_ARGS_HELP, MSG_SERVER_COMPONENTS_HELP,
-};
+use crate::messages::{MSG_SERVER_ADDITIONAL_ARGS_HELP, MSG_SERVER_COMPONENTS_HELP};
 
 #[derive(Debug, Parser)]
 pub struct RunExternalNodeArgs {
@@ -10,8 +8,6 @@ pub struct RunExternalNodeArgs {
     pub reinit: bool,
     #[arg(long, help = MSG_SERVER_COMPONENTS_HELP)]
     pub components: Option<Vec<String>>,
-    #[arg(long, help = MSG_ENABLE_CONSENSUS_HELP, default_missing_value = "true", num_args = 0..=1)]
-    pub enable_consensus: Option<bool>,
     #[arg(last = true, help = MSG_SERVER_ADDITIONAL_ARGS_HELP)]
     pub additional_args: Vec<String>,
 }

--- a/zkstack_cli/crates/zkstack/src/commands/external_node/run.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/external_node/run.rs
@@ -31,7 +31,6 @@ async fn run_external_node(
     if args.reinit {
         init::init(shell, chain_config).await?
     }
-    let enable_consensus = args.enable_consensus.unwrap_or(false);
     let server = RunExternalNode::new(args.components.clone(), chain_config)?;
-    server.run(shell, enable_consensus, args.additional_args.clone())
+    server.run(shell, args.additional_args.clone())
 }

--- a/zkstack_cli/crates/zkstack/src/external_node.rs
+++ b/zkstack_cli/crates/zkstack/src/external_node.rs
@@ -41,12 +41,7 @@ impl RunExternalNode {
         })
     }
 
-    pub fn run(
-        &self,
-        shell: &Shell,
-        enable_consensus: bool,
-        additional_args: Vec<String>,
-    ) -> anyhow::Result<()> {
+    pub fn run(&self, shell: &Shell, additional_args: Vec<String>) -> anyhow::Result<()> {
         let code_path = self.code_path.to_str().unwrap();
         let config_general_config = &self.general_config.to_str().unwrap();
         let en_config = &self.en_config.to_str().unwrap();
@@ -57,10 +52,7 @@ impl RunExternalNode {
         if let Some(components) = self.components() {
             passed_args.push(format!("--components={}", components))
         }
-        if enable_consensus {
-            passed_args.push("--enable-consensus".to_string());
-            passed_args.push(format!("--consensus-path={consensus_config}"))
-        }
+        passed_args.push(format!("--consensus-path={consensus_config}"));
         // Need to insert the additional args at the end, since they may include positional ones
         passed_args.extend(additional_args);
 

--- a/zkstack_cli/crates/zkstack/src/messages.rs
+++ b/zkstack_cli/crates/zkstack/src/messages.rs
@@ -281,7 +281,6 @@ pub(super) const MSG_CHAIN_TRANSACTIONS_BUILT: &str = "Chain transactions succes
 
 /// Run server related messages
 pub(super) const MSG_SERVER_COMPONENTS_HELP: &str = "Components of server to run";
-pub(super) const MSG_ENABLE_CONSENSUS_HELP: &str = "Enable consensus";
 pub(super) const MSG_SERVER_GENESIS_HELP: &str = "Run server in genesis mode";
 pub(super) const MSG_SERVER_ADDITIONAL_ARGS_HELP: &str =
     "Additional arguments that can be passed through the CLI";


### PR DESCRIPTION
## What ❔

Removes JSON RPC syncing.

## Why ❔

Remove deprecated feature.

## Is this a breaking change?
- [x] Yes
- [ ] No

## Operational changes

ENs that still use JSON RPC syncing should follow https://github.com/matter-labs/zksync-era/blob/main/docs/src/guides/external-node/10_decentralization.md.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
