### PR TITLE
fix: correct various typos across documentation and code

### DIFF
--- a/core/node/da_clients/src/celestia/generated/cosmos.tx.v1beta1.rs
+++ b/core/node/da_clients/src/celestia/generated/cosmos.tx.v1beta1.rs
@@ -238,7 +238,7 @@ impl ::prost::Name for ModeInfo {
 ///
 /// Fee includes the amount of coins paid in fees and the maximum
 /// gas to be used by the transaction. The ratio yields an effective "gasprice",
-/// which must be above some miminum to be accepted into the mempool.
+/// which must be above some minimum to be accepted into the mempool.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Fee {
     /// amount is the amount of coins to be paid as a fee

--- a/core/node/state_keeper/src/testonly/test_batch_executor.rs
+++ b/core/node/state_keeper/src/testonly/test_batch_executor.rs
@@ -287,7 +287,7 @@ impl TestScenario {
     /// Launches the test and checks for sequencer panic with message.
     /// Provided `SealManager` is expected to be externally configured to adhere the written scenario logic.
     pub(crate) async fn run_panic(self, sealer: Arc<dyn ConditionalSealer>, message: &str) {
-        let join_error = self.run(sealer).await.expect_err("Not paniced");
+        let join_error = self.run(sealer).await.expect_err("Not panicked");
         let panic_message = join_error.into_panic().downcast::<&'static str>().unwrap();
         assert!(panic_message.contains(message), "Different panic message");
     }

--- a/docs/src/guides/advanced/17_batch_reverter.md
+++ b/docs/src/guides/advanced/17_batch_reverter.md
@@ -2,8 +2,8 @@
 
 ### Motivation
 
-In extremly rare circumstances due to an operator mistake or a bug zksync-era you may revert unexecuted L1 batches. This
-could be usefull if an unprovable batch would be committed or a commit tranasction failed due to mismatch between server
+In extremely rare circumstances due to an operator mistake or a bug zksync-era you may revert unexecuted L1 batches. This
+could be useful if an unprovable batch would be committed or a commit transaction failed due to mismatch between server
 and blockchain state.
 
 ### Overview
@@ -52,7 +52,7 @@ Suggested values for rollback: SuggestedRollbackValues {
 ```
 
 - Rollback blocks on contract: run `send-eth-transaction` (Only if revert on L1 is needed). Note: here and later
-  `--l1-batch-number` is the number of latest batch **remining** after revert.
+  `--l1-batch-number` is the number of latest batch **remaining** after revert.
 
 ```bash
 root@server-0:/# RUST_LOG=info ETH_SENDER_SENDER_OPERATOR_PRIVATE_KEY=CHANGE_ME ./usr/bin/block_reverter send-eth-transaction \

--- a/docs/src/specs/contracts/bridging/interop/interop_center/bundles_calls.md
+++ b/docs/src/specs/contracts/bridging/interop/interop_center/bundles_calls.md
@@ -47,7 +47,7 @@ contract InteropCenter {
   // If it fails, it can be called again.
   function executeInteropBundle(interopMessage, proof);
 
-  // If the bundle didn't execute succesfully yet, it can be marked as cancelled.
+  // If the bundle didn't execute successfully yet, it can be marked as cancelled.
   // See details below.
   function cancelInteropBundle(interopMessage, proof);
 }

--- a/docs/src/specs/contracts/bridging/interop/interop_center/interop_messages.md
+++ b/docs/src/specs/contracts/bridging/interop/interop_center/interop_messages.md
@@ -39,7 +39,7 @@ contract InteropCenter {
    uint256 messageNum; // a 'nonce' to guarantee different hashes.
  }
 
- // Verifies if such interop message was ever producted.
+ // Verifies if such interop message was ever produced.
  function verifyInteropMessage(bytes32 interopHash, Proof merkleProof) return bool;
 }
 ```

--- a/prover/crates/lib/witness_generator_service/README.md
+++ b/prover/crates/lib/witness_generator_service/README.md
@@ -1,7 +1,7 @@
 # Witness generator Service
 
 This crate provides the building blocks for running Witness generator. It consists of five rounds: BasicCircuits,
-LeafAggregation, NodeAggregation, RecursionTip and Scheduler. Each round has its own implemenatation of `JobManager` and
+LeafAggregation, NodeAggregation, RecursionTip and Scheduler. Each round has its own implementation of `JobManager` and
 `ArtifactsManager`.
 
 The primitive exported by this lib is witness_generator_runner.
@@ -22,7 +22,7 @@ database.
 
 ## Witness generator Runner
 
-Runner is tied to correspoding tables depending on a round:
+Runner is tied to corresponding tables depending on a round:
 
 - BasicCircuits - `witness_inputs_fri`
 - LeafAggregation - `leaf_aggregation_witness_jobs_fri`

--- a/prover/crates/lib/witness_generator_service/src/rounds/recursion_tip/mod.rs
+++ b/prover/crates/lib/witness_generator_service/src/rounds/recursion_tip/mod.rs
@@ -185,7 +185,7 @@ impl JobManager for RecursionTip {
         assert_eq!(
             leaf_vk_commits.len(),
             EXPECTED_RECURSION_TIP_LEAVES,
-            "expected 16 leaf vk commits, which corresponds to the numebr of circuits, got {}",
+            "expected 16 leaf vk commits, which corresponds to the number of circuits, got {}",
             leaf_vk_commits.len()
         );
         let leaf_layer_parameters: [RecursionLeafParametersWitness<GoldilocksField>;

--- a/zkstack_cli/README.md
+++ b/zkstack_cli/README.md
@@ -525,7 +525,7 @@ Format code:
 zkstack dev fmt
 ```
 
-By default, this command runs all formatters. To run a specific fomatter use the following subcommands:
+By default, this command runs all formatters. To run a specific formatter use the following subcommands:
 
 - `rustfmt`: Runs `cargo fmt`.
 - `prettier`: Runs `prettier`.

--- a/zkstack_cli/crates/zkstack/README.md
+++ b/zkstack_cli/crates/zkstack/README.md
@@ -564,7 +564,7 @@ Setup keys
 
 - `--mode`
 
-  Possible valuess: `download`, `generate`
+  Possible values: `download`, `generate`
 
 - `--region`
 
@@ -589,7 +589,7 @@ Run prover
 
 - `--tag' - Tag of the docker image to run.
 
-  Default value is `latest2.0` but you can specify your prefered one.
+  Default value is `latest2.0` but you can specify your preferred one.
 
 - `--round <ROUND>`
 

--- a/zkstack_cli/crates/zkstack/src/messages.rs
+++ b/zkstack_cli/crates/zkstack/src/messages.rs
@@ -108,7 +108,7 @@ pub(super) const MSG_CHAIN_CONFIGS_INITIALIZED: &str = "Chain configs were initi
 pub(super) const MSG_CHAIN_OWNERSHIP_TRANSFERRED: &str =
     "Chain ownership was transferred successfully";
 pub(super) const MSG_EVM_EMULATOR_ENABLED: &str = "EVM emulator enabled successfully";
-pub(super) const MSG_CHAIN_REGISTERED: &str = "Chain registraion was successful";
+pub(super) const MSG_CHAIN_REGISTERED: &str = "Chain registration was successful";
 pub(super) const MSG_DISTRIBUTING_ETH_SPINNER: &str = "Distributing eth...";
 pub(super) const MSG_MINT_BASE_TOKEN_SPINNER: &str =
     "Minting base token to the governance addresses...";


### PR DESCRIPTION


## **Description:**
```markdown
This PR addresses several minor typos found throughout the codebase to improve code quality and documentation clarity.

### Changes Made:

**Documentation Files:**
- `docs/src/guides/advanced/17_batch_reverter.md`: Fixed "extremly" → "extremely", "usefull" → "useful", "tranasction" → "transaction", "remining" → "remaining"
- `docs/src/specs/contracts/bridging/interop/interop_center/bundles_calls.md`: Fixed "succesfully" → "successfully"
- `docs/src/specs/contracts/bridging/interop/interop_center/interop_messages.md`: Fixed "producted" → "produced"
- `prover/crates/lib/witness_generator_service/README.md`: Fixed "implemenatation" → "implementation", "correspoding" → "corresponding"
- `zkstack_cli/README.md`: Fixed "fomatter" → "formatter"
- `zkstack_cli/crates/zkstack/README.md`: Fixed "valuess" → "values", "prefered" → "preferred"

**Source Code:**
- `core/node/da_clients/src/celestia/generated/cosmos.tx.v1beta1.rs`: Fixed "miminum" → "minimum" in comment
- `core/node/state_keeper/src/testonly/test_batch_executor.rs`: Fixed "paniced" → "panicked" in test message
- `prover/crates/lib/witness_generator_service/src/rounds/recursion_tip/mod.rs`: Fixed "numebr" → "number" in assertion message
- `zkstack_cli/crates/zkstack/src/messages.rs`: Fixed "registraion" → "registration" in constant message
```