### PR TITLE
fix(eth-proof-manager): use correct status while fallbacking

### DIFF
--- a/core/lib/dal/src/eth_proof_manager_dal.rs
+++ b/core/lib/dal/src/eth_proof_manager_dal.rs
@@ -344,7 +344,7 @@ impl EthProofManagerDal<'_, '_> {
             UPDATE eth_proof_manager SET status = $1, updated_at = NOW()
             WHERE l1_batch_number = $2
             "#,
-            EthProofManagerStatus::Unpicked.as_str(),
+            EthProofManagerStatus::Fallbacked.as_str(),
             i64::from(batch_number.0),
         )
         .instrument("fallback_certain_batch")


### PR DESCRIPTION
## What ❔

Set `fallbacked` status when fallbacking a batch

## Why ❔

Batch can be fallbacked twice

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
