### PR TITLE
feat(zkstack): Generating keys for compressor

### DIFF
--- a/zkstack_cli/crates/config/src/general.rs
+++ b/zkstack_cli/crates/config/src/general.rs
@@ -211,6 +211,10 @@ impl GeneralConfigPatch {
             .get("proof_compressor.universal_setup_download_url")
     }
 
+    pub fn proof_compressor_setup_path(&self) -> anyhow::Result<PathBuf> {
+        self.0.base().get("proof_compressor.universal_setup_path")
+    }
+
     pub fn set_proof_compressor_setup_path(&mut self, path: &Path) -> anyhow::Result<()> {
         self.0
             .insert_path("proof_compressor.universal_setup_path", path)


### PR DESCRIPTION
## What ❔
Added zkstack feature to generate keys for compressor
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔
There is no functionality in zkstack to generate keys for compressor.
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
