### PR TITLE
fix(api): Return back fee params backward compatibility for non gateway chains

### DIFF
--- a/core/lib/dal/src/base_token_dal.rs
+++ b/core/lib/dal/src/base_token_dal.rs
@@ -32,10 +32,30 @@ impl BaseTokenDal<'_, '_> {
             RETURNING
             id
             "#,
-            BigDecimal::from_u64(base_token_conversion_ratio.l1.numerator.get()),
-            BigDecimal::from_u64(base_token_conversion_ratio.l1.denominator.get()),
-            BigDecimal::from_u64(base_token_conversion_ratio.sl.numerator.get()),
-            BigDecimal::from_u64(base_token_conversion_ratio.sl.denominator.get()),
+            BigDecimal::from_u64(
+                base_token_conversion_ratio
+                    .l1_conversion_ratio()
+                    .numerator
+                    .get()
+            ),
+            BigDecimal::from_u64(
+                base_token_conversion_ratio
+                    .l1_conversion_ratio()
+                    .denominator
+                    .get()
+            ),
+            BigDecimal::from_u64(
+                base_token_conversion_ratio
+                    .sl_conversion_ratio()
+                    .numerator
+                    .get()
+            ),
+            BigDecimal::from_u64(
+                base_token_conversion_ratio
+                    .sl_conversion_ratio()
+                    .denominator
+                    .get()
+            ),
             ratio_timestamp,
         )
         .instrument("insert_token_ratio")

--- a/core/node/base_token_adjuster/src/base_token_ratio_persister.rs
+++ b/core/node/base_token_adjuster/src/base_token_ratio_persister.rs
@@ -298,8 +298,14 @@ mod tests {
 
         // Check the latest ratio matches expected values
         let ratio = ratio.unwrap();
-        assert_eq!(ratio.ratio.sl.numerator.get(), expected_num_ratio);
-        assert_eq!(ratio.ratio.sl.denominator.get(), expected_denom_ratio);
+        assert_eq!(
+            ratio.ratio.sl_conversion_ratio().numerator.get(),
+            expected_num_ratio
+        );
+        assert_eq!(
+            ratio.ratio.sl_conversion_ratio().denominator.get(),
+            expected_denom_ratio
+        );
     }
 
     const TOKEN_1_ADDRESS: Address = Address::repeat_byte(0x01);

--- a/core/node/state_keeper/src/io/tests/mod.rs
+++ b/core/node/state_keeper/src/io/tests/mod.rs
@@ -125,7 +125,7 @@ async fn test_filter_with_no_pending_batch(commitment_mode: L1BatchCommitmentMod
     // Create a copy of the tx filter that the mempool will use.
     let want_filter = l2_tx_filter(
         &tester.create_batch_fee_input_provider().await,
-        ProtocolVersionId::latest().into(),
+        ProtocolVersionId::latest(),
     )
     .await
     .unwrap();
@@ -174,7 +174,7 @@ async fn test_timestamps(
     // Insert a transaction to trigger L1 batch creation.
     let tx_filter = l2_tx_filter(
         &tester.create_batch_fee_input_provider().await,
-        ProtocolVersionId::latest().into(),
+        ProtocolVersionId::latest(),
     )
     .await
     .unwrap();
@@ -569,7 +569,7 @@ async fn l2_block_processing_after_snapshot_recovery(commitment_mode: L1BatchCom
     // Insert a transaction into the mempool in order to open a new batch.
     let tx_filter = l2_tx_filter(
         &tester.create_batch_fee_input_provider().await,
-        ProtocolVersionId::latest().into(),
+        ProtocolVersionId::latest(),
     )
     .await
     .unwrap();
@@ -724,7 +724,7 @@ async fn continue_unsealed_batch_on_restart(commitment_mode: L1BatchCommitmentMo
     // Insert a transaction into the mempool in order to open a new batch.
     let tx_filter = l2_tx_filter(
         &tester.create_batch_fee_input_provider().await,
-        ProtocolVersionId::latest().into(),
+        ProtocolVersionId::latest(),
     )
     .await
     .unwrap();
@@ -821,7 +821,7 @@ async fn test_mempool_with_timestamp_assertion() {
     // Create a copy of the tx filter that the mempool will use.
     let want_filter = l2_tx_filter(
         &tester.create_batch_fee_input_provider().await,
-        ProtocolVersionId::latest().into(),
+        ProtocolVersionId::latest(),
     )
     .await
     .unwrap();


### PR DESCRIPTION
## What ❔

Use default base token conversion params for preserving backward compatibility 

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
