### PR TITLE
fix(eth-watch): return internal errors from BatchRootProcessor

### DIFF
--- a/core/node/eth_watch/src/event_processors/appended_chain_batch_root.rs
+++ b/core/node/eth_watch/src/event_processors/appended_chain_batch_root.rs
@@ -113,12 +113,17 @@ impl EventProcessor for BatchRootProcessor {
                 }
             });
 
-        let sl_chain_id = self.sl_l2_client.chain_id().await?;
+        let sl_chain_id = self
+            .sl_l2_client
+            .chain_id()
+            .await
+            .context("sl_l2_client.chain_id()")?;
         for (sl_l1_batch_number, chain_batches) in new_events {
             let chain_agg_proof = self
                 .sl_l2_client
                 .get_chain_log_proof(sl_l1_batch_number, self.l2_chain_id)
-                .await?
+                .await
+                .context("sl_l2_client.get_chain_log_proof()")?
                 .context("Missing chain log proof for finalized batch")?;
             let chain_proof_vector =
                 Self::chain_proof_vector(sl_l1_batch_number, chain_agg_proof, sl_chain_id);
@@ -141,7 +146,8 @@ impl EventProcessor for BatchRootProcessor {
             let chain_root_remote = self
                 .sl_l2_client
                 .get_chain_root_l2(sl_l1_batch_number, self.l2_chain_id)
-                .await?;
+                .await
+                .context("sl_l2_client.get_chain_root_l2()")?;
             assert_eq!(
                 chain_root_local,
                 chain_root_remote.unwrap(),


### PR DESCRIPTION
## What ❔

Return internal errors from BatchRootProcessor instead of client errors

## Why ❔

BatchRootProcessor has its state -- merkle tree. It must be consistent with postgres: after each `process_events` call, set of batches that have `batch_chain_merkle_path` in postgres and set of batches present in the merkle tree should be the same. Otherwise on restart eth watch will be in crashloop.
Eth watch treats client error as retryable so if merkle tree was updated and then client returns error -> process_events returns before batch_chain_merkle_path is stored. Returning internal error fixes the issue because eth watch exits and restarts on them

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
