### PR TITLE
chore: add linter for new crates required crates.io fields

### DIFF
--- a/.github/workflows/ci-core-lint-reusable.yml
+++ b/.github/workflows/ci-core-lint-reusable.yml
@@ -3,6 +3,53 @@ on:
   workflow_call:
 
 jobs:
+
+  # Linter for new crates
+  # checks that all required fields are present in Cargo.toml files of newly added crates
+  check-new-crates:
+    name: Check new crates
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
+        with:
+          files: '**/Cargo.toml'
+
+      - name: Lint Cargo.toml files of new crates
+        if: ${{ steps.changed-files.outputs.added_files != '' }}
+        env:
+          ADDED_FILES: ${{ steps.changed-files.outputs.added_files }}
+          REQUIRED_FIELDS: 'name version edition description license'
+        run: |
+          MISSING_ANY=false
+          for FILE in ${ADDED_FILES}; do
+            echo "✅ New crate added: ${FILE}"
+            PACKAGE_NAME="$(yq -oy .package.name ${FILE})"
+            echo "Checking required fields fields for a new package ${PACKAGE_NAME}..."
+            MISSING_FIELDS=""
+            for FIELD in ${REQUIRED_FIELDS}; do
+              if ! yq -oy -e .package.${FIELD} ${FILE} > /dev/null 2>&1; then
+                echo "Error: missing field '${FIELD}' in ${FILE} for crates.io publishing!"
+                MISSING_FIELDS="${MISSING_FIELDS} ${FIELD}"
+                MISSING_ANY=true
+              fi
+            done
+            if [ "${MISSING_FIELDS}" != "" ]; then
+              echo "----------------------------------------"
+              echo "❌ Error: missing fields '$(echo "${MISSING_FIELDS}" | xargs)' in ${FILE} for crates.io publishing!"
+              echo "❌ Please, add all required fields to the Cargo.toml file of the new crate."
+              echo "----------------------------------------"
+            fi
+          done
+          if [[ "${MISSING_ANY}" == true ]]; then
+            exit 1
+          fi
+
   code_lint:
     runs-on: matterlabs-ci-runner-highmem-long
     steps:


### PR DESCRIPTION
## What ❔

* [x] Lint newly added crates for the fields required to publish to crates.io

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To prevent issues with `crates.io` publishing on the later stages caused by missing fields in new `Cargo.toml` files.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Tests

Tested in a separate workflow with multiple crates with wrong configuration:
https://github.com/matter-labs/zksync-era/actions/runs/17213648618/job/48831624156

<img width="883" height="75" alt="image" src="https://github.com/user-attachments/assets/c4bb468f-55ef-4e7e-8cf4-ef827c37b852" />


## Is this a breaking change?
- [ ] Yes
- [x] No

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
