### PR TITLE
fix(eth-proof-manager): Fallbacking batch if successfully submitted

### DIFF
--- a/core/node/eth_proof_manager/src/sender/submit_proof_request.rs
+++ b/core/node/eth_proof_manager/src/sender/submit_proof_request.rs
@@ -72,12 +72,7 @@ impl ProofRequestSubmitter {
         if let Some(batch_id) = batch_id {
             match self.submit_request(batch_id).await {
                 Ok(_) => {
-                    self.connection_pool
-                        .connection()
-                        .await?
-                        .eth_proof_manager_dal()
-                        .fallback_batch(batch_id)
-                        .await?;
+                    tracing::info!("Submitted proof request for batch {}", batch_id);
                 }
                 Err(e) => {
                     tracing::error!(


### PR DESCRIPTION
## What ❔

Batch is being fallbacked if proof request was successfully submitted - this is not correct behaviour

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
