### PR TITLE
chore: enable node_framework feature for eth_client in da_clients

### DIFF
--- a/core/node/da_clients/Cargo.toml
+++ b/core/node/da_clients/Cargo.toml
@@ -22,7 +22,7 @@ chrono.workspace = true
 
 zksync_config.workspace = true
 zksync_types.workspace = true
-zksync_eth_client.workspace = true
+zksync_eth_client = { workspace = true, features = ["node_framework"] }
 zksync_object_store = { workspace = true, features = ["node_framework"] }
 zksync_da_client = { workspace = true, features = ["node_framework"] }
 zksync_basic_types.workspace = true


### PR DESCRIPTION
## What ❔

* [x] Enable node_framework feature for eth_client in da_clients.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To fix crates.io publishing issue for `node/da_clients`

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
