### PR TITLE
fix(ff): do not send precommits before v29

### DIFF
--- a/core/node/eth_sender/src/eth_tx_aggregator.rs
+++ b/core/node/eth_sender/src/eth_tx_aggregator.rs
@@ -684,7 +684,9 @@ impl EthTxAggregator {
             }
         }
 
-        let precommit_params = self.precommit_params(storage).await?;
+        let precommit_params = self
+            .precommit_params(storage, chain_protocol_version_id)
+            .await?;
 
         if let Some(agg_op) = self
             .aggregator
@@ -737,7 +739,12 @@ impl EthTxAggregator {
     async fn precommit_params(
         &mut self,
         storage: &mut Connection<'_, Core>,
+        chain_protocol_version_id: ProtocolVersionId,
     ) -> Result<Option<PrecommitParams>, EthSenderError> {
+        if chain_protocol_version_id.is_pre_interop_fast_blocks() {
+            // If we are in the pre-interop fast blocks mode, we don't use precommit operations
+            return Ok(None);
+        }
         if let Some(params) = self.config.precommit_params.clone() {
             return Ok(Some(params));
         }


### PR DESCRIPTION
## What ❔

Check that precommits are not yet enabled on l1 
## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
