### PR TITLE
fix: remove zksync_contracts dep from zkstack_cli 

### DIFF
--- a/zkstack_cli/Cargo.lock
+++ b/zkstack_cli/Cargo.lock
@@ -7839,7 +7839,6 @@ dependencies = [
  "zksync_basic_types",
  "zksync_consensus_crypto",
  "zksync_consensus_roles",
- "zksync_contracts",
  "zksync_system_constants",
  "zksync_types",
  "zksync_web3_decl",

--- a/zkstack_cli/Cargo.toml
+++ b/zkstack_cli/Cargo.toml
@@ -31,7 +31,6 @@ zksync_basic_types = { path = "../core/lib/basic_types" }
 zksync_system_constants = { path = "../core/lib/constants" }
 zksync_types = { path = "../core/lib/types" }
 zksync_web3_decl = { path = "../core/lib/web3_decl" }
-zksync_contracts = { path = "../core/lib/contracts" }
 zksync_consensus_roles = "=0.13"
 zksync_consensus_crypto = "=0.13"
 

--- a/zkstack_cli/crates/zkstack/Cargo.toml
+++ b/zkstack_cli/crates/zkstack/Cargo.toml
@@ -44,7 +44,6 @@ zksync_consensus_roles.workspace = true
 zksync_consensus_crypto.workspace = true
 zksync_web3_decl.workspace = true
 zksync_system_constants.workspace = true
-zksync_contracts.workspace = true
 prost.workspace = true
 reqwest.workspace = true
 sha2.workspace = true

--- a/zkstack_cli/crates/zkstack/src/abi.rs
+++ b/zkstack_cli/crates/zkstack/src/abi.rs
@@ -10,6 +10,7 @@ abigen!(
     function ctmAssetIdFromChainId(uint256)(bytes32)
     function baseTokenAssetId(uint256)(bytes32)
     function chainTypeManager(uint256)(address)
+    function chainAssetHandler() external view returns (address)
 ]"
 );
 
@@ -36,6 +37,95 @@ abigen!(
 ]"
 );
 
+abigen!(
+    ChainTypeManagerUpgradeFnAbi,
+    r#"[
+      {
+        "type": "function",
+        "name": "upgradeChainFromVersion",
+        "stateMutability": "nonpayable",
+        "inputs": [
+          { "name": "version", "type": "uint256" },
+          {
+            "name": "cfg",
+            "type": "tuple",
+            "components": [
+              {
+                "name": "validators",
+                "type": "tuple[]",
+                "components": [
+                  { "name": "addr", "type": "address" },
+                  { "name": "weight", "type": "uint8" },
+                  { "name": "active", "type": "bool" },
+                  { "name": "selectors", "type": "bytes4[]" }
+                ]
+              },
+              { "name": "admin", "type": "address" },
+              { "name": "data", "type": "bytes" }
+            ]
+          }
+        ],
+        "outputs": []
+      }
+    ]"#
+);
+
+abigen!(
+    DiamondCutAbi,
+    r#"[
+      {
+        "type": "function",
+        "name": "diamondCut",
+        "stateMutability": "nonpayable",
+        "inputs": [
+          {
+            "name": "_diamondCut",
+            "type": "tuple",
+            "components": [
+              {
+                "name": "facetCuts",
+                "type": "tuple[]",
+                "components": [
+                  { "name": "facet", "type": "address" },
+                  { "name": "action", "type": "uint8" },
+                  { "name": "isFreezable", "type": "bool" },
+                  { "name": "selectors", "type": "bytes4[]" }
+                ]
+              },
+              { "name": "initAddress", "type": "address" },
+              { "name": "initCalldata", "type": "bytes" }
+            ]
+          }
+        ],
+        "outputs": []
+      }
+    ]"#
+);
+
+abigen!(
+    ChainAdminOwnableAbi,
+    r#"[
+      {
+        "type": "function",
+        "name": "multicall",
+        "stateMutability": "payable",
+        "inputs": [
+          {
+            "name": "_calls",
+            "type": "tuple[]",
+            "components": [
+              { "name": "target", "type": "address" },
+              { "name": "value",  "type": "uint256" },
+              { "name": "data",   "type": "bytes" }
+            ]
+          },
+          { "name": "_requireSuccess", "type": "bool" }
+        ],
+        "outputs": []
+      }
+    ]"#
+);
+
 // "validators" is from pre-v29, used for backward compatibility. Will be removed once v29 is released.
 abigen!(
     ValidatorTimelockAbi,
@@ -47,5 +137,12 @@ abigen!(
     function PROVER_ROLE()(bytes32)
     function EXECUTOR_ROLE()(bytes32)
     function validators(uint256 _chainId, address _validator)(bool)
+    ]"
+);
+
+abigen!(
+    IChainAssetHandlerAbi,
+    r"[
+    event MigrationStarted(uint256 indexed chainId, bytes32 indexed assetId, uint256 indexed settlementLayerChainId)
     ]"
 );

--- a/zkstack_cli/crates/zkstack/src/commands/chain/admin_call_builder.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/admin_call_builder.rs
@@ -1,10 +1,5 @@
 use std::path::Path;
 
-use crate::abi::{
-    CHAINADMINOWNABLEABI_ABI as CHAIN_ADMIN_OWNABLE_ABI,
-    CHAINTYPEMANAGERUPGRADEFNABI_ABI as CHAIN_TYPE_MANAGER_UPGRADE_ABI,
-    DIAMONDCUTABI_ABI as DIAMOND_CUT_ABI,
-};
 use ethers::{
     abi::{decode, Abi, ParamType, Token},
     types::Bytes,
@@ -14,6 +9,12 @@ use serde::Serialize;
 use xshell::Shell;
 use zkstack_cli_common::forge::ForgeScriptArgs;
 use zksync_types::{Address, U256};
+
+use crate::abi::{
+    CHAINADMINOWNABLEABI_ABI as CHAIN_ADMIN_OWNABLE_ABI,
+    CHAINTYPEMANAGERUPGRADEFNABI_ABI as CHAIN_TYPE_MANAGER_UPGRADE_ABI,
+    DIAMONDCUTABI_ABI as DIAMOND_CUT_ABI,
+};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct AdminCall {

--- a/zkstack_cli/crates/zkstack/src/commands/chain/admin_call_builder.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/admin_call_builder.rs
@@ -1,15 +1,19 @@
 use std::path::Path;
 
+use crate::abi::{
+    CHAINADMINOWNABLEABI_ABI as CHAIN_ADMIN_OWNABLE_ABI,
+    CHAINTYPEMANAGERUPGRADEFNABI_ABI as CHAIN_TYPE_MANAGER_UPGRADE_ABI,
+    DIAMONDCUTABI_ABI as DIAMOND_CUT_ABI,
+};
 use ethers::{
-    abi::{decode, ParamType, Token},
+    abi::{decode, Abi, ParamType, Token},
     types::Bytes,
     utils::hex,
 };
 use serde::Serialize;
 use xshell::Shell;
 use zkstack_cli_common::forge::ForgeScriptArgs;
-use zksync_contracts::chain_admin_contract;
-use zksync_types::{ethabi, Address, U256};
+use zksync_types::{Address, U256};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct AdminCall {
@@ -83,14 +87,14 @@ where
 #[derive(Debug, Clone)]
 pub struct AdminCallBuilder {
     calls: Vec<AdminCall>,
-    chain_admin_abi: ethabi::Contract,
+    chain_admin_abi: Abi,
 }
 
 impl AdminCallBuilder {
     pub fn new(calls: Vec<AdminCall>) -> Self {
         Self {
             calls,
-            chain_admin_abi: chain_admin_contract(),
+            chain_admin_abi: CHAIN_ADMIN_OWNABLE_ABI.clone(),
         }
     }
 
@@ -149,19 +153,29 @@ impl AdminCallBuilder {
         protocol_version: u64,
         diamond_cut_data: zksync_types::web3::Bytes,
     ) {
-        let diamond_cut = zksync_contracts::DIAMOND_CUT
-            .decode_input(&diamond_cut_data.0)
-            .unwrap()[0]
-            .clone();
-        let zkchain_abi = zksync_contracts::hyperchain_contract();
+        let diamond_cut_fn = DIAMOND_CUT_ABI
+            .function("diamondCut")
+            .expect("diamondCut ABI not found");
 
-        let data = zkchain_abi
+        let upgrade_fn = CHAIN_TYPE_MANAGER_UPGRADE_ABI
             .function("upgradeChainFromVersion")
-            .unwrap()
-            .encode_input(&[Token::Uint(protocol_version.into()), diamond_cut])
-            .unwrap();
-        let description = "Executing upgrade:".to_string();
+            .expect("upgradeChainFromVersion ABI not found");
 
+        let decoded = diamond_cut_fn
+            .decode_input(diamond_cut_data.0.get(4..).unwrap_or(&diamond_cut_data.0))
+            .or_else(|_| diamond_cut_fn.decode_input(&diamond_cut_data.0))
+            .expect("invalid diamondCut calldata");
+
+        let cfg_tuple = decoded
+            .into_iter()
+            .next()
+            .expect("diamondCut expects 1 argument (tuple)");
+
+        let data = upgrade_fn
+            .encode_input(&[Token::Uint(U256::from(protocol_version)), cfg_tuple])
+            .expect("encode upgradeChainFromVersion failed");
+
+        let description = "Executing upgrade:".to_string();
         let call = AdminCall {
             description,
             data: data.to_vec(),

--- a/zkstack_cli/crates/zkstack/src/commands/chain/gateway/gateway_common.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/gateway/gateway_common.rs
@@ -7,6 +7,7 @@ use chrono::Utc;
 use ethers::{
     providers::{Http, Middleware, Provider},
     types::{Filter, TransactionReceipt},
+    utils::keccak256,
 };
 use xshell::Shell;
 use zkstack_cli_common::{
@@ -16,7 +17,6 @@ use zkstack_cli_common::{
 };
 use zkstack_cli_config::EcosystemConfig;
 use zksync_basic_types::{Address, H256, U256, U64};
-use zksync_contracts::bridgehub_contract;
 use zksync_system_constants::L2_BRIDGEHUB_ADDRESS;
 use zksync_types::{
     server_notification::{GatewayMigrationNotification, GatewayMigrationState},
@@ -30,7 +30,7 @@ use super::{
     notify_server_calldata::{get_notify_server_calls, NotifyServerCallsArgs},
 };
 use crate::{
-    abi::{BridgehubAbi, ChainTypeManagerAbi, ZkChainAbi},
+    abi::{BridgehubAbi, ChainTypeManagerAbi, IChainAssetHandlerAbi, ZkChainAbi},
     commands::chain::{admin_call_builder::AdminCallBuilder, utils::send_tx},
     consts::DEFAULT_EVENTS_BLOCK_RANGE,
     messages::MSG_CHAIN_NOT_INITIALIZED,
@@ -118,10 +118,13 @@ pub(crate) async fn get_migration_transaction(
         .expect("Failed to fetch latest block")
         .as_u64();
 
-    let bridgehub_contract = bridgehub_contract();
+    let bridgehub = BridgehubAbi::new(bridgehub_address, provider.clone());
+    let chain_asset_handler_addr = bridgehub.chain_asset_handler().await?;
+    let chain_asset_handler =
+        IChainAssetHandlerAbi::new(chain_asset_handler_addr, provider.clone());
 
     let max_interval_to_search = Utc::now() - MAX_SEARCHING_MIGRATION_TXS_INTERVAL;
-    let latest_event_log = loop {
+    let latest_tx_hash: Option<H256> = loop {
         let lower_bound = search_upper_bound.saturating_sub(DEFAULT_EVENTS_BLOCK_RANGE);
 
         logger::info(format!(
@@ -129,21 +132,15 @@ pub(crate) async fn get_migration_transaction(
             lower_bound, search_upper_bound
         ));
 
-        let filter = Filter::new()
-            .address(bridgehub_address)
-            .topic0(
-                bridgehub_contract
-                    .event("MigrationStarted")
-                    .unwrap()
-                    .signature(),
-            )
+        let ev = chain_asset_handler
+            .migration_started_filter()
+            .topic1(U256::from(l2_chain_id))
             .from_block(lower_bound)
-            .topic1(u256_to_h256(U256::from(l2_chain_id)))
             .to_block(search_upper_bound);
 
-        let result_logs = provider.get_logs(&filter).await?;
-        if !result_logs.is_empty() {
-            break result_logs.last().cloned();
+        let results = ev.query_with_meta().await?;
+        if let Some((_, meta)) = results.last() {
+            break Some(meta.transaction_hash);
         }
 
         if lower_bound == 0 {
@@ -162,11 +159,7 @@ pub(crate) async fn get_migration_transaction(
         search_upper_bound = lower_bound - 1;
     };
 
-    let Some(log) = latest_event_log else {
-        return Ok(None);
-    };
-
-    Ok(log.transaction_hash)
+    Ok(latest_tx_hash)
 }
 
 async fn get_batch_execution_status(
@@ -532,8 +525,9 @@ pub(crate) async fn extract_priority_ops(
     receipt: TransactionReceipt,
     expected_diamond_proxy: Address,
 ) -> anyhow::Result<Vec<H256>> {
-    let contract = zksync_contracts::hyperchain_contract();
-    let expected_topic_0 = contract.event("NewPriorityRequest").unwrap().signature();
+    let expected_topic_0: ethers::types::H256 = ethers::types::H256::from(keccak256(
+        b"NewPriorityRequest(uint256,bytes32,uint64,(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,uint256[],bytes,bytes),bytes[])",
+    ));
 
     let priority_ops = receipt
         .logs

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/track_priority_txs.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/track_priority_txs.rs
@@ -7,13 +7,13 @@ use cliclack::clear_screen;
 use ethers::{
     providers::{Http, Middleware, Provider},
     types::{Filter, H256},
+    utils::keccak256,
 };
 use zkstack_cli_common::{
     ethereum::{get_ethers_provider, get_zk_client_from_url},
     logger,
 };
 use zksync_basic_types::Address;
-use zksync_contracts::hyperchain_contract;
 use zksync_types::l1::L1Tx;
 use zksync_web3_decl::{
     client::{Client, L2},
@@ -92,10 +92,9 @@ async fn get_txs_status(
     l1_tx_hash: Option<H256>,
     l2_tx_hash: Option<H256>,
 ) -> anyhow::Result<Vec<TxStatus>> {
-    let topic = hyperchain_contract()
-        .event("NewPriorityRequest")
-        .unwrap()
-        .signature();
+    let topic: ethers::types::H256 = ethers::types::H256::from(keccak256(
+        b"NewPriorityRequest(uint256,bytes32,uint64,(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,uint256[],bytes,bytes),bytes[])",
+    ));
 
     // Get the latest block so we know how far we can go
     let latest_block = l1_provider


### PR DESCRIPTION
## What ❔

- removes zksync_contracts dep from zkstack_cli 
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

- zkstack_cli breaks due to path issue when used outside of zksync_era repo

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
