### PR TITLE
fix: rename function due to misspell

### DIFF
--- a/core/lib/types/src/fee_model.rs
+++ b/core/lib/types/src/fee_model.rs
@@ -617,7 +617,7 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_baxtch_fee_model_input_v2_only_compute_overhead() {
+    fn test_compute_batch_fee_model_input_v2_only_compute_overhead() {
         // Here we use sensible config, but when only compute is used to close the batch
         let config = FeeModelConfigV2 {
             minimal_l2_gas_price: 100_000_000_000,


### PR DESCRIPTION
## What ❔

rename `test_compute_baxtch_fee_model_input_v2_only_compute_overhead` to `test_compute_batch_fee_model_input_v2_only_compute_overhead`

## Why ❔

because in previous name was minor error in word `batch` - it was `baxtch`
## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
