### PR TITLE
fix: change callReqSchema validation to passthrough mode

### DIFF
--- a/private-rpc/src/rpc/methods/utils.ts
+++ b/private-rpc/src/rpc/methods/utils.ts
@@ -111,7 +111,7 @@ const callReqSchema = z
             })
             .optional()
     })
-    .strict();
+    .passthrough();
 
 const callResponseSchema = z.object({
     jsonrpc: z.literal('2.0'),


### PR DESCRIPTION
## What ❔
Change callReqSchema in private-rpc to passthrough.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

RPC call is sending `chainId` as part of the params in an `eth_call`. In case other modifications to the params arise, `passthrough()` is added to avoid these sort of errors in the future.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
