### PR TITLE
fix: make sed work on macOS and Linux

### DIFF
--- a/etc/nix/update-foundry-zksync.sh
+++ b/etc/nix/update-foundry-zksync.sh
@@ -11,16 +11,32 @@ update_sha() {
 
     case "$platform" in
         "linux_amd64")
-            sed -i.bak "s/linux_amd_bin_sha = \".*\"/linux_amd_bin_sha = \"$new_sha\"/" "$file" && rm -f "$file.bak"
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+                sed -i "" "s/linux_amd_bin_sha = \".*\"/linux_amd_bin_sha = \"$new_sha\"/" "$file"
+            else
+                sed -i "s/linux_amd_bin_sha = \".*\"/linux_amd_bin_sha = \"$new_sha\"/" "$file"
+            fi
             ;;
         "linux_arm64")
-            sed -i.bak "s/linux_arm_bin_sha = \".*\"/linux_arm_bin_sha = \"$new_sha\"/" "$file" && rm -f "$file.bak"
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+                sed -i "" "s/linux_arm_bin_sha = \".*\"/linux_arm_bin_sha = \"$new_sha\"/" "$file"
+            else
+                sed -i "s/linux_arm_bin_sha = \".*\"/linux_arm_bin_sha = \"$new_sha\"/" "$file"
+            fi
             ;;
         "darwin_amd64")
-            sed -i.bak "s/darwin_amd_bin_sha = \".*\"/darwin_amd_bin_sha = \"$new_sha\"/" "$file" && rm -f "$file.bak"
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+                sed -i "" "s/darwin_amd_bin_sha = \".*\"/darwin_amd_bin_sha = \"$new_sha\"/" "$file"
+            else
+                sed -i "s/darwin_amd_bin_sha = \".*\"/darwin_amd_bin_sha = \"$new_sha\"/" "$file"
+            fi
             ;;
         "darwin_arm64")
-            sed -i.bak "s/darwin_arm_bin_sha = \".*\"/darwin_arm_bin_sha = \"$new_sha\"/" "$file" && rm -f "$file.bak"
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+                sed -i "" "s/darwin_arm_bin_sha = \".*\"/darwin_arm_bin_sha = \"$new_sha\"/" "$file"
+            else
+                sed -i "s/darwin_arm_bin_sha = \".*\"/darwin_arm_bin_sha = \"$new_sha\"/" "$file"
+            fi
             ;;
     esac
 }
@@ -33,7 +49,11 @@ fi
 # Update version in the file if provided as argument
 if [ "$1" ]; then
     VERSION="$1"
-    sed -i "s/version *= *\".*\"/version = \"$VERSION\"/" ./foundry-zksync.nix
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i "" "s/version *= *\".*\"/version = \"$VERSION\"/" ./foundry-zksync.nix
+    else
+        sed -i "s/version *= *\".*\"/version = \"$VERSION\"/" ./foundry-zksync.nix
+    fi
 fi
 
 echo "Updating foundry-zksync to version $VERSION..."


### PR DESCRIPTION
## What ❔

fix `sed -i` so the script works on both macOS and Linux.

## Why ❔

`sed -i` behaves differently on macOS and Linux.
on macOS it requires a backup suffix, otherwise it breaks.
this change ensures cross-platform compatibility by checking `OSTYPE`.

## Is this a breaking change?

* [ ] Yes
* [x] No

## Operational changes

none, just updates the script to work correctly on both platforms.

## Checklist

* [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
* [ ] Tests for the changes have been added / updated.
* [ ] Documentation comments have been added / updated.
* [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
