### PR TITLE
feat(eth_sender): Allow to use validator timelock from the config

### DIFF
--- a/core/lib/config/src/configs/eth_sender.rs
+++ b/core/lib/config/src/configs/eth_sender.rs
@@ -53,6 +53,7 @@ impl EthConfig {
                 max_acceptable_base_fee_in_wei: 100000000000,
                 time_in_mempool_multiplier_cap: None,
                 precommit_params: None,
+                force_use_validator_timelock: false,
             },
             gas_adjuster: GasAdjusterConfig {
                 default_priority_fee_per_gas: 1000000000,
@@ -173,6 +174,9 @@ pub struct SenderConfig {
     /// Parameters for precommit operation.
     #[config(nest)]
     pub precommit_params: Option<PrecommitParams>,
+    /// Allow to force change the validator timelock address.
+    #[config(default)]
+    pub force_use_validator_timelock: bool,
 }
 
 /// We send precommit if l2_blocks_to_aggregate OR deadline_sec passed since last precommit or beginning of batch.
@@ -296,6 +300,7 @@ mod tests {
                     l2_blocks_to_aggregate: 1,
                     deadline: Duration::from_secs(1),
                 }),
+                force_use_validator_timelock: false,
             },
             gas_adjuster: GasAdjusterConfig {
                 default_priority_fee_per_gas: 20000000000,
@@ -395,6 +400,7 @@ mod tests {
             gas_limit_mode: Calculated
             max_acceptable_base_fee_in_wei: 100000000000
             time_in_mempool_multiplier_cap: 10
+            force_use_validator_timelock: false
             precommit_params:
               l2_blocks_to_aggregate: 1
               deadline: 1 sec
@@ -451,6 +457,7 @@ mod tests {
             gas_limit_mode: Calculated
             max_acceptable_base_fee_in_wei: 100000000000
             time_in_mempool_multiplier_cap: 10
+            force_use_validator_timelock: false
             precommit_params:
               l2_blocks_to_aggregate: 1
               deadline: 1 sec

--- a/core/node/eth_sender/src/eth_tx_aggregator.rs
+++ b/core/node/eth_sender/src/eth_tx_aggregator.rs
@@ -576,7 +576,9 @@ impl EthTxAggregator {
         // For chains before v26 (gateway) we use the timelock address from config.
         // After that, the timelock address can be fetched from STM as it is the valid one
         // for versions starting from v26 and is not expected to change in the near future.
-        if chain_protocol_version_id < ProtocolVersionId::gateway_upgrade() {
+        if chain_protocol_version_id < ProtocolVersionId::gateway_upgrade()
+            || self.config.force_use_validator_timelock
+        {
             self.config_timelock_contract_address
         } else {
             assert!(


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
