### PR TITLE
fix(zkstack_cli): Prevent duplicate repo clones in ecosystem create #4058

### DIFF
--- a/zkstack_cli/crates/zkstack/src/commands/chain/create.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/create.rs
@@ -16,7 +16,6 @@ use crate::{
         MSG_CREATING_CHAIN_CONFIGURATIONS_SPINNER, MSG_EVM_EMULATOR_HASH_MISSING_ERR,
         MSG_SELECTED_CONFIG,
     },
-    utils::link_to_code::resolve_link_to_code,
 };
 
 pub async fn run(args: ChainCreateArgs, shell: &Shell) -> anyhow::Result<()> {
@@ -94,14 +93,8 @@ pub(crate) async fn create_chain_inner(
         "ecosystem_config.list_of_chains() after: {:?}",
         ecosystem_config.list_of_chains()
     );
-    let link_to_code = resolve_link_to_code(
-        shell,
-        &chain_path,
-        args.link_to_code.clone(),
-        args.update_submodules,
-    )?;
     let genesis_config_path =
-        EcosystemConfig::default_configs_path(&link_to_code).join(GENESIS_FILE);
+        EcosystemConfig::default_configs_path(&ecosystem_config.link_to_code).join(GENESIS_FILE);
     let default_genesis_config = GenesisConfig::read(shell, &genesis_config_path).await?;
     let has_evm_emulation_support = default_genesis_config.evm_emulator_hash()?.is_some();
     if args.evm_emulator && !has_evm_emulation_support {


### PR DESCRIPTION
## What ❔

This PR prevents the `zksync-era` repository from being cloned multiple times during the `zkstack ecosystem create` command.

* Fixes #4058.
* Likely further resolves the genesis hash mismatch discussed in [this discussion](https://github.com/zkSync-Community-Hub/zksync-developers/discussions/1035)

## Why ❔

When running zkstack ecosystem create with default options, the command would download two copies of the zksync-era repository instead of one. This is a bug.

The root cause is in the `create_chain_inner` function. It calls [`resolve_link_to_code`](https://github.com/matter-labs/zksync-era/blob/a8e595265642f07232c1802618c61017a1d21fab/zkstack_cli/crates/zkstack/src/commands/chain/create.rs#L97C24-L97C44) to find the genesis config but passes `base_path` set to the new chains directory. If `link-to-code` is not set, it would clone `zksync-era` into the chains path since the path of the newly cloned zksync-era in the root folder of the ecosystem is not passed down.

I propose to remove `resolve_link_to_code` and use `&ecosystem_config.link_to_code` because `resolve_link_to_code` is redundant: An ecosystem and specifically `link_to_code` always needs to be set before a chain can be created. ItsThis approach is consistent with other parts of the function that already use `ecosystem_config` ([1](https://github.com/matter-labs/zksync-era/blob/a8e595265642f07232c1802618c61017a1d21fab/zkstack_cli/crates/zkstack/src/commands/chain/create.rs#L118C23-L118C52), [2](https://github.com/matter-labs/zksync-era/blob/a8e595265642f07232c1802618c61017a1d21fab/zkstack_cli/crates/zkstack/src/commands/chain/create.rs#L135)).

This fix should also fix [genesis config related issues](https://github.com/zkSync-Community-Hub/zksync-developers/discussions/1035) as the config from the correct zksync-era version at `link_to_code` is used.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

## Checklist
- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
