### PR TITLE
feat: Handling of ZK token address for price conversion

### DIFF
--- a/core/lib/constants/src/contracts.rs
+++ b/core/lib/constants/src/contracts.rs
@@ -227,3 +227,9 @@ pub const SHARED_BRIDGE_ETHER_TOKEN_ADDRESS: Address = H160([
 /// Default `ERA_CHAIN_ID`. All hyperchains start with this chain id and later on during their registration
 /// an "initial upgrade" transaction overrides it with the correct value.
 pub const DEFAULT_ERA_CHAIN_ID: u32 = 270;
+
+/// ZK token address on Ethereum Mainnet
+pub const ZK_L1_ADDRESS: Address = H160([
+    0x66, 0xa5, 0xcf, 0xb2, 0xe9, 0xc5, 0x29, 0xf1, 0x4f, 0xe6, 0x36, 0x4a, 0xd1, 0x07, 0x5d, 0xf3,
+    0xa6, 0x49, 0xc0, 0xa5,
+]);

--- a/core/lib/external_price_api/src/lib.rs
+++ b/core/lib/external_price_api/src/lib.rs
@@ -10,7 +10,7 @@ mod utils;
 use std::fmt;
 
 use async_trait::async_trait;
-use zksync_types::{base_token_ratio::BaseTokenApiRatio, Address};
+use zksync_types::{base_token_ratio::BaseTokenApiRatio, Address, ZK_L1_ADDRESS};
 
 /// Enum representing the token for which the ratio is fetched.
 #[derive(Debug, Clone, Copy)]
@@ -25,11 +25,7 @@ impl APIToken {
         if address == Address::zero() || address == Address::from_low_u64_be(1) {
             Self::Eth
             // ZK needs special handling due to being not recognized by API clients
-        } else if address
-            == "0x66A5cFB2e9c529f14FE6364Ad1075dF3a649C0A5"
-                .parse::<Address>()
-                .unwrap()
-        {
+        } else if address == ZK_L1_ADDRESS {
             Self::ZK
         } else {
             Self::ERC20(address)


### PR DESCRIPTION
## What ❔

- Special handling for ZK L1 token address

## Why ❔

- ZK L1 address is not listed on Coingecko or CMC right now.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
