### PR TITLE
chore(zkstack): rename trait

### DIFF
--- a/zkstack_cli/crates/config/src/apps.rs
+++ b/zkstack_cli/crates/config/src/apps.rs
@@ -5,7 +5,7 @@ use xshell::Shell;
 
 use crate::{
     consts::{APPS_CONFIG_FILE, DEFAULT_EXPLORER_PORT, DEFAULT_PORTAL_PORT, LOCAL_CONFIGS_PATH},
-    traits::{FileConfigWithDefaultName, ReadConfig, SaveConfig, ZkStackConfig},
+    traits::{FileConfigWithDefaultName, ReadConfig, SaveConfig, ZkStackConfigTrait},
 };
 
 /// Ecosystem level configuration for the apps (portal and explorer).
@@ -20,7 +20,7 @@ pub struct AppEcosystemConfig {
     pub http_port: u16,
 }
 
-impl ZkStackConfig for AppsEcosystemConfig {}
+impl ZkStackConfigTrait for AppsEcosystemConfig {}
 impl FileConfigWithDefaultName for AppsEcosystemConfig {
     const FILE_NAME: &'static str = APPS_CONFIG_FILE;
 }

--- a/zkstack_cli/crates/config/src/chain.rs
+++ b/zkstack_cli/crates/config/src/chain.rs
@@ -17,7 +17,7 @@ use crate::{
     gateway::GatewayConfig,
     traits::{
         FileConfigWithDefaultName, ReadConfig, ReadConfigWithBasePath, SaveConfig,
-        SaveConfigWithBasePath, ZkStackConfig,
+        SaveConfigWithBasePath, ZkStackConfigTrait,
     },
     ContractsConfig, GatewayChainConfig, GeneralConfig, GenesisConfig, SecretsConfig,
     WalletsConfig, GATEWAY_CHAIN_FILE,
@@ -191,4 +191,4 @@ impl FileConfigWithDefaultName for ChainConfigInternal {
     const FILE_NAME: &'static str = CONFIG_NAME;
 }
 
-impl ZkStackConfig for ChainConfigInternal {}
+impl ZkStackConfigTrait for ChainConfigInternal {}

--- a/zkstack_cli/crates/config/src/contracts.rs
+++ b/zkstack_cli/crates/config/src/contracts.rs
@@ -15,7 +15,7 @@ use crate::{
         },
         register_chain::output::RegisterChainOutput,
     },
-    traits::{FileConfigWithDefaultName, ZkStackConfig},
+    traits::{FileConfigWithDefaultName, ZkStackConfigTrait},
 };
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
@@ -215,7 +215,7 @@ impl FileConfigWithDefaultName for ContractsConfig {
     const FILE_NAME: &'static str = CONTRACTS_FILE;
 }
 
