### PR TITLE
fix(zkstack): make GW migration script compatible with pre-v29

### DIFF
--- a/zkstack_cli/crates/zkstack/src/abi.rs
+++ b/zkstack_cli/crates/zkstack/src/abi.rs
@@ -34,6 +34,7 @@ abigen!(
 ]"
 );
 
+// "validators" is from pre-v29, used for backward compatibility. Will be removed once v29 is released.
 abigen!(
     ValidatorTimelockAbi,
     r"[
@@ -43,5 +44,6 @@ abigen!(
     function COMMITTER_ROLE()(bytes32)
     function PROVER_ROLE()(bytes32)
     function EXECUTOR_ROLE()(bytes32)
+    function validators(uint256 _chainId, address _validator)(bool)
     ]"
 );


### PR DESCRIPTION
## What ❔

Make GW migration calldata script compatible with pre-v29 contracts

## Why ❔

It didn't work with pre-v29 contracts that blocked the GW migrations

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
