### PR TITLE
fix: fix docs

### DIFF
--- a/prover/docs/src/00_intro.md
+++ b/prover/docs/src/00_intro.md
@@ -36,7 +36,7 @@ We'll cover how the components work further in documentation.
 [cp]: https://github.com/matter-labs/zksync-era/tree/main/prover/crates/bin/circuit_prover
 [pc]: https://github.com/matter-labs/zksync-era/tree/main/prover/crates/bin/proof_fri_compressor
 [pdh]: https://github.com/matter-labs/zksync-era/tree/main/core/node/proof_data_handler
-[pjm]: https://github.com/matter-labs/zksync-era/tree/main/prover/crates/bin/prover-job-monitor
+[pjm]: https://github.com/matter-labs/zksync-era/tree/main/prover/crates/bin/prover_job_monitor
 [vkg]: https://github.com/matter-labs/zksync-era/tree/main/prover/crates/bin/vk_setup_data_generator_server_fri
 [pcli]: https://github.com/matter-labs/zksync-era/tree/main/prover/crates/bin/prover_cli
 [mc]: https://github.com/matter-labs/zksync-era/tree/main/core/node/metadata_calculator


### PR DESCRIPTION
## What ❔

Fixed the error where the link couldn't be accessed when accessing the document.

## Why ❔

While accessing the document, I found that the document link returned a 404 error, which caused me trouble. I spent a lot of time troubleshooting this issue, and then fixed it. I hope that future users accessing the document won't encounter the problem of being unable to access it.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
