### PR TITLE
fix(eth-sender): Check the existance of eth txs before getting the correct block for statistics

### DIFF
--- a/core/lib/dal/.sqlx/query-b882586949146ef1e7867b133ad6cb00d88e73118347e1f33c041ef27bf62ebc.json
+++ b/core/lib/dal/.sqlx/query-b882586949146ef1e7867b133ad6cb00d88e73118347e1f33c041ef27bf62ebc.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT EXISTS(\n                    SELECT 1\n                    FROM eth_txs WHERE tx_type = $1\n                )\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "b882586949146ef1e7867b133ad6cb00d88e73118347e1f33c041ef27bf62ebc"
+}


### PR DESCRIPTION

## What ❔

Execute light query for checking the existance of eth tx with necessary type. If it exists, we can execute statistics query. Which are more expensive

## Why ❔

For majority of l2 blocks, the eth transcations doesn't exist. So it leads to extremely expensive queries.   

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
