### PR TITLE
fix(prover): Propagating errors for CP & Compressor

### DIFF
--- a/prover/crates/bin/circuit_prover/src/main.rs
+++ b/prover/crates/bin/circuit_prover/src/main.rs
@@ -75,9 +75,12 @@ async fn main() -> anyhow::Result<()> {
     let (metrics_stop_sender, metrics_stop_receiver) = tokio::sync::watch::channel(false);
 
     tokio::select! {
-        _ = run_inner(cancellation_token.clone(), metrics_stop_receiver, &mut managed_tasks) => {},
+        res = run_inner(cancellation_token.clone(), metrics_stop_receiver, &mut managed_tasks) => {
+            res?
+        },
         _ = stop_signal_receiver => {
             tracing::info!("Stop request received, shutting down");
+            ()
         }
     }
     let shutdown_time = Instant::now();

--- a/prover/crates/bin/proof_fri_compressor/src/main.rs
+++ b/prover/crates/bin/proof_fri_compressor/src/main.rs
@@ -63,9 +63,12 @@ async fn main() -> anyhow::Result<()> {
     let (metrics_stop_sender, metrics_stop_receiver) = tokio::sync::watch::channel(false);
 
     tokio::select! {
-        _ = run_inner(cancellation_token.clone(), metrics_stop_receiver, &mut managed_tasks) => {},
+        res = run_inner(cancellation_token.clone(), metrics_stop_receiver, &mut managed_tasks) => {
+            res?
+        },
         _ = stop_signal_receiver => {
             tracing::info!("Stop request received, shutting down");
+            ()
         }
     }
     let shutdown_time = Instant::now();


### PR DESCRIPTION
## What ❔
Fix for error propagating for CP & Compressor. We need run_inner for instant cancelling all the operations upon receiving SIGTERM
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔
Errors weren't propagating from tokio::select!
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
