### PR TITLE
fix(state-keeper): set interop roots on first block in batch

### DIFF
--- a/core/lib/dal/.sqlx/query-a1339010617c0c882029ccd0959c2bfd23e63b4dafe3f65c1f01ec3cc195cc6a.json
+++ b/core/lib/dal/.sqlx/query-a1339010617c0c882029ccd0959c2bfd23e63b4dafe3f65c1f01ec3cc195cc6a.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                interop_roots.chain_id,\n                interop_roots.dependency_block_number,\n                interop_roots.interop_root_sides\n            FROM interop_roots\n            WHERE\n                processed_block_number =\n                (SELECT MIN(number) FROM miniblocks WHERE l1_batch_number IS NULL)\n            ORDER BY chain_id, dependency_block_number DESC;\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "chain_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "dependency_block_number",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "interop_root_sides",
+        "type_info": "ByteaArray"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a1339010617c0c882029ccd0959c2bfd23e63b4dafe3f65c1f01ec3cc195cc6a"
+}

--- a/core/lib/vm_executor/src/storage.rs
+++ b/core/lib/vm_executor/src/storage.rs
@@ -91,7 +91,7 @@ pub fn l1_batch_params(
                 timestamp: l1_batch_timestamp,
                 prev_block_hash: prev_l2_block_hash,
                 max_virtual_blocks_to_create: virtual_blocks,
-                interop_roots: interop_roots,
+                interop_roots,
             },
         },
     )

--- a/core/lib/vm_executor/src/storage.rs
+++ b/core/lib/vm_executor/src/storage.rs
@@ -11,8 +11,8 @@ use zksync_dal::{Connection, Core, CoreDal, DalError};
 use zksync_multivm::interface::{L1BatchEnv, L2BlockEnv, SystemEnv, TxExecutionMode};
 use zksync_types::{
     block::L2BlockHeader, bytecode::BytecodeHash, commitment::PubdataParams,
-    fee_model::BatchFeeInput, snapshots::SnapshotRecoveryStatus, Address, L1BatchNumber,
-    L2BlockNumber, L2ChainId, ProtocolVersionId, H256, ZKPORTER_IS_AVAILABLE,
+    fee_model::BatchFeeInput, snapshots::SnapshotRecoveryStatus, Address, InteropRoot,
+    L1BatchNumber, L2BlockNumber, L2ChainId, ProtocolVersionId, H256, ZKPORTER_IS_AVAILABLE,
 };
 
 const BATCH_COMPUTATIONAL_GAS_LIMIT: u32 = u32::MAX;
