### PR TITLE
fix: add net_version to private-rpc

### DIFF
--- a/private-rpc/src/rpc/rpc-method-handlers.ts
+++ b/private-rpc/src/rpc/rpc-method-handlers.ts
@@ -21,6 +21,7 @@ export const allHandlers = [
        ───────────────────────────── */
     unrestricted('eth_blockNumber'),
     unrestricted('eth_chainId'),
+    unrestricted('net_version'),
     validatedEthereumCall('eth_call', 2),
     validatedEthereumCall('eth_estimateGas', 2),
     unrestricted('eth_gasPrice'),


### PR DESCRIPTION
## What ❔

Add missing `net_version` to private-rpc.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
