### PR TITLE
fix(consensus): Debug page server port reuse

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -12004,9 +12004,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_concurrency"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd78167a0cc7ce83103929aabc58b4f819ca9fc4acac4ae4076f2d1748215839"
+checksum = "75d6c6ee96606feeaf8376dca54815591a96702d86bf94faf44dc280b763645a"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -12043,9 +12043,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_bft"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6523e081cbba284b73304f22ac5a721eaf8621f2d296eace902fa3a11529d3b"
+checksum = "384b5ea41eca2c5a611bbdead6f4d89fece55af0e975089cc08a68990fae1349"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -12062,9 +12062,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_crypto"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b27bfa499a47d8a8916eb1d251f612790209deef18868d0033c08ca3e4a7b8f4"
+checksum = "42985ecd42d50132d2b5ba6d4d5c0ddd5c2aa8165ec55755cadab5dd5e01ce88"
 dependencies = [
  "anyhow",
  "blst",
@@ -12080,25 +12080,27 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_engine"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ca7fedf8035dbd2f495027c665e1c8b31f11479450dac94605e57736f73f2f"
+checksum = "72b5228e97d5b2545494c77b6fdf486be0684f4829cb6c5fbc08abadfb5a3c28"
 dependencies = [
  "anyhow",
  "async-trait",
+ "hex",
  "rand 0.8.5",
  "tracing",
  "vise",
  "zksync_concurrency",
+ "zksync_consensus_crypto",
  "zksync_consensus_roles",
  "zksync_protobuf_build",
 ]
 
 [[package]]
 name = "zksync_consensus_executor"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbee3826f28748658c81d500c166515ef2182d960ee76430f0fb4d49c04058c"
+checksum = "1d517e8b71bb782b1c231800a6154f900ce37791a56af0cbffe747615a2669f5"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -12114,9 +12116,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_network"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7458668821020a85a1d9445edb089bce2845a7b9418f6a907064c19353582e8e"
+checksum = "33bd1eecc2bcbb9dc51edab70f6cbe32930b34a58cefd367906482463a02cbf0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12148,9 +12150,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_roles"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b060555df53620677c82d4da9ae0b4438f8d6f11fbb82c0633e8d9c5381b1cd"
+checksum = "3ebd80ccee65a942a4da2286fce540b047671a67808c9cfd67d695ff654d5c62"
 dependencies = [
  "anyhow",
  "bit-vec 0.6.3",
@@ -12168,9 +12170,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_utils"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df57fdc2a2791ae0031e86931f2d08b31a54a46f5f28b0f833f2e4aa598bc59"
+checksum = "4c1d64d96be295de498c908b03e9f2f87fc3bb8dc1e74da60c757c10eaa1d6a4"
 dependencies = [
  "rand 0.8.5",
  "thiserror 1.0.69",
@@ -13281,9 +13283,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_protobuf"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76eacd3b54bf8ea132a2a265fc6c78d0839b48b9a07ae2cb7d02a4b6b7389d"
+checksum = "e362c8e7025907707d0b4d153728817425620a654439eb73a5375efa17aaed7f"
 dependencies = [
  "anyhow",
  "bit-vec 0.6.3",
@@ -13302,9 +13304,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_protobuf_build"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1cd4ac0c6767585fc3f68fc5c5d87322ff8d48c62c8c6d913442553bce0fc1"
+checksum = "7cfec98c42651ec08eee8fd23ff5f9e7325a70803e4984a761da0923f912291b"
 dependencies = [
  "anyhow",
  "heck 0.5.0",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -268,16 +268,16 @@ bellman = { package = "zksync_bellman", version = "=0.32.1" }
 zksync_vm2 = "=0.4.0"
 
 # Consensus dependencies.
-zksync_concurrency = "=0.11.4"
-zksync_consensus_bft = "=0.11.4"
-zksync_consensus_crypto = "=0.11.4"
-zksync_consensus_engine = "=0.11.4"
-zksync_consensus_executor = "=0.11.4"
-zksync_consensus_network = "=0.11.4"
-zksync_consensus_roles = "=0.11.4"
-zksync_consensus_utils = "=0.11.4"
-zksync_protobuf = "=0.11.4"
-zksync_protobuf_build = "=0.11.4"
+zksync_concurrency = "=0.13"
+zksync_consensus_bft = "=0.13"
+zksync_consensus_crypto = "=0.13"
+zksync_consensus_engine = "=0.13"
+zksync_consensus_executor = "=0.13"
+zksync_consensus_network = "=0.13"
+zksync_consensus_roles = "=0.13"
+zksync_consensus_utils = "=0.13"
+zksync_protobuf = "=0.13"
+zksync_protobuf_build = "=0.13"
 
 # "Local" dependencies
 zksync_multivm = { version = "28.7.0-non-semver-compat", path = "lib/multivm" }

--- a/core/lib/config/src/configs/consensus.rs
+++ b/core/lib/config/src/configs/consensus.rs
@@ -146,9 +146,14 @@ pub struct ConsensusConfig {
     /// that will be advertised to peers, so that they can connect to this
     /// node.
     pub public_addr: Host,
+    /// Local socket address to expose the node debug page.
+    pub debug_page_addr: Option<std::net::SocketAddr>,
     /// Maximal allowed size of the payload in bytes.
     #[config(default_t = ByteSize(2_500_000), with = Fallback(SizeUnit::Bytes))]
     pub max_payload_size: ByteSize,
+    /// Maximal allowed size of transactions propagated through the p2p network, in bytes.
+    #[config(default_t = ByteSize(1_000_000), with = Fallback(SizeUnit::Bytes))]
+    pub max_transaction_size: ByteSize,
     /// View timeout duration.
     #[config(default_t = Duration::from_secs(2), with = Fallback(CustomDurationFormat))]
     pub view_timeout: Duration,
@@ -170,19 +175,20 @@ pub struct ConsensusConfig {
     /// establish and maintain.
     #[config(default, with = Entries::WELL_KNOWN.named("key", "addr"))]
     pub gossip_static_outbound: BTreeMap<NodePublicKey, Host>,
+    /// Rate limiting configuration for the p2p RPCs.
+    #[config(nest)]
+    pub rpc: RpcConfig,
+
+    /// Rate at which the node tries to read from the ConsensusRegistry contract, in milliseconds.
+    /// It should be set to a value that is much less than what we expect a validator epoch to be.
+    #[config(default_t = Duration::from_secs(30), with = Fallback(CustomDurationFormat))]
+    pub consensus_registry_read_rate: Duration,
 
     /// MAIN NODE ONLY: consensus genesis specification.
     /// Used to (re)initialize genesis if needed.
     /// External nodes fetch the genesis from the main node.
     #[config(nest)]
     pub genesis_spec: Option<GenesisSpec>,
-
-    /// Rate limiting configuration for the p2p RPCs.
-    #[config(nest)]
-    pub rpc: RpcConfig,
-
-    /// Local socket address to expose the node debug page.
-    pub debug_page_addr: Option<std::net::SocketAddr>,
 }
 
 impl ConsensusConfig {
@@ -200,6 +206,7 @@ impl ConsensusConfig {
             server_addr: "127.0.0.1:0".parse().unwrap(),
             public_addr: Host("127.0.0.1:0".into()),
             max_payload_size: ByteSize(2000000),
+            max_transaction_size: ByteSize(1000000),
             view_timeout: Duration::from_secs(3),
             max_batch_size: ByteSize(125001024),
             gossip_dynamic_inbound_limit: 10,
@@ -225,6 +232,7 @@ impl ConsensusConfig {
                 get_block_rps: NonZeroUsize::new(5).unwrap(),
             },
             debug_page_addr: Some("127.0.0.1:0".parse().unwrap()),
+            consensus_registry_read_rate: Duration::from_secs(3),
         }
     }
 }
@@ -255,6 +263,7 @@ mod tests {
             server_addr: "127.0.0.1:2954".parse().unwrap(),
             public_addr: Host("127.0.0.1:2954".into()),
             max_payload_size: ByteSize(2000000),
+            max_transaction_size: ByteSize(1000000),
             view_timeout: Duration::from_secs(3),
             max_batch_size: ByteSize(125001024),
             gossip_dynamic_inbound_limit: 10,
@@ -280,6 +289,7 @@ mod tests {
                 get_block_rps: NonZeroUsize::new(5).unwrap(),
             },
             debug_page_addr: Some("127.0.0.1:3000".parse().unwrap()),
+            consensus_registry_read_rate: Duration::from_secs(3),
         }
     }
 
@@ -290,6 +300,7 @@ mod tests {
             public_addr: 127.0.0.1:2954
             debug_page_addr: 127.0.0.1:3000
             max_payload_size: 2000000
+            max_transaction_size: 1000000
             view_timeout:
               seconds: 3
               nanos: 0
@@ -314,6 +325,9 @@ mod tests {
             port: 2954
             rpc:
               get_block_rps: 5
+            consensus_registry_read_rate:
+              seconds: 30
+              nanos: 0
         "#;
         let yaml = Yaml::new("test.yml", serde_yaml::from_str(yaml).unwrap()).unwrap();
         let config: ConsensusConfig = test_complete(yaml).unwrap();
@@ -327,6 +341,7 @@ mod tests {
             public_addr: 127.0.0.1:2954
             debug_page_addr: 127.0.0.1:3000
             max_payload_size: 2000000 bytes
+            max_transaction_size: 1000000 bytes
             view_timeout: 3s
             gossip_dynamic_inbound_limit: 10
             gossip_static_inbound:
@@ -346,6 +361,9 @@ mod tests {
             port: 2954
             rpc:
               get_block_rps: 5
+            consensus_registry_read_rate:
+              seconds: 30
+              nanos: 0
         "#;
         let yaml = Yaml::new("test.yml", serde_yaml::from_str(yaml).unwrap()).unwrap();
         let config: ConsensusConfig = test_complete(yaml).unwrap();

--- a/core/node/consensus/src/config.rs
+++ b/core/node/consensus/src/config.rs
@@ -148,6 +148,7 @@ pub(super) fn executor(
         server_addr: cfg.server_addr,
         public_addr: net::Host(cfg.public_addr.0.clone()),
         max_payload_size: cfg.max_payload_size.0 as usize,
+        max_tx_size: cfg.max_transaction_size.0 as usize,
         view_timeout: cfg.view_timeout.try_into().context("view_timeout")?,
         node_key: node_key(secrets)
             .context("node_key")?

--- a/core/node/consensus/src/en.rs
+++ b/core/node/consensus/src/en.rs
@@ -107,9 +107,18 @@ impl EN {
             .wrap("Store::new()")?;
             s.spawn_bg(async { Ok(runner.run(ctx).await.context("Store::runner()")?) });
 
-            let (engine_manager, engine_runner) = EngineManager::new(ctx, Box::new(store.clone()))
-                .await
-                .wrap("BlockStore::new()")?;
+            let (engine_manager, engine_runner) = EngineManager::new(
+                ctx,
+                Box::new(store.clone()),
+                time::Duration::seconds(
+                    cfg.consensus_registry_read_rate
+                        .as_secs()
+                        .try_into()
+                        .unwrap(),
+                ),
+            )
+            .await
+            .wrap("BlockStore::new()")?;
             s.spawn_bg(async { Ok(engine_runner.run(ctx).await.context("BlockStore::run()")?) });
 
             let executor = executor::Executor {

--- a/core/node/consensus/src/storage/store.rs
+++ b/core/node/consensus/src/storage/store.rs
@@ -327,6 +327,10 @@ impl EngineInterface for Store {
             .await
             .wrap("set_replica_state()")
     }
+
+    async fn push_tx(&self, _ctx: &ctx::Ctx, _tx: engine::Transaction) -> ctx::Result<bool> {
+        unimplemented!()
+    }
 }
 
 /// Background task of the `Store`.

--- a/core/node/consensus/src/testonly.rs
+++ b/core/node/consensus/src/testonly.rs
@@ -135,6 +135,7 @@ fn make_config(
         server_addr: *cfg.server_addr,
         public_addr: config::Host(cfg.public_addr.0.clone()),
         max_payload_size: u64::MAX.into(),
+        max_transaction_size: u64::MAX.into(),
         max_batch_size: u64::MAX.into(),
         view_timeout: Duration::from_secs(2),
         gossip_dynamic_inbound_limit: cfg.gossip.dynamic_inbound_limit,
@@ -158,6 +159,7 @@ fn make_config(
         genesis_spec,
         rpc: RpcConfig::default(),
         debug_page_addr: None,
+        consensus_registry_read_rate: Duration::from_secs(1),
     }
 }
 

--- a/core/node/consensus/src/tests/mod.rs
+++ b/core/node/consensus/src/tests/mod.rs
@@ -4,7 +4,12 @@ use anyhow::Context as _;
 use rand::Rng as _;
 use test_casing::{test_casing, Product};
 use tracing::Instrument as _;
-use zksync_concurrency::{ctx, error::Wrap as _, scope, time};
+use zksync_concurrency::{
+    ctx,
+    error::Wrap as _,
+    scope,
+    time::{self, Duration},
+};
 use zksync_config::configs::consensus as config;
 use zksync_consensus_crypto::TextFmt as _;
 use zksync_consensus_engine::{EngineInterface as _, EngineManager};
@@ -170,9 +175,10 @@ async fn test_validator_block_store(version: ProtocolVersionId) {
                 .await
                 .unwrap();
             s.spawn_bg(runner.run(ctx));
-            let (engine_manager, runner) = EngineManager::new(ctx, Box::new(store.clone()))
-                .await
-                .unwrap();
+            let (engine_manager, runner) =
+                EngineManager::new(ctx, Box::new(store.clone()), Duration::seconds(1))
+                    .await
+                    .unwrap();
             s.spawn_bg(runner.run(ctx));
             engine_manager
                 .queue_block(ctx, block.clone())

--- a/core/node/state_keeper/src/executor/tests/mod.rs
+++ b/core/node/state_keeper/src/executor/tests/mod.rs
@@ -468,7 +468,8 @@ async fn complex_rollback_test() {
     block_hasher.push_tx_hash(txs2[1].hash());
     let block_hash2 = block_hasher.finalize(ProtocolVersionId::latest());
 
-    let blocks = [(
+    let blocks = [
+        (
             L2BlockEnv {
                 number: 2,
                 timestamp: 102,
@@ -485,7 +486,8 @@ async fn complex_rollback_test() {
                 max_virtual_blocks_to_create: 1,
             },
             txs3,
-        )];
+        ),
+    ];
     for scenario in scenarios {
         let mut executor = tester
             .create_batch_executor_with_init_transactions(

--- a/core/node/state_keeper/src/executor/tests/mod.rs
+++ b/core/node/state_keeper/src/executor/tests/mod.rs
@@ -468,8 +468,7 @@ async fn complex_rollback_test() {
     block_hasher.push_tx_hash(txs2[1].hash());
     let block_hash2 = block_hasher.finalize(ProtocolVersionId::latest());
 
-    let blocks = vec![
-        (
+    let blocks = [(
             L2BlockEnv {
                 number: 2,
                 timestamp: 102,
@@ -486,8 +485,7 @@ async fn complex_rollback_test() {
                 max_virtual_blocks_to_create: 1,
             },
             txs3,
-        ),
-    ];
+        )];
     for scenario in scenarios {
         let mut executor = tester
             .create_batch_executor_with_init_transactions(

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -8898,9 +8898,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_concurrency"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd78167a0cc7ce83103929aabc58b4f819ca9fc4acac4ae4076f2d1748215839"
+checksum = "75d6c6ee96606feeaf8376dca54815591a96702d86bf94faf44dc280b763645a"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -8935,9 +8935,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_crypto"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b27bfa499a47d8a8916eb1d251f612790209deef18868d0033c08ca3e4a7b8f4"
+checksum = "42985ecd42d50132d2b5ba6d4d5c0ddd5c2aa8165ec55755cadab5dd5e01ce88"
 dependencies = [
  "anyhow",
  "blst",
@@ -8953,25 +8953,27 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_engine"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ca7fedf8035dbd2f495027c665e1c8b31f11479450dac94605e57736f73f2f"
+checksum = "72b5228e97d5b2545494c77b6fdf486be0684f4829cb6c5fbc08abadfb5a3c28"
 dependencies = [
  "anyhow",
  "async-trait",
+ "hex",
  "rand 0.8.5",
  "tracing",
  "vise",
  "zksync_concurrency",
+ "zksync_consensus_crypto",
  "zksync_consensus_roles",
  "zksync_protobuf_build",
 ]
 
 [[package]]
 name = "zksync_consensus_roles"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b060555df53620677c82d4da9ae0b4438f8d6f11fbb82c0633e8d9c5381b1cd"
+checksum = "3ebd80ccee65a942a4da2286fce540b047671a67808c9cfd67d695ff654d5c62"
 dependencies = [
  "anyhow",
  "bit-vec 0.6.3",
@@ -8989,9 +8991,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_utils"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df57fdc2a2791ae0031e86931f2d08b31a54a46f5f28b0f833f2e4aa598bc59"
+checksum = "4c1d64d96be295de498c908b03e9f2f87fc3bb8dc1e74da60c757c10eaa1d6a4"
 dependencies = [
  "rand 0.8.5",
  "thiserror 1.0.69",
@@ -9327,9 +9329,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_protobuf"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76eacd3b54bf8ea132a2a265fc6c78d0839b48b9a07ae2cb7d02a4b6b7389d"
+checksum = "e362c8e7025907707d0b4d153728817425620a654439eb73a5375efa17aaed7f"
 dependencies = [
  "anyhow",
  "bit-vec 0.6.3",
@@ -9348,9 +9350,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_protobuf_build"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1cd4ac0c6767585fc3f68fc5c5d87322ff8d48c62c8c6d913442553bce0fc1"
+checksum = "7cfec98c42651ec08eee8fd23ff5f9e7325a70803e4984a761da0923f912291b"
 dependencies = [
  "anyhow",
  "heck 0.5.0",

--- a/prover/crates/bin/prover_autoscaler/src/global/scaler.rs
+++ b/prover/crates/bin/prover_autoscaler/src/global/scaler.rs
@@ -1618,7 +1618,7 @@ mod tests {
         };
 
         assert_eq!(
-            scaler.calculate(&"prover".into(), 2 * 1500 + 1 * 3000 - 1500, &clusters),
+            scaler.calculate(&"prover".into(), 2 * 1500 + 3000 - 1500, &clusters),
             [
                 (
                     PoolKey {
@@ -1660,7 +1660,7 @@ mod tests {
             "Override priority: H100 in foo, then L4 in bar"
         );
         assert_eq!(
-            scaler2.calculate(&"prover".into(), 2 * 1500 + 1 * 3000 - 1500, &clusters),
+            scaler2.calculate(&"prover".into(), 2 * 1500 + 3000 - 1500, &clusters),
             [
                 (
                     PoolKey {
@@ -1682,7 +1682,7 @@ mod tests {
         );
 
         assert_eq!(
-            scaler.calculate(&"prover".into(), 0 * 1500 + 0 * 3000, &clusters_h100),
+            scaler.calculate(&"prover".into(), (0 * 3000), &clusters_h100),
             [
                 (
                     PoolKey {

--- a/zkstack_cli/Cargo.lock
+++ b/zkstack_cli/Cargo.lock
@@ -7941,9 +7941,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_concurrency"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd78167a0cc7ce83103929aabc58b4f819ca9fc4acac4ae4076f2d1748215839"
+checksum = "75d6c6ee96606feeaf8376dca54815591a96702d86bf94faf44dc280b763645a"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -7960,9 +7960,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_crypto"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b27bfa499a47d8a8916eb1d251f612790209deef18868d0033c08ca3e4a7b8f4"
+checksum = "42985ecd42d50132d2b5ba6d4d5c0ddd5c2aa8165ec55755cadab5dd5e01ce88"
 dependencies = [
  "anyhow",
  "blst",
@@ -7978,9 +7978,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_roles"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b060555df53620677c82d4da9ae0b4438f8d6f11fbb82c0633e8d9c5381b1cd"
+checksum = "3ebd80ccee65a942a4da2286fce540b047671a67808c9cfd67d695ff654d5c62"
 dependencies = [
  "anyhow",
  "bit-vec 0.6.3",
@@ -7998,9 +7998,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_utils"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df57fdc2a2791ae0031e86931f2d08b31a54a46f5f28b0f833f2e4aa598bc59"
+checksum = "4c1d64d96be295de498c908b03e9f2f87fc3bb8dc1e74da60c757c10eaa1d6a4"
 dependencies = [
  "rand 0.8.5",
  "thiserror 1.0.69",
@@ -8046,9 +8046,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_protobuf"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76eacd3b54bf8ea132a2a265fc6c78d0839b48b9a07ae2cb7d02a4b6b7389d"
+checksum = "e362c8e7025907707d0b4d153728817425620a654439eb73a5375efa17aaed7f"
 dependencies = [
  "anyhow",
  "bit-vec 0.6.3",
@@ -8067,9 +8067,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_protobuf_build"
-version = "0.11.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1cd4ac0c6767585fc3f68fc5c5d87322ff8d48c62c8c6d913442553bce0fc1"
+checksum = "7cfec98c42651ec08eee8fd23ff5f9e7325a70803e4984a761da0923f912291b"
 dependencies = [
  "anyhow",
  "heck",

--- a/zkstack_cli/Cargo.toml
+++ b/zkstack_cli/Cargo.toml
@@ -32,8 +32,8 @@ zksync_system_constants = { path = "../core/lib/constants" }
 zksync_types = { path = "../core/lib/types" }
 zksync_web3_decl = { path = "../core/lib/web3_decl" }
 zksync_contracts = { path = "../core/lib/contracts" }
-zksync_consensus_roles = "=0.11.4"
-zksync_consensus_crypto = "=0.11.4"
+zksync_consensus_roles = "=0.13"
+zksync_consensus_crypto = "=0.13"
 
 # External dependencies
 anyhow = "1.0.82"


### PR DESCRIPTION
## What ❔

Introduces a new consensus version that contains a fix that solves the debug page server being stopped because another debug page server is already using the same port.
Also adds new config parameters: one that determines how often a  node reads from the ConsensusRegistry contract for validator set updates, another for the maximum size of transactions propagated in the p2p network.

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes

The new parameters can be left at their default values.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
