### PR TITLE
feat(zk-environment) Add `anvil` to `zk-environment`

### DIFF
--- a/docker/zk-environment/Dockerfile
+++ b/docker/zk-environment/Dockerfile
@@ -50,6 +50,7 @@ RUN git clone https://github.com/matter-labs/foundry-zksync
 RUN cd foundry-zksync && git reset --hard 27360d4c8d12beddbb730dae07ad33a206b38f4b && cargo build --release --bins
 RUN mv ./foundry-zksync/target/release/forge /usr/local/cargo/bin/
 RUN mv ./foundry-zksync/target/release/cast /usr/local/cargo/bin/
+RUN mv ./foundry-zksync/target/release/anvil /usr/local/cargo/bin/
 
 # Main builder.
 FROM debian:bookworm as rust-lightweight-base


### PR DESCRIPTION
## What ❔

Adds `anvil` to `zk-environment` docker image

## Why ❔

It's needed for zksync-os-server end to end tests