### PR TITLE
fix: prevent uncommitted chain migrating from gw

### DIFF
--- a/zkstack_cli/crates/zkstack/src/commands/chain/gateway/migrate_from_gateway.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/gateway/migrate_from_gateway.rs
@@ -27,9 +27,10 @@ use zkstack_cli_config::{
     forge_interface::script_params::GATEWAY_UTILS_SCRIPT_PATH, EcosystemConfig,
 };
 use zksync_basic_types::{H256, U256};
+use zksync_types::L1BatchNumber;
 use zksync_web3_decl::{
     client::{Client, L2},
-    namespaces::EthNamespaceClient,
+    namespaces::{EthNamespaceClient, ZksNamespaceClient},
 };
 
 use crate::{
@@ -116,6 +117,26 @@ pub async fn run(args: MigrateFromGatewayArgs, shell: &Shell) -> anyhow::Result<
     let gw_rpc_url = general_config.l2_http_url()?;
     let gateway_provider = get_ethers_provider(&gw_rpc_url)?;
     let gateway_zk_client = get_zk_client(&gw_rpc_url, chain_config.chain_id.as_u64())?;
+
+    // We prevent chains with uncommitted batches from initiating migration from gateway.
+    // As interop is only supported on top of gateway, an uncommited batch specifying some interop roots
+    // will not be able to settle on the L1.
+    let l1_batch_number = L1BatchNumber::from(
+        gateway_zk_client
+            .get_l1_batch_number()
+            .await
+            .expect("Failed to get l1 batch number")
+            .as_u32(),
+    );
+    let l1_batch_details = gateway_zk_client
+        .get_l1_batch_details(l1_batch_number)
+        .await
+        .expect("Failed to get l1 batch details");
+
+    if l1_batch_details.is_none() {
+        logger::error("Gateway chain has uncommitted batches. Please commit them first.");
+        anyhow::bail!("Gateway chain has uncommitted batches. Please commit them first.");
+    }
 
     if calldata.is_empty() {
         logger::info("Chain already migrated!");


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
