### PR TITLE
fix(prover): Make scale_errors sticky for scale_errors_duration

### DIFF
--- a/prover/crates/bin/prover_autoscaler/src/global/scaler.rs
+++ b/prover/crates/bin/prover_autoscaler/src/global/scaler.rs
@@ -108,6 +108,11 @@ impl<K: Key> Scaler<K> {
                     .and_then(|inner_map| inner_map.get(&key))
                     .copied()
                     .unwrap_or(0),
+                scale_errors: namespace_value
+                    .scale_errors
+                    .iter()
+                    .filter(|v| v.time > Utc::now() - self.config.scale_errors_duration)
+                    .count(),
                 ..Default::default()
             });
 
@@ -1770,7 +1775,7 @@ mod tests {
                     (PodStatus::Running, 1)
                 ]
                 .into(),
-                scale_errors: 1,
+                scale_errors: 2,
                 max_pool_size: 100,
             }]
         );


### PR DESCRIPTION


## What ❔

Make scale_errors sticky for scale_errors_duration

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To prevent autoscaler to forget about recent scale_errors add all the errors during scale_errors_duration to the cluster. This makes scale_errors for currently pending pods to be counted twice to push the cluster, which we tried the last and failed, to the bottom of the list.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.


ref ZKD-2912