### PR TITLE
fix: use FullPubdataBuilder for all pre-gateway batches

### DIFF
--- a/core/lib/multivm/src/pubdata_builders/mod.rs
+++ b/core/lib/multivm/src/pubdata_builders/mod.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 pub use full_builder::FullPubdataBuilder;
 pub use hashed_builder::HashedPubdataBuilder;
 use zksync_types::commitment::{PubdataParams, PubdataType};
-
+use zksync_types::ProtocolVersionId;
 use crate::interface::pubdata::PubdataBuilder;
 
 mod full_builder;
@@ -12,7 +12,11 @@ mod hashed_builder;
 mod tests;
 mod utils;
 
-pub fn pubdata_params_to_builder(params: PubdataParams) -> Rc<dyn PubdataBuilder> {
+pub fn pubdata_params_to_builder(params: PubdataParams, protocol_version: ProtocolVersionId) -> Rc<dyn PubdataBuilder> {
+    if protocol_version.is_pre_gateway() {
+        return Rc::new(FullPubdataBuilder::new(params.l2_da_validator_address));
+    }
+
     match params.pubdata_type {
         PubdataType::NoDA => Rc::new(HashedPubdataBuilder::new(params.l2_da_validator_address)),
         PubdataType::Rollup

--- a/core/lib/multivm/src/pubdata_builders/mod.rs
+++ b/core/lib/multivm/src/pubdata_builders/mod.rs
@@ -2,8 +2,11 @@ use std::rc::Rc;
 
 pub use full_builder::FullPubdataBuilder;
 pub use hashed_builder::HashedPubdataBuilder;
-use zksync_types::commitment::{PubdataParams, PubdataType};
-use zksync_types::ProtocolVersionId;
+use zksync_types::{
+    commitment::{PubdataParams, PubdataType},
+    ProtocolVersionId,
+};
+
 use crate::interface::pubdata::PubdataBuilder;
 
 mod full_builder;
@@ -12,7 +15,10 @@ mod hashed_builder;
 mod tests;
 mod utils;
 
-pub fn pubdata_params_to_builder(params: PubdataParams, protocol_version: ProtocolVersionId) -> Rc<dyn PubdataBuilder> {
+pub fn pubdata_params_to_builder(
+    params: PubdataParams,
+    protocol_version: ProtocolVersionId,
+) -> Rc<dyn PubdataBuilder> {
     if protocol_version.is_pre_gateway() {
         return Rc::new(FullPubdataBuilder::new(params.l2_da_validator_address));
     }

--- a/core/lib/tee_verifier/src/lib.rs
+++ b/core/lib/tee_verifier/src/lib.rs
@@ -21,7 +21,10 @@ use zksync_multivm::{
 };
 use zksync_prover_interface::inputs::{StorageLogMetadata, WitnessInputMerklePaths};
 use zksync_tee_prover_interface::inputs::V1TeeVerifierInput;
-use zksync_types::{block::L2BlockExecutionData, commitment::PubdataParams, u256_to_h256, L1BatchNumber, ProtocolVersionId, StorageLog, StorageValue, Transaction, H256};
+use zksync_types::{
+    block::L2BlockExecutionData, commitment::PubdataParams, u256_to_h256, L1BatchNumber,
+    ProtocolVersionId, StorageLog, StorageValue, Transaction, H256,
+};
 
 /// A structure to hold the result of verification.
 pub struct VerificationResult {
@@ -85,7 +88,12 @@ impl Verify for V1TeeVerifierInput {
         let storage_snapshot = StorageSnapshot::new(storage, factory_deps);
         let storage_view = StorageView::new(storage_snapshot).to_rc_ptr();
         let vm = LegacyVmInstance::new(self.l1_batch_env, self.system_env.clone(), storage_view);
-        let vm_out = execute_vm(self.l2_blocks_execution_data, vm, self.pubdata_params, self.system_env.version)?;
+        let vm_out = execute_vm(
+            self.l2_blocks_execution_data,
+            vm,
+            self.pubdata_params,
+            self.system_env.version,
+        )?;
 
         let block_output_with_proofs = get_bowp(self.merkle_paths)?;
 

--- a/core/lib/vm_executor/src/batch/factory.rs
+++ b/core/lib/vm_executor/src/batch/factory.rs
@@ -169,8 +169,8 @@ impl<S: ReadStorage + Send + 'static, Tr: BatchTracer> BatchExecutorFactory<S>
             executor.run(
                 storage,
                 l1_batch_params,
-                system_env,
-                pubdata_params_to_builder(pubdata_params),
+                system_env.clone(),
+                pubdata_params_to_builder(pubdata_params, system_env.version),
             )
         });
         Box::new(MainBatchExecutor::new(handle, commands_sender))


### PR DESCRIPTION
## What ❔

Use `FullPubdataBuilder` for all pre-gateway batches in `pubdata_params_to_builder`

## Why ❔

There are chains like Cronos that have NoDA batches created pre-v26. 
For them, the EN's state-keeper is failing to process such batches because `HashedPubdataBuilder` can't be used in pre-v26 batches.

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
