### PR TITLE
feat: Remove legacy prover mode from CI

### DIFF
--- a/.github/workflows/ci-prover-e2e.yml
+++ b/.github/workflows/ci-prover-e2e.yml
@@ -9,7 +9,6 @@ jobs:
         fail-fast: false
         matrix:
           compressor-mode: ["fflonk", "plonk"]
-          gateway-mode: ["legacy", "prover-cluster"]
     env:
       RUNNER_COMPOSE_FILE: "docker-compose-gpu-runner-cuda-12-0.yml"
       YQ_VERSION: "4.45.1"
@@ -30,7 +29,7 @@ jobs:
 
       - name: Init
         run: |
-          mkdir -p prover_logs_${{matrix.compressor-mode}}_${{matrix.gateway-mode}}
+          mkdir -p prover_logs_${{matrix.compressor-mode}}
           ci_run git config --global --add safe.directory "*"
           ci_run chmod -R +x ./bin
           
@@ -54,13 +53,6 @@ jobs:
           WEB3_HTTP_URL=$(yq -e '.api.web3_json_rpc.http_url' < ./chains/proving_chain/configs/general.yaml)
           echo "Using Web3 HTTP URL: $WEB3_HTTP_URL"
           echo "URL=$WEB3_HTTP_URL" >> $GITHUB_ENV
-
-      - name: Switch gateway API mode
-        working-directory: ./chains/proving_chain/configs
-        if: matrix.gateway-mode == 'prover-cluster'
-        run: |
-          sudo yq -e -i '.prover_gateway.api_mode = "PROVER_CLUSTER"' general.yaml
-          yq '.prover_gateway.api_mode' < general.yaml
 
       - name: Change block_commit_deadline_ms to 60000 to submit txs to batch 1
         working-directory: ./chains/proving_chain/configs
@@ -111,10 +103,10 @@ jobs:
 
       - name: Run prover gateway
         run: |
-          ci_run zkstack prover run --component=gateway --docker=false &>prover_logs_${{matrix.compressor-mode}}_${{matrix.gateway-mode}}/gateway.log &
+          ci_run zkstack prover run --component=gateway --docker=false &>prover_logs_${{matrix.compressor-mode}}/gateway.log &
       - name: Run Prover Job Monitor
         run: |
-          ci_run zkstack prover run --component=prover-job-monitor --docker=false &>prover_logs_${{matrix.compressor-mode}}_${{matrix.gateway-mode}}/prover-job-monitor.log &
+          ci_run zkstack prover run --component=prover-job-monitor --docker=false &>prover_logs_${{matrix.compressor-mode}}/prover-job-monitor.log &
       - name: Wait for batch to be passed through prover gateway
         env:
           DATABASE_URL: postgres://postgres:notsecurepassword@localhost:5432/zksync_prover_localhost_proving_chain
@@ -126,10 +118,10 @@ jobs:
           ci_run ./bin/prover_checkers/batch_availability_checker
       - name: Run Witness Generator
         run: |
-          ci_run zkstack prover run --component=witness-generator --round=all-rounds --docker=false &>prover_logs_${{matrix.compressor-mode}}_${{matrix.gateway-mode}}/witness-generator.log &
+          ci_run zkstack prover run --component=witness-generator --round=all-rounds --docker=false &>prover_logs_${{matrix.compressor-mode}}/witness-generator.log &
       - name: Run Circuit Prover
         run: |
-          ci_run zkstack prover run --component=circuit-prover --threads=32 --docker=false &>prover_logs_${{matrix.compressor-mode}}_${{matrix.gateway-mode}}/circuit_prover.log &
+          ci_run zkstack prover run --component=circuit-prover --threads=32 --docker=false &>prover_logs_${{matrix.compressor-mode}}/circuit_prover.log &
       - name: Wait for prover jobs to finish
         env:
           DATABASE_URL: postgres://postgres:notsecurepassword@localhost:5432/zksync_prover_localhost_proving_chain
@@ -143,7 +135,7 @@ jobs:
       - name: Kill prover & start compressor
         run: |
           sudo ./bin/prover_checkers/kill_prover
-          ci_run zkstack prover run --component=compressor --docker=false --mode=${{matrix.compressor-mode}} &>prover_logs_${{matrix.compressor-mode}}_${{matrix.gateway-mode}}/compressor.log &
+          ci_run zkstack prover run --component=compressor --docker=false --mode=${{matrix.compressor-mode}} &>prover_logs_${{matrix.compressor-mode}}/compressor.log &
 
       - name: Wait for batch to be executed on L1
         env:
@@ -159,8 +151,8 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: prover_logs_${{matrix.compressor-mode}}_${{matrix.gateway-mode}}
-          path: prover_logs_${{matrix.compressor-mode}}_${{matrix.gateway-mode}}
+          name: prover_logs_${{matrix.compressor-mode}}
+          path: prover_logs_${{matrix.compressor-mode}}
 
       - name: Show sccache logs
         if: always()


### PR DESCRIPTION
## What ❔

Remove legacy prover mode from e2e CI test

## Why ❔

Legacy API mode was removed from code

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
