### PR TITLE
feat(private-rpc): Add secret query parameter validation for user retrieval

### DIFF
--- a/private-rpc/src/routes/users-routes.ts
+++ b/private-rpc/src/routes/users-routes.ts
@@ -46,12 +46,21 @@ export function usersRoutes(app: WebServer) {
         schema: {
             params: z.object({
                 address: addressSchema
+            }),
+            querystring: z.object({
+                secret: z.string()
             })
         }
     };
 
     app.get('/:address', getUserSchema, (req, reply) => {
-        const { authorizer } = app.context;
+        const { authorizer, createTokenSecret } = app.context;
+        const { secret } = req.query;
+
+        if (secret !== createTokenSecret) {
+            throw new HttpError('forbidden', 403);
+        }
+
         const authorized = authorizer.isAddressWhitelisted(req.params.address);
         return reply.send({ authorized });
     });


### PR DESCRIPTION
## What ❔
- Introduced a new query parameter `secret` to the user retrieval route.
- Implemented validation to ensure the provided secret matches the expected token, returning a 403 error if it does not.

## Why ❔

- Enhance security

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
