### PR TITLE
fix: Copy proof manager contracts to server dockerfile

### DIFF
--- a/docker/server-v2/Dockerfile
+++ b/docker/server-v2/Dockerfile
@@ -35,6 +35,8 @@ COPY contracts/system-contracts/zkout/ /contracts/system-contracts/zkout/
 COPY contracts/l1-contracts/out/ /contracts/l1-contracts/out/
 COPY contracts/l1-contracts/zkout/ /contracts/l1-contracts/zkout/
 COPY contracts/l2-contracts/zkout/ /contracts/l2-contracts/zkout/
+COPY proof-manager-contracts/out/ /proof-manager-contracts/out/
+COPY proof-manager-contracts/zkout/ /proof-manager-contracts/zkout/
 COPY etc/tokens/ /etc/tokens/
 COPY etc/ERC20/ /etc/ERC20/
 COPY etc/multivm_bootloaders/ /etc/multivm_bootloaders/


### PR DESCRIPTION
## What ❔

Copy proof-manager-contracts build artifacts to server's Dockerfile

## Why ❔

They are needed for EthProofManager component

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
