### PR TITLE
feat: add public bucket address config variable

### DIFF
--- a/core/lib/config/src/configs/eth_proof_manager.rs
+++ b/core/lib/config/src/configs/eth_proof_manager.rs
@@ -11,6 +11,9 @@ pub struct EthProofManagerConfig {
     /// HTTP RPC URL of L2(where contracts are deployed)
     #[config(default_t = "http://127.0.0.1:8545".to_string())]
     pub http_rpc_url: String,
+    /// Public object store URL
+    #[config(default_t = "".to_string())]
+    pub public_object_store_url: String,
     /// Object store config
     #[config(nest, default)]
     pub object_store: ObjectStoreConfig,

--- a/core/lib/object_store/src/raw.rs
+++ b/core/lib/object_store/src/raw.rs
@@ -24,7 +24,7 @@ pub enum Bucket {
 }
 
 impl Bucket {
-    pub(crate) fn as_str(self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::ProverJobs => "prover_jobs",
             Self::WitnessInput => "witness_inputs",

--- a/core/node/eth_proof_manager/src/tests/mod.rs
+++ b/core/node/eth_proof_manager/src/tests/mod.rs
@@ -60,6 +60,7 @@ impl TestContext {
         EthProofManagerConfig {
             l2_chain_id: 270,
             http_rpc_url: "http://127.0.0.1:3050".to_string(),
+            public_object_store_url: "".to_string(),
             object_store: ObjectStoreConfig {
                 mode: ObjectStoreMode::FileBacked {
                     file_backed_base_path: "/tmp/zksync/object_store".to_string().into(),


### PR DESCRIPTION
## What ❔

Add config variable for ETH proof manager component which defines public bucket url address

## Why ❔

Because public URL for reads doesn't match the private one for writes

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
