### PR TITLE
chore: Remove prover workflow

### DIFF
--- a/.github/workflows/release-zkos-stage.yml
+++ b/.github/workflows/release-zkos-stage.yml
@@ -73,20 +73,6 @@ jobs:
       DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
-
-  build-push-prover-images:
-    name: Build and push images
-    needs: [ setup, changed_files ]
-    uses: ./.github/workflows/build-zksync-os-prover-template.yml
-    if: needs.changed_files.outputs.prover == 'true' || needs.changed_files.outputs.all == 'true'
-    with:
-      image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}
-      action: "push"
-    secrets:
-      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-
-
   regenerate-keys:
     name: Regenerate keys
     needs: [ setup, changed_files ]


### PR DESCRIPTION
The workflow has been moved to zksync-airbender-prover and that will be the source of truth for the prover codebase. Removing this workflow so it won't cause confusion in the future (my image is pushed, but I can't see automation kicking in or images are not being updated).
