### PR TITLE
chore(zkstack): Use trait for zkstack config

### DIFF
--- a/zkstack_cli/crates/common/src/contracts.rs
+++ b/zkstack_cli/crates/common/src/contracts.rs
@@ -4,26 +4,26 @@ use xshell::{cmd, Shell};
 
 use crate::cmd::Cmd;
 
-pub fn build_l1_contracts(shell: Shell, link_to_code: &Path) -> anyhow::Result<()> {
-    let _dir_guard = shell.push_dir(link_to_code.join("contracts/l1-contracts"));
+pub fn build_l1_contracts(shell: Shell, link_to_contracts: &Path) -> anyhow::Result<()> {
+    let _dir_guard = shell.push_dir(link_to_contracts.join("l1-contracts"));
     // Do not update era-contract's lockfile to avoid dirty submodule
     // Note, tha the v26 contracts depend on the node_modules to be present at the time of the compilation.
     Cmd::new(cmd!(shell, "yarn install --frozen-lockfile")).run()?;
     Ok(Cmd::new(cmd!(shell, "yarn build:foundry")).run()?)
 }
 
-pub fn build_l1_da_contracts(shell: Shell, link_to_code: &Path) -> anyhow::Result<()> {
-    let _dir_guard = shell.push_dir(link_to_code.join("contracts/da-contracts"));
+pub fn build_l1_da_contracts(shell: Shell, link_to_contracts: &Path) -> anyhow::Result<()> {
+    let _dir_guard = shell.push_dir(link_to_contracts.join("da-contracts"));
     Ok(Cmd::new(cmd!(shell, "forge build")).run()?)
 }
 
-pub fn build_l2_contracts(shell: Shell, link_to_code: &Path) -> anyhow::Result<()> {
-    let _dir_guard = shell.push_dir(link_to_code.join("contracts/l2-contracts"));
+pub fn build_l2_contracts(shell: Shell, link_to_contracts: &Path) -> anyhow::Result<()> {
+    let _dir_guard = shell.push_dir(link_to_contracts.join("l2-contracts"));
     Cmd::new(cmd!(shell, "yarn build:foundry")).run()?;
     Ok(())
 }
 
-pub fn build_system_contracts(shell: Shell, link_to_code: &Path) -> anyhow::Result<()> {
-    let _dir_guard = shell.push_dir(link_to_code.join("contracts/system-contracts"));
+pub fn build_system_contracts(shell: Shell, link_to_contracts: &Path) -> anyhow::Result<()> {
+    let _dir_guard = shell.push_dir(link_to_contracts.join("system-contracts"));
     Ok(Cmd::new(cmd!(shell, "yarn build:foundry")).run()?)
 }

--- a/zkstack_cli/crates/config/src/apps.rs
+++ b/zkstack_cli/crates/config/src/apps.rs
@@ -5,7 +5,7 @@ use xshell::Shell;
 
 use crate::{
     consts::{APPS_CONFIG_FILE, DEFAULT_EXPLORER_PORT, DEFAULT_PORTAL_PORT, LOCAL_CONFIGS_PATH},
-    traits::{FileConfigWithDefaultName, ReadConfig, SaveConfig, ZkStackConfigTrait},
+    traits::{FileConfigTrait, FileConfigWithDefaultName, ReadConfig, SaveConfig},
 };
 
 /// Ecosystem level configuration for the apps (portal and explorer).
@@ -20,7 +20,7 @@ pub struct AppEcosystemConfig {
     pub http_port: u16,
 }
 
-impl ZkStackConfigTrait for AppsEcosystemConfig {}
+impl FileConfigTrait for AppsEcosystemConfig {}
 impl FileConfigWithDefaultName for AppsEcosystemConfig {
     const FILE_NAME: &'static str = APPS_CONFIG_FILE;
 }

--- a/zkstack_cli/crates/config/src/chain.rs
+++ b/zkstack_cli/crates/config/src/chain.rs
@@ -93,6 +93,7 @@ impl Serialize for ChainConfig {
 }
 
 impl ChainConfig {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: u32,
         name: String,

--- a/zkstack_cli/crates/config/src/chain.rs
+++ b/zkstack_cli/crates/config/src/chain.rs
@@ -12,8 +12,8 @@ use zksync_basic_types::L2ChainId;
 
 use crate::{
     consts::{
-        CONFIG_NAME, CONTRACTS_FILE, EN_CONFIG_FILE, GENERAL_FILE, GENESIS_FILE,
-        L1_CONTRACTS_FOUNDRY, SECRETS_FILE, WALLETS_FILE,
+        CONFIG_NAME, CONTRACTS_FILE, CONTRACTS_PATH, EN_CONFIG_FILE, GENERAL_FILE, GENESIS_FILE,
+        L1_CONTRACTS_FOUNDRY_INSIDE_CONTRACTS, SECRETS_FILE, WALLETS_FILE,
     },
     create_localhost_wallets,
     gateway::GatewayConfig,
@@ -22,7 +22,7 @@ use crate::{
         SaveConfigWithBasePath,
     },
     ContractsConfig, EcosystemConfig, GatewayChainConfig, GeneralConfig, GenesisConfig,
-    SecretsConfig, WalletsConfig, GATEWAY_CHAIN_FILE,
+    SecretsConfig, WalletsConfig, ZkStackConfigTrait, CONFIGS_PATH, GATEWAY_CHAIN_FILE,
 };
 
 /// Chain configuration file. This file is created in the chain
@@ -62,7 +62,7 @@ pub struct ChainConfig {
     pub prover_version: ProverMode,
     pub l1_network: L1Network,
     pub self_path: PathBuf,
-    pub link_to_code: PathBuf,
+    link_to_code: PathBuf,
     pub rocks_db_path: PathBuf,
     pub artifacts: PathBuf,
     pub configs: PathBuf,
@@ -93,6 +93,48 @@ impl Serialize for ChainConfig {
 }
 
 impl ChainConfig {
+    pub fn new(
+        id: u32,
+        name: String,
+        chain_id: L2ChainId,
+        prover_version: ProverMode,
+        l1_network: L1Network,
+        self_path: PathBuf,
+        link_to_code: PathBuf,
+        rocks_db_path: PathBuf,
+        artifacts: PathBuf,
+        configs: PathBuf,
+        external_node_config_path: Option<PathBuf>,
+        l1_batch_commit_data_generator_mode: L1BatchCommitmentMode,
+        base_token: BaseToken,
+        wallet_creation: WalletCreation,
+        shell: OnceCell<Shell>,
+        legacy_bridge: Option<bool>,
+        evm_emulator: bool,
+        tight_ports: bool,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            chain_id,
+            prover_version,
+            l1_network,
+            self_path,
+            link_to_code,
+            rocks_db_path,
+            artifacts,
+            configs,
+            external_node_config_path,
+            l1_batch_commit_data_generator_mode,
+            base_token,
+            wallet_creation,
+            shell,
+            legacy_bridge,
+            evm_emulator,
+            tight_ports,
+        }
+    }
+
     pub(crate) fn get_shell(&self) -> &Shell {
         self.shell.get().expect("Not initialized")
     }
@@ -116,10 +158,6 @@ impl ChainConfig {
             return Ok(wallets);
         }
         anyhow::bail!("Wallets configs has not been found");
-    }
-
-    pub fn get_preexisting_ecosystem_contracts_path(&self) -> PathBuf {
-        todo!()
     }
 
     pub fn get_contracts_config(&self) -> anyhow::Result<ContractsConfig> {
@@ -160,10 +198,6 @@ impl ChainConfig {
 
     pub fn path_to_gateway_chain_config(&self) -> PathBuf {
         self.configs.join(GATEWAY_CHAIN_FILE)
-    }
-
-    pub fn path_to_l1_foundry(&self) -> PathBuf {
-        self.link_to_code.join(L1_CONTRACTS_FOUNDRY)
     }
 
     pub fn save(&self, shell: &Shell, path: impl AsRef<Path>) -> anyhow::Result<()> {
@@ -263,3 +297,22 @@ impl FileConfigWithDefaultName for ChainConfigInternal {
 }
 
 impl FileConfigTrait for ChainConfigInternal {}
+
+impl ZkStackConfigTrait for ChainConfig {
+    fn link_to_code(&self) -> PathBuf {
+        self.link_to_code.clone()
+    }
+
+    fn default_configs_path(&self) -> PathBuf {
+        self.link_to_code().join(CONFIGS_PATH)
+    }
+
+    fn contracts_path(&self) -> PathBuf {
+        self.link_to_code().join(CONTRACTS_PATH)
+    }
+
+    fn path_to_l1_foundry(&self) -> PathBuf {
+        self.contracts_path()
+            .join(L1_CONTRACTS_FOUNDRY_INSIDE_CONTRACTS)
+    }
+}

--- a/zkstack_cli/crates/config/src/chain.rs
+++ b/zkstack_cli/crates/config/src/chain.rs
@@ -18,8 +18,8 @@ use crate::{
     create_localhost_wallets,
     gateway::GatewayConfig,
     traits::{
-        FileConfigWithDefaultName, ReadConfig, ReadConfigWithBasePath, SaveConfig,
-        SaveConfigWithBasePath, ZkStackConfigTrait,
+        FileConfigTrait, FileConfigWithDefaultName, ReadConfig, ReadConfigWithBasePath, SaveConfig,
+        SaveConfigWithBasePath,
     },
     ContractsConfig, EcosystemConfig, GatewayChainConfig, GeneralConfig, GenesisConfig,
     SecretsConfig, WalletsConfig, GATEWAY_CHAIN_FILE,
@@ -262,4 +262,4 @@ impl FileConfigWithDefaultName for ChainConfigInternal {
     const FILE_NAME: &'static str = CONFIG_NAME;
 }
 
-impl ZkStackConfigTrait for ChainConfigInternal {}
+impl FileConfigTrait for ChainConfigInternal {}

--- a/zkstack_cli/crates/config/src/chain.rs
+++ b/zkstack_cli/crates/config/src/chain.rs
@@ -61,8 +61,6 @@ pub struct ChainConfig {
     pub chain_id: L2ChainId,
     pub prover_version: ProverMode,
     pub l1_network: L1Network,
-    pub self_path: PathBuf,
-    link_to_code: PathBuf,
     pub rocks_db_path: PathBuf,
     pub artifacts: PathBuf,
     pub configs: PathBuf,
@@ -70,10 +68,12 @@ pub struct ChainConfig {
     pub l1_batch_commit_data_generator_mode: L1BatchCommitmentMode,
     pub base_token: BaseToken,
     pub wallet_creation: WalletCreation,
-    pub shell: OnceCell<Shell>,
     pub legacy_bridge: Option<bool>,
     pub evm_emulator: bool,
     pub tight_ports: bool,
+    shell: OnceCell<Shell>,
+    self_path: PathBuf,
+    link_to_code: PathBuf,
 }
 
 #[derive(Debug, Clone)]

--- a/zkstack_cli/crates/config/src/consts.rs
+++ b/zkstack_cli/crates/config/src/consts.rs
@@ -42,6 +42,7 @@ pub(crate) const LOCAL_CONFIGS_PATH: &str = "configs/";
 pub(crate) const LOCAL_GENERATED_PATH: &str = ".generated/";
 pub(crate) const LOCAL_DB_PATH: &str = "db/";
 pub(crate) const LOCAL_ARTIFACTS_PATH: &str = "artifacts/";
+pub(crate) const CONTRACTS_PATH: &str = "contracts/";
 
 /// Name of apps config file
 pub const APPS_CONFIG_FILE: &str = "apps.yaml";
@@ -105,8 +106,8 @@ pub const EXPLORER_BATCHES_PROCESSING_POLLING_INTERVAL: u64 = 1000;
 /// Path to ecosystem contacts
 pub(crate) const ECOSYSTEM_PATH: &str = "etc/env/ecosystems";
 
-/// Path to l1 contracts foundry folder inside zksync-era
-pub(crate) const L1_CONTRACTS_FOUNDRY: &str = "contracts/l1-contracts";
+pub(crate) const L1_CONTRACTS_FOUNDRY_INSIDE_CONTRACTS: &str = "l1-contracts";
+
 /// Path to proving networks contracts
 pub(crate) const PROVING_NETWORKS_PATH: &str = "proof-manager-contracts";
 /// Path to proving networks contracts deploy script

--- a/zkstack_cli/crates/config/src/contracts.rs
+++ b/zkstack_cli/crates/config/src/contracts.rs
@@ -15,7 +15,7 @@ use crate::{
         },
         register_chain::output::RegisterChainOutput,
     },
-    traits::{FileConfigWithDefaultName, ZkStackConfigTrait},
+    traits::{FileConfigTrait, FileConfigWithDefaultName},
 };
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
@@ -215,7 +215,7 @@ impl FileConfigWithDefaultName for ContractsConfig {
     const FILE_NAME: &'static str = CONTRACTS_FILE;
 }
 
-impl ZkStackConfigTrait for ContractsConfig {}
+impl FileConfigTrait for ContractsConfig {}
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 pub struct EcosystemContracts {
@@ -248,7 +248,7 @@ pub struct EcosystemContracts {
     pub server_notifier_proxy_addr: Option<Address>,
 }
 
-impl ZkStackConfigTrait for EcosystemContracts {}
+impl FileConfigTrait for EcosystemContracts {}
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct BridgesContracts {

--- a/zkstack_cli/crates/config/src/docker_compose.rs
+++ b/zkstack_cli/crates/config/src/docker_compose.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::traits::ZkStackConfigTrait;
+use crate::traits::FileConfigTrait;
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct DockerComposeConfig {
@@ -36,7 +36,7 @@ pub struct DockerComposeService {
     pub other: serde_json::Value,
 }
 
-impl ZkStackConfigTrait for DockerComposeConfig {}
+impl FileConfigTrait for DockerComposeConfig {}
 
 impl DockerComposeConfig {
     pub fn add_service(&mut self, name: &str, service: DockerComposeService) {

--- a/zkstack_cli/crates/config/src/ecosystem.rs
+++ b/zkstack_cli/crates/config/src/ecosystem.rs
@@ -21,7 +21,7 @@ use crate::{
         input::{Erc20DeploymentConfig, InitialDeploymentConfig},
         output::{ERC20Tokens, Erc20Token},
     },
-    traits::{FileConfigWithDefaultName, ReadConfig, SaveConfig, ZkStackConfigTrait},
+    traits::{FileConfigTrait, FileConfigWithDefaultName, ReadConfig, SaveConfig},
     ChainConfig, ChainConfigInternal, ContractsConfig, WalletsConfig,
     PROVING_NETWORKS_DEPLOY_SCRIPT_PATH, PROVING_NETWORKS_PATH,
 };
@@ -95,9 +95,9 @@ impl FileConfigWithDefaultName for EcosystemConfig {
     const FILE_NAME: &'static str = CONFIG_NAME;
 }
 
-impl ZkStackConfigTrait for EcosystemConfigInternal {}
+impl FileConfigTrait for EcosystemConfigInternal {}
 
-impl ZkStackConfigTrait for EcosystemConfig {}
+impl FileConfigTrait for EcosystemConfig {}
 
 impl EcosystemConfig {
     fn get_shell(&self) -> &Shell {

--- a/zkstack_cli/crates/config/src/ecosystem.rs
+++ b/zkstack_cli/crates/config/src/ecosystem.rs
@@ -48,15 +48,15 @@ struct EcosystemConfigInternal {
 pub struct EcosystemConfig {
     pub name: String,
     pub l1_network: L1Network,
-    link_to_code: PathBuf,
     pub bellman_cuda_dir: Option<PathBuf>,
     pub chains: PathBuf,
     pub config: PathBuf,
-    default_chain: String,
     pub era_chain_id: L2ChainId,
     pub prover_version: ProverMode,
     pub wallet_creation: WalletCreation,
-    pub shell: OnceCell<Shell>,
+    default_chain: String,
+    link_to_code: PathBuf,
+    shell: OnceCell<Shell>,
 }
 
 impl Serialize for EcosystemConfig {

--- a/zkstack_cli/crates/config/src/ecosystem.rs
+++ b/zkstack_cli/crates/config/src/ecosystem.rs
@@ -12,9 +12,9 @@ use zksync_basic_types::L2ChainId;
 
 use crate::{
     consts::{
-        CONFIGS_PATH, CONFIG_NAME, CONTRACTS_FILE, ECOSYSTEM_PATH, ERA_CHAIN_ID,
-        ERC20_CONFIGS_FILE, ERC20_DEPLOYMENT_FILE, INITIAL_DEPLOYMENT_FILE, L1_CONTRACTS_FOUNDRY,
-        LOCAL_ARTIFACTS_PATH, LOCAL_DB_PATH, WALLETS_FILE,
+        CONFIGS_PATH, CONFIG_NAME, CONTRACTS_FILE, CONTRACTS_PATH, ECOSYSTEM_PATH, ERA_CHAIN_ID,
+        ERC20_CONFIGS_FILE, ERC20_DEPLOYMENT_FILE, INITIAL_DEPLOYMENT_FILE,
+        L1_CONTRACTS_FOUNDRY_INSIDE_CONTRACTS, LOCAL_ARTIFACTS_PATH, LOCAL_DB_PATH, WALLETS_FILE,
     },
     create_localhost_wallets,
     forge_interface::deploy_ecosystem::{
@@ -22,7 +22,7 @@ use crate::{
         output::{ERC20Tokens, Erc20Token},
     },
     traits::{FileConfigTrait, FileConfigWithDefaultName, ReadConfig, SaveConfig},
-    ChainConfig, ChainConfigInternal, ContractsConfig, WalletsConfig,
+    ChainConfig, ChainConfigInternal, ContractsConfig, WalletsConfig, ZkStackConfigTrait,
     PROVING_NETWORKS_DEPLOY_SCRIPT_PATH, PROVING_NETWORKS_PATH,
 };
 
@@ -48,11 +48,11 @@ struct EcosystemConfigInternal {
 pub struct EcosystemConfig {
     pub name: String,
     pub l1_network: L1Network,
-    pub link_to_code: PathBuf,
+    link_to_code: PathBuf,
     pub bellman_cuda_dir: Option<PathBuf>,
     pub chains: PathBuf,
     pub config: PathBuf,
-    pub default_chain: String,
+    default_chain: String,
     pub era_chain_id: L2ChainId,
     pub prover_version: ProverMode,
     pub wallet_creation: WalletCreation,
@@ -100,6 +100,35 @@ impl FileConfigTrait for EcosystemConfigInternal {}
 impl FileConfigTrait for EcosystemConfig {}
 
 impl EcosystemConfig {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        name: String,
+        l1_network: L1Network,
+        link_to_code: PathBuf,
+        bellman_cuda_dir: Option<PathBuf>,
+        chains: PathBuf,
+        config: PathBuf,
+        default_chain: String,
+        era_chain_id: L2ChainId,
+        prover_version: ProverMode,
+        wallet_creation: WalletCreation,
+        shell: OnceCell<Shell>,
+    ) -> Self {
+        Self {
+            name,
+            l1_network,
+            link_to_code,
+            bellman_cuda_dir,
+            chains,
+            config,
+            default_chain,
+            era_chain_id,
+            prover_version,
+            wallet_creation,
+            shell,
+        }
+    }
+
     fn get_shell(&self) -> &Shell {
         self.shell.get().expect("Must be initialized")
     }
@@ -140,6 +169,10 @@ impl EcosystemConfig {
         Ok(ecosystem)
     }
 
+    pub fn set_default_chain(&mut self, name: String) {
+        self.default_chain = name
+    }
+
     pub fn current_chain(&self) -> &str {
         global_config()
             .chain_name
@@ -161,29 +194,29 @@ impl EcosystemConfig {
 
         let config = ChainConfigInternal::read(self.get_shell(), path.join(CONFIG_NAME).clone())?;
 
-        Ok(ChainConfig {
-            id: config.id,
-            name: config.name,
-            chain_id: config.chain_id,
-            prover_version: config.prover_version,
-            configs: config.configs,
-            external_node_config_path: config.external_node_config_path,
-            l1_batch_commit_data_generator_mode: config.l1_batch_commit_data_generator_mode,
-            l1_network: self.l1_network,
-            self_path: path,
-            link_to_code: config.link_to_code.unwrap_or(self.link_to_code.clone()),
-            base_token: config.base_token,
-            rocks_db_path: config.rocks_db_path,
-            wallet_creation: config.wallet_creation,
-            shell: self.get_shell().clone().into(),
+        Ok(ChainConfig::new(
+            config.id,
+            config.name,
+            config.chain_id,
+            config.prover_version,
+            self.l1_network,
+            path,
+            config.link_to_code.unwrap_or(self.link_to_code.clone()),
+            config.rocks_db_path,
             // It's required for backward compatibility
-            artifacts: config
+            config
                 .artifacts_path
                 .unwrap_or_else(|| self.get_chain_artifacts_path(name)),
-            legacy_bridge: config.legacy_bridge,
-            evm_emulator: config.evm_emulator,
-            tight_ports: config.tight_ports,
-        })
+            config.configs,
+            config.external_node_config_path,
+            config.l1_batch_commit_data_generator_mode,
+            config.base_token,
+            config.wallet_creation,
+            self.get_shell().clone().into(),
+            config.legacy_bridge,
+            config.evm_emulator,
+            config.tight_ports,
+        ))
     }
 
     pub fn get_initial_deployment_config(&self) -> anyhow::Result<InitialDeploymentConfig> {
@@ -217,17 +250,12 @@ impl EcosystemConfig {
         ContractsConfig::read(self.get_shell(), self.config.join(CONTRACTS_FILE))
     }
 
-    pub fn path_to_l1_foundry(&self) -> PathBuf {
-        self.link_to_code.join(L1_CONTRACTS_FOUNDRY)
-    }
-
     pub fn path_to_proving_networks(&self) -> PathBuf {
         self.link_to_code.join(PROVING_NETWORKS_PATH)
     }
 
     pub fn path_to_proving_networks_deploy_script(&self) -> PathBuf {
-        self.link_to_code
-            .join(PROVING_NETWORKS_PATH)
+        self.path_to_proving_networks()
             .join(PROVING_NETWORKS_DEPLOY_SCRIPT_PATH)
     }
 
@@ -244,14 +272,6 @@ impl EcosystemConfig {
                 }
             })
             .collect()
-    }
-
-    pub fn get_default_configs_path(&self) -> PathBuf {
-        Self::default_configs_path(&self.link_to_code)
-    }
-
-    pub fn default_configs_path(link_to_code: &Path) -> PathBuf {
-        link_to_code.join(CONFIGS_PATH)
     }
 
     /// Path to the predefined ecosystem configs
@@ -303,4 +323,23 @@ pub fn get_default_era_chain_id() -> L2ChainId {
 
 pub fn get_link_to_prover(link_to_code: &Path) -> PathBuf {
     link_to_code.join("prover")
+}
+
+impl ZkStackConfigTrait for EcosystemConfig {
+    fn link_to_code(&self) -> PathBuf {
+        self.link_to_code.clone()
+    }
+
+    fn default_configs_path(&self) -> PathBuf {
+        self.link_to_code().join(CONFIGS_PATH)
+    }
+
+    fn contracts_path(&self) -> PathBuf {
+        self.link_to_code().join(CONTRACTS_PATH)
+    }
+
+    fn path_to_l1_foundry(&self) -> PathBuf {
+        self.contracts_path()
+            .join(L1_CONTRACTS_FOUNDRY_INSIDE_CONTRACTS)
+    }
 }

--- a/zkstack_cli/crates/config/src/explorer.rs
+++ b/zkstack_cli/crates/config/src/explorer.rs
@@ -8,7 +8,7 @@ use crate::{
         EXPLORER_CONFIG_FILE, EXPLORER_JS_CONFIG_FILE, LOCAL_APPS_PATH, LOCAL_CONFIGS_PATH,
         LOCAL_GENERATED_PATH,
     },
-    traits::{ReadConfig, SaveConfig, ZkStackConfigTrait},
+    traits::{FileConfigTrait, ReadConfig, SaveConfig},
 };
 
 /// Explorer JSON configuration file. This file contains configuration for the explorer app.
@@ -145,4 +145,4 @@ impl Default for ExplorerConfig {
     }
 }
 
-impl ZkStackConfigTrait for ExplorerConfig {}
+impl FileConfigTrait for ExplorerConfig {}

--- a/zkstack_cli/crates/config/src/explorer_compose.rs
+++ b/zkstack_cli/crates/config/src/explorer_compose.rs
@@ -20,7 +20,7 @@ use crate::{
         EXPLORER_WORKER_DOCKER_IMAGE, LOCAL_CHAINS_PATH, LOCAL_CONFIGS_PATH,
     },
     docker_compose::{DockerComposeConfig, DockerComposeService},
-    traits::ZkStackConfigTrait,
+    traits::FileConfigTrait,
     EXPLORER_API_DOCKER_IMAGE_TAG, EXPLORER_API_PRIVIDIUM_DOCKER_IMAGE_TAG,
     EXPLORER_BATCHES_PROCESSING_POLLING_INTERVAL, EXPLORER_DATA_FETCHER_DOCKER_IMAGE_TAG,
     EXPLORER_DATA_FETCHER_PRIVIDIUM_DOCKER_IMAGE_TAG, EXPLORER_WORKER_DOCKER_IMAGE_TAG,
@@ -112,7 +112,7 @@ pub struct ExplorerBackendComposeConfig {
     pub docker_compose: DockerComposeConfig,
 }
 
-impl ZkStackConfigTrait for ExplorerBackendComposeConfig {}
+impl FileConfigTrait for ExplorerBackendComposeConfig {}
 
 impl ExplorerBackendComposeConfig {
     const API_NAME: &'static str = "api";

--- a/zkstack_cli/crates/config/src/forge_interface/accept_ownership/mod.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/accept_ownership/mod.rs
@@ -1,9 +1,9 @@
 use ethers::types::Address;
 use serde::{Deserialize, Serialize};
 
-use crate::traits::ZkStackConfigTrait;
+use crate::traits::FileConfigTrait;
 
-impl ZkStackConfigTrait for AcceptOwnershipInput {}
+impl FileConfigTrait for AcceptOwnershipInput {}
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AcceptOwnershipInput {

--- a/zkstack_cli/crates/config/src/forge_interface/deploy_ecosystem/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/deploy_ecosystem/input.rs
@@ -11,7 +11,7 @@ use zksync_basic_types::{protocol_version::ProtocolSemanticVersion, L2ChainId};
 
 use crate::{
     consts::INITIAL_DEPLOYMENT_FILE,
-    traits::{FileConfigWithDefaultName, ZkStackConfigTrait},
+    traits::{FileConfigTrait, FileConfigWithDefaultName},
     ContractsConfig, GenesisConfig, WalletsConfig, ERC20_DEPLOYMENT_FILE,
 };
 
@@ -89,7 +89,7 @@ impl FileConfigWithDefaultName for InitialDeploymentConfig {
     const FILE_NAME: &'static str = INITIAL_DEPLOYMENT_FILE;
 }
 
-impl ZkStackConfigTrait for InitialDeploymentConfig {}
+impl FileConfigTrait for InitialDeploymentConfig {}
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Erc20DeploymentConfig {
@@ -100,7 +100,7 @@ impl FileConfigWithDefaultName for Erc20DeploymentConfig {
     const FILE_NAME: &'static str = ERC20_DEPLOYMENT_FILE;
 }
 
-impl ZkStackConfigTrait for Erc20DeploymentConfig {}
+impl FileConfigTrait for Erc20DeploymentConfig {}
 
 impl Default for Erc20DeploymentConfig {
     fn default() -> Self {
@@ -144,7 +144,7 @@ pub struct DeployL1Config {
     pub tokens: TokensDeployL1Config,
 }
 
-impl ZkStackConfigTrait for DeployL1Config {}
+impl FileConfigTrait for DeployL1Config {}
 
 impl DeployL1Config {
     pub fn new(
@@ -247,7 +247,7 @@ pub struct DeployErc20Config {
     pub additional_addresses_for_minting: Vec<Address>,
 }
 
-impl ZkStackConfigTrait for DeployErc20Config {}
+impl FileConfigTrait for DeployErc20Config {}
 
 impl DeployErc20Config {
     pub fn new(

--- a/zkstack_cli/crates/config/src/forge_interface/deploy_ecosystem/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/deploy_ecosystem/output.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     consts::ERC20_CONFIGS_FILE,
-    traits::{FileConfigWithDefaultName, ZkStackConfigTrait},
+    traits::{FileConfigTrait, FileConfigWithDefaultName},
 };
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -40,7 +40,7 @@ pub struct DeployL1DeployedAddressesOutput {
     pub server_notifier_proxy_addr: Address,
 }
 
-impl ZkStackConfigTrait for DeployL1Output {}
+impl FileConfigTrait for DeployL1Output {}
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DeployL1ContractsConfigOutput {
@@ -103,4 +103,4 @@ impl FileConfigWithDefaultName for ERC20Tokens {
     const FILE_NAME: &'static str = ERC20_CONFIGS_FILE;
 }
 
-impl ZkStackConfigTrait for ERC20Tokens {}
+impl FileConfigTrait for ERC20Tokens {}

--- a/zkstack_cli/crates/config/src/forge_interface/deploy_gateway_tx_filterer/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/deploy_gateway_tx_filterer/input.rs
@@ -2,7 +2,7 @@ use ethers::types::{Address, H256};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    forge_interface::deploy_ecosystem::input::InitialDeploymentConfig, traits::ZkStackConfigTrait,
+    forge_interface::deploy_ecosystem::input::InitialDeploymentConfig, traits::FileConfigTrait,
     ContractsConfig,
 };
 
@@ -16,7 +16,7 @@ pub struct GatewayTxFiltererInput {
     pub create2_factory_salt: H256,
 }
 
-impl ZkStackConfigTrait for GatewayTxFiltererInput {}
+impl FileConfigTrait for GatewayTxFiltererInput {}
 
 impl GatewayTxFiltererInput {
     pub fn new(

--- a/zkstack_cli/crates/config/src/forge_interface/deploy_gateway_tx_filterer/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/deploy_gateway_tx_filterer/output.rs
@@ -1,7 +1,7 @@
 use ethers::types::Address;
 use serde::{Deserialize, Serialize};
 
-use crate::traits::ZkStackConfigTrait;
+use crate::traits::FileConfigTrait;
 
 /// Represents the output config written after deployment.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -9,4 +9,4 @@ pub struct GatewayTxFiltererOutput {
     pub gateway_tx_filterer_proxy: Address,
 }
 
-impl ZkStackConfigTrait for GatewayTxFiltererOutput {}
+impl FileConfigTrait for GatewayTxFiltererOutput {}

--- a/zkstack_cli/crates/config/src/forge_interface/deploy_l2_contracts/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/deploy_l2_contracts/input.rs
@@ -2,9 +2,9 @@ use ethers::types::Address;
 use serde::{Deserialize, Serialize};
 use zksync_basic_types::{commitment::L1BatchCommitmentMode, L2ChainId, U256};
 
-use crate::{traits::ZkStackConfigTrait, ChainConfig, ContractsConfig, DAValidatorType};
+use crate::{traits::FileConfigTrait, ChainConfig, ContractsConfig, DAValidatorType};
 
-impl ZkStackConfigTrait for DeployL2ContractsInput {}
+impl FileConfigTrait for DeployL2ContractsInput {}
 
 /// Fields corresponding to `contracts/l1-contracts/deploy-script-config-template/config-deploy-l2-config.toml`
 /// which are read by `contracts/l1-contracts/deploy-scripts/DeployL2Contracts.sol`.

--- a/zkstack_cli/crates/config/src/forge_interface/deploy_l2_contracts/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/deploy_l2_contracts/output.rs
@@ -1,16 +1,16 @@
 use ethers::types::Address;
 use serde::{Deserialize, Serialize};
 
-use crate::traits::ZkStackConfigTrait;
+use crate::traits::FileConfigTrait;
 
-impl ZkStackConfigTrait for InitializeBridgeOutput {}
-impl ZkStackConfigTrait for DefaultL2UpgradeOutput {}
-impl ZkStackConfigTrait for ConsensusRegistryOutput {}
-impl ZkStackConfigTrait for Multicall3Output {}
+impl FileConfigTrait for InitializeBridgeOutput {}
+impl FileConfigTrait for DefaultL2UpgradeOutput {}
+impl FileConfigTrait for ConsensusRegistryOutput {}
+impl FileConfigTrait for Multicall3Output {}
 
-impl ZkStackConfigTrait for TimestampAsserterOutput {}
+impl FileConfigTrait for TimestampAsserterOutput {}
 
-impl ZkStackConfigTrait for L2DAValidatorAddressOutput {}
+impl FileConfigTrait for L2DAValidatorAddressOutput {}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InitializeBridgeOutput {

--- a/zkstack_cli/crates/config/src/forge_interface/gateway_preparation/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/gateway_preparation/input.rs
@@ -3,7 +3,7 @@ use ethers::utils::hex;
 use serde::{Deserialize, Serialize};
 use zksync_basic_types::{web3::Bytes, Address};
 
-use crate::{gateway::GatewayConfig, traits::ZkStackConfigTrait, ChainConfig, ContractsConfig};
+use crate::{gateway::GatewayConfig, traits::FileConfigTrait, ChainConfig, ContractsConfig};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GatewayPreparationConfig {
@@ -21,7 +21,7 @@ pub struct GatewayPreparationConfig {
     pub l1_nullifier_proxy_addr: Address,
 }
 
-impl ZkStackConfigTrait for GatewayPreparationConfig {}
+impl FileConfigTrait for GatewayPreparationConfig {}
 
 impl GatewayPreparationConfig {
     pub fn new(

--- a/zkstack_cli/crates/config/src/forge_interface/gateway_vote_preparation/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/gateway_vote_preparation/input.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     forge_interface::deploy_ecosystem::input::{GenesisInput, InitialDeploymentConfig},
-    traits::ZkStackConfigTrait,
+    traits::FileConfigTrait,
     ContractsConfig,
 };
 
@@ -56,7 +56,7 @@ pub struct GatewayVotePreparationConfig {
     pub force_deployments_data: String,
 }
 
-impl ZkStackConfigTrait for GatewayVotePreparationConfig {}
+impl FileConfigTrait for GatewayVotePreparationConfig {}
 
 impl GatewayVotePreparationConfig {
     #[allow(clippy::too_many_arguments)]

--- a/zkstack_cli/crates/config/src/forge_interface/gateway_vote_preparation/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/gateway_vote_preparation/output.rs
@@ -1,7 +1,7 @@
 use ethers::abi::Address;
 use serde::{Deserialize, Serialize};
 
-use crate::traits::ZkStackConfigTrait;
+use crate::traits::FileConfigTrait;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DeployGatewayCTMOutput {
@@ -14,7 +14,7 @@ pub struct DeployGatewayCTMOutput {
     pub ecosystem_admin_calls_to_execute: String,
 }
 
-impl ZkStackConfigTrait for DeployGatewayCTMOutput {}
+impl FileConfigTrait for DeployGatewayCTMOutput {}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct StateTransitionDeployedAddresses {

--- a/zkstack_cli/crates/config/src/forge_interface/paymaster/mod.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/paymaster/mod.rs
@@ -2,7 +2,7 @@ use ethers::types::Address;
 use serde::{Deserialize, Serialize};
 use zksync_basic_types::L2ChainId;
 
-use crate::{traits::ZkStackConfigTrait, ChainConfig};
+use crate::{traits::FileConfigTrait, ChainConfig};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DeployPaymasterInput {
@@ -22,11 +22,11 @@ impl DeployPaymasterInput {
     }
 }
 
-impl ZkStackConfigTrait for DeployPaymasterInput {}
+impl FileConfigTrait for DeployPaymasterInput {}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DeployPaymasterOutput {
     pub paymaster: Address,
 }
 
-impl ZkStackConfigTrait for DeployPaymasterOutput {}
+impl FileConfigTrait for DeployPaymasterOutput {}

--- a/zkstack_cli/crates/config/src/forge_interface/register_chain/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/register_chain/input.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use zkstack_cli_types::L1BatchCommitmentMode;
 use zksync_basic_types::{L2ChainId, H256};
 
-use crate::{traits::ZkStackConfigTrait, ChainConfig, ContractsConfig};
+use crate::{traits::FileConfigTrait, ChainConfig, ContractsConfig};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RegisterChainL1Config {
@@ -66,7 +66,7 @@ pub struct ChainL1Config {
     pub allow_evm_emulator: bool,
 }
 
-impl ZkStackConfigTrait for RegisterChainL1Config {}
+impl FileConfigTrait for RegisterChainL1Config {}
 
 impl RegisterChainL1Config {
     pub fn new(chain_config: &ChainConfig, contracts: &ContractsConfig) -> anyhow::Result<Self> {

--- a/zkstack_cli/crates/config/src/forge_interface/register_chain/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/register_chain/output.rs
@@ -1,7 +1,7 @@
 use ethers::types::Address;
 use serde::{Deserialize, Serialize};
 
-use crate::traits::ZkStackConfigTrait;
+use crate::traits::FileConfigTrait;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RegisterChainOutput {
@@ -13,4 +13,4 @@ pub struct RegisterChainOutput {
     pub chain_proxy_admin_addr: Address,
 }
 
-impl ZkStackConfigTrait for RegisterChainOutput {}
+impl FileConfigTrait for RegisterChainOutput {}

--- a/zkstack_cli/crates/config/src/forge_interface/setup_legacy_bridge/mod.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/setup_legacy_bridge/mod.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use zksync_basic_types::{Address, L2ChainId, H256};
 
-use crate::traits::ZkStackConfigTrait;
+use crate::traits::FileConfigTrait;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SetupLegacyBridgeInput {
@@ -19,4 +19,4 @@ pub struct SetupLegacyBridgeInput {
     pub create2factory_addr: Address,
 }
 
-impl ZkStackConfigTrait for SetupLegacyBridgeInput {}
+impl FileConfigTrait for SetupLegacyBridgeInput {}

--- a/zkstack_cli/crates/config/src/forge_interface/upgrade_ecosystem/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/upgrade_ecosystem/input.rs
@@ -4,7 +4,7 @@ use zksync_basic_types::L2ChainId;
 
 use crate::{
     forge_interface::deploy_ecosystem::input::{GenesisInput, InitialDeploymentConfig},
-    traits::ZkStackConfigTrait,
+    traits::FileConfigTrait,
     ContractsConfig,
 };
 
@@ -37,7 +37,7 @@ pub struct EcosystemUpgradeInput {
     pub specific_config: EcosystemUpgradeSpecificConfig,
 }
 
-impl ZkStackConfigTrait for EcosystemUpgradeInput {}
+impl FileConfigTrait for EcosystemUpgradeInput {}
 
 impl EcosystemUpgradeInput {
     #[allow(clippy::too_many_arguments)]

--- a/zkstack_cli/crates/config/src/forge_interface/upgrade_ecosystem/output.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/upgrade_ecosystem/output.rs
@@ -2,7 +2,7 @@ use ethers::types::{Address, H256};
 use serde::{Deserialize, Serialize};
 use zksync_basic_types::web3::Bytes;
 
-use crate::traits::{FileConfigWithDefaultName, ZkStackConfigTrait};
+use crate::traits::{FileConfigTrait, FileConfigWithDefaultName};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct EcosystemUpgradeOutput {
@@ -111,4 +111,4 @@ pub struct GovernanceCalls {
     pub stage2_calls: Bytes,
 }
 
-impl ZkStackConfigTrait for EcosystemUpgradeOutput {}
+impl FileConfigTrait for EcosystemUpgradeOutput {}

--- a/zkstack_cli/crates/config/src/gateway.rs
+++ b/zkstack_cli/crates/config/src/gateway.rs
@@ -8,7 +8,7 @@ use zksync_basic_types::{web3::Bytes, Address, SLChainId};
 use crate::{
     forge_interface::gateway_vote_preparation::output::DeployGatewayCTMOutput,
     raw::{PatchedConfig, RawConfig},
-    traits::{FileConfigWithDefaultName, ZkStackConfigTrait},
+    traits::{FileConfigTrait, FileConfigWithDefaultName},
     GATEWAY_FILE,
 };
 
@@ -28,7 +28,7 @@ impl FileConfigWithDefaultName for GatewayConfig {
     const FILE_NAME: &'static str = GATEWAY_FILE;
 }
 
-impl ZkStackConfigTrait for GatewayConfig {}
+impl FileConfigTrait for GatewayConfig {}
 
 impl From<DeployGatewayCTMOutput> for GatewayConfig {
     fn from(output: DeployGatewayCTMOutput) -> Self {

--- a/zkstack_cli/crates/config/src/manipulations.rs
+++ b/zkstack_cli/crates/config/src/manipulations.rs
@@ -2,11 +2,14 @@ use std::path::Path;
 
 use xshell::Shell;
 
-use crate::consts::{CONFIGS_PATH, WALLETS_FILE};
+use crate::consts::WALLETS_FILE;
 
-pub fn copy_configs(shell: &Shell, link_to_code: &Path, target_path: &Path) -> anyhow::Result<()> {
-    let original_configs = link_to_code.join(CONFIGS_PATH);
-    for file in shell.read_dir(original_configs)? {
+pub fn copy_configs(
+    shell: &Shell,
+    default_configs: &Path,
+    target_path: &Path,
+) -> anyhow::Result<()> {
+    for file in shell.read_dir(default_configs)? {
         if file.is_dir() {
             continue;
         }

--- a/zkstack_cli/crates/config/src/portal.rs
+++ b/zkstack_cli/crates/config/src/portal.rs
@@ -9,7 +9,7 @@ use crate::{
         LOCAL_APPS_PATH, LOCAL_CONFIGS_PATH, LOCAL_GENERATED_PATH, PORTAL_CONFIG_FILE,
         PORTAL_JS_CONFIG_FILE,
     },
-    traits::{ReadConfig, SaveConfig, ZkStackConfigTrait},
+    traits::{FileConfigTrait, ReadConfig, SaveConfig},
 };
 
 /// Portal JSON configuration file. This file contains configuration for the portal app.
@@ -172,4 +172,4 @@ impl Default for PortalConfig {
     }
 }
 
-impl ZkStackConfigTrait for PortalConfig {}
+impl FileConfigTrait for PortalConfig {}

--- a/zkstack_cli/crates/config/src/traits.rs
+++ b/zkstack_cli/crates/config/src/traits.rs
@@ -8,7 +8,7 @@ use zkstack_cli_common::files::{
 };
 
 // Configs that we use only inside ZK Stack CLI, we don't have protobuf implementation for them.
-pub trait ZkStackConfigTrait {}
+pub trait FileConfigTrait {}
 
 pub trait FileConfigWithDefaultName {
     const FILE_NAME: &'static str;
@@ -18,7 +18,7 @@ pub trait FileConfigWithDefaultName {
     }
 }
 
-impl<T: Serialize + ZkStackConfigTrait> SaveConfig for T {
+impl<T: Serialize + FileConfigTrait> SaveConfig for T {
     fn save(&self, shell: &Shell, path: impl AsRef<Path>) -> anyhow::Result<()> {
         save_with_comment(shell, path, self, "")
     }
@@ -48,7 +48,7 @@ pub trait ReadConfig: Sized {
 
 impl<T> ReadConfig for T
 where
-    T: DeserializeOwned + Clone + ZkStackConfigTrait,
+    T: DeserializeOwned + Clone + FileConfigTrait,
 {
     fn read(shell: &Shell, path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let error_context = || format!("Failed to parse config file {:?}.", path.as_ref());

--- a/zkstack_cli/crates/config/src/wallets.rs
+++ b/zkstack_cli/crates/config/src/wallets.rs
@@ -4,7 +4,7 @@ use zkstack_cli_common::wallets::Wallet;
 
 use crate::{
     consts::WALLETS_FILE,
-    traits::{FileConfigWithDefaultName, ZkStackConfigTrait},
+    traits::{FileConfigTrait, FileConfigWithDefaultName},
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,6 +59,6 @@ pub(crate) struct EthMnemonicConfig {
     pub(crate) base_path: String,
 }
 
-impl ZkStackConfigTrait for EthMnemonicConfig {}
+impl FileConfigTrait for EthMnemonicConfig {}
 
-impl ZkStackConfigTrait for WalletsConfig {}
+impl FileConfigTrait for WalletsConfig {}

--- a/zkstack_cli/crates/config/src/zkstack_config.rs
+++ b/zkstack_cli/crates/config/src/zkstack_config.rs
@@ -3,10 +3,7 @@ use std::path::PathBuf;
 use anyhow::bail;
 use xshell::Shell;
 
-use crate::{
-    consts::L1_CONTRACTS_FOUNDRY, ChainConfig, ChainConfigInternal, EcosystemConfig,
-    EcosystemConfigFromFileError,
-};
+use crate::{ChainConfig, ChainConfigInternal, EcosystemConfig, EcosystemConfigFromFileError};
 
 pub enum ZkStackConfig {
     EcosystemConfig(EcosystemConfig),
@@ -40,14 +37,44 @@ impl ZkStackConfig {
     pub fn ecosystem(shell: &Shell) -> Result<EcosystemConfig, EcosystemConfigFromFileError> {
         EcosystemConfig::from_file(shell)
     }
+}
 
-    pub fn link_to_code(&self) -> PathBuf {
+impl ZkStackConfigTrait for ZkStackConfig {
+    fn link_to_code(&self) -> PathBuf {
         match self {
-            ZkStackConfig::EcosystemConfig(ecosystem) => ecosystem.link_to_code.clone(),
-            ZkStackConfig::ChainConfig(chain) => chain.link_to_code.clone(),
+            ZkStackConfig::EcosystemConfig(ecosystem) => ecosystem.link_to_code().clone(),
+            ZkStackConfig::ChainConfig(chain) => chain.link_to_code().clone(),
         }
     }
-    pub fn path_to_l1_foundry(&self) -> PathBuf {
-        self.link_to_code().join(L1_CONTRACTS_FOUNDRY)
+
+    fn default_configs_path(&self) -> PathBuf {
+        match self {
+            ZkStackConfig::EcosystemConfig(ecosystem) => ecosystem.default_configs_path().clone(),
+            ZkStackConfig::ChainConfig(chain) => chain.default_configs_path().clone(),
+        }
     }
+
+    fn contracts_path(&self) -> PathBuf {
+        match self {
+            ZkStackConfig::EcosystemConfig(ecosystem) => ecosystem.contracts_path().clone(),
+            ZkStackConfig::ChainConfig(chain) => chain.contracts_path().clone(),
+        }
+    }
+
+    fn path_to_l1_foundry(&self) -> PathBuf {
+        match self {
+            ZkStackConfig::EcosystemConfig(ecosystem) => ecosystem.path_to_l1_foundry().clone(),
+            ZkStackConfig::ChainConfig(chain) => chain.path_to_l1_foundry().clone(),
+        }
+    }
+}
+
+pub trait ZkStackConfigTrait {
+    /// Link to the repository, please use it with a caution and prefer specific links
+    fn link_to_code(&self) -> PathBuf;
+
+    fn default_configs_path(&self) -> PathBuf;
+    fn contracts_path(&self) -> PathBuf;
+
+    fn path_to_l1_foundry(&self) -> PathBuf;
 }

--- a/zkstack_cli/crates/zkstack/src/admin_functions.rs
+++ b/zkstack_cli/crates/zkstack/src/admin_functions.rs
@@ -17,7 +17,7 @@ use zkstack_cli_common::{
 };
 use zkstack_cli_config::{
     forge_interface::script_params::ACCEPT_GOVERNANCE_SCRIPT_PARAMS,
-    traits::{ReadConfig, ZkStackConfigTrait},
+    traits::{FileConfigTrait, ReadConfig},
     ChainConfig, ContractsConfig, EcosystemConfig,
 };
 use zksync_basic_types::U256;
@@ -412,7 +412,7 @@ struct AdminScriptOutputInner {
     encoded_data: String,
 }
 
-impl ZkStackConfigTrait for AdminScriptOutputInner {}
+impl FileConfigTrait for AdminScriptOutputInner {}
 
 #[derive(Debug, Clone, Default)]
 pub struct AdminScriptOutput {

--- a/zkstack_cli/crates/zkstack/src/admin_functions.rs
+++ b/zkstack_cli/crates/zkstack/src/admin_functions.rs
@@ -18,7 +18,7 @@ use zkstack_cli_common::{
 use zkstack_cli_config::{
     forge_interface::script_params::ACCEPT_GOVERNANCE_SCRIPT_PARAMS,
     traits::{FileConfigTrait, ReadConfig},
-    ChainConfig, ContractsConfig, EcosystemConfig,
+    ChainConfig, ContractsConfig, EcosystemConfig, ZkStackConfigTrait,
 };
 use zksync_basic_types::U256;
 

--- a/zkstack_cli/crates/zkstack/src/commands/chain/accept_chain_ownership.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/accept_chain_ownership.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use xshell::Shell;
 use zkstack_cli_common::{forge::ForgeScriptArgs, logger, spinner::Spinner};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use crate::{
     admin_functions::accept_admin,

--- a/zkstack_cli/crates/zkstack/src/commands/chain/args/create.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/args/create.rs
@@ -82,7 +82,7 @@ impl ChainCreateArgs {
         number_of_chains: u32,
         l1_network: &L1Network,
         possible_erc20: Vec<Erc20Token>,
-        link_to_code: &str,
+        link_to_code: PathBuf,
     ) -> anyhow::Result<ChainCreateArgsFinal> {
         let mut chain_name = self
             .chain_name
@@ -242,7 +242,7 @@ impl ChainCreateArgs {
             set_as_default,
             legacy_bridge: self.legacy_bridge,
             evm_emulator,
-            link_to_code: link_to_code.to_string(),
+            link_to_code,
             update_submodules: self.update_submodules,
             tight_ports: self.tight_ports,
         })
@@ -261,7 +261,7 @@ pub struct ChainCreateArgsFinal {
     pub set_as_default: bool,
     pub legacy_bridge: bool,
     pub evm_emulator: bool,
-    pub link_to_code: String,
+    pub link_to_code: PathBuf,
     pub update_submodules: Option<bool>,
     pub tight_ports: bool,
 }

--- a/zkstack_cli/crates/zkstack/src/commands/chain/build_transactions.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/build_transactions.rs
@@ -2,7 +2,9 @@ use anyhow::Context;
 use ethers::utils::hex::ToHex;
 use xshell::Shell;
 use zkstack_cli_common::{git, logger, spinner::Spinner};
-use zkstack_cli_config::{copy_configs, traits::SaveConfigWithBasePath, ZkStackConfig};
+use zkstack_cli_config::{
+    copy_configs, traits::SaveConfigWithBasePath, ZkStackConfig, ZkStackConfigTrait,
+};
 
 use crate::{
     commands::chain::{
@@ -29,12 +31,12 @@ pub(crate) async fn run(args: BuildTransactionsArgs, shell: &Shell) -> anyhow::R
         .load_current_chain()
         .context(MSG_CHAIN_NOT_FOUND_ERR)?;
 
-    let args = args.fill_values_with_prompt(config.default_chain.clone());
+    let args = args.fill_values_with_prompt(chain_config.name.clone());
 
-    git::submodule_update(shell, &config.link_to_code)?;
+    git::submodule_update(shell, &config.link_to_code())?;
 
     let spinner = Spinner::new(MSG_PREPARING_CONFIG_SPINNER);
-    copy_configs(shell, &config.link_to_code, &chain_config.configs)?;
+    copy_configs(shell, &config.default_configs_path(), &chain_config.configs)?;
 
     logger::note(MSG_SELECTED_CONFIG, logger::object_to_string(&chain_config));
 
@@ -73,12 +75,12 @@ pub(crate) async fn run(args: BuildTransactionsArgs, shell: &Shell) -> anyhow::R
         .context(MSG_CHAIN_TXN_OUT_PATH_INVALID_ERR)?;
 
     shell.copy_file(
-        config.link_to_code.join(REGISTER_CHAIN_TXNS_FILE_SRC),
+        config.link_to_code().join(REGISTER_CHAIN_TXNS_FILE_SRC),
         args.out.join(REGISTER_CHAIN_TXNS_FILE_DST),
     )?;
 
     shell.copy_file(
-        config.link_to_code.join(SCRIPT_CONFIG_FILE_SRC),
+        config.link_to_code().join(SCRIPT_CONFIG_FILE_SRC),
         args.out.join(SCRIPT_CONFIG_FILE_DST),
     )?;
     spinner.finish();

--- a/zkstack_cli/crates/zkstack/src/commands/chain/build_transactions.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/build_transactions.rs
@@ -19,10 +19,10 @@ use crate::{
 };
 
 pub const REGISTER_CHAIN_TXNS_FILE_SRC: &str =
-    "contracts/l1-contracts/broadcast/RegisterZKChain.s.sol/9/dry-run/run-latest.json";
+    "l1-contracts/broadcast/RegisterZKChain.s.sol/9/dry-run/run-latest.json";
 pub const REGISTER_CHAIN_TXNS_FILE_DST: &str = "register-zk-chain-txns.json";
 
-const SCRIPT_CONFIG_FILE_SRC: &str = "contracts/l1-contracts/script-config/register-zk-chain.toml";
+const SCRIPT_CONFIG_FILE_SRC: &str = "l1-contracts/script-config/register-zk-chain.toml";
 const SCRIPT_CONFIG_FILE_DST: &str = "register-zk-chain.toml";
 
 pub(crate) async fn run(args: BuildTransactionsArgs, shell: &Shell) -> anyhow::Result<()> {
@@ -75,12 +75,12 @@ pub(crate) async fn run(args: BuildTransactionsArgs, shell: &Shell) -> anyhow::R
         .context(MSG_CHAIN_TXN_OUT_PATH_INVALID_ERR)?;
 
     shell.copy_file(
-        config.link_to_code().join(REGISTER_CHAIN_TXNS_FILE_SRC),
+        config.contracts_path().join(REGISTER_CHAIN_TXNS_FILE_SRC),
         args.out.join(REGISTER_CHAIN_TXNS_FILE_DST),
     )?;
 
     shell.copy_file(
-        config.link_to_code().join(SCRIPT_CONFIG_FILE_SRC),
+        config.contracts_path().join(SCRIPT_CONFIG_FILE_SRC),
         args.out.join(SCRIPT_CONFIG_FILE_DST),
     )?;
     spinner.finish();

--- a/zkstack_cli/crates/zkstack/src/commands/chain/deploy_l2_contracts.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/deploy_l2_contracts.rs
@@ -19,7 +19,7 @@ use zkstack_cli_config::{
         script_params::DEPLOY_L2_CONTRACTS_SCRIPT_PARAMS,
     },
     traits::{ReadConfig, SaveConfig, SaveConfigWithBasePath},
-    ChainConfig, ContractsConfig, EcosystemConfig, ZkStackConfig,
+    ChainConfig, ContractsConfig, EcosystemConfig, ZkStackConfig, ZkStackConfigTrait,
 };
 
 use crate::{
@@ -132,7 +132,7 @@ async fn build_and_deploy(
     mut update_config: impl FnMut(&Shell, &Path) -> anyhow::Result<()>,
     with_broadcast: bool,
 ) -> anyhow::Result<()> {
-    build_l2_contracts(shell.clone(), &ecosystem_config.link_to_code)?;
+    build_l2_contracts(shell.clone(), &ecosystem_config.contracts_path())?;
     call_forge(
         shell,
         chain_config,

--- a/zkstack_cli/crates/zkstack/src/commands/chain/deploy_paymaster.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/deploy_paymaster.rs
@@ -6,7 +6,7 @@ use zkstack_cli_config::{
         script_params::DEPLOY_PAYMASTER_SCRIPT_PARAMS,
     },
     traits::{ReadConfig, SaveConfig, SaveConfigWithBasePath},
-    ChainConfig, ContractsConfig, ZkStackConfig,
+    ChainConfig, ContractsConfig, ZkStackConfig, ZkStackConfigTrait,
 };
 
 use crate::utils::forge::{check_the_balance, fill_forge_private_key, WalletOwner};
@@ -30,7 +30,7 @@ pub async fn deploy_paymaster(
     let foundry_contracts_path = chain_config.path_to_l1_foundry();
     input.save(
         shell,
-        DEPLOY_PAYMASTER_SCRIPT_PARAMS.input(&chain_config.path_to_l1_foundry()),
+        DEPLOY_PAYMASTER_SCRIPT_PARAMS.input(&foundry_contracts_path),
     )?;
     let secrets = chain_config.get_secrets_config().await?;
 
@@ -58,7 +58,7 @@ pub async fn deploy_paymaster(
 
     let output = DeployPaymasterOutput::read(
         shell,
-        DEPLOY_PAYMASTER_SCRIPT_PARAMS.output(&chain_config.path_to_l1_foundry()),
+        DEPLOY_PAYMASTER_SCRIPT_PARAMS.output(&foundry_contracts_path),
     )?;
 
     contracts_config.l2.testnet_paymaster_addr = output.paymaster;

--- a/zkstack_cli/crates/zkstack/src/commands/chain/enable_evm_emulator.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/enable_evm_emulator.rs
@@ -1,6 +1,6 @@
 use xshell::Shell;
 use zkstack_cli_common::{forge::ForgeScriptArgs, logger};
-use zkstack_cli_config::{EcosystemConfig, GenesisConfig, ZkStackConfig, GENESIS_FILE};
+use zkstack_cli_config::{GenesisConfig, ZkStackConfig, ZkStackConfigTrait, GENESIS_FILE};
 
 use crate::{
     enable_evm_emulator::enable_evm_emulator,
@@ -10,8 +10,7 @@ use crate::{
 pub async fn run(args: ForgeScriptArgs, shell: &Shell) -> anyhow::Result<()> {
     let chain_config = ZkStackConfig::current_chain(shell)?;
 
-    let genesis_config_path =
-        EcosystemConfig::default_configs_path(&chain_config.link_to_code).join(GENESIS_FILE);
+    let genesis_config_path = chain_config.default_configs_path().join(GENESIS_FILE);
     let default_genesis_config = GenesisConfig::read(shell, &genesis_config_path).await?;
 
     let has_evm_emulation_support = default_genesis_config.evm_emulator_hash()?.is_some();

--- a/zkstack_cli/crates/zkstack/src/commands/chain/gateway/convert_to_gateway.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/gateway/convert_to_gateway.rs
@@ -10,7 +10,6 @@ use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use xshell::Shell;
 use zkstack_cli_common::{
-    config::global_config,
     ethereum::get_ethers_provider,
     forge::{Forge, ForgeScriptArgs},
     wallets::Wallet,
@@ -25,7 +24,7 @@ use zkstack_cli_config::{
     },
     override_config,
     traits::{ReadConfig, SaveConfig, SaveConfigWithBasePath},
-    ChainConfig, EcosystemConfig, GatewayConfig, ZkStackConfig,
+    ChainConfig, EcosystemConfig, GatewayConfig, ZkStackConfig, ZkStackConfigTrait,
 };
 use zkstack_cli_types::ProverMode;
 
@@ -75,10 +74,9 @@ fn parse_decimal_u256(s: &str) -> Result<U256, String> {
 
 pub async fn run(convert_to_gw_args: ConvertToGatewayArgs, shell: &Shell) -> anyhow::Result<()> {
     let args = convert_to_gw_args.forge_args;
-    let chain_name = global_config().chain_name.clone();
     let ecosystem_config = ZkStackConfig::ecosystem(shell)?;
     let chain_config = ecosystem_config
-        .load_chain(chain_name)
+        .load_current_chain()
         .context(MSG_CHAIN_NOT_INITIALIZED)?;
     let l1_url = chain_config.get_secrets_config().await?.l1_rpc_url()?;
     let chain_contracts_config = chain_config.get_contracts_config()?;
@@ -87,7 +85,7 @@ pub async fn run(convert_to_gw_args: ConvertToGatewayArgs, shell: &Shell) -> any
     override_config(
         shell,
         &ecosystem_config
-            .link_to_code
+            .default_configs_path()
             .join(PATH_TO_GATEWAY_OVERRIDE_CONFIG),
         &chain_config,
     )?;

--- a/zkstack_cli/crates/zkstack/src/commands/chain/gateway/create_tx_filterer.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/gateway/create_tx_filterer.rs
@@ -15,7 +15,7 @@ use zkstack_cli_config::{
         script_params::DEPLOY_GATEWAY_TX_FILTERER,
     },
     traits::{ReadConfig, SaveConfig, SaveConfigWithBasePath},
-    ChainConfig, EcosystemConfig, ZkStackConfig,
+    ChainConfig, EcosystemConfig, ZkStackConfig, ZkStackConfigTrait,
 };
 
 use crate::{

--- a/zkstack_cli/crates/zkstack/src/commands/chain/gateway/finalize_chain_migration_from_gw.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/gateway/finalize_chain_migration_from_gw.rs
@@ -9,6 +9,7 @@ use xshell::Shell;
 use zkstack_cli_common::{
     ethereum::get_zk_client, logger, wallets::Wallet, zks_provider::ZKSProvider,
 };
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 use zksync_types::L2_BRIDGEHUB_ADDRESS;
 
 use super::{
@@ -19,7 +20,6 @@ use super::{
     messages::message_for_gateway_migration_progress_state,
     migrate_from_gateway::finish_migrate_chain_from_gateway,
 };
-use crate::commands::chain::utils::get_default_foundry_path;
 
 lazy_static! {
     static ref GATEWAY_UTILS_INTERFACE: BaseContract = BaseContract::from(
@@ -99,11 +99,12 @@ pub async fn run(
     let withdrawal_params = gateway_zk_client
         .get_finalize_withdrawal_params(migraiton_tx, 0)
         .await?;
+    let foundry_contracts_path = ZkStackConfig::from_file(shell)?.path_to_l1_foundry();
 
     finish_migrate_chain_from_gateway(
         shell,
         Default::default(),
-        &get_default_foundry_path(shell)?,
+        &foundry_contracts_path,
         Wallet::new(
             params
                 .private_key

--- a/zkstack_cli/crates/zkstack/src/commands/chain/gateway/gateway_common.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/gateway/gateway_common.rs
@@ -15,7 +15,7 @@ use zkstack_cli_common::{
     forge::ForgeScriptArgs,
     logger,
 };
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 use zksync_basic_types::{Address, H256, U256, U64};
 use zksync_system_constants::L2_BRIDGEHUB_ADDRESS;
 use zksync_types::{

--- a/zkstack_cli/crates/zkstack/src/commands/chain/gateway/grant_gateway_whitelist.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/gateway/grant_gateway_whitelist.rs
@@ -1,11 +1,12 @@
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 use xshell::Shell;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 use zksync_types::Address;
 
 use crate::{
     admin_functions::{grant_gateway_whitelist, AdminScriptMode},
-    commands::chain::utils::{display_admin_script_output, get_default_foundry_path},
+    commands::chain::utils::display_admin_script_output,
 };
 
 #[derive(Debug, Serialize, Deserialize, Parser)]
@@ -21,12 +22,13 @@ pub struct GrantGatewayWhitelistCalldataArgs {
 }
 
 pub async fn run(shell: &Shell, args: GrantGatewayWhitelistCalldataArgs) -> anyhow::Result<()> {
+    let foundry_path = ZkStackConfig::from_file(shell)?.path_to_l1_foundry();
     let result = grant_gateway_whitelist(
         shell,
         // We do not care about forge args that much here, since
         // we only need to obtain the calldata
         &Default::default(),
-        &get_default_foundry_path(shell)?,
+        &foundry_path,
         AdminScriptMode::OnlySave,
         args.gateway_chain_id,
         args.bridgehub_addr,

--- a/zkstack_cli/crates/zkstack/src/commands/chain/gateway/migrate_from_gateway.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/gateway/migrate_from_gateway.rs
@@ -15,7 +15,6 @@ use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use xshell::Shell;
 use zkstack_cli_common::{
-    config::global_config,
     ethereum::{get_ethers_provider, get_zk_client},
     forge::{Forge, ForgeScriptArgs},
     logger,
@@ -24,7 +23,7 @@ use zkstack_cli_common::{
     zks_provider::{FinalizeWithdrawalParams, ZKSProvider},
 };
 use zkstack_cli_config::{
-    forge_interface::script_params::GATEWAY_UTILS_SCRIPT_PATH, ZkStackConfig,
+    forge_interface::script_params::GATEWAY_UTILS_SCRIPT_PATH, ZkStackConfig, ZkStackConfigTrait,
 };
 use zksync_basic_types::{H256, U256};
 use zksync_web3_decl::{
@@ -71,9 +70,8 @@ lazy_static! {
 pub async fn run(args: MigrateFromGatewayArgs, shell: &Shell) -> anyhow::Result<()> {
     let ecosystem_config = ZkStackConfig::ecosystem(shell)?;
 
-    let chain_name = global_config().chain_name.clone();
     let chain_config = ecosystem_config
-        .load_chain(chain_name)
+        .load_current_chain()
         .context(MSG_CHAIN_NOT_INITIALIZED)?;
 
     let gateway_chain_config = ecosystem_config

--- a/zkstack_cli/crates/zkstack/src/commands/chain/gateway/migrate_from_gateway_calldata.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/gateway/migrate_from_gateway_calldata.rs
@@ -8,7 +8,7 @@ use ethers::{
 use lazy_static::lazy_static;
 use xshell::Shell;
 use zkstack_cli_common::{ethereum::get_ethers_provider, logger};
-use zkstack_cli_config::{traits::ReadConfig, ContractsConfig};
+use zkstack_cli_config::{traits::ReadConfig, ContractsConfig, ZkStackConfig, ZkStackConfigTrait};
 
 use super::{
     gateway_common::{
@@ -19,7 +19,7 @@ use super::{
 use crate::{
     abi::{BridgehubAbi, ZkChainAbi},
     admin_functions::{start_migrate_chain_from_gateway, AdminScriptMode},
-    commands::chain::utils::{display_admin_script_output, get_default_foundry_path},
+    commands::chain::utils::display_admin_script_output,
 };
 
 lazy_static! {
@@ -64,7 +64,7 @@ pub struct MigrateFromGatewayCalldataArgs {
 ///
 pub async fn run(shell: &Shell, params: MigrateFromGatewayCalldataArgs) -> anyhow::Result<()> {
     let forge_args = Default::default();
-    let contracts_foundry_path = get_default_foundry_path(shell)?;
+    let contracts_foundry_path = ZkStackConfig::from_file(shell)?.path_to_l1_foundry();
 
     if !params.no_cross_check {
         let state = get_gateway_migration_state(

--- a/zkstack_cli/crates/zkstack/src/commands/chain/gateway/migrate_to_gateway.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/gateway/migrate_to_gateway.rs
@@ -5,7 +5,7 @@ use xshell::Shell;
 use zkstack_cli_common::{
     config::global_config, ethereum::get_ethers_provider, forge::ForgeScriptArgs, logger,
 };
-use zkstack_cli_config::{GatewayChainConfigPatch, ZkStackConfig};
+use zkstack_cli_config::{GatewayChainConfigPatch, ZkStackConfig, ZkStackConfigTrait};
 use zkstack_cli_types::L1BatchCommitmentMode;
 use zksync_basic_types::U256;
 use zksync_system_constants::L2_BRIDGEHUB_ADDRESS;

--- a/zkstack_cli/crates/zkstack/src/commands/chain/gateway/migrate_to_gateway_calldata.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/gateway/migrate_to_gateway_calldata.rs
@@ -8,7 +8,7 @@ use ethers::{
 };
 use xshell::Shell;
 use zkstack_cli_common::{ethereum::get_ethers_provider, forge::ForgeScriptArgs, logger};
-use zkstack_cli_config::{traits::ReadConfig, GatewayConfig};
+use zkstack_cli_config::{traits::ReadConfig, GatewayConfig, ZkStackConfig, ZkStackConfigTrait};
 use zksync_basic_types::{Address, H256, U256};
 use zksync_system_constants::{L2_BRIDGEHUB_ADDRESS, L2_CHAIN_ASSET_HANDLER_ADDRESS};
 use zksync_types::ProtocolVersionId;
@@ -25,10 +25,7 @@ use crate::{
         admin_l1_l2_tx, enable_validator_via_gateway, finalize_migrate_to_gateway,
         set_da_validator_pair_via_gateway, AdminScriptOutput,
     },
-    commands::chain::{
-        admin_call_builder::AdminCall,
-        utils::{display_admin_script_output, get_default_foundry_path},
-    },
+    commands::chain::{admin_call_builder::AdminCall, utils::display_admin_script_output},
     utils::addresses::apply_l1_to_l2_alias,
 };
 
@@ -342,7 +339,7 @@ impl MigrateToGatewayCalldataArgs {
 ///
 pub async fn run(shell: &Shell, params: MigrateToGatewayCalldataArgs) -> anyhow::Result<()> {
     let forge_args = Default::default();
-    let contracts_foundry_path = get_default_foundry_path(shell)?;
+    let contracts_foundry_path = ZkStackConfig::from_file(shell)?.path_to_l1_foundry();
 
     let should_cross_check = !params.no_cross_check.unwrap_or_default();
 

--- a/zkstack_cli/crates/zkstack/src/commands/chain/gateway/notify_server_calldata.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/gateway/notify_server_calldata.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use serde::{Deserialize, Serialize};
 use xshell::Shell;
 use zkstack_cli_common::{forge::ForgeScriptArgs, logger};
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 use zksync_types::Address;
 
 use super::{
@@ -18,7 +19,7 @@ use crate::{
         notify_server_migration_from_gateway, notify_server_migration_to_gateway, AdminScriptMode,
         AdminScriptOutput,
     },
-    commands::chain::utils::{display_admin_script_output, get_default_foundry_path},
+    commands::chain::utils::display_admin_script_output,
 };
 
 #[derive(Debug, Serialize, Deserialize, Parser)]
@@ -108,13 +109,14 @@ pub async fn run(
             }
         }
     }
+    let contracts_foundry_path = ZkStackConfig::from_file(shell)?.path_to_l1_foundry();
 
     let result = get_notify_server_calls(
         shell,
         // We do not care about forge args that much here, since
         // we only need to obtain the calldata
         &Default::default(),
-        &get_default_foundry_path(shell)?,
+        &contracts_foundry_path,
         args.params,
         direction,
     )

--- a/zkstack_cli/crates/zkstack/src/commands/chain/genesis/database.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/genesis/database.rs
@@ -7,7 +7,9 @@ use zkstack_cli_common::{
     db::{drop_db_if_exists, init_db, migrate_db, DatabaseConfig},
     logger,
 };
-use zkstack_cli_config::{override_config, ChainConfig, FileArtifacts, ZkStackConfig};
+use zkstack_cli_config::{
+    override_config, ChainConfig, FileArtifacts, ZkStackConfig, ZkStackConfigTrait,
+};
 use zkstack_cli_types::ProverMode;
 use zksync_basic_types::commitment::L1BatchCommitmentMode;
 
@@ -35,7 +37,7 @@ pub async fn run(args: GenesisArgs, shell: &Shell) -> anyhow::Result<()> {
     initialize_server_database(
         shell,
         &args.server_db,
-        &chain_config.link_to_code,
+        &chain_config.link_to_code(),
         args.dont_drop,
     )
     .await?;
@@ -93,11 +95,12 @@ pub async fn update_configs(
     general.set_file_artifacts(file_artifacts)?;
     general.save().await?;
 
-    let link_to_code = &config.link_to_code;
     if config.prover_version != ProverMode::NoProofs {
         override_config(
             shell,
-            &link_to_code.join(PATH_TO_ONLY_REAL_PROOFS_OVERRIDE_CONFIG),
+            &config
+                .default_configs_path()
+                .join(PATH_TO_ONLY_REAL_PROOFS_OVERRIDE_CONFIG),
             config,
         )?;
     }
@@ -106,7 +109,9 @@ pub async fn update_configs(
     {
         override_config(
             shell,
-            &link_to_code.join(PATH_TO_VALIDIUM_OVERRIDE_CONFIG),
+            &config
+                .default_configs_path()
+                .join(PATH_TO_VALIDIUM_OVERRIDE_CONFIG),
             config,
         )?;
     }

--- a/zkstack_cli/crates/zkstack/src/commands/chain/genesis/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/genesis/mod.rs
@@ -1,7 +1,7 @@
 use clap::{command, Parser, Subcommand};
 use xshell::Shell;
 use zkstack_cli_common::{logger, spinner::Spinner};
-use zkstack_cli_config::{ChainConfig, ZkStackConfig};
+use zkstack_cli_config::{ChainConfig, ZkStackConfig, ZkStackConfigTrait};
 
 use crate::{
     commands::chain::{
@@ -72,8 +72,13 @@ pub async fn genesis(
     logger::info(MSG_STARTING_GENESIS);
 
     let spinner = Spinner::new(MSG_INITIALIZING_DATABASES_SPINNER);
-    initialize_server_database(shell, &args.server_db, &config.link_to_code, args.dont_drop)
-        .await?;
+    initialize_server_database(
+        shell,
+        &args.server_db,
+        &config.link_to_code(),
+        args.dont_drop,
+    )
+    .await?;
     spinner.finish();
 
     let spinner = Spinner::new(MSG_STARTING_GENESIS_SPINNER);

--- a/zkstack_cli/crates/zkstack/src/commands/chain/genesis/server.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/genesis/server.rs
@@ -7,7 +7,7 @@ use zkstack_cli_common::{
 };
 use zkstack_cli_config::{
     traits::FileConfigWithDefaultName, ChainConfig, ContractsConfig, WalletsConfig, ZkStackConfig,
-    GENERAL_FILE, GENESIS_FILE, SECRETS_FILE,
+    ZkStackConfigTrait, GENERAL_FILE, GENESIS_FILE, SECRETS_FILE,
 };
 
 use crate::messages::{
@@ -33,7 +33,7 @@ pub fn run_server_genesis(
     let server = Server::new(
         server_command,
         None,
-        chain_config.link_to_code.clone(),
+        chain_config.link_to_code().clone(),
         false,
     );
     server

--- a/zkstack_cli/crates/zkstack/src/commands/chain/init/configs.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/init/configs.rs
@@ -4,6 +4,7 @@ use zkstack_cli_common::logger;
 use zkstack_cli_config::{
     copy_configs, traits::SaveConfigWithBasePath, ChainConfig, ConsensusGenesisSpecs,
     ContractsConfig, EcosystemConfig, RawConsensusKeys, Weighted, ZkStackConfig,
+    ZkStackConfigTrait,
 };
 use zksync_basic_types::Address;
 
@@ -48,7 +49,11 @@ pub async fn init_configs(
 ) -> anyhow::Result<ContractsConfig> {
     // Port scanner should run before copying configs to avoid marking initial ports as assigned
     let mut ecosystem_ports = EcosystemPortsScanner::scan(shell, Some(&chain_config.name))?;
-    copy_configs(shell, &ecosystem_config.link_to_code, &chain_config.configs)?;
+    copy_configs(
+        shell,
+        &ecosystem_config.default_configs_path(),
+        &chain_config.configs,
+    )?;
 
     if !init_args.no_port_reallocation {
         ecosystem_ports.allocate_ports_in_yaml(

--- a/zkstack_cli/crates/zkstack/src/commands/chain/init/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/init/mod.rs
@@ -3,7 +3,7 @@ use clap::{command, Parser, Subcommand};
 use xshell::Shell;
 use zkstack_cli_common::{git, logger, spinner::Spinner};
 use zkstack_cli_config::{
-    traits::SaveConfigWithBasePath, ChainConfig, EcosystemConfig, ZkStackConfig,
+    traits::SaveConfigWithBasePath, ChainConfig, EcosystemConfig, ZkStackConfig, ZkStackConfigTrait,
 };
 use zkstack_cli_types::{BaseToken, L1BatchCommitmentMode};
 use zksync_basic_types::Address;
@@ -64,7 +64,7 @@ async fn run_init(args: InitArgs, shell: &Shell) -> anyhow::Result<()> {
         .context(MSG_CHAIN_NOT_FOUND_ERR)?;
 
     if args.update_submodules.is_none() || args.update_submodules == Some(true) {
-        git::submodule_update(shell, &config.link_to_code)?;
+        git::submodule_update(shell, &config.link_to_code())?;
     }
 
     let args = args.fill_values_with_prompt(&chain_config);

--- a/zkstack_cli/crates/zkstack/src/commands/chain/register_chain.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/register_chain.rs
@@ -11,7 +11,7 @@ use zkstack_cli_config::{
         script_params::REGISTER_CHAIN_SCRIPT_PARAMS,
     },
     traits::{ReadConfig, SaveConfig, SaveConfigWithBasePath},
-    ChainConfig, ContractsConfig, EcosystemConfig, ZkStackConfig,
+    ChainConfig, ContractsConfig, EcosystemConfig, ZkStackConfig, ZkStackConfigTrait,
 };
 
 use crate::{

--- a/zkstack_cli/crates/zkstack/src/commands/chain/set_da_validator_pair.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/set_da_validator_pair.rs
@@ -6,7 +6,7 @@ use xshell::Shell;
 use zkstack_cli_common::{
     ethereum::get_ethers_provider, forge::ForgeScriptArgs, logger, spinner::Spinner,
 };
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 use zksync_basic_types::Address;
 use zksync_system_constants::L2_BRIDGEHUB_ADDRESS;
 use zksync_web3_decl::jsonrpsee::core::Serialize;
@@ -14,7 +14,6 @@ use zksync_web3_decl::jsonrpsee::core::Serialize;
 use crate::{
     abi::{BridgehubAbi, ZkChainAbi},
     admin_functions::{set_da_validator_pair, set_da_validator_pair_via_gateway, AdminScriptMode},
-    commands::chain::utils::get_default_foundry_path,
     messages::{
         MSG_CHAIN_NOT_INITIALIZED, MSG_DA_VALIDATOR_PAIR_UPDATED_TO,
         MSG_GATEWAY_URL_MUST_BE_PRESET, MSG_GOT_SETTLEMENT_LAYER_ADDRESS_FROM_GW,
@@ -85,10 +84,12 @@ pub async fn run(args: SetDAValidatorPairArgs, shell: &Shell) -> anyhow::Result<
             .await?
             .as_u64();
         let refund_recipient = chain_config.get_wallets_config()?.governor.address;
+        let contracts_foundry_path = ZkStackConfig::from_file(shell)?.path_to_l1_foundry();
+
         set_da_validator_pair_via_gateway(
             shell,
             &args.forge_args.clone(),
-            &get_default_foundry_path(shell)?,
+            &contracts_foundry_path,
             AdminScriptMode::Broadcast(chain_config.get_wallets_config()?.governor),
             contracts_config.ecosystem_contracts.bridgehub_proxy_addr,
             args.max_l1_gas_price

--- a/zkstack_cli/crates/zkstack/src/commands/chain/set_da_validator_pair_calldata.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/set_da_validator_pair_calldata.rs
@@ -4,9 +4,10 @@ use ethers::providers::Middleware;
 use serde::{Deserialize, Serialize};
 use xshell::Shell;
 use zkstack_cli_common::{ethereum::get_ethers_provider, logger};
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 use zksync_types::{Address, L2_BRIDGEHUB_ADDRESS};
 
-use super::utils::{display_admin_script_output, get_default_foundry_path};
+use super::utils::display_admin_script_output;
 use crate::{
     abi::BridgehubAbi,
     admin_functions::{set_da_validator_pair, set_da_validator_pair_via_gateway, AdminScriptMode},
@@ -103,11 +104,12 @@ pub async fn run(shell: &Shell, args: SetDAValidatorPairCalldataArgs) -> anyhow:
         if chain_diamond_proxy_on_gateway == Address::zero() {
             anyhow::bail!("The chain does not settle on GW yet, the address is known");
         }
+        let contracts_foundry_path = ZkStackConfig::from_file(shell)?.path_to_l1_foundry();
 
         let output = set_da_validator_pair_via_gateway(
             shell,
             &Default::default(),
-            &get_default_foundry_path(shell)?,
+            &contracts_foundry_path,
             AdminScriptMode::OnlySave,
             args.bridgehub_address,
             args.max_l1_gas_price

--- a/zkstack_cli/crates/zkstack/src/commands/chain/set_pubdata_pricing_mode.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/set_pubdata_pricing_mode.rs
@@ -12,6 +12,7 @@ use zkstack_cli_common::{
 };
 use zkstack_cli_config::{
     forge_interface::script_params::ACCEPT_GOVERNANCE_SCRIPT_PARAMS, ZkStackConfig,
+    ZkStackConfigTrait,
 };
 use zksync_basic_types::Address;
 

--- a/zkstack_cli/crates/zkstack/src/commands/chain/set_token_multiplier_setter.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/set_token_multiplier_setter.rs
@@ -12,6 +12,7 @@ use zkstack_cli_common::{
 };
 use zkstack_cli_config::{
     forge_interface::script_params::ACCEPT_GOVERNANCE_SCRIPT_PARAMS, ZkStackConfig,
+    ZkStackConfigTrait,
 };
 use zksync_basic_types::Address;
 

--- a/zkstack_cli/crates/zkstack/src/commands/chain/set_transaction_filterer.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/set_transaction_filterer.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 use xshell::Shell;
+use zkstack_cli_config::ZkStackConfigTrait;
 use zksync_types::Address;
 
 use super::utils::display_admin_script_output;

--- a/zkstack_cli/crates/zkstack/src/commands/chain/setup_legacy_bridge.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/setup_legacy_bridge.rs
@@ -9,7 +9,7 @@ use zkstack_cli_config::{
         script_params::SETUP_LEGACY_BRIDGE, setup_legacy_bridge::SetupLegacyBridgeInput,
     },
     traits::SaveConfig,
-    ChainConfig, ContractsConfig, EcosystemConfig,
+    ChainConfig, ContractsConfig, EcosystemConfig, ZkStackConfigTrait,
 };
 
 use crate::{

--- a/zkstack_cli/crates/zkstack/src/commands/chain/utils.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/utils.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use anyhow::Context;
 use ethers::{
     abi::encode,
@@ -9,9 +7,7 @@ use ethers::{
     types::{TransactionReceipt, TransactionRequest},
     utils::hex,
 };
-use xshell::Shell;
 use zkstack_cli_common::{logger, spinner::Spinner};
-use zkstack_cli_config::ZkStackConfig;
 use zksync_types::{web3::keccak256, Address, H256, L2_NATIVE_TOKEN_VAULT_ADDRESS, U256};
 
 use crate::{
@@ -26,10 +22,6 @@ pub fn encode_ntv_asset_id(l1_chain_id: U256, addr: Address) -> H256 {
     ]);
 
     H256(keccak256(&encoded_data))
-}
-
-pub fn get_default_foundry_path(shell: &Shell) -> anyhow::Result<PathBuf> {
-    Ok(ZkStackConfig::ecosystem(shell)?.path_to_l1_foundry())
 }
 
 pub fn display_admin_script_output(result: AdminScriptOutput) {

--- a/zkstack_cli/crates/zkstack/src/commands/containers.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/containers.rs
@@ -3,7 +3,9 @@ use std::path::Path;
 use anyhow::{anyhow, Context};
 use xshell::Shell;
 use zkstack_cli_common::{docker, logger, spinner::Spinner};
-use zkstack_cli_config::{ZkStackConfig, DOCKER_COMPOSE_FILE, ERA_OBSERVABILITY_COMPOSE_FILE};
+use zkstack_cli_config::{
+    ZkStackConfig, ZkStackConfigTrait, DOCKER_COMPOSE_FILE, ERA_OBSERVABILITY_COMPOSE_FILE,
+};
 
 use super::args::ContainersArgs;
 use crate::{
@@ -19,7 +21,7 @@ pub fn run(shell: &Shell, args: ContainersArgs) -> anyhow::Result<()> {
     let args = args.fill_values_with_prompt();
     let chain = ZkStackConfig::current_chain(shell).context(MSG_FAILED_TO_FIND_ECOSYSTEM_ERR)?;
 
-    initialize_docker(shell, &chain.link_to_code)?;
+    initialize_docker(shell, &chain.link_to_code())?;
 
     logger::info(MSG_STARTING_CONTAINERS);
 

--- a/zkstack_cli/crates/zkstack/src/commands/contract_verifier/build.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/contract_verifier/build.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, logger};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use crate::messages::{
     MSG_BUILDING_CONTRACT_VERIFIER, MSG_CHAIN_NOT_FOUND_ERR,
@@ -13,7 +13,7 @@ pub(crate) async fn build(shell: &Shell) -> anyhow::Result<()> {
     let chain = ecosystem
         .load_current_chain()
         .context(MSG_CHAIN_NOT_FOUND_ERR)?;
-    let _dir_guard = shell.push_dir(chain.link_to_code.join("core"));
+    let _dir_guard = shell.push_dir(chain.link_to_code().join("core"));
 
     logger::info(MSG_BUILDING_CONTRACT_VERIFIER);
 

--- a/zkstack_cli/crates/zkstack/src/commands/contract_verifier/init.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/contract_verifier/init.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use super::args::{init::InitContractVerifierArgs, releases::Version};
 use crate::messages::{msg_binary_already_exists, msg_downloading_binary_spinner};
@@ -11,7 +11,7 @@ pub(crate) async fn run(shell: &Shell, args: InitContractVerifierArgs) -> anyhow
     let args = args.fill_values_with_prompt(shell)?;
     // Todo allow to provide link to code as an argument
     let ecosystem = ZkStackConfig::ecosystem(shell)?;
-    let link_to_code = ecosystem.link_to_code;
+    let link_to_code = ecosystem.link_to_code();
 
     download_binaries(
         shell,

--- a/zkstack_cli/crates/zkstack/src/commands/contract_verifier/run.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/contract_verifier/run.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, logger};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use crate::messages::{MSG_FAILED_TO_RUN_CONTRACT_VERIFIER_ERR, MSG_RUNNING_CONTRACT_VERIFIER};
 
@@ -11,7 +11,7 @@ pub(crate) async fn run(shell: &Shell) -> anyhow::Result<()> {
     let config_path = chain.path_to_general_config();
     let secrets_path = chain.path_to_secrets_config();
 
-    let _dir_guard = shell.push_dir(&chain.link_to_code);
+    let _dir_guard = shell.push_dir(chain.link_to_code());
 
     logger::info(MSG_RUNNING_CONTRACT_VERIFIER);
 

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/clean/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/clean/mod.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use clap::Subcommand;
 use xshell::Shell;
 use zkstack_cli_common::{docker, logger};
-use zkstack_cli_config::{ZkStackConfig, DOCKER_COMPOSE_FILE};
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait, DOCKER_COMPOSE_FILE};
 
 use crate::commands::dev::messages::{
     MSG_CONTRACTS_CLEANING, MSG_CONTRACTS_CLEANING_FINISHED, MSG_DOCKER_COMPOSE_DOWN,

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/contracts.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/contracts.rs
@@ -9,7 +9,7 @@ use zkstack_cli_common::{
     logger,
     spinner::Spinner,
 };
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use crate::commands::dev::messages::{
     MSG_BUILDING_CONTRACTS, MSG_BUILDING_CONTRACTS_SUCCESS, MSG_BUILDING_L1_CONTRACTS_SPINNER,
@@ -79,27 +79,27 @@ struct ContractBuilder {
 }
 
 impl ContractBuilder {
-    fn new(link_to_code: PathBuf, contract_type: ContractType) -> Self {
+    fn new(link_to_contracts: PathBuf, contract_type: ContractType) -> Self {
         match contract_type {
             ContractType::L1 => Self {
                 cmd: Box::new(build_l1_contracts),
                 msg: MSG_BUILDING_L1_CONTRACTS_SPINNER.to_string(),
-                link_to_code,
+                link_to_code: link_to_contracts,
             },
             ContractType::L1DA => Self {
                 cmd: Box::new(build_l1_da_contracts),
                 msg: MSG_BUILDING_L1_DA_CONTRACTS_SPINNER.to_string(),
-                link_to_code,
+                link_to_code: link_to_contracts,
             },
             ContractType::L2 => Self {
                 cmd: Box::new(build_l2_contracts),
                 msg: MSG_BUILDING_L2_CONTRACTS_SPINNER.to_string(),
-                link_to_code,
+                link_to_code: link_to_contracts,
             },
             ContractType::SystemContracts => Self {
                 cmd: Box::new(build_system_contracts),
                 msg: MSG_BUILDING_SYSTEM_CONTRACTS_SPINNER.to_string(),
-                link_to_code,
+                link_to_code: link_to_contracts,
             },
         }
     }
@@ -121,11 +121,11 @@ pub fn run(shell: &Shell, args: ContractsArgs) -> anyhow::Result<()> {
 
     logger::info(MSG_BUILDING_CONTRACTS);
 
-    let link_to_code = ZkStackConfig::from_file(shell)?.link_to_code();
+    let contracts_path = ZkStackConfig::from_file(shell)?.contracts_path();
 
     contracts
         .iter()
-        .map(|contract| ContractBuilder::new(link_to_code.clone(), *contract))
+        .map(|contract| ContractBuilder::new(contracts_path.clone(), *contract))
         .try_for_each(|builder| builder.build(shell.clone()))?;
 
     logger::outro(MSG_BUILDING_CONTRACTS_SUCCESS);

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/contracts.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/contracts.rs
@@ -75,7 +75,7 @@ type CommandType = Box<dyn FnOnce(Shell, &Path) -> anyhow::Result<()>>;
 struct ContractBuilder {
     cmd: CommandType,
     msg: String,
-    link_to_code: PathBuf,
+    link_to_contracts: PathBuf,
 }
 
 impl ContractBuilder {
@@ -84,29 +84,29 @@ impl ContractBuilder {
             ContractType::L1 => Self {
                 cmd: Box::new(build_l1_contracts),
                 msg: MSG_BUILDING_L1_CONTRACTS_SPINNER.to_string(),
-                link_to_code: link_to_contracts,
+                link_to_contracts,
             },
             ContractType::L1DA => Self {
                 cmd: Box::new(build_l1_da_contracts),
                 msg: MSG_BUILDING_L1_DA_CONTRACTS_SPINNER.to_string(),
-                link_to_code: link_to_contracts,
+                link_to_contracts,
             },
             ContractType::L2 => Self {
                 cmd: Box::new(build_l2_contracts),
                 msg: MSG_BUILDING_L2_CONTRACTS_SPINNER.to_string(),
-                link_to_code: link_to_contracts,
+                link_to_contracts,
             },
             ContractType::SystemContracts => Self {
                 cmd: Box::new(build_system_contracts),
                 msg: MSG_BUILDING_SYSTEM_CONTRACTS_SPINNER.to_string(),
-                link_to_code: link_to_contracts,
+                link_to_contracts,
             },
         }
     }
 
     fn build(self, shell: Shell) -> anyhow::Result<()> {
         let spinner = Spinner::new(&self.msg);
-        (self.cmd)(shell, &self.link_to_code)?;
+        (self.cmd)(shell, &self.link_to_contracts)?;
         spinner.finish();
         Ok(())
     }

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/check_sqlx_data.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/check_sqlx_data.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use super::args::DatabaseCommonArgs;
 use crate::commands::dev::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/migrate.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/migrate.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use super::args::DatabaseCommonArgs;
 use crate::commands::dev::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/new_migration.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/new_migration.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use super::args::new_migration::{DatabaseNewMigrationArgs, SelectedDatabase};
 use crate::commands::dev::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/prepare.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/prepare.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use super::args::DatabaseCommonArgs;
 use crate::commands::dev::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/reset.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/reset.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use xshell::Shell;
 use zkstack_cli_common::logger;
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use super::{args::DatabaseCommonArgs, drop::drop_database, setup::setup_database};
 use crate::commands::dev::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/setup.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/database/setup.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use super::args::DatabaseCommonArgs;
 use crate::commands::dev::{

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/fmt.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/fmt.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, spinner::Spinner};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use super::sql_fmt::format_sql;
 use crate::commands::dev::{commands::lint_utils::Target, messages::msg_running_fmt_spinner};

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/genesis.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/genesis.rs
@@ -1,6 +1,6 @@
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, spinner::Spinner};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use crate::commands::dev::{
     commands::database::reset::reset_database, dals::get_core_dal,
@@ -12,7 +12,7 @@ pub(crate) async fn run(shell: &Shell) -> anyhow::Result<()> {
     let spinner = Spinner::new(MSG_GENESIS_FILE_GENERATION_STARTED);
     let secrets_path = chain.path_to_secrets_config().canonicalize().unwrap();
     let dal = get_core_dal(shell, None).await?;
-    reset_database(shell, chain.link_to_code, dal).await?;
+    reset_database(shell, chain.link_to_code(), dal).await?;
     let _dir = shell.push_dir("core");
     Cmd::new(cmd!(shell,"cargo run --package genesis_generator --bin genesis_generator -- --config-path={secrets_path}")).run()?;
     spinner.finish();

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/init_test_wallet.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/init_test_wallet.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 use xshell::Shell;
 use zkstack_cli_common::logger;
-use zkstack_cli_config::{traits::SaveConfig, ZkStackConfig};
+use zkstack_cli_config::{traits::SaveConfig, ZkStackConfig, ZkStackConfigTrait};
 
 use crate::commands::dev::{
     commands::test::utils::{TestWallets, TEST_WALLETS_PATH},
@@ -22,17 +22,12 @@ pub async fn run(shell: &Shell) -> anyhow::Result<()> {
     logger::info(MSG_INIT_TEST_WALLET_RUN_INFO);
 
     // Load test wallets configuration
-    let wallets_path: PathBuf = ecosystem_config.link_to_code.join(TEST_WALLETS_PATH);
+    let wallets_path: PathBuf = ecosystem_config.link_to_code().join(TEST_WALLETS_PATH);
     let wallets: TestWallets = serde_json::from_str(shell.read_file(&wallets_path)?.as_ref())
         .context(MSG_DESERIALIZE_TEST_WALLETS_ERR)?;
 
     let mut chain_wallets = chain_config.get_wallets_config()?;
     let test_wallet = wallets.get_test_wallet(&chain_config)?;
-
-    let wallets_path: PathBuf = ecosystem_config.link_to_code.join(TEST_WALLETS_PATH);
-    let raw_wallets = shell.read_file(&wallets_path)?;
-    let wallets: TestWallets =
-        serde_json::from_str(&raw_wallets).context(MSG_DESERIALIZE_TEST_WALLETS_ERR)?;
 
     wallets
         .init_test_wallet(&ecosystem_config, &chain_config)

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/lint.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/lint.rs
@@ -8,7 +8,7 @@ use anyhow::{bail, Context};
 use clap::Parser;
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use crate::commands::{
     autocomplete::{autocomplete_file_name, generate_completions},

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/prover/info.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/prover/info.rs
@@ -4,12 +4,12 @@ use anyhow::Context as _;
 use url::Url;
 use xshell::{cmd, Shell};
 use zkstack_cli_common::logger;
-use zkstack_cli_config::{ChainConfig, ZkStackConfig};
+use zkstack_cli_config::{get_link_to_prover, ChainConfig, ZkStackConfig, ZkStackConfigTrait};
 
 pub async fn run(shell: &Shell) -> anyhow::Result<()> {
     let chain_config = ZkStackConfig::current_chain(shell)?;
 
-    let link_to_prover = chain_config.link_to_code.join("prover");
+    let link_to_prover = get_link_to_prover(&chain_config.link_to_code());
 
     let protocol_version = get_protocol_version(shell, &link_to_prover).await?;
     let snark_wrapper = get_snark_wrapper(&link_to_prover).await?;

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/prover/insert_batch.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/prover/insert_batch.rs
@@ -1,6 +1,6 @@
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{check_prerequisites, cmd::Cmd, logger, PROVER_CLI_PREREQUISITE};
-use zkstack_cli_config::{get_link_to_prover, ZkStackConfig};
+use zkstack_cli_config::{get_link_to_prover, ZkStackConfig, ZkStackConfigTrait};
 
 use crate::commands::dev::commands::prover::{
     args::insert_batch::{InsertBatchArgs, InsertBatchArgsFinal},
@@ -13,7 +13,8 @@ pub async fn run(shell: &Shell, args: InsertBatchArgs) -> anyhow::Result<()> {
     let chain_config = ZkStackConfig::current_chain(shell)?;
 
     let version =
-        info::get_protocol_version(shell, &get_link_to_prover(&chain_config.link_to_code)).await?;
+        info::get_protocol_version(shell, &get_link_to_prover(&chain_config.link_to_code()))
+            .await?;
     let prover_url = info::get_database_url(&chain_config).await?.to_string();
 
     let InsertBatchArgsFinal { number, version } = args.fill_values_with_prompts(version);

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/prover/insert_version.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/prover/insert_version.rs
@@ -1,6 +1,6 @@
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{check_prerequisites, cmd::Cmd, logger, PROVER_CLI_PREREQUISITE};
-use zkstack_cli_config::{get_link_to_prover, ZkStackConfig};
+use zkstack_cli_config::{get_link_to_prover, ZkStackConfig, ZkStackConfigTrait};
 
 use crate::commands::dev::commands::prover::{
     args::insert_version::{InsertVersionArgs, InsertVersionArgsFinal},
@@ -11,13 +11,11 @@ pub async fn run(shell: &Shell, args: InsertVersionArgs) -> anyhow::Result<()> {
     check_prerequisites(shell, &PROVER_CLI_PREREQUISITE, false);
 
     let chain_config = ZkStackConfig::current_chain(shell)?;
+    let prover_link = get_link_to_prover(&chain_config.link_to_code());
 
-    let version =
-        info::get_protocol_version(shell, &get_link_to_prover(&chain_config.link_to_code)).await?;
-    let snark_wrapper =
-        info::get_snark_wrapper(&get_link_to_prover(&chain_config.link_to_code)).await?;
-    let fflonk_snark_wrapper =
-        info::get_fflonk_snark_wrapper(&get_link_to_prover(&chain_config.link_to_code)).await?;
+    let version = info::get_protocol_version(shell, &prover_link).await?;
+    let snark_wrapper = info::get_snark_wrapper(&prover_link).await?;
+    let fflonk_snark_wrapper = info::get_fflonk_snark_wrapper(&prover_link).await?;
 
     let prover_url = info::get_database_url(&chain_config).await?.to_string();
 

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/send_transactions/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/send_transactions/mod.rs
@@ -14,7 +14,7 @@ use serde::Deserialize;
 use tokio::time::sleep;
 use xshell::Shell;
 use zkstack_cli_common::{ethereum::create_ethers_client, logger};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 use zksync_basic_types::{H160, U256};
 
 use crate::commands::dev::{
@@ -66,7 +66,7 @@ pub async fn run(shell: &Shell, args: SendTransactionsArgs) -> anyhow::Result<()
 
     let timestamp = Local::now().format("%Y%m%d_%H%M%S").to_string();
     let log_file = chain_config
-        .link_to_code
+        .link_to_code()
         .join(DEFAULT_UNSIGNED_TRANSACTIONS_DIR)
         .join(format!("{}_receipt.log", timestamp));
 

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/sql_fmt.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/sql_fmt.rs
@@ -10,7 +10,7 @@ use sha2::{Digest, Sha256};
 use sqruff_lib::{api::simple::get_simple_config, core::linter::core::Linter};
 use walkdir::WalkDir;
 use xshell::{cmd, Shell};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use crate::commands::dev::messages::msg_file_is_not_formatted;
 

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/build.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/build.rs
@@ -1,5 +1,5 @@
 use xshell::Shell;
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use super::utils::{build_contracts, install_and_build_dependencies};
 

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/gateway_migration.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/gateway_migration.rs
@@ -1,6 +1,6 @@
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
-use zkstack_cli_config::{ChainConfig, ZkStackConfig};
+use zkstack_cli_config::{ChainConfig, ZkStackConfig, ZkStackConfigTrait};
 
 use super::utils::install_and_build_dependencies;
 use crate::commands::dev::{
@@ -12,12 +12,12 @@ const GATEWAY_SWITCH_TESTS_PATH: &str = "core/tests/gateway-migration-test";
 
 pub fn run(shell: &Shell, args: GatewayMigrationArgs) -> anyhow::Result<()> {
     let chain_config = ZkStackConfig::current_chain(shell)?;
-    shell.change_dir(chain_config.link_to_code.join(GATEWAY_SWITCH_TESTS_PATH));
+    shell.change_dir(chain_config.link_to_code().join(GATEWAY_SWITCH_TESTS_PATH));
 
     logger::info(MSG_GATEWAY_UPGRADE_TEST_RUN_INFO);
 
     if !args.no_deps {
-        install_and_build_dependencies(shell, &chain_config.link_to_code)?;
+        install_and_build_dependencies(shell, &chain_config.link_to_code())?;
     }
 
     run_test(

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/integration.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/integration.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, config::global_config, logger};
-use zkstack_cli_config::{EcosystemConfig, ZkStackConfig};
+use zkstack_cli_config::{EcosystemConfig, ZkStackConfig, ZkStackConfigTrait};
 
 use super::{
     args::integration::IntegrationArgs,
@@ -64,11 +64,11 @@ impl<'a> IntegrationTestRunner<'a> {
     pub async fn build_command(self) -> anyhow::Result<xshell::Cmd<'a>> {
         let ecosystem_config = self.ecosystem_config;
         self.shell
-            .change_dir(ecosystem_config.link_to_code.join(TS_INTEGRATION_PATH));
+            .change_dir(ecosystem_config.link_to_code().join(TS_INTEGRATION_PATH));
 
         if !self.no_deps {
-            install_and_build_dependencies(self.shell, &ecosystem_config.link_to_code)?;
-            build_contracts(self.shell, &ecosystem_config.link_to_code)?;
+            install_and_build_dependencies(self.shell, &ecosystem_config.link_to_code())?;
+            build_contracts(self.shell, &ecosystem_config.link_to_code())?;
         }
 
         let test_pattern: &[_] = if let Some(pattern) = self.test_pattern {

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/l1_contracts.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/l1_contracts.rs
@@ -1,6 +1,6 @@
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, logger};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use crate::commands::dev::messages::MSG_L1_CONTRACTS_TEST_SUCCESS;
 

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/prover.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/prover.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use url::Url;
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, logger};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{get_link_to_prover, ZkStackConfig, ZkStackConfigTrait};
 
 use crate::commands::dev::{
     commands::test::db::reset_test_databases,
@@ -20,7 +20,7 @@ pub async fn run(shell: &Shell) -> anyhow::Result<()> {
     }];
     reset_test_databases(shell, &config.link_to_code(), dals).await?;
 
-    let _dir_guard = shell.push_dir(config.link_to_code().join("prover"));
+    let _dir_guard = shell.push_dir(get_link_to_prover(&config.link_to_code()));
     Cmd::new(cmd!(shell, "cargo test --release --workspace --locked"))
         .with_force_run()
         .env("TEST_DATABASE_PROVER_URL", TEST_DATABASE_PROVER_URL)

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/recovery.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/recovery.rs
@@ -1,6 +1,6 @@
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, logger, server::Server, spinner::Spinner};
-use zkstack_cli_config::{EcosystemConfig, ZkStackConfig};
+use zkstack_cli_config::{EcosystemConfig, ZkStackConfig, ZkStackConfigTrait};
 
 use super::{args::recovery::RecoveryArgs, utils::install_and_build_dependencies};
 use crate::commands::dev::messages::{MSG_RECOVERY_TEST_RUN_INFO, MSG_RECOVERY_TEST_RUN_SUCCESS};
@@ -9,13 +9,13 @@ const RECOVERY_TESTS_PATH: &str = "core/tests/recovery-test";
 
 pub async fn run(shell: &Shell, args: RecoveryArgs) -> anyhow::Result<()> {
     let config = ZkStackConfig::ecosystem(shell)?;
-    shell.change_dir(config.link_to_code.join(RECOVERY_TESTS_PATH));
+    shell.change_dir(config.link_to_code().join(RECOVERY_TESTS_PATH));
 
     logger::info(MSG_RECOVERY_TEST_RUN_INFO);
-    Server::new(None, None, config.link_to_code.clone(), false).build(shell)?;
+    Server::new(None, None, config.link_to_code().clone(), false).build(shell)?;
 
     if !args.no_deps {
-        install_and_build_dependencies(shell, &config.link_to_code)?;
+        install_and_build_dependencies(shell, &config.link_to_code())?;
     }
 
     run_test(shell, &args, &config).await?;

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/revert.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/revert.rs
@@ -1,6 +1,6 @@
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, logger};
-use zkstack_cli_config::{EcosystemConfig, ZkStackConfig};
+use zkstack_cli_config::{EcosystemConfig, ZkStackConfig, ZkStackConfigTrait};
 
 use super::{args::revert::RevertArgs, utils::install_and_build_dependencies};
 use crate::commands::dev::messages::{MSG_REVERT_TEST_RUN_INFO, MSG_REVERT_TEST_RUN_SUCCESS};
@@ -9,12 +9,12 @@ const REVERT_TESTS_PATH: &str = "core/tests/revert-test";
 
 pub async fn run(shell: &Shell, args: RevertArgs) -> anyhow::Result<()> {
     let ecosystem_config = ZkStackConfig::ecosystem(shell)?;
-    shell.change_dir(ecosystem_config.link_to_code.join(REVERT_TESTS_PATH));
+    shell.change_dir(ecosystem_config.link_to_code().join(REVERT_TESTS_PATH));
 
     logger::info(MSG_REVERT_TEST_RUN_INFO);
 
     if !args.no_deps {
-        install_and_build_dependencies(shell, &ecosystem_config.link_to_code)?;
+        install_and_build_dependencies(shell, &ecosystem_config.link_to_code())?;
     }
 
     run_test(shell, &args, &ecosystem_config).await?;

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/rust.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/rust.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use url::Url;
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, logger};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use super::args::rust::RustArgs;
 use crate::commands::dev::{
@@ -16,7 +16,7 @@ use crate::commands::dev::{
 pub async fn run(shell: &Shell, args: RustArgs) -> anyhow::Result<()> {
     let chain = ZkStackConfig::current_chain(shell)?;
     let general_config = chain.get_general_config().await;
-    let link_to_code = chain.link_to_code;
+    let link_to_code = chain.link_to_code();
 
     let (test_server_url, test_prover_url) = if let Ok(general_config) = general_config {
         (

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/upgrade.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/upgrade.rs
@@ -1,6 +1,6 @@
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, logger, spinner::Spinner};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use super::{args::upgrade::UpgradeArgs, utils::install_and_build_dependencies};
 use crate::commands::dev::messages::{MSG_UPGRADE_TEST_RUN_INFO, MSG_UPGRADE_TEST_RUN_SUCCESS};
@@ -9,12 +9,12 @@ const UPGRADE_TESTS_PATH: &str = "core/tests/upgrade-test";
 
 pub fn run(shell: &Shell, args: UpgradeArgs) -> anyhow::Result<()> {
     let config = ZkStackConfig::current_chain(shell)?;
-    shell.change_dir(config.link_to_code.join(UPGRADE_TESTS_PATH));
+    shell.change_dir(config.link_to_code().join(UPGRADE_TESTS_PATH));
 
     logger::info(MSG_UPGRADE_TEST_RUN_INFO);
 
     if !args.no_deps {
-        install_and_build_dependencies(shell, &config.link_to_code)?;
+        install_and_build_dependencies(shell, &config.link_to_code())?;
     }
 
     run_test(shell, &config.name)?;

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/wallet.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/test/wallet.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 use xshell::Shell;
 use zkstack_cli_common::logger;
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use super::utils::{TestWallets, TEST_WALLETS_PATH};
 use crate::commands::dev::messages::{
@@ -15,7 +15,7 @@ pub fn run(shell: &Shell) -> anyhow::Result<()> {
 
     let config = ZkStackConfig::current_chain(shell)?;
 
-    let wallets_path: PathBuf = config.link_to_code.join(TEST_WALLETS_PATH);
+    let wallets_path: PathBuf = config.link_to_code().join(TEST_WALLETS_PATH);
     let wallets: TestWallets = serde_json::from_str(shell.read_file(wallets_path)?.as_ref())
         .context(MSG_DESERIALIZE_TEST_WALLETS_ERR)?;
 

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/default_chain_upgrade.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/default_chain_upgrade.rs
@@ -8,7 +8,7 @@ use zkstack_cli_common::{
 };
 use zkstack_cli_config::{
     traits::{FileConfigTrait, ReadConfig},
-    ZkStackConfig,
+    ZkStackConfig, ZkStackConfigTrait,
 };
 use zksync_basic_types::{
     protocol_version::ProtocolVersionId, web3::Bytes, Address, L1BatchNumber, L2BlockNumber, U256,
@@ -24,7 +24,7 @@ use crate::{
     commands::{
         chain::{
             admin_call_builder::{AdminCall, AdminCallBuilder},
-            utils::{get_default_foundry_path, send_tx},
+            utils::send_tx,
         },
         dev::commands::upgrades::{
             args::chain::{ChainUpgradeParams, DefaultChainUpgradeArgs, UpgradeArgsInner},
@@ -248,14 +248,14 @@ pub(crate) async fn run_chain_upgrade(
     upgrade_version: UpgradeVersion,
 ) -> anyhow::Result<()> {
     let forge_args = &Default::default();
-    let foundry_contracts_path = get_default_foundry_path(shell)?;
+    let contracts_foundry_path = ZkStackConfig::from_file(shell)?.path_to_l1_foundry();
     let chain_config = ZkStackConfig::current_chain(shell)?;
 
     let mut args = args_input.clone().fill_if_empty(shell).await?;
     if args.upgrade_description_path.is_none() {
         args.upgrade_description_path = Some(
             chain_config
-                .link_to_code
+                .contracts_path()
                 .join(upgrade_version.get_default_upgrade_description_path())
                 .to_string_lossy()
                 .to_string(),
@@ -321,7 +321,7 @@ pub(crate) async fn run_chain_upgrade(
             .prepare_upgrade_chain_on_gateway_calls(
                 shell,
                 forge_args,
-                &foundry_contracts_path,
+                &contracts_foundry_path,
                 args.chain_id.expect("chain_id is required"),
                 args.gw_chain_id.expect("gw_chain_id is required"),
                 upgrade_info
@@ -348,7 +348,7 @@ pub(crate) async fn run_chain_upgrade(
             let enable_validator_calls = crate::admin_functions::enable_validator_via_gateway(
                 shell,
                 forge_args,
-                &foundry_contracts_path,
+                &contracts_foundry_path,
                 crate::admin_functions::AdminScriptMode::OnlySave,
                 upgrade_info
                     .deployed_addresses
@@ -399,7 +399,7 @@ pub(crate) async fn run_chain_upgrade(
                 let enable_validator_calls = crate::admin_functions::enable_validator(
                     shell,
                     forge_args,
-                    &foundry_contracts_path,
+                    &contracts_foundry_path,
                     crate::admin_functions::AdminScriptMode::OnlySave,
                     upgrade_info
                         .deployed_addresses

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/default_chain_upgrade.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/default_chain_upgrade.rs
@@ -7,7 +7,7 @@ use zkstack_cli_common::{
     logger,
 };
 use zkstack_cli_config::{
-    traits::{ReadConfig, ZkStackConfigTrait},
+    traits::{FileConfigTrait, ReadConfig},
     ZkStackConfig,
 };
 use zksync_basic_types::{
@@ -199,7 +199,7 @@ pub struct UpgradeInfo {
     pub(crate) chain_upgrade_diamond_cut: Bytes,
 }
 
-impl ZkStackConfigTrait for UpgradeInfo {}
+impl FileConfigTrait for UpgradeInfo {}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ContractsConfig {

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/default_ecosystem_upgrade.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/default_ecosystem_upgrade.rs
@@ -27,7 +27,8 @@ use zkstack_cli_config::{
         },
     },
     traits::{ReadConfig, ReadConfigWithBasePath, SaveConfig, SaveConfigWithBasePath},
-    ChainConfig, ContractsConfig, EcosystemConfig, GenesisConfig, ZkStackConfig, GENESIS_FILE,
+    ChainConfig, ContractsConfig, EcosystemConfig, GenesisConfig, ZkStackConfig,
+    ZkStackConfigTrait, GENESIS_FILE,
 };
 use zkstack_cli_types::ProverMode;
 use zksync_types::{h256_to_address, H256, SHARED_BRIDGE_ETHER_TOKEN_ADDRESS, U256};
@@ -53,7 +54,7 @@ pub async fn run(
     println!("Running ecosystem gateway upgrade args");
 
     let ecosystem_config = ZkStackConfig::ecosystem(shell)?;
-    git::submodule_update(shell, &ecosystem_config.link_to_code)?;
+    git::submodule_update(shell, &ecosystem_config.link_to_code())?;
 
     let upgrade_version = args.upgrade_version;
 
@@ -137,9 +138,7 @@ async fn no_governance_prepare(
     };
     dbg!(&l1_rpc_url);
 
-    let genesis_config_path = ecosystem_config
-        .get_default_configs_path()
-        .join(GENESIS_FILE);
+    let genesis_config_path = ecosystem_config.default_configs_path().join(GENESIS_FILE);
     let default_genesis_config = GenesisConfig::read(shell, &genesis_config_path).await?;
     let default_genesis_input = GenesisInput::new(&default_genesis_config)?;
     let current_contracts_config = ecosystem_config.get_contracts_config()?;

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/types.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/types.rs
@@ -15,15 +15,11 @@ pub enum UpgradeVersion {
 impl UpgradeVersion {
     pub const fn get_default_upgrade_description_path(&self) -> &'static str {
         match self {
-            UpgradeVersion::V29InteropAFf => {
-                "./contracts/l1-contracts/script-out/v29-upgrade-ecosystem.toml"
-            }
+            UpgradeVersion::V29InteropAFf => "./l1-contracts/script-out/v29-upgrade-ecosystem.toml",
             UpgradeVersion::V28_1Vk => {
-                "./contracts/l1-contracts/script-out/zk-os-v28-1-upgrade-ecosystem.toml"
+                "./l1-contracts/script-out/zk-os-v28-1-upgrade-ecosystem.toml"
             }
-            UpgradeVersion::V28_1VkEra => {
-                "./contracts/l1-contracts/script-out/v28-1-upgrade-ecosystem.toml"
-            }
+            UpgradeVersion::V28_1VkEra => "./l1-contracts/script-out/v28-1-upgrade-ecosystem.toml",
         }
     }
 }

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/v27_evm_eq.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/v27_evm_eq.rs
@@ -4,7 +4,7 @@ use ethers::utils::hex;
 use serde::{Deserialize, Serialize};
 use xshell::Shell;
 use zkstack_cli_common::ethereum::{get_ethers_provider, get_zk_client};
-use zkstack_cli_config::traits::{ReadConfig, ZkStackConfigTrait};
+use zkstack_cli_config::traits::{FileConfigTrait, ReadConfig};
 use zksync_basic_types::{
     protocol_version::ProtocolVersionId, web3::Bytes, Address, L1BatchNumber, L2BlockNumber, U256,
 };
@@ -142,7 +142,7 @@ pub struct V27UpgradeInfo {
     old_protocol_version: u64,
 }
 
-impl ZkStackConfigTrait for V27UpgradeInfo {}
+impl FileConfigTrait for V27UpgradeInfo {}
 
 pub(crate) async fn run(shell: &Shell, args: V27EvmInterpreterCalldataArgs) -> anyhow::Result<()> {
     // 0. Read the GatewayUpgradeInfo

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/v28_precompiles.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/v28_precompiles.rs
@@ -4,7 +4,7 @@ use ethers::utils::hex;
 use serde::{Deserialize, Serialize};
 use xshell::Shell;
 use zkstack_cli_common::ethereum::{get_ethers_provider, get_zk_client};
-use zkstack_cli_config::traits::{ReadConfig, ZkStackConfigTrait};
+use zkstack_cli_config::traits::{FileConfigTrait, ReadConfig};
 use zksync_basic_types::{
     protocol_version::ProtocolVersionId, web3::Bytes, Address, L1BatchNumber, L2BlockNumber, U256,
 };
@@ -201,7 +201,7 @@ pub struct V28UpgradeInfo {
     gateway_upgrade_diamond_cut: Bytes,
 }
 
-impl ZkStackConfigTrait for V28UpgradeInfo {}
+impl FileConfigTrait for V28UpgradeInfo {}
 
 pub(crate) async fn run(shell: &Shell, args: V28PrecompilesCalldataArgs) -> anyhow::Result<()> {
     let forge_args = &Default::default();

--- a/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/v28_precompiles.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/dev/commands/upgrades/v28_precompiles.rs
@@ -4,7 +4,10 @@ use ethers::utils::hex;
 use serde::{Deserialize, Serialize};
 use xshell::Shell;
 use zkstack_cli_common::ethereum::{get_ethers_provider, get_zk_client};
-use zkstack_cli_config::traits::{FileConfigTrait, ReadConfig};
+use zkstack_cli_config::{
+    traits::{FileConfigTrait, ReadConfig},
+    ZkStackConfig, ZkStackConfigTrait,
+};
 use zksync_basic_types::{
     protocol_version::ProtocolVersionId, web3::Bytes, Address, L1BatchNumber, L2BlockNumber, U256,
 };
@@ -17,10 +20,7 @@ use zksync_web3_decl::{
 use crate::{
     abi::{BridgehubAbi, ZkChainAbi},
     commands::{
-        chain::{
-            admin_call_builder::{AdminCall, AdminCallBuilder},
-            utils::get_default_foundry_path,
-        },
+        chain::admin_call_builder::{AdminCall, AdminCallBuilder},
         dev::commands::upgrades::utils::{print_error, set_upgrade_timestamp_calldata},
     },
     utils::addresses::apply_l1_to_l2_alias,
@@ -205,7 +205,7 @@ impl FileConfigTrait for V28UpgradeInfo {}
 
 pub(crate) async fn run(shell: &Shell, args: V28PrecompilesCalldataArgs) -> anyhow::Result<()> {
     let forge_args = &Default::default();
-    let foundry_contracts_path = get_default_foundry_path(shell)?;
+    let foundry_contracts_path = ZkStackConfig::from_file(shell)?.path_to_l1_foundry();
 
     // 0. Read the GatewayUpgradeInfo
 

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/create.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/create.rs
@@ -24,7 +24,7 @@ pub struct EcosystemCreateArgs {
     #[clap(long, help = MSG_L1_NETWORK_HELP, value_enum)]
     pub l1_network: Option<L1Network>,
     #[clap(long, help = MSG_LINK_TO_CODE_HELP, value_hint = ValueHint::DirPath)]
-    pub link_to_code: Option<String>,
+    pub link_to_code: Option<PathBuf>,
     #[clap(flatten)]
     #[serde(flatten)]
     pub chain: ChainCreateArgs,
@@ -44,7 +44,11 @@ impl EcosystemCreateArgs {
             .unwrap_or_else(|| Prompt::new(MSG_ECOSYSTEM_NAME_PROMPT).ask());
         ecosystem_name = slugify!(&ecosystem_name, separator = "_");
 
-        let link_to_code = self.link_to_code.unwrap_or_else(|| get_link_to_code(shell));
+        let link_to_code = if let Some(link_to_code) = self.link_to_code {
+            Some(link_to_code)
+        } else {
+            get_link_to_code(shell)
+        };
 
         let l1_network = self
             .l1_network
@@ -54,7 +58,8 @@ impl EcosystemCreateArgs {
 
         let chain = self
             .chain
-            .fill_values_with_prompt(0, &l1_network, vec![], &link_to_code)?;
+            // TODO link to code unwrap should be handled better
+            .fill_values_with_prompt(0, &l1_network, vec![], link_to_code.clone().unwrap())?;
 
         let start_containers = self.start_containers.unwrap_or_else(|| {
             PromptConfirm::new(MSG_START_CONTAINERS_PROMPT)
@@ -79,7 +84,7 @@ impl EcosystemCreateArgs {
 pub struct EcosystemCreateArgsFinal {
     pub ecosystem_name: String,
     pub l1_network: L1Network,
-    pub link_to_code: String,
+    pub link_to_code: Option<PathBuf>,
     pub wallet_creation: WalletCreation,
     pub wallet_path: Option<PathBuf>,
     pub chain_args: ChainCreateArgsFinal,

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/build_transactions.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/build_transactions.rs
@@ -16,10 +16,10 @@ use crate::messages::{
 };
 
 const DEPLOY_TRANSACTIONS_FILE_SRC: &str =
-    "contracts/l1-contracts/broadcast/DeployL1.s.sol/9/dry-run/run-latest.json";
+    "cl1-contracts/broadcast/DeployL1.s.sol/9/dry-run/run-latest.json";
 const DEPLOY_TRANSACTIONS_FILE_DST: &str = "deploy-l1-txns.json";
 
-const SCRIPT_CONFIG_FILE_SRC: &str = "contracts/l1-contracts/script-config/config-deploy-l1.toml";
+const SCRIPT_CONFIG_FILE_SRC: &str = "l1-contracts/script-config/config-deploy-l1.toml";
 const SCRIPT_CONFIG_FILE_DST: &str = "config-deploy-l1.toml";
 
 pub async fn run(args: BuildTransactionsArgs, shell: &Shell) -> anyhow::Result<()> {
@@ -37,7 +37,7 @@ pub async fn run(args: BuildTransactionsArgs, shell: &Shell) -> anyhow::Result<(
 
     let spinner = Spinner::new(MSG_INTALLING_DEPS_SPINNER);
     install_yarn_dependencies(shell, &ecosystem_config.link_to_code())?;
-    build_system_contracts(shell, &ecosystem_config.link_to_code())?;
+    build_system_contracts(shell, &ecosystem_config.contracts_path())?;
     spinner.finish();
 
     let spinner = Spinner::new(MSG_BUILDING_ECOSYSTEM_CONTRACTS_SPINNER);
@@ -64,13 +64,15 @@ pub async fn run(args: BuildTransactionsArgs, shell: &Shell) -> anyhow::Result<(
 
     shell.copy_file(
         ecosystem_config
-            .link_to_code()
+            .contracts_path()
             .join(DEPLOY_TRANSACTIONS_FILE_SRC),
         args.out.join(DEPLOY_TRANSACTIONS_FILE_DST),
     )?;
 
     shell.copy_file(
-        ecosystem_config.link_to_code().join(SCRIPT_CONFIG_FILE_SRC),
+        ecosystem_config
+            .contracts_path()
+            .join(SCRIPT_CONFIG_FILE_SRC),
         args.out.join(SCRIPT_CONFIG_FILE_DST),
     )?;
     spinner.finish();

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/build_transactions.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/build_transactions.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use xshell::Shell;
 use zkstack_cli_common::{git, logger, spinner::Spinner};
-use zkstack_cli_config::{traits::SaveConfigWithBasePath, ZkStackConfig};
+use zkstack_cli_config::{traits::SaveConfigWithBasePath, ZkStackConfig, ZkStackConfigTrait};
 
 use super::{
     args::build_transactions::BuildTransactionsArgs,
@@ -26,7 +26,7 @@ pub async fn run(args: BuildTransactionsArgs, shell: &Shell) -> anyhow::Result<(
     let args = args.fill_values_with_prompt();
     let ecosystem_config = ZkStackConfig::ecosystem(shell)?;
 
-    git::submodule_update(shell, &ecosystem_config.link_to_code)?;
+    git::submodule_update(shell, &ecosystem_config.link_to_code())?;
 
     let initial_deployment_config = match ecosystem_config.get_initial_deployment_config() {
         Ok(config) => config,
@@ -36,8 +36,8 @@ pub async fn run(args: BuildTransactionsArgs, shell: &Shell) -> anyhow::Result<(
     logger::info(MSG_BUILDING_ECOSYSTEM);
 
     let spinner = Spinner::new(MSG_INTALLING_DEPS_SPINNER);
-    install_yarn_dependencies(shell, &ecosystem_config.link_to_code)?;
-    build_system_contracts(shell, &ecosystem_config.link_to_code)?;
+    install_yarn_dependencies(shell, &ecosystem_config.link_to_code())?;
+    build_system_contracts(shell, &ecosystem_config.link_to_code())?;
     spinner.finish();
 
     let spinner = Spinner::new(MSG_BUILDING_ECOSYSTEM_CONTRACTS_SPINNER);
@@ -64,13 +64,13 @@ pub async fn run(args: BuildTransactionsArgs, shell: &Shell) -> anyhow::Result<(
 
     shell.copy_file(
         ecosystem_config
-            .link_to_code
+            .link_to_code()
             .join(DEPLOY_TRANSACTIONS_FILE_SRC),
         args.out.join(DEPLOY_TRANSACTIONS_FILE_DST),
     )?;
 
     shell.copy_file(
-        ecosystem_config.link_to_code.join(SCRIPT_CONFIG_FILE_SRC),
+        ecosystem_config.link_to_code().join(SCRIPT_CONFIG_FILE_SRC),
         args.out.join(SCRIPT_CONFIG_FILE_DST),
     )?;
     spinner.finish();

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/change_default.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/change_default.rs
@@ -20,6 +20,6 @@ pub fn run(args: ChangeDefaultChain, shell: &Shell) -> anyhow::Result<()> {
     if !chains.contains(&chain_name) {
         anyhow::bail!(msg_chain_doesnt_exist_err(&chain_name, &chains));
     }
-    ecosystem_config.default_chain = chain_name;
+    ecosystem_config.set_default_chain(chain_name);
     ecosystem_config.save_with_base_path(shell, ".")
 }

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/common.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/common.rs
@@ -23,7 +23,7 @@ use zkstack_cli_config::{
         },
     },
     traits::{ReadConfig, SaveConfig, SaveConfigWithBasePath},
-    ContractsConfig, EcosystemConfig, GenesisConfig, GENESIS_FILE,
+    ContractsConfig, EcosystemConfig, GenesisConfig, ZkStackConfigTrait, GENESIS_FILE,
 };
 use zkstack_cli_types::{L1Network, ProverMode};
 
@@ -53,7 +53,7 @@ pub async fn deploy_l1(
     bridgehub_address: Option<H160>,
 ) -> anyhow::Result<ContractsConfig> {
     let deploy_config_path = DEPLOY_ECOSYSTEM_SCRIPT_PARAMS.input(&config.path_to_l1_foundry());
-    let genesis_config_path = config.get_default_configs_path().join(GENESIS_FILE);
+    let genesis_config_path = config.default_configs_path().join(GENESIS_FILE);
     let default_genesis_config = GenesisConfig::read(shell, &genesis_config_path).await?;
     let default_genesis_input = GenesisInput::new(&default_genesis_config)?;
 
@@ -125,7 +125,7 @@ pub async fn deploy_l1_core_contracts(
 ) -> anyhow::Result<ContractsConfig> {
     let deploy_config_path =
         DEPLOY_ECOSYSTEM_CORE_CONTRACTS_SCRIPT_PARAMS.input(&config.path_to_l1_foundry());
-    let genesis_config_path = config.get_default_configs_path().join(GENESIS_FILE);
+    let genesis_config_path = config.default_configs_path().join(GENESIS_FILE);
     let default_genesis_config = GenesisConfig::read(shell, &genesis_config_path).await?;
     let default_genesis_input = GenesisInput::new(&default_genesis_config)?;
     let wallets_config = config.get_wallets()?;

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/create.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/create.rs
@@ -4,6 +4,7 @@ use zkstack_cli_common::{logger, spinner::Spinner};
 use zkstack_cli_config::{
     create_local_configs_dir, create_wallets, get_default_era_chain_id,
     traits::SaveConfigWithBasePath, EcosystemConfig, EcosystemConfigFromFileError, ZkStackConfig,
+    ZkStackConfigTrait,
 };
 
 use crate::{
@@ -69,25 +70,25 @@ async fn create(args: EcosystemCreateArgs, shell: &Shell) -> anyhow::Result<()> 
     create_erc20_deployment_config(shell, &configs_path)?;
     create_apps_config(shell, &configs_path)?;
 
-    let ecosystem_config = EcosystemConfig {
-        name: ecosystem_name.clone(),
-        l1_network: args.l1_network,
+    let ecosystem_config = EcosystemConfig::new(
+        ecosystem_name.clone(),
+        args.l1_network,
         link_to_code,
-        bellman_cuda_dir: None,
-        chains: chains_path.clone(),
-        config: configs_path,
-        era_chain_id: get_default_era_chain_id(),
-        default_chain: default_chain_name.clone(),
-        prover_version: chain_config.prover_version,
-        wallet_creation: args.wallet_creation,
-        shell: shell.clone().into(),
-    };
+        None,
+        chains_path.clone(),
+        configs_path,
+        default_chain_name.clone(),
+        get_default_era_chain_id(),
+        chain_config.prover_version,
+        args.wallet_creation,
+        shell.clone().into(),
+    );
 
     // Use 0 id for ecosystem  wallets
     create_wallets(
         shell,
         &ecosystem_config.config,
-        &ecosystem_config.link_to_code,
+        &ecosystem_config.link_to_code(),
         0,
         args.wallet_creation,
         args.wallet_path,
@@ -101,7 +102,7 @@ async fn create(args: EcosystemCreateArgs, shell: &Shell) -> anyhow::Result<()> 
 
     if args.start_containers {
         let spinner = Spinner::new(MSG_STARTING_CONTAINERS_SPINNER);
-        initialize_docker(shell, &ecosystem_config.link_to_code)?;
+        initialize_docker(shell, &ecosystem_config.link_to_code())?;
         start_containers(shell, false)?;
         spinner.finish();
     }

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/init.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/init.rs
@@ -12,7 +12,7 @@ use zkstack_cli_common::{
 use zkstack_cli_config::{
     forge_interface::deploy_ecosystem::input::InitialDeploymentConfig,
     traits::{FileConfigWithDefaultName, ReadConfig, SaveConfigWithBasePath},
-    ContractsConfig, EcosystemConfig, ZkStackConfig,
+    ContractsConfig, EcosystemConfig, ZkStackConfig, ZkStackConfigTrait,
 };
 use zkstack_cli_types::L1Network;
 
@@ -44,7 +44,7 @@ pub async fn run(args: EcosystemInitArgs, shell: &Shell) -> anyhow::Result<()> {
     let ecosystem_config = ZkStackConfig::ecosystem(shell)?;
 
     if args.update_submodules.is_none() || args.update_submodules == Some(true) {
-        git::submodule_update(shell, &ecosystem_config.link_to_code)?;
+        git::submodule_update(shell, &ecosystem_config.link_to_code())?;
     }
 
     let initial_deployment_config = match ecosystem_config.get_initial_deployment_config() {
@@ -106,11 +106,11 @@ async fn init_ecosystem(
 ) -> anyhow::Result<ContractsConfig> {
     let spinner = Spinner::new(MSG_INTALLING_DEPS_SPINNER);
     if !init_args.skip_contract_compilation_override {
-        install_yarn_dependencies(shell, &ecosystem_config.link_to_code)?;
-        build_da_contracts(shell, &ecosystem_config.link_to_code)?;
-        build_l1_contracts(shell.clone(), &ecosystem_config.link_to_code)?;
-        build_system_contracts(shell.clone(), &ecosystem_config.link_to_code)?;
-        build_l2_contracts(shell.clone(), &ecosystem_config.link_to_code)?;
+        install_yarn_dependencies(shell, &ecosystem_config.contracts_path())?;
+        build_da_contracts(shell, &ecosystem_config.contracts_path())?;
+        build_l1_contracts(shell.clone(), &ecosystem_config.contracts_path())?;
+        build_system_contracts(shell.clone(), &ecosystem_config.contracts_path())?;
+        build_l2_contracts(shell.clone(), &ecosystem_config.contracts_path())?;
     }
     spinner.finish();
 

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/init.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/init.rs
@@ -106,7 +106,7 @@ async fn init_ecosystem(
 ) -> anyhow::Result<ContractsConfig> {
     let spinner = Spinner::new(MSG_INTALLING_DEPS_SPINNER);
     if !init_args.skip_contract_compilation_override {
-        install_yarn_dependencies(shell, &ecosystem_config.contracts_path())?;
+        install_yarn_dependencies(shell, &ecosystem_config.link_to_code())?;
         build_da_contracts(shell, &ecosystem_config.contracts_path())?;
         build_l1_contracts(shell.clone(), &ecosystem_config.contracts_path())?;
         build_system_contracts(shell.clone(), &ecosystem_config.contracts_path())?;

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/init_core_contracts.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/init_core_contracts.rs
@@ -9,6 +9,7 @@ use zkstack_cli_common::{
 use zkstack_cli_config::{
     forge_interface::deploy_ecosystem::input::InitialDeploymentConfig,
     traits::SaveConfigWithBasePath, ContractsConfig, EcosystemConfig, ZkStackConfig,
+    ZkStackConfigTrait,
 };
 
 use super::{
@@ -32,7 +33,7 @@ pub async fn run(args: InitCoreContractsArgs, shell: &Shell) -> anyhow::Result<(
     let ecosystem_config = ZkStackConfig::ecosystem(shell)?;
 
     if args.update_submodules.is_none() || args.update_submodules == Some(true) {
-        git::submodule_update(shell, &ecosystem_config.link_to_code)?;
+        git::submodule_update(shell, &ecosystem_config.link_to_code())?;
     }
 
     let initial_deployment_config = match ecosystem_config.get_initial_deployment_config() {
@@ -83,11 +84,11 @@ async fn init_ecosystem(
 ) -> anyhow::Result<ContractsConfig> {
     let spinner = Spinner::new(MSG_INTALLING_DEPS_SPINNER);
     if !init_args.skip_contract_compilation_override {
-        install_yarn_dependencies(shell, &ecosystem_config.link_to_code)?;
-        build_da_contracts(shell, &ecosystem_config.link_to_code)?;
-        build_l1_contracts(shell.clone(), &ecosystem_config.link_to_code)?;
-        build_system_contracts(shell.clone(), &ecosystem_config.link_to_code)?;
-        build_l2_contracts(shell.clone(), &ecosystem_config.link_to_code)?;
+        install_yarn_dependencies(shell, &ecosystem_config.contracts_path())?;
+        build_da_contracts(shell, &ecosystem_config.contracts_path())?;
+        build_l1_contracts(shell.clone(), &ecosystem_config.contracts_path())?;
+        build_system_contracts(shell.clone(), &ecosystem_config.contracts_path())?;
+        build_l2_contracts(shell.clone(), &ecosystem_config.contracts_path())?;
     }
     spinner.finish();
 

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/init_core_contracts.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/init_core_contracts.rs
@@ -84,7 +84,7 @@ async fn init_ecosystem(
 ) -> anyhow::Result<ContractsConfig> {
     let spinner = Spinner::new(MSG_INTALLING_DEPS_SPINNER);
     if !init_args.skip_contract_compilation_override {
-        install_yarn_dependencies(shell, &ecosystem_config.contracts_path())?;
+        install_yarn_dependencies(shell, &ecosystem_config.link_to_code())?;
         build_da_contracts(shell, &ecosystem_config.contracts_path())?;
         build_l1_contracts(shell.clone(), &ecosystem_config.contracts_path())?;
         build_system_contracts(shell.clone(), &ecosystem_config.contracts_path())?;

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/init_new_ctm.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/init_new_ctm.rs
@@ -63,7 +63,7 @@ async fn init_ctm(
 ) -> anyhow::Result<ContractsConfig> {
     let spinner = Spinner::new(MSG_INTALLING_DEPS_SPINNER);
     if !init_args.skip_contract_compilation_override {
-        install_yarn_dependencies(shell, &ecosystem_config.contracts_path())?;
+        install_yarn_dependencies(shell, &ecosystem_config.link_to_code())?;
         build_da_contracts(shell, &ecosystem_config.contracts_path())?;
         build_l1_contracts(shell.clone(), &ecosystem_config.contracts_path())?;
         build_system_contracts(shell.clone(), &ecosystem_config.contracts_path())?;

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/init_new_ctm.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/init_new_ctm.rs
@@ -9,6 +9,7 @@ use zkstack_cli_common::{
 use zkstack_cli_config::{
     forge_interface::deploy_ecosystem::input::InitialDeploymentConfig,
     traits::SaveConfigWithBasePath, ContractsConfig, EcosystemConfig, ZkStackConfig,
+    ZkStackConfigTrait,
 };
 
 use super::{
@@ -28,7 +29,7 @@ pub async fn run(args: InitNewCTMArgs, shell: &Shell) -> anyhow::Result<()> {
     let ecosystem_config = ZkStackConfig::ecosystem(shell)?;
 
     if args.update_submodules.is_none() || args.update_submodules == Some(true) {
-        git::submodule_update(shell, &ecosystem_config.link_to_code)?;
+        git::submodule_update(shell, &ecosystem_config.link_to_code())?;
     }
 
     let initial_deployment_config = match ecosystem_config.get_initial_deployment_config() {
@@ -62,11 +63,11 @@ async fn init_ctm(
 ) -> anyhow::Result<ContractsConfig> {
     let spinner = Spinner::new(MSG_INTALLING_DEPS_SPINNER);
     if !init_args.skip_contract_compilation_override {
-        install_yarn_dependencies(shell, &ecosystem_config.link_to_code)?;
-        build_da_contracts(shell, &ecosystem_config.link_to_code)?;
-        build_l1_contracts(shell.clone(), &ecosystem_config.link_to_code)?;
-        build_system_contracts(shell.clone(), &ecosystem_config.link_to_code)?;
-        build_l2_contracts(shell.clone(), &ecosystem_config.link_to_code)?;
+        install_yarn_dependencies(shell, &ecosystem_config.contracts_path())?;
+        build_da_contracts(shell, &ecosystem_config.contracts_path())?;
+        build_l1_contracts(shell.clone(), &ecosystem_config.contracts_path())?;
+        build_system_contracts(shell.clone(), &ecosystem_config.contracts_path())?;
+        build_l2_contracts(shell.clone(), &ecosystem_config.contracts_path())?;
     }
     spinner.finish();
 

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/register_ctm.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/register_ctm.rs
@@ -1,6 +1,6 @@
 use xshell::Shell;
 use zkstack_cli_common::{forge::ForgeScriptArgs, git, logger};
-use zkstack_cli_config::{EcosystemConfig, ZkStackConfig};
+use zkstack_cli_config::{EcosystemConfig, ZkStackConfig, ZkStackConfigTrait};
 
 use super::{
     args::init::{RegisterCTMArgs, RegisterCTMArgsFinal},
@@ -12,7 +12,7 @@ pub async fn run(args: RegisterCTMArgs, shell: &Shell) -> anyhow::Result<()> {
     let ecosystem_config = ZkStackConfig::ecosystem(shell)?;
 
     if args.update_submodules.is_none() || args.update_submodules == Some(true) {
-        git::submodule_update(shell, &ecosystem_config.link_to_code)?;
+        git::submodule_update(shell, &ecosystem_config.link_to_code())?;
     }
 
     let mut final_ecosystem_args = args

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/utils.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/utils.rs
@@ -8,12 +8,15 @@ pub(super) fn install_yarn_dependencies(shell: &Shell, link_to_code: &Path) -> a
     Ok(Cmd::new(cmd!(shell, "yarn install")).run()?)
 }
 
-pub(super) fn build_system_contracts(shell: &Shell, link_to_code: &Path) -> anyhow::Result<()> {
-    let _dir_guard = shell.push_dir(link_to_code.join("contracts"));
+pub(super) fn build_system_contracts(
+    shell: &Shell,
+    link_to_contracts: &Path,
+) -> anyhow::Result<()> {
+    let _dir_guard = shell.push_dir(link_to_contracts);
     Ok(Cmd::new(cmd!(shell, "yarn sc build")).run()?)
 }
 
-pub(super) fn build_da_contracts(shell: &Shell, link_to_code: &Path) -> anyhow::Result<()> {
-    let _dir_guard = shell.push_dir(link_to_code.join("contracts"));
+pub(super) fn build_da_contracts(shell: &Shell, link_to_contracts: &Path) -> anyhow::Result<()> {
+    let _dir_guard = shell.push_dir(link_to_contracts);
     Ok(Cmd::new(cmd!(shell, "yarn da build:foundry")).run()?)
 }

--- a/zkstack_cli/crates/zkstack/src/commands/external_node/build.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/external_node/build.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{cmd::Cmd, logger};
-use zkstack_cli_config::ZkStackConfig;
+use zkstack_cli_config::{ZkStackConfig, ZkStackConfigTrait};
 
 use crate::messages::{MSG_BUILDING_EN, MSG_FAILED_TO_BUILD_EN_ERR};
 

--- a/zkstack_cli/crates/zkstack/src/commands/external_node/init.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/external_node/init.rs
@@ -4,7 +4,9 @@ use zkstack_cli_common::{
     db::{drop_db_if_exists, init_db, migrate_db, DatabaseConfig},
     spinner::Spinner,
 };
-use zkstack_cli_config::{ChainConfig, SecretsConfig, ZkStackConfig, SECRETS_FILE};
+use zkstack_cli_config::{
+    ChainConfig, SecretsConfig, ZkStackConfig, ZkStackConfigTrait, SECRETS_FILE,
+};
 
 use crate::{
     consts::SERVER_MIGRATIONS,
@@ -42,7 +44,7 @@ pub async fn init(shell: &Shell, chain_config: &ChainConfig) -> anyhow::Result<(
         &chain_config.rocks_db_path,
         RocksDBDirOption::ExternalNode,
     )?;
-    let path_to_server_migration = chain_config.link_to_code.join(SERVER_MIGRATIONS);
+    let path_to_server_migration = chain_config.link_to_code().join(SERVER_MIGRATIONS);
     migrate_db(shell, &path_to_server_migration, &db_config.full_url()).await?;
     spin.finish();
     Ok(())

--- a/zkstack_cli/crates/zkstack/src/commands/private_rpc/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/private_rpc/mod.rs
@@ -11,7 +11,8 @@ use zkstack_cli_config::{
     docker_compose::{DockerComposeConfig, DockerComposeService},
     private_proxy_compose::{create_private_rpc_service, get_private_rpc_docker_compose_path},
     traits::SaveConfig,
-    ChainConfig, ZkStackConfig, DEFAULT_PRIVATE_RPC_PORT, DEFAULT_PRIVATE_RPC_TOKEN_SECRET,
+    ChainConfig, ZkStackConfig, ZkStackConfigTrait, DEFAULT_PRIVATE_RPC_PORT,
+    DEFAULT_PRIVATE_RPC_TOKEN_SECRET,
 };
 
 use crate::{
@@ -102,7 +103,7 @@ async fn initialize_private_rpc_database(
     let db_url = db_config.full_url();
     let url_str = db_url.as_str();
     let migrations_dir = chain_config
-        .link_to_code
+        .link_to_code()
         .join("private-rpc")
         .join("drizzle")
         .display()
@@ -143,7 +144,7 @@ pub async fn init(shell: &Shell, args: PrivateRpcCommandInitArgs) -> anyhow::Res
 
     let chain_name = chain_config.name.clone();
 
-    let _dir_guard = shell.push_dir(chain_config.link_to_code.join("private-rpc"));
+    let _dir_guard = shell.push_dir(chain_config.link_to_code().join("private-rpc"));
 
     logger::info(msg_private_rpc_docker_image_being_built());
     Cmd::new(cmd!(

--- a/zkstack_cli/crates/zkstack/src/commands/prover/compressor_keys.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/compressor_keys.rs
@@ -3,7 +3,9 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 use xshell::Shell;
 use zkstack_cli_common::{logger, spinner::Spinner};
-use zkstack_cli_config::{get_link_to_prover, GeneralConfigPatch, ZkStackConfig};
+use zkstack_cli_config::{
+    get_link_to_prover, GeneralConfigPatch, ZkStackConfig, ZkStackConfigTrait,
+};
 
 use super::args::compressor_keys::CompressorKeysArgs;
 use crate::messages::{MSG_DOWNLOADING_SETUP_COMPRESSOR_KEY_SPINNER, MSG_SETUP_KEY_PATH_ERROR};
@@ -12,7 +14,7 @@ pub(crate) async fn run(shell: &Shell, args: CompressorKeysArgs) -> anyhow::Resu
     let chain_config = ZkStackConfig::current_chain(shell)?;
     let mut general_config = chain_config.get_general_config().await?.patched();
 
-    let default_path = get_default_compressor_keys_path(&chain_config.link_to_code)?;
+    let default_path = get_default_compressor_keys_path(&chain_config.link_to_code())?;
     let args = args.fill_values_with_prompt(&default_path);
 
     let path = args.path.context(MSG_SETUP_KEY_PATH_ERROR)?;

--- a/zkstack_cli/crates/zkstack/src/commands/prover/init.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/init.rs
@@ -11,6 +11,7 @@ use zkstack_cli_common::{
 };
 use zkstack_cli_config::{
     copy_configs, get_link_to_prover, ObjectStoreConfig, ObjectStoreMode, ZkStackConfig,
+    ZkStackConfigTrait,
 };
 
 use super::{
@@ -36,7 +37,8 @@ pub(crate) async fn run(args: ProverInitArgs, shell: &Shell) -> anyhow::Result<(
         .load_current_chain()
         .context(MSG_CHAIN_NOT_FOUND_ERR)?;
 
-    let default_compressor_key_path = get_default_compressor_keys_path(&chain_config.link_to_code)?;
+    let default_compressor_key_path =
+        get_default_compressor_keys_path(&chain_config.link_to_code())?;
 
     let args = args.fill_values_with_prompt(shell, &default_compressor_key_path, &chain_config)?;
 
@@ -45,7 +47,11 @@ pub(crate) async fn run(args: ProverInitArgs, shell: &Shell) -> anyhow::Result<(
         || chain_config.get_wallets_config().is_err()
         || chain_config.get_contracts_config().is_err()
     {
-        copy_configs(shell, &chain_config.link_to_code, &chain_config.configs)?;
+        copy_configs(
+            shell,
+            &chain_config.default_configs_path(),
+            &chain_config.configs,
+        )?;
     }
 
     let mut general_config = chain_config.get_general_config().await?.patched();
@@ -81,7 +87,7 @@ pub(crate) async fn run(args: ProverInitArgs, shell: &Shell) -> anyhow::Result<(
         initialize_prover_database(
             shell,
             &prover_db.database_config,
-            &chain_config.link_to_code,
+            &chain_config.link_to_code(),
             prover_db.dont_drop,
         )
         .await?;

--- a/zkstack_cli/crates/zkstack/src/commands/prover/run.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/run.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::{anyhow, Context};
 use xshell::{cmd, Shell};
 use zkstack_cli_common::{check_prerequisites, cmd::Cmd, logger, GPU_PREREQUISITES};
-use zkstack_cli_config::{get_link_to_prover, ChainConfig, ZkStackConfig};
+use zkstack_cli_config::{get_link_to_prover, ChainConfig, ZkStackConfig, ZkStackConfigTrait};
 
 use super::args::run::{ProverComponent, ProverRunArgs};
 use crate::messages::{
@@ -21,7 +21,7 @@ pub(crate) async fn run(args: ProverRunArgs, shell: &Shell) -> anyhow::Result<()
 
     let path_to_ecosystem = shell.current_dir();
 
-    let link_to_prover = get_link_to_prover(&chain.link_to_code);
+    let link_to_prover = get_link_to_prover(&chain.link_to_code());
     shell.change_dir(link_to_prover.clone());
 
     let component = args.component.context(anyhow!(MSG_MISSING_COMPONENT_ERR))?;
@@ -64,7 +64,7 @@ pub(crate) async fn run(args: ProverRunArgs, shell: &Shell) -> anyhow::Result<()
 
     if in_docker {
         let path_to_configs = chain.configs.clone();
-        let path_to_prover = get_link_to_prover(&chain.link_to_code);
+        let path_to_prover = get_link_to_prover(&chain.link_to_code());
         update_setup_data_path(&chain, "prover/data/keys").await?;
         run_dockerized_component(
             shell,

--- a/zkstack_cli/crates/zkstack/src/commands/prover/setup_keys.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/prover/setup_keys.rs
@@ -3,7 +3,7 @@ use xshell::{cmd, Shell};
 use zkstack_cli_common::{
     check_prerequisites, cmd::Cmd, logger, spinner::Spinner, GCLOUD_PREREQUISITE, GPU_PREREQUISITES,
 };
-use zkstack_cli_config::{get_link_to_prover, ZkStackConfig};
+use zkstack_cli_config::{get_link_to_prover, ZkStackConfig, ZkStackConfigTrait};
 
 use crate::{
     commands::prover::args::setup_keys::{Mode, Region, SetupKeysArgs},
@@ -16,7 +16,7 @@ use crate::{
 pub(crate) async fn run(args: SetupKeysArgs, shell: &Shell) -> anyhow::Result<()> {
     let args = args.fill_values_with_prompt();
     let ecosystem_config = ZkStackConfig::ecosystem(shell)?;
-    let link_to_prover = get_link_to_prover(&ecosystem_config.link_to_code);
+    let link_to_prover = get_link_to_prover(&ecosystem_config.link_to_code());
 
     if args.mode == Mode::Generate {
         check_prerequisites(shell, &GPU_PREREQUISITES, false);
@@ -27,8 +27,7 @@ pub(crate) async fn run(args: SetupKeysArgs, shell: &Shell) -> anyhow::Result<()
         let proof_compressor_setup_path = general_config
             .proof_compressor_setup_path()
             .context(MSG_SETUP_KEY_PATH_ERROR)?;
-        let prover_path = get_link_to_prover(&ecosystem_config.link_to_code);
-        let proof_compressor_setup_path = prover_path.join(proof_compressor_setup_path);
+        let proof_compressor_setup_path = link_to_prover.join(proof_compressor_setup_path);
 
         if proof_compressor_setup_path.exists() {
             logger::info(format!(

--- a/zkstack_cli/crates/zkstack/src/commands/server.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/server.rs
@@ -8,7 +8,7 @@ use zkstack_cli_common::{
 };
 use zkstack_cli_config::{
     traits::FileConfigWithDefaultName, ChainConfig, ContractsConfig, WalletsConfig, ZkStackConfig,
-    GENERAL_FILE, GENESIS_FILE, SECRETS_FILE,
+    ZkStackConfigTrait, GENERAL_FILE, GENESIS_FILE, SECRETS_FILE,
 };
 
 use crate::{
@@ -30,7 +30,7 @@ pub async fn run(shell: &Shell, args: ServerArgs) -> anyhow::Result<()> {
 }
 
 fn build_server(chain_config: &ChainConfig, shell: &Shell) -> anyhow::Result<()> {
-    let _dir_guard = shell.push_dir(chain_config.link_to_code.join("core"));
+    let _dir_guard = shell.push_dir(chain_config.link_to_code().join("core"));
 
     logger::info(MSG_BUILDING_SERVER);
 
@@ -48,7 +48,7 @@ async fn run_server(
     let server = Server::new(
         args.server_command,
         args.components.clone(),
-        chain_config.link_to_code.clone(),
+        chain_config.link_to_code(),
         args.uring,
     );
 

--- a/zkstack_cli/crates/zkstack/src/commands/update.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/update.rs
@@ -9,8 +9,8 @@ use zkstack_cli_common::{
     yaml::{merge_yaml, ConfigDiff},
 };
 use zkstack_cli_config::{
-    ChainConfig, EcosystemConfig, ZkStackConfig, CONTRACTS_FILE, EN_CONFIG_FILE,
-    ERA_OBSERBAVILITY_DIR, GENERAL_FILE, GENESIS_FILE, SECRETS_FILE,
+    ChainConfig, EcosystemConfig, ZkStackConfig, ZkStackConfigTrait, CONTRACTS_FILE,
+    EN_CONFIG_FILE, ERA_OBSERBAVILITY_DIR, GENERAL_FILE, GENESIS_FILE, SECRETS_FILE,
 };
 
 use super::args::UpdateArgs;
@@ -33,11 +33,11 @@ pub async fn run(shell: &Shell, args: UpdateArgs) -> anyhow::Result<()> {
         update_repo(shell, &ecosystem)?;
     }
 
-    let general_config_path = ecosystem.get_default_configs_path().join(GENERAL_FILE);
-    let external_node_config_path = ecosystem.get_default_configs_path().join(EN_CONFIG_FILE);
-    let genesis_config_path = ecosystem.get_default_configs_path().join(GENESIS_FILE);
-    let contracts_config_path = ecosystem.get_default_configs_path().join(CONTRACTS_FILE);
-    let secrets_path = ecosystem.get_default_configs_path().join(SECRETS_FILE);
+    let general_config_path = ecosystem.default_configs_path().join(GENERAL_FILE);
+    let external_node_config_path = ecosystem.default_configs_path().join(EN_CONFIG_FILE);
+    let genesis_config_path = ecosystem.default_configs_path().join(GENESIS_FILE);
+    let contracts_config_path = ecosystem.default_configs_path().join(CONTRACTS_FILE);
+    let secrets_path = ecosystem.default_configs_path().join(SECRETS_FILE);
 
     for chain in ecosystem.list_of_chains() {
         logger::step(msg_updating_chain(&chain));
@@ -69,7 +69,7 @@ pub async fn run(shell: &Shell, args: UpdateArgs) -> anyhow::Result<()> {
 }
 
 fn update_repo(shell: &Shell, ecosystem: &EcosystemConfig) -> anyhow::Result<()> {
-    let link_to_code = &ecosystem.link_to_code;
+    let link_to_code = &ecosystem.link_to_code();
 
     let spinner = Spinner::new(MSG_PULLING_ZKSYNC_CODE_SPINNER);
     git::pull(shell, link_to_code)?;
@@ -184,11 +184,11 @@ async fn update_chain(
 
     let secrets = chain.get_secrets_config().await?;
     if let Some(url) = secrets.core_database_url()? {
-        let path_to_migration = chain.link_to_code.join(SERVER_MIGRATIONS);
+        let path_to_migration = chain.link_to_code().join(SERVER_MIGRATIONS);
         migrate_db(shell, &path_to_migration, &url).await?;
     }
     if let Some(url) = secrets.prover_database_url()? {
-        let path_to_migration = chain.link_to_code.join(PROVER_MIGRATIONS);
+        let path_to_migration = chain.link_to_code().join(PROVER_MIGRATIONS);
         migrate_db(shell, &path_to_migration, &url).await?;
     }
     Ok(())

--- a/zkstack_cli/crates/zkstack/src/consts.rs
+++ b/zkstack_cli/crates/zkstack/src/consts.rs
@@ -36,8 +36,7 @@ pub const CIRCUIT_PROVER_BINARY_NAME: &str = "zksync_circuit_prover";
 pub const COMPRESSOR_BINARY_NAME: &str = "zksync_proof_fri_compressor";
 pub const PROVER_JOB_MONITOR_BINARY_NAME: &str = "zksync_prover_job_monitor";
 
-pub const PATH_TO_ONLY_REAL_PROOFS_OVERRIDE_CONFIG: &str =
-    "etc/env/file_based/overrides/only_real_proofs.yaml";
-pub const PATH_TO_VALIDIUM_OVERRIDE_CONFIG: &str = "etc/env/file_based/overrides/validium.yaml";
+pub const PATH_TO_ONLY_REAL_PROOFS_OVERRIDE_CONFIG: &str = "/overrides/only_real_proofs.yaml";
+pub const PATH_TO_VALIDIUM_OVERRIDE_CONFIG: &str = "/overrides/validium.yaml";
 
-pub const PATH_TO_GATEWAY_OVERRIDE_CONFIG: &str = "etc/env/file_based/overrides/gateway.yaml";
+pub const PATH_TO_GATEWAY_OVERRIDE_CONFIG: &str = "/overrides/gateway.yaml";

--- a/zkstack_cli/crates/zkstack/src/consts.rs
+++ b/zkstack_cli/crates/zkstack/src/consts.rs
@@ -36,7 +36,7 @@ pub const CIRCUIT_PROVER_BINARY_NAME: &str = "zksync_circuit_prover";
 pub const COMPRESSOR_BINARY_NAME: &str = "zksync_proof_fri_compressor";
 pub const PROVER_JOB_MONITOR_BINARY_NAME: &str = "zksync_prover_job_monitor";
 
-pub const PATH_TO_ONLY_REAL_PROOFS_OVERRIDE_CONFIG: &str = "/overrides/only_real_proofs.yaml";
-pub const PATH_TO_VALIDIUM_OVERRIDE_CONFIG: &str = "/overrides/validium.yaml";
+pub const PATH_TO_ONLY_REAL_PROOFS_OVERRIDE_CONFIG: &str = "overrides/only_real_proofs.yaml";
+pub const PATH_TO_VALIDIUM_OVERRIDE_CONFIG: &str = "overrides/validium.yaml";
 
-pub const PATH_TO_GATEWAY_OVERRIDE_CONFIG: &str = "/overrides/gateway.yaml";
+pub const PATH_TO_GATEWAY_OVERRIDE_CONFIG: &str = "overrides/gateway.yaml";

--- a/zkstack_cli/crates/zkstack/src/external_node.rs
+++ b/zkstack_cli/crates/zkstack/src/external_node.rs
@@ -3,7 +3,8 @@ use std::path::PathBuf;
 use anyhow::Context;
 use xshell::Shell;
 use zkstack_cli_config::{
-    ChainConfig, CONSENSUS_CONFIG_FILE, EN_CONFIG_FILE, GENERAL_FILE, SECRETS_FILE,
+    ChainConfig, ZkStackConfigTrait, CONSENSUS_CONFIG_FILE, EN_CONFIG_FILE, GENERAL_FILE,
+    SECRETS_FILE,
 };
 
 use crate::messages::MSG_FAILED_TO_RUN_SERVER_ERR;
@@ -33,7 +34,7 @@ impl RunExternalNode {
 
         Ok(Self {
             components,
-            code_path: chain_config.link_to_code.clone(),
+            code_path: chain_config.link_to_code().clone(),
             general_config,
             secrets,
             en_config,

--- a/zkstack_cli/crates/zkstack/src/utils/link_to_code.rs
+++ b/zkstack_cli/crates/zkstack/src/utils/link_to_code.rs
@@ -1,7 +1,4 @@
-use std::{
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::path::{Path, PathBuf};
 
 use anyhow::bail;
 use strum::{EnumIter, IntoEnumIterator};
@@ -32,8 +29,7 @@ impl std::fmt::Display for LinkToCodeSelection {
     }
 }
 
-fn check_link_to_code(shell: &Shell, path: &str) -> anyhow::Result<()> {
-    let path = Path::new(path);
+fn check_link_to_code(shell: &Shell, path: &Path) -> anyhow::Result<()> {
     if !shell.path_exists(path) {
         bail!(msg_path_to_zksync_does_not_exist_err(
             path.to_str().unwrap()
@@ -54,8 +50,8 @@ fn check_link_to_code(shell: &Shell, path: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn pick_new_link_to_code(shell: &Shell) -> String {
-    let link_to_code: String = Prompt::new(MSG_LINK_TO_CODE_PROMPT).ask();
+fn pick_new_link_to_code(shell: &Shell) -> PathBuf {
+    let link_to_code: PathBuf = Prompt::new(MSG_LINK_TO_CODE_PROMPT).ask();
     match check_link_to_code(shell, &link_to_code) {
         Ok(_) => link_to_code,
         Err(err) => {
@@ -69,20 +65,20 @@ fn pick_new_link_to_code(shell: &Shell) -> String {
     }
 }
 
-pub(crate) fn get_link_to_code(shell: &Shell) -> String {
+pub(crate) fn get_link_to_code(shell: &Shell) -> Option<PathBuf> {
     let link_to_code_selection =
         PromptSelect::new(MSG_REPOSITORY_ORIGIN_PROMPT, LinkToCodeSelection::iter()).ask();
     match link_to_code_selection {
-        LinkToCodeSelection::Clone => "".to_string(),
+        LinkToCodeSelection::Clone => None,
         LinkToCodeSelection::Path => {
-            let mut path: String = Prompt::new(MSG_LINK_TO_CODE_PROMPT).ask();
+            let mut path: PathBuf = Prompt::new(MSG_LINK_TO_CODE_PROMPT).ask();
             if let Err(err) = check_link_to_code(shell, &path) {
                 logger::warn(err);
                 if !PromptConfirm::new(MSG_CONFIRM_STILL_USE_FOLDER).ask() {
                     path = pick_new_link_to_code(shell);
                 }
             }
-            path
+            Some(path)
         }
     }
 }
@@ -90,10 +86,15 @@ pub(crate) fn get_link_to_code(shell: &Shell) -> String {
 pub(crate) fn resolve_link_to_code(
     shell: &Shell,
     base_path: &Path,
-    link_to_code: String,
+    link_to_code: Option<PathBuf>,
     update_submodules: Option<bool>,
 ) -> anyhow::Result<PathBuf> {
-    if link_to_code.is_empty() {
+    if let Some(link_to_code) = link_to_code {
+        if update_submodules.is_none() || update_submodules == Some(true) {
+            git::submodule_update(shell, &link_to_code)?;
+        }
+        Ok(link_to_code)
+    } else {
         if base_path.join("zksync-era").exists() {
             return Ok(base_path.join("zksync-era"));
         }
@@ -104,11 +105,5 @@ pub(crate) fn resolve_link_to_code(
         let link_to_code = git::clone(shell, base_path, ZKSYNC_ERA_GIT_REPO, "zksync-era")?;
         spinner.finish();
         Ok(link_to_code)
-    } else {
-        let path = PathBuf::from_str(&link_to_code)?;
-        if update_submodules.is_none() || update_submodules == Some(true) {
-            git::submodule_update(shell, &path)?;
-        }
-        Ok(path)
     }
 }


### PR DESCRIPTION
## What ❔

Before for chain/ecosystem trait we had only `link_to_code` and all other path has been calculated from this link. 
Now it's a trait, that allows to implement custom paths for `link_to_code`, `contracts`, `configs`

## Why ❔

For supporting different ways of initialization, we need to support different path.
e.g. we have zksync_os, where we will be able to pass custom `contracts_path`. 

For docker based deployment we will be able to calculate custom path inside containers. 


## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
