### PR TITLE
feat(en): Ignore main node client in overall health

### DIFF
--- a/core/lib/web3_decl/src/node/main_node_client.rs
+++ b/core/lib/web3_decl/src/node/main_node_client.rs
@@ -99,4 +99,8 @@ impl CheckHealth for MainNodeHealthCheck {
         }
         HealthStatus::Ready.into()
     }
+
+    fn consider_in_overall_health(&self) -> bool {
+        false
+    }
 }


### PR DESCRIPTION
## What ❔

Return 200 for health check even if not all components are ready. 

## Why ❔

For now only if all components are healthy we can consider server healthy, but we can ignore some components being unhealthy and still consider server be healthy. e.g. for external node if main node is down, we could still serve the traffic 

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
