### PR TITLE
Fix manifest version handling in parallel storage tests

### DIFF
--- a/core/lib/merkle_tree/src/storage/parallel.rs
+++ b/core/lib/merkle_tree/src/storage/parallel.rs
@@ -520,7 +520,7 @@ mod tests {
     fn mock_patch_set(start: u64, leaf_count: u64) -> PatchSet {
         assert!(start <= leaf_count);
 
-        let manifest = Manifest::new(UPDATED_VERSION, &());
+        let manifest = Manifest::new(UPDATED_VERSION + 1, &());
         let mut root_node = InternalNode::default();
         root_node.insert_child_ref(0, ChildRef::leaf(UPDATED_VERSION));
         let root = Root::new(leaf_count, Node::Internal(root_node));


### PR DESCRIPTION
The `mock_patch_set` function previously created a `Manifest` with `UPDATED_VERSION` as its version count. This caused `fault_injection_with_parallel_persistence` to fail, since recovery logic rolled back one version too far.

By using `Manifest::new(UPDATED_VERSION + 1, &())`, the manifest now correctly reflects the next version during patch creation. This ensures proper recovery behavior and fixes the failing test.

## What ❔

Updated mock_patch_set to increment the manifest version count when creating a patch.
Specifically changed Manifest::new(UPDATED_VERSION, &()) → Manifest::new(UPDATED_VERSION + 1, &()).
Fixes the failing test fault_injection_with_parallel_persistence.

## Why ❔

Recovery logic relies on version_count to decide the last completed version.
Without incrementing, the recovery mechanism rolled back one version too far.
With this fix, recovery behavior is consistent and the test passes.
Aligns with intended versioning semantics in manifest creation.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

No configuration changes.
No new flags or scripts modified.
Transparent fix; no impact for external operators.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