@@ -67,6 +67,7 @@ pub fn l1_batch_params(
     protocol_version: ProtocolVersionId,
     virtual_blocks: u32,
     chain_id: L2ChainId,
+    interop_roots: Vec<InteropRoot>,
 ) -> (SystemEnv, L1BatchEnv) {
     (
         SystemEnv {
@@ -90,7 +91,7 @@ pub fn l1_batch_params(
                 timestamp: l1_batch_timestamp,
                 prev_block_hash: prev_l2_block_hash,
                 max_virtual_blocks_to_create: virtual_blocks,
-                interop_roots: vec![],
+                interop_roots: interop_roots,
             },
         },
     )
@@ -354,6 +355,8 @@ impl L1BatchParamsProvider {
                 .context("`protocol_version` must be set for L2 block")?,
             first_l2_block_in_batch.header.virtual_blocks,
             chain_id,
+            // TODO: check if we should fetch any interop roots
+            Default::default(),
         );
 
         Ok(RestoredL1BatchEnv {

--- a/core/node/eth_sender/src/eth_tx_aggregator.rs
+++ b/core/node/eth_sender/src/eth_tx_aggregator.rs
@@ -1174,7 +1174,7 @@ impl EthTxAggregator {
             .await?;
 
         if latest_processed_l1_batch_number.is_none() {
-            return Ok(true);
+            return Ok(false);
         }
 
         let last_sent_successfully_eth_tx = storage

--- a/core/node/node_sync/src/external_io.rs
+++ b/core/node/node_sync/src/external_io.rs
@@ -324,7 +324,7 @@ impl StateKeeperIO for ExternalIO {
                         pubdata_limit: params.pubdata_limit,
                     })
                     .await?;
-                return Ok(Some(params));
+                Ok(Some(params))
             }
             other => {
                 anyhow::bail!("unexpected action in the action queue: {other:?}");

--- a/core/node/node_sync/src/fetcher.rs
+++ b/core/node/node_sync/src/fetcher.rs
@@ -182,7 +182,7 @@ impl IoCursorExt for IoCursor {
                     first_l2_block: L2BlockParams::new_raw(
                         block.timestamp * 1000,
                         block.virtual_blocks,
-                        vec![],
+                        block.interop_roots,
                     ),
                     pubdata_params: block.pubdata_params,
                     pubdata_limit: block.pubdata_limit,

--- a/core/node/state_keeper/src/io/mempool.rs
+++ b/core/node/state_keeper/src/io/mempool.rs
@@ -682,7 +682,7 @@ impl MempoolIO {
                 let mut storage = self.pool.connection_tagged("state_keeper").await?;
                 let gateway_migration_state = self.gateway_status(&mut storage).await;
                 let limit = get_bootloader_max_msg_roots_in_batch(protocol_version.into());
-                // We only import interop roots when settling on gateway, but stop doing so when migration is in progress.!
+                // We only import interop roots when settling on gateway, but stop doing so when migration is in progress.
                 let interop_roots =
                     if matches!(self.settlement_layer, Some(SettlementLayer::Gateway(_)))
                         && gateway_migration_state == GatewayMigrationState::NotInProgress

--- a/core/node/state_keeper/src/io/mempool.rs
+++ b/core/node/state_keeper/src/io/mempool.rs
@@ -563,6 +563,16 @@ impl MempoolIO {
             let protocol_version = unsealed_storage_batch
                 .protocol_version
                 .context("unsealed batch is missing protocol version")?;
+
+            let interop_roots = if protocol_version.is_pre_interop_fast_blocks() {
+                vec![]
+            } else {
+                let mut storage = self.pool.connection_tagged("state_keeper").await?;
+                storage
+                    .interop_root_dal()
+                    .get_interop_roots_for_first_l2_block_in_pending_batch()
+                    .await?
+            };
             return Ok(Some(L1BatchParams {
                 protocol_version,
                 validation_computational_gas_limit: self.validation_computational_gas_limit,
@@ -570,7 +580,11 @@ impl MempoolIO {
                 fee_input: unsealed_storage_batch.fee_input,
                 // We only persist timestamp in seconds.
                 // Unsealed batch is only used upon restart so it's ok to not use exact precise millis here.
-                first_l2_block: L2BlockParams::new(unsealed_storage_batch.timestamp * 1000),
+                first_l2_block: L2BlockParams::new_raw(
+                    unsealed_storage_batch.timestamp * 1000,
+                    1,
+                    interop_roots,
+                ),
                 pubdata_params: self.pubdata_params(protocol_version)?,
                 pubdata_limit: unsealed_storage_batch.pubdata_limit,
             }));

--- a/core/node/state_keeper/src/io/mempool.rs
+++ b/core/node/state_keeper/src/io/mempool.rs
@@ -564,15 +564,11 @@ impl MempoolIO {
                 .protocol_version
                 .context("unsealed batch is missing protocol version")?;
 
-            let interop_roots = if protocol_version.is_pre_interop_fast_blocks() {
-                vec![]
-            } else {
-                let mut storage = self.pool.connection_tagged("state_keeper").await?;
-                storage
-                    .interop_root_dal()
-                    .get_interop_roots_for_first_l2_block_in_pending_batch()
-                    .await?
-            };
+            let mut storage = self.pool.connection_tagged("state_keeper").await?;
+            let interop_roots = storage
+                .interop_root_dal()
+                .get_interop_roots_for_first_l2_block_in_pending_batch()
+                .await?;
             return Ok(Some(L1BatchParams {
                 protocol_version,
                 validation_computational_gas_limit: self.validation_computational_gas_limit,

--- a/core/node/state_keeper/src/io/mod.rs
+++ b/core/node/state_keeper/src/io/mod.rs
@@ -159,6 +159,7 @@ impl L1BatchParams {
             self.protocol_version,
             self.first_l2_block.virtual_blocks,
             chain_id,
+            self.first_l2_block.interop_roots.clone(),
         );
 
         BatchInitParams {


### PR DESCRIPTION
## What ❔

We were not properly attaching interop information on the first block in the batch.
This meant, that if we were sealing only 1 block per batch, interop roots were never included (this happened during manual tests).

This fix is ignored during protocol upgrades, as this could cause the batch to fail. The reason for it is that during v29 protocol upgrade, interop roots cannot be set given that the `L2InteropRootStorage` contract is not yet deployed.

Additionally, this PR introduces a check to skip importing of interop roots if settling on the L1, which can cause batch execution to fail as we do not support L1 interop. This issue was not revealed until after enabling interop roots on first block in a batch.