### PR TITLE
chore: update extra substituter URL in nixConfig

### DIFF
--- a/.github/workflows/build-tee-prover-template.yml
+++ b/.github/workflows/build-tee-prover-template.yml
@@ -44,13 +44,13 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ github.token }}
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= tee-pot:SS6HcrpG87S1M6HZGPsfo7d1xJccCGev7/tXc5+I4jg=
-            substituters = https://cache.nixos.org/ https://attic.teepot.org/tee-pot
+            substituters = https://cache.nixos.org/ https://static.188.92.12.49.clients.your-server.de/tee-pot
             sandbox = true
 
       - name: Setup Attic cache
         uses: ryanccn/attic-action@f6b7e98e9ba10c6db4841e4996cd3fe4bdb3f3ed # v0.3.2
         with:
-          endpoint: https://attic.teepot.org/
+          endpoint: https://static.188.92.12.49.clients.your-server.de/
           cache: tee-pot
           token: ${{ secrets.ATTIC_TOKEN }}
 

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   description = "ZKsync-era";
 
   nixConfig = {
-    extra-substituters = [ "https://attic.teepot.org/tee-pot" ];
+    extra-substituters = [ "https://static.188.92.12.49.clients.your-server.de/tee-pot" ];
     extra-trusted-public-keys = [ "tee-pot:SS6HcrpG87S1M6HZGPsfo7d1xJccCGev7/tXc5+I4jg=" ];
   };
 


### PR DESCRIPTION
## What ❔

* Replaced outdated substituter URL with a new static IP-based URL.

## Why ❔

* transition to devops controlled DNS

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