-impl ZkStackConfig for ContractsConfig {}
+impl ZkStackConfigTrait for ContractsConfig {}
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 pub struct EcosystemContracts {
@@ -248,7 +248,7 @@ pub struct EcosystemContracts {
     pub server_notifier_proxy_addr: Option<Address>,
 }
 
-impl ZkStackConfig for EcosystemContracts {}
+impl ZkStackConfigTrait for EcosystemContracts {}
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct BridgesContracts {

--- a/zkstack_cli/crates/config/src/docker_compose.rs
+++ b/zkstack_cli/crates/config/src/docker_compose.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::traits::ZkStackConfig;
+use crate::traits::ZkStackConfigTrait;
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct DockerComposeConfig {
@@ -36,7 +36,7 @@ pub struct DockerComposeService {
     pub other: serde_json::Value,
 }
 
-impl ZkStackConfig for DockerComposeConfig {}
+impl ZkStackConfigTrait for DockerComposeConfig {}
 
 impl DockerComposeConfig {
     pub fn add_service(&mut self, name: &str, service: DockerComposeService) {

--- a/zkstack_cli/crates/config/src/ecosystem.rs
+++ b/zkstack_cli/crates/config/src/ecosystem.rs
@@ -21,7 +21,7 @@ use crate::{
         input::{Erc20DeploymentConfig, InitialDeploymentConfig},
         output::{ERC20Tokens, Erc20Token},
     },
-    traits::{FileConfigWithDefaultName, ReadConfig, SaveConfig, ZkStackConfig},
+    traits::{FileConfigWithDefaultName, ReadConfig, SaveConfig, ZkStackConfigTrait},
     ChainConfig, ChainConfigInternal, ContractsConfig, WalletsConfig,
     PROVING_NETWORKS_DEPLOY_SCRIPT_PATH, PROVING_NETWORKS_PATH,
 };
@@ -95,9 +95,9 @@ impl FileConfigWithDefaultName for EcosystemConfig {
     const FILE_NAME: &'static str = CONFIG_NAME;
 }
 
-impl ZkStackConfig for EcosystemConfigInternal {}
+impl ZkStackConfigTrait for EcosystemConfigInternal {}
 
-impl ZkStackConfig for EcosystemConfig {}
+impl ZkStackConfigTrait for EcosystemConfig {}
 
 impl EcosystemConfig {
     fn get_shell(&self) -> &Shell {

--- a/zkstack_cli/crates/config/src/explorer.rs
+++ b/zkstack_cli/crates/config/src/explorer.rs
@@ -8,7 +8,7 @@ use crate::{
         EXPLORER_CONFIG_FILE, EXPLORER_JS_CONFIG_FILE, LOCAL_APPS_PATH, LOCAL_CONFIGS_PATH,
         LOCAL_GENERATED_PATH,
     },
-    traits::{ReadConfig, SaveConfig, ZkStackConfig},
+    traits::{ReadConfig, SaveConfig, ZkStackConfigTrait},
 };
 
 /// Explorer JSON configuration file. This file contains configuration for the explorer app.
@@ -145,4 +145,4 @@ impl Default for ExplorerConfig {
     }
 }
 
-impl ZkStackConfig for ExplorerConfig {}
+impl ZkStackConfigTrait for ExplorerConfig {}

--- a/zkstack_cli/crates/config/src/explorer_compose.rs
+++ b/zkstack_cli/crates/config/src/explorer_compose.rs
@@ -20,7 +20,7 @@ use crate::{
         EXPLORER_WORKER_DOCKER_IMAGE, LOCAL_CHAINS_PATH, LOCAL_CONFIGS_PATH,
     },
     docker_compose::{DockerComposeConfig, DockerComposeService},
-    traits::ZkStackConfig,
+    traits::ZkStackConfigTrait,
     EXPLORER_API_DOCKER_IMAGE_TAG, EXPLORER_API_PRIVIDIUM_DOCKER_IMAGE_TAG,
     EXPLORER_BATCHES_PROCESSING_POLLING_INTERVAL, EXPLORER_DATA_FETCHER_DOCKER_IMAGE_TAG,
     EXPLORER_DATA_FETCHER_PRIVIDIUM_DOCKER_IMAGE_TAG, EXPLORER_WORKER_DOCKER_IMAGE_TAG,
@@ -112,7 +112,7 @@ pub struct ExplorerBackendComposeConfig {
     pub docker_compose: DockerComposeConfig,
 }
 
-impl ZkStackConfig for ExplorerBackendComposeConfig {}
+impl ZkStackConfigTrait for ExplorerBackendComposeConfig {}
 
 impl ExplorerBackendComposeConfig {
     const API_NAME: &'static str = "api";

--- a/zkstack_cli/crates/config/src/forge_interface/accept_ownership/mod.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/accept_ownership/mod.rs
@@ -1,9 +1,9 @@
 use ethers::types::Address;
 use serde::{Deserialize, Serialize};
 
-use crate::traits::ZkStackConfig;
+use crate::traits::ZkStackConfigTrait;
 
-impl ZkStackConfig for AcceptOwnershipInput {}
+impl ZkStackConfigTrait for AcceptOwnershipInput {}
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AcceptOwnershipInput {

--- a/zkstack_cli/crates/config/src/forge_interface/deploy_ecosystem/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/deploy_ecosystem/input.rs
@@ -11,7 +11,7 @@ use zksync_basic_types::{protocol_version::ProtocolSemanticVersion, L2ChainId};
 
 use crate::{
     consts::INITIAL_DEPLOYMENT_FILE,
-    traits::{FileConfigWithDefaultName, ZkStackConfig},
+    traits::{FileConfigWithDefaultName, ZkStackConfigTrait},
     ContractsConfig, GenesisConfig, WalletsConfig, ERC20_DEPLOYMENT_FILE,
 };
 
@@ -89,7 +89,7 @@ impl FileConfigWithDefaultName for InitialDeploymentConfig {
     const FILE_NAME: &'static str = INITIAL_DEPLOYMENT_FILE;
 }
 
-impl ZkStackConfig for InitialDeploymentConfig {}
+impl ZkStackConfigTrait for InitialDeploymentConfig {}
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Erc20DeploymentConfig {
@@ -100,7 +100,7 @@ impl FileConfigWithDefaultName for Erc20DeploymentConfig {
     const FILE_NAME: &'static str = ERC20_DEPLOYMENT_FILE;
 }
 
-impl ZkStackConfig for Erc20DeploymentConfig {}
+impl ZkStackConfigTrait for Erc20DeploymentConfig {}
 
 impl Default for Erc20DeploymentConfig {
     fn default() -> Self {
@@ -144,7 +144,7 @@ pub struct DeployL1Config {
     pub tokens: TokensDeployL1Config,
 }
 
-impl ZkStackConfig for DeployL1Config {}
+impl ZkStackConfigTrait for DeployL1Config {}
 
 impl DeployL1Config {
     pub fn new(
@@ -247,7 +247,7 @@ pub struct DeployErc20Config {
     pub additional_addresses_for_minting: Vec<Address>,
 }
 
-impl ZkStackConfig for DeployErc20Config {}
+impl ZkStackConfigTrait for DeployErc20Config {}
 
 impl DeployErc20Config {
     pub fn new(

--- a/zkstack_cli/crates/config/src/forge_interface/deploy_ecosystem/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/deploy_ecosystem/output.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     consts::ERC20_CONFIGS_FILE,
-    traits::{FileConfigWithDefaultName, ZkStackConfig},
+    traits::{FileConfigWithDefaultName, ZkStackConfigTrait},
 };
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -40,7 +40,7 @@ pub struct DeployL1DeployedAddressesOutput {
     pub server_notifier_proxy_addr: Address,
 }
 
-impl ZkStackConfig for DeployL1Output {}
+impl ZkStackConfigTrait for DeployL1Output {}
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DeployL1ContractsConfigOutput {
@@ -103,4 +103,4 @@ impl FileConfigWithDefaultName for ERC20Tokens {
     const FILE_NAME: &'static str = ERC20_CONFIGS_FILE;
 }
 
-impl ZkStackConfig for ERC20Tokens {}
+impl ZkStackConfigTrait for ERC20Tokens {}

--- a/zkstack_cli/crates/config/src/forge_interface/deploy_gateway_tx_filterer/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/deploy_gateway_tx_filterer/input.rs
@@ -2,7 +2,7 @@ use ethers::types::{Address, H256};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    forge_interface::deploy_ecosystem::input::InitialDeploymentConfig, traits::ZkStackConfig,
+    forge_interface::deploy_ecosystem::input::InitialDeploymentConfig, traits::ZkStackConfigTrait,
     ContractsConfig,
 };
 
@@ -16,7 +16,7 @@ pub struct GatewayTxFiltererInput {
     pub create2_factory_salt: H256,
 }
 
-impl ZkStackConfig for GatewayTxFiltererInput {}
+impl ZkStackConfigTrait for GatewayTxFiltererInput {}
 
 impl GatewayTxFiltererInput {
     pub fn new(

--- a/zkstack_cli/crates/config/src/forge_interface/deploy_gateway_tx_filterer/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/deploy_gateway_tx_filterer/output.rs
@@ -1,7 +1,7 @@
 use ethers::types::Address;
 use serde::{Deserialize, Serialize};
 
-use crate::traits::ZkStackConfig;
+use crate::traits::ZkStackConfigTrait;
 
 /// Represents the output config written after deployment.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -9,4 +9,4 @@ pub struct GatewayTxFiltererOutput {
     pub gateway_tx_filterer_proxy: Address,
 }
 
-impl ZkStackConfig for GatewayTxFiltererOutput {}
+impl ZkStackConfigTrait for GatewayTxFiltererOutput {}

--- a/zkstack_cli/crates/config/src/forge_interface/deploy_l2_contracts/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/deploy_l2_contracts/input.rs
@@ -2,9 +2,9 @@ use ethers::types::Address;
 use serde::{Deserialize, Serialize};
 use zksync_basic_types::{commitment::L1BatchCommitmentMode, L2ChainId, U256};
 
-use crate::{traits::ZkStackConfig, ChainConfig, ContractsConfig, DAValidatorType};
+use crate::{traits::ZkStackConfigTrait, ChainConfig, ContractsConfig, DAValidatorType};
 
-impl ZkStackConfig for DeployL2ContractsInput {}
+impl ZkStackConfigTrait for DeployL2ContractsInput {}
 
 /// Fields corresponding to `contracts/l1-contracts/deploy-script-config-template/config-deploy-l2-config.toml`
 /// which are read by `contracts/l1-contracts/deploy-scripts/DeployL2Contracts.sol`.

--- a/zkstack_cli/crates/config/src/forge_interface/deploy_l2_contracts/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/deploy_l2_contracts/output.rs
@@ -1,16 +1,16 @@
 use ethers::types::Address;
 use serde::{Deserialize, Serialize};
 
-use crate::traits::ZkStackConfig;
+use crate::traits::ZkStackConfigTrait;
 
-impl ZkStackConfig for InitializeBridgeOutput {}
-impl ZkStackConfig for DefaultL2UpgradeOutput {}
-impl ZkStackConfig for ConsensusRegistryOutput {}
-impl ZkStackConfig for Multicall3Output {}
+impl ZkStackConfigTrait for InitializeBridgeOutput {}
+impl ZkStackConfigTrait for DefaultL2UpgradeOutput {}
+impl ZkStackConfigTrait for ConsensusRegistryOutput {}
+impl ZkStackConfigTrait for Multicall3Output {}
 
-impl ZkStackConfig for TimestampAsserterOutput {}
+impl ZkStackConfigTrait for TimestampAsserterOutput {}
 
-impl ZkStackConfig for L2DAValidatorAddressOutput {}
+impl ZkStackConfigTrait for L2DAValidatorAddressOutput {}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InitializeBridgeOutput {

--- a/zkstack_cli/crates/config/src/forge_interface/gateway_preparation/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/gateway_preparation/input.rs
@@ -3,7 +3,7 @@ use ethers::utils::hex;
 use serde::{Deserialize, Serialize};
 use zksync_basic_types::{web3::Bytes, Address};
 
-use crate::{gateway::GatewayConfig, traits::ZkStackConfig, ChainConfig, ContractsConfig};
+use crate::{gateway::GatewayConfig, traits::ZkStackConfigTrait, ChainConfig, ContractsConfig};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GatewayPreparationConfig {
@@ -21,7 +21,7 @@ pub struct GatewayPreparationConfig {
     pub l1_nullifier_proxy_addr: Address,
 }
 
-impl ZkStackConfig for GatewayPreparationConfig {}
+impl ZkStackConfigTrait for GatewayPreparationConfig {}
 
 impl GatewayPreparationConfig {
     pub fn new(

--- a/zkstack_cli/crates/config/src/forge_interface/gateway_vote_preparation/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/gateway_vote_preparation/input.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     forge_interface::deploy_ecosystem::input::{GenesisInput, InitialDeploymentConfig},
-    traits::ZkStackConfig,
+    traits::ZkStackConfigTrait,
     ContractsConfig,
 };
 
@@ -56,7 +56,7 @@ pub struct GatewayVotePreparationConfig {
     pub force_deployments_data: String,
 }
 
-impl ZkStackConfig for GatewayVotePreparationConfig {}
+impl ZkStackConfigTrait for GatewayVotePreparationConfig {}
 
 impl GatewayVotePreparationConfig {
     #[allow(clippy::too_many_arguments)]

--- a/zkstack_cli/crates/config/src/forge_interface/gateway_vote_preparation/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/gateway_vote_preparation/output.rs
@@ -1,7 +1,7 @@
 use ethers::abi::Address;
 use serde::{Deserialize, Serialize};
 
-use crate::traits::ZkStackConfig;
+use crate::traits::ZkStackConfigTrait;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DeployGatewayCTMOutput {
@@ -14,7 +14,7 @@ pub struct DeployGatewayCTMOutput {
     pub ecosystem_admin_calls_to_execute: String,
 }
 
-impl ZkStackConfig for DeployGatewayCTMOutput {}
+impl ZkStackConfigTrait for DeployGatewayCTMOutput {}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct StateTransitionDeployedAddresses {

--- a/zkstack_cli/crates/config/src/forge_interface/paymaster/mod.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/paymaster/mod.rs
@@ -2,7 +2,7 @@ use ethers::types::Address;
 use serde::{Deserialize, Serialize};
 use zksync_basic_types::L2ChainId;
 
-use crate::{traits::ZkStackConfig, ChainConfig};
+use crate::{traits::ZkStackConfigTrait, ChainConfig};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DeployPaymasterInput {
@@ -22,11 +22,11 @@ impl DeployPaymasterInput {
     }
 }
 
-impl ZkStackConfig for DeployPaymasterInput {}
+impl ZkStackConfigTrait for DeployPaymasterInput {}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DeployPaymasterOutput {
     pub paymaster: Address,
 }
 
-impl ZkStackConfig for DeployPaymasterOutput {}
+impl ZkStackConfigTrait for DeployPaymasterOutput {}

--- a/zkstack_cli/crates/config/src/forge_interface/register_chain/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/register_chain/input.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use zkstack_cli_types::L1BatchCommitmentMode;
 use zksync_basic_types::{L2ChainId, H256};
 
-use crate::{traits::ZkStackConfig, ChainConfig, ContractsConfig};
+use crate::{traits::ZkStackConfigTrait, ChainConfig, ContractsConfig};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RegisterChainL1Config {
@@ -66,7 +66,7 @@ pub struct ChainL1Config {
     pub allow_evm_emulator: bool,
 }
 
-impl ZkStackConfig for RegisterChainL1Config {}
+impl ZkStackConfigTrait for RegisterChainL1Config {}
 
 impl RegisterChainL1Config {
     pub fn new(chain_config: &ChainConfig, contracts: &ContractsConfig) -> anyhow::Result<Self> {

--- a/zkstack_cli/crates/config/src/forge_interface/register_chain/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/register_chain/output.rs
@@ -1,7 +1,7 @@
 use ethers::types::Address;
 use serde::{Deserialize, Serialize};
 
-use crate::traits::ZkStackConfig;
+use crate::traits::ZkStackConfigTrait;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RegisterChainOutput {
@@ -13,4 +13,4 @@ pub struct RegisterChainOutput {
     pub chain_proxy_admin_addr: Address,
 }
 
-impl ZkStackConfig for RegisterChainOutput {}
+impl ZkStackConfigTrait for RegisterChainOutput {}

--- a/zkstack_cli/crates/config/src/forge_interface/setup_legacy_bridge/mod.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/setup_legacy_bridge/mod.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use zksync_basic_types::{Address, L2ChainId, H256};
 
-use crate::traits::ZkStackConfig;
+use crate::traits::ZkStackConfigTrait;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SetupLegacyBridgeInput {
@@ -19,4 +19,4 @@ pub struct SetupLegacyBridgeInput {
     pub create2factory_addr: Address,
 }
 
-impl ZkStackConfig for SetupLegacyBridgeInput {}
+impl ZkStackConfigTrait for SetupLegacyBridgeInput {}

--- a/zkstack_cli/crates/config/src/forge_interface/upgrade_ecosystem/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/upgrade_ecosystem/input.rs
@@ -4,7 +4,7 @@ use zksync_basic_types::L2ChainId;
 
 use crate::{
     forge_interface::deploy_ecosystem::input::{GenesisInput, InitialDeploymentConfig},
-    traits::ZkStackConfig,
+    traits::ZkStackConfigTrait,
     ContractsConfig,
 };
 
@@ -37,7 +37,7 @@ pub struct EcosystemUpgradeInput {
     pub specific_config: EcosystemUpgradeSpecificConfig,
 }
 
-impl ZkStackConfig for EcosystemUpgradeInput {}
+impl ZkStackConfigTrait for EcosystemUpgradeInput {}
 
 impl EcosystemUpgradeInput {
     #[allow(clippy::too_many_arguments)]

--- a/zkstack_cli/crates/config/src/forge_interface/upgrade_ecosystem/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/upgrade_ecosystem/output.rs
@@ -2,7 +2,7 @@ use ethers::types::{Address, H256};
 use serde::{Deserialize, Serialize};
 use zksync_basic_types::web3::Bytes;
 
-use crate::traits::{FileConfigWithDefaultName, ZkStackConfig};
+use crate::traits::{FileConfigWithDefaultName, ZkStackConfigTrait};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct EcosystemUpgradeOutput {
@@ -111,4 +111,4 @@ pub struct GovernanceCalls {
     pub stage2_calls: Bytes,
 }
 
-impl ZkStackConfig for EcosystemUpgradeOutput {}
+impl ZkStackConfigTrait for EcosystemUpgradeOutput {}

--- a/zkstack_cli/crates/config/src/gateway.rs
+++ b/zkstack_cli/crates/config/src/gateway.rs
@@ -8,7 +8,7 @@ use zksync_basic_types::{web3::Bytes, Address, SLChainId};
 use crate::{
     forge_interface::gateway_vote_preparation::output::DeployGatewayCTMOutput,
     raw::{PatchedConfig, RawConfig},
-    traits::{FileConfigWithDefaultName, ZkStackConfig},
+    traits::{FileConfigWithDefaultName, ZkStackConfigTrait},
     GATEWAY_FILE,
 };
 
@@ -28,7 +28,7 @@ impl FileConfigWithDefaultName for GatewayConfig {
     const FILE_NAME: &'static str = GATEWAY_FILE;
 }
 
-impl ZkStackConfig for GatewayConfig {}
+impl ZkStackConfigTrait for GatewayConfig {}
 
 impl From<DeployGatewayCTMOutput> for GatewayConfig {
     fn from(output: DeployGatewayCTMOutput) -> Self {

--- a/zkstack_cli/crates/config/src/portal.rs
+++ b/zkstack_cli/crates/config/src/portal.rs
@@ -9,7 +9,7 @@ use crate::{
         LOCAL_APPS_PATH, LOCAL_CONFIGS_PATH, LOCAL_GENERATED_PATH, PORTAL_CONFIG_FILE,
         PORTAL_JS_CONFIG_FILE,
     },
-    traits::{ReadConfig, SaveConfig, ZkStackConfig},
+    traits::{ReadConfig, SaveConfig, ZkStackConfigTrait},
 };
 
 /// Portal JSON configuration file. This file contains configuration for the portal app.
@@ -172,4 +172,4 @@ impl Default for PortalConfig {
     }
 }
 
-impl ZkStackConfig for PortalConfig {}
+impl ZkStackConfigTrait for PortalConfig {}

--- a/zkstack_cli/crates/config/src/traits.rs
+++ b/zkstack_cli/crates/config/src/traits.rs
@@ -8,7 +8,7 @@ use zkstack_cli_common::files::{
 };
 
 // Configs that we use only inside ZK Stack CLI, we don't have protobuf implementation for them.
-pub trait ZkStackConfig {}
+pub trait ZkStackConfigTrait {}
 
 pub trait FileConfigWithDefaultName {
     const FILE_NAME: &'static str;
@@ -18,7 +18,7 @@ pub trait FileConfigWithDefaultName {
     }
 }
 
-impl<T: Serialize + ZkStackConfig> SaveConfig for T {
+impl<T: Serialize + ZkStackConfigTrait> SaveConfig for T {
     fn save(&self, shell: &Shell, path: impl AsRef<Path>) -> anyhow::Result<()> {
         save_with_comment(shell, path, self, "")
     }
@@ -48,7 +48,7 @@ pub trait ReadConfig: Sized {
 
 impl<T> ReadConfig for T
 where
-    T: DeserializeOwned + Clone + ZkStackConfig,
+    T: DeserializeOwned + Clone + ZkStackConfigTrait,
 {
     fn read(shell: &Shell, path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let error_context = || format!("Failed to parse config file {:?}.", path.as_ref());

--- a/zkstack_cli/crates/config/src/wallets.rs
+++ b/zkstack_cli/crates/config/src/wallets.rs
@@ -4,7 +4,7 @@ use zkstack_cli_common::wallets::Wallet;
 
 use crate::{
     consts::WALLETS_FILE,
-    traits::{FileConfigWithDefaultName, ZkStackConfig},
+    traits::{FileConfigWithDefaultName, ZkStackConfigTrait},
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,6 +59,6 @@ pub(crate) struct EthMnemonicConfig {
     pub(crate) base_path: String,
 }
 
-impl ZkStackConfig for EthMnemonicConfig {}
+impl ZkStackConfigTrait for EthMnemonicConfig {}
 
-impl ZkStackConfig for WalletsConfig {}
+impl ZkStackConfigTrait for WalletsConfig {}

--- a/zkstack_cli/crates/zkstack/src/admin_functions.rs
+++ b/zkstack_cli/crates/zkstack/src/admin_functions.rs
@@ -17,7 +17,7 @@ use zkstack_cli_common::{
 };
 use zkstack_cli_config::{
     forge_interface::script_params::ACCEPT_GOVERNANCE_SCRIPT_PARAMS,
-    traits::{ReadConfig, ZkStackConfig},
+    traits::{ReadConfig, ZkStackConfigTrait},
     ChainConfig, ContractsConfig, EcosystemConfig,
 };
 use zksync_basic_types::U256;
@@ -388,7 +388,7 @@ struct AdminScriptOutputInner {
     encoded_data: String,
 }
 
-impl ZkStackConfig for AdminScriptOutputInner {}
+impl ZkStackConfigTrait for AdminScriptOutputInner {}
 
 #[derive(Debug, Clone, Default)]
 pub struct AdminScriptOutput {

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/default_chain_upgrade.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/default_chain_upgrade.rs
@@ -7,7 +7,7 @@ use zkstack_cli_common::{
     logger,
 };
 use zkstack_cli_config::{
-    traits::{ReadConfig, ZkStackConfig},
+    traits::{ReadConfig, ZkStackConfigTrait},
     EcosystemConfig,
 };
 use zksync_basic_types::{
@@ -228,7 +228,7 @@ pub struct GatewayStateTransition {
     pub(crate) validator_timelock_addr: Address,
 }
 
-impl ZkStackConfig for UpgradeInfo {}
+impl ZkStackConfigTrait for UpgradeInfo {}
 
 pub struct UpdatedValidators {
     pub operator: Option<Address>,

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/v27_evm_eq.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/v27_evm_eq.rs
@@ -4,7 +4,7 @@ use ethers::utils::hex;
 use serde::{Deserialize, Serialize};
 use xshell::Shell;
 use zkstack_cli_common::ethereum::{get_ethers_provider, get_zk_client};
-use zkstack_cli_config::traits::{ReadConfig, ZkStackConfig};
+use zkstack_cli_config::traits::{ReadConfig, ZkStackConfigTrait};
 use zksync_basic_types::{
     protocol_version::ProtocolVersionId, web3::Bytes, Address, L1BatchNumber, L2BlockNumber, U256,
 };
@@ -142,7 +142,7 @@ pub struct V27UpgradeInfo {
     old_protocol_version: u64,
 }
 
-impl ZkStackConfig for V27UpgradeInfo {}
+impl ZkStackConfigTrait for V27UpgradeInfo {}
 
 pub(crate) async fn run(shell: &Shell, args: V27EvmInterpreterCalldataArgs) -> anyhow::Result<()> {
     // 0. Read the GatewayUpgradeInfo

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/v28_precompiles.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/v28_precompiles.rs
@@ -4,7 +4,7 @@ use ethers::utils::hex;
 use serde::{Deserialize, Serialize};
 use xshell::Shell;
 use zkstack_cli_common::ethereum::{get_ethers_provider, get_zk_client};
-use zkstack_cli_config::traits::{ReadConfig, ZkStackConfig};
+use zkstack_cli_config::traits::{ReadConfig, ZkStackConfigTrait};
 use zksync_basic_types::{
     protocol_version::ProtocolVersionId, web3::Bytes, Address, L1BatchNumber, L2BlockNumber, U256,
 };
@@ -201,7 +201,7 @@ pub struct V28UpgradeInfo {
     gateway_upgrade_diamond_cut: Bytes,
 }
 
-impl ZkStackConfig for V28UpgradeInfo {}
+impl ZkStackConfigTrait for V28UpgradeInfo {}
 
 pub(crate) async fn run(shell: &Shell, args: V28PrecompilesCalldataArgs) -> anyhow::Result<()> {
     let forge_args = &Default::default();


### PR DESCRIPTION
## What ❔

Rename trait for compatibility with zstack chain changes

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
