### PR TITLE
docs(readme): fix brand capitalization (YouTube)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ at your option.
 - [Twitter for Developers](https://twitter.com/zkSyncDevs)
 - [Discord](https://join.zksync.dev/)
 - [Mirror](https://zksync.mirror.xyz/)
-- [Youtube](https://www.youtube.com/@zkSync-era)
+- [YouTube](https://www.youtube.com/@zkSync-era)
 
 ## Disclaimer
 


### PR DESCRIPTION
### Summary
Fixes the brand capitalization in the README’s “Official Links” list: “Youtube” → “YouTube”.

### Why
Ensures correct brand usage and improves documentation quality. No code changes.

Type: docs
Scope: readme