### PR TITLE
feat: improve JSON-RPC parameter error messages

### DIFF
--- a/core/lib/basic_types/src/web3/mod.rs
+++ b/core/lib/basic_types/src/web3/mod.rs
@@ -241,10 +241,17 @@ where
             Sequence(Vec<T>),
         }
 
-        Ok(match Repr::<T>::deserialize(deserializer)? {
-            Repr::Single(element) => Self(vec![element]),
-            Repr::Sequence(elements) => Self(elements),
-        })
+        match Repr::<T>::deserialize(deserializer) {
+            Ok(Repr::Single(element)) => Ok(Self(vec![element])),
+            Ok(Repr::Sequence(elements)) => Ok(Self(elements)),
+            Err(e) => Err(serde::de::Error::custom(format!(
+                "Invalid parameter format. Expected either a single value or an array of values. \
+                 Common issues: hex strings with extra spaces, malformed JSON objects, or invalid data types. \
+                 Make sure hex strings are properly formatted (e.g., '0x123abc' not '0x123 abc'). \
+                 Original error: {}",
+                e
+            ))),
+        }
     }
 }
 
@@ -1097,3 +1104,5 @@ impl Serialize for Work {
         }
     }
 }
+
+mod test_better_errors;


### PR DESCRIPTION
## What ❔

Replace unhelpful "untagged enum" serde errors with actionable guidance for developers when JSON-RPC parameters are malformed.

Changes:
- Enhanced ValueOrArray<T> deserialization error messages
- Enhanced FilterChanges deserialization error messages
- Added specific guidance for common issues (hex formatting, etc.)

## Why ❔

Before:
"data did not match any variant of untagged enum Repr at line 1 column 95"

After:
"Invalid parameter format. Expected either a single value or an array of values. Common issues: hex strings with extra spaces, malformed JSON objects, or invalid data types. Make sure hex strings are properly formatted (e.g., '0x123abc' not '0x123 abc')."

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
