### PR TITLE
fix(en): make interop_roots optional

### DIFF
--- a/core/lib/dal/src/models/storage_sync.rs
+++ b/core/lib/dal/src/models/storage_sync.rs
@@ -130,7 +130,7 @@ impl SyncBlock {
             protocol_version: self.protocol_version,
             pubdata_params: Some(self.pubdata_params),
             pubdata_limit: self.pubdata_limit,
-            interop_roots: self.interop_roots,
+            interop_roots: Some(self.interop_roots),
         }
     }
 

--- a/core/lib/types/src/api/en.rs
+++ b/core/lib/types/src/api/en.rs
@@ -48,7 +48,7 @@ pub struct SyncBlock {
     /// Pubdata limit for the batch.
     pub pubdata_limit: Option<u64>,
     /// Interop roots for this block
-    pub interop_roots: Vec<InteropRoot>,
+    pub interop_roots: Option<Vec<InteropRoot>>,
 }
 
 /// Global configuration of the consensus served by the main node to the external nodes.

--- a/core/node/node_sync/src/fetcher.rs
+++ b/core/node/node_sync/src/fetcher.rs
@@ -109,7 +109,7 @@ impl TryFrom<SyncBlock> for FetchedBlock {
                 .collect(),
             pubdata_params,
             pubdata_limit: block.pubdata_limit,
-            interop_roots: block.interop_roots.clone(),
+            interop_roots: block.interop_roots.clone().unwrap_or_default(),
         })
     }
 }

--- a/core/node/node_sync/src/tests.rs
+++ b/core/node/node_sync/src/tests.rs
@@ -69,7 +69,7 @@ impl MockMainNodeClient {
             protocol_version: ProtocolVersionId::latest(),
             pubdata_params: Default::default(),
             pubdata_limit: Some(100_000),
-            interop_roots: vec![],
+            interop_roots: Some(vec![]),
         };
 
         Self {


### PR DESCRIPTION
## What ❔

make interop_roots optional

## Why ❔

back compatibility (en v29 works with main node v28)

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
