### PR TITLE
fix: secret parsing whitelisting private rpc

### DIFF
--- a/private-rpc/src/routes/users-routes.ts
+++ b/private-rpc/src/routes/users-routes.ts
@@ -55,7 +55,7 @@ export function usersRoutes(app: WebServer) {
 
     app.get('/:address', getUserSchema, (req, reply) => {
         const { authorizer, createTokenSecret } = app.context;
-        const { secret } = req.query;
+        const secret = req.headers['x-secret'];
 
         if (secret !== createTokenSecret) {
             throw new HttpError('forbidden', 403);

--- a/private-rpc/src/routes/users-routes.ts
+++ b/private-rpc/src/routes/users-routes.ts
@@ -47,9 +47,6 @@ export function usersRoutes(app: WebServer) {
             params: z.object({
                 address: addressSchema
             }),
-            querystring: z.object({
-                secret: z.string()
-            })
         }
     };
 
@@ -58,6 +55,7 @@ export function usersRoutes(app: WebServer) {
         const secret = req.headers['x-secret'];
 
         if (secret !== createTokenSecret) {
+            console.warn(`Invalid secret sent: ${secret}`)
             throw new HttpError('forbidden', 403);
         }
 

--- a/private-rpc/src/routes/users-routes.ts
+++ b/private-rpc/src/routes/users-routes.ts
@@ -46,7 +46,7 @@ export function usersRoutes(app: WebServer) {
         schema: {
             params: z.object({
                 address: addressSchema
-            }),
+            })
         }
     };
 
@@ -55,7 +55,7 @@ export function usersRoutes(app: WebServer) {
         const secret = req.headers['x-secret'];
 
         if (secret !== createTokenSecret) {
-            console.warn(`Invalid secret sent: ${secret}`)
+            console.warn(`Invalid secret sent: ${secret}`);
             throw new HttpError('forbidden', 403);
         }
 


### PR DESCRIPTION
## What ❔

Fix a mismatch between secret sending between `private-rpc` and `block-explorer`.

Currently the `block-explorer` sends the secret in the header: https://github.com/matter-labs/block-explorer/blob/prividium-mode/packages/api/src/auth/auth.controller.ts#L227. The mismatch was ocurring due to `private-rpc` sending it as a query param.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
