### PR TITLE
fix(zkstack): add default (de)serialization for proof manager contracts config

### DIFF
--- a/zkstack_cli/crates/config/src/contracts.rs
+++ b/zkstack_cli/crates/config/src/contracts.rs
@@ -24,7 +24,8 @@ pub struct ContractsConfig {
     pub create2_factory_salt: H256,
     pub ecosystem_contracts: EcosystemContracts,
     pub bridges: BridgesContracts,
-    pub proving_network: ProvingNetworkContracts,
+    #[serde(default)]
+    pub proof_manager_contracts: EthProofManagerContracts,
     pub l1: L1Contracts,
     pub l2: L2Contracts,
     #[serde(flatten)]
@@ -136,15 +137,15 @@ impl ContractsConfig {
         self.l2.legacy_shared_bridge_addr = register_chain_output.l2_legacy_shared_bridge_addr;
     }
 
-    pub fn set_proving_network_addresses(
+    pub fn set_eth_proof_manager_addresses(
         &mut self,
         impl_addr: String,
         proxy_addr: String,
         proxy_admin_addr: String,
     ) -> anyhow::Result<()> {
-        self.proving_network.proof_manager_addr = H160::from_str(&impl_addr)?;
-        self.proving_network.proxy_addr = H160::from_str(&proxy_addr)?;
-        self.proving_network.proxy_admin_addr = H160::from_str(&proxy_admin_addr)?;
+        self.proof_manager_contracts.proof_manager_addr = H160::from_str(&impl_addr)?;
+        self.proof_manager_contracts.proxy_addr = H160::from_str(&proxy_addr)?;
+        self.proof_manager_contracts.proxy_admin_addr = H160::from_str(&proxy_admin_addr)?;
 
         Ok(())
     }
@@ -290,7 +291,7 @@ pub struct L1Contracts {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
-pub struct ProvingNetworkContracts {
+pub struct EthProofManagerContracts {
     pub proof_manager_addr: Address,
     pub proxy_addr: Address,
     pub proxy_admin_addr: Address,

--- a/zkstack_cli/crates/zkstack/src/commands/prover/deploy_proving_networks.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/deploy_proving_networks.rs
@@ -80,7 +80,7 @@ pub(crate) async fn deploy_proving_networks(
 
     let mut contracts_config = config.get_contracts_config()?;
 
-    contracts_config.set_proving_network_addresses(impl_addr, proxy_addr, proxy_admin_addr)?;
+    contracts_config.set_eth_proof_manager_addresses(impl_addr, proxy_addr, proxy_admin_addr)?;
 
     contracts_config.save_with_base_path(shell, &config.config)?;
 


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
