### PR TITLE
feat: add flag to save calldata

### DIFF
--- a/zkstack_cli/crates/config/src/forge_interface/script_params.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/script_params.rs
@@ -38,7 +38,7 @@ pub const DEPLOY_ECOSYSTEM_CORE_CONTRACTS_SCRIPT_PARAMS: ForgeScriptParams = For
 
 pub const REGISTER_CTM_SCRIPT_PARAMS: ForgeScriptParams = ForgeScriptParams {
     input: "script-config/config-deploy-l1.toml",
-    output: "script-out/output-deploy-l1.toml",
+    output: "script-out/register-ctm-l1.toml",
     script_path: "deploy-scripts/RegisterCTM.s.sol",
 };
 

--- a/zkstack_cli/crates/zkstack/src/admin_functions.rs
+++ b/zkstack_cli/crates/zkstack/src/admin_functions.rs
@@ -407,7 +407,7 @@ impl AdminScriptMode {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
-struct AdminScriptOutputInner {
+pub(crate) struct AdminScriptOutputInner {
     admin_address: Address,
     encoded_data: String,
 }

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/init.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/init.rs
@@ -269,6 +269,8 @@ pub struct RegisterCTMArgs {
     pub update_submodules: Option<bool>,
     #[clap(long, help = MSG_DEV_ARG_HELP)]
     pub dev: bool,
+    #[clap(long, default_missing_value = "false", num_args = 0..=1)]
+    pub only_save_calldata: bool,
 }
 
 impl RegisterCTMArgs {
@@ -281,6 +283,7 @@ impl RegisterCTMArgs {
             forge_args,
             update_submodules,
             dev,
+            only_save_calldata,
         } = self;
 
         let ecosystem = ecosystem.fill_values_with_prompt(l1_network, dev).await?;
@@ -289,6 +292,7 @@ impl RegisterCTMArgs {
             ecosystem,
             forge_args,
             update_submodules,
+            only_save_calldata,
         })
     }
 }
@@ -298,6 +302,7 @@ pub struct RegisterCTMArgsFinal {
     pub ecosystem: EcosystemArgsFinal,
     pub forge_args: ForgeScriptArgs,
     pub update_submodules: Option<bool>,
+    pub only_save_calldata: bool,
 }
 
 impl From<EcosystemInitArgsFinal> for RegisterCTMArgsFinal {
@@ -306,6 +311,7 @@ impl From<EcosystemInitArgsFinal> for RegisterCTMArgsFinal {
             ecosystem: args.ecosystem,
             forge_args: args.forge_args,
             update_submodules: None,
+            only_save_calldata: false,
         }
     }
 }

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/common.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/common.rs
@@ -29,6 +29,7 @@ use zkstack_cli_types::{L1Network, ProverMode};
 
 use super::args::init::EcosystemInitArgsFinal;
 use crate::{
+    admin_functions::{AdminScriptOutput, AdminScriptOutputInner},
     commands::chain::{self},
     messages::{msg_chain_load_err, msg_initializing_chain, MSG_DEPLOYING_ERC20_SPINNER},
     utils::forge::{check_the_balance, fill_forge_private_key, WalletOwner},
@@ -38,6 +39,8 @@ lazy_static! {
     static ref DEPLOY_L1_FUNCTIONS: BaseContract = BaseContract::from(
         parse_abi(&["function runWithBridgehub(address bridgehub) public",]).unwrap(),
     );
+    static ref REGISTER_CTM_FUNCTIONS: BaseContract =
+        BaseContract::from(parse_abi(&["function registerCTM(bool shouldSend) public",]).unwrap(),);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -193,13 +196,18 @@ pub async fn register_ctm_on_existing_bh(
     config: &EcosystemConfig,
     l1_rpc_url: &str,
     sender: Option<String>,
-    broadcast: bool,
-) -> anyhow::Result<()> {
+    only_save_calldata: bool,
+) -> anyhow::Result<AdminScriptOutput> {
     let wallets_config = config.get_wallets()?;
+
+    let calldata = REGISTER_CTM_FUNCTIONS
+        .encode("registerCTM", !only_save_calldata)
+        .unwrap();
 
     let mut forge = Forge::new(&config.path_to_foundry_scripts())
         .script(&REGISTER_CTM_SCRIPT_PARAMS.script(), forge_args.clone())
         .with_ffi()
+        .with_calldata(&calldata)
         .with_rpc_url(l1_rpc_url.to_string());
 
     if config.l1_network == L1Network::Localhost {
@@ -214,14 +222,15 @@ pub async fn register_ctm_on_existing_bh(
             fill_forge_private_key(forge, Some(&wallets_config.governor), WalletOwner::Governor)?;
     }
 
-    if broadcast {
+    if !only_save_calldata {
         forge = forge.with_broadcast();
         check_the_balance(&forge).await?;
     }
 
+    let output_path = REGISTER_CTM_SCRIPT_PARAMS.output(&config.path_to_foundry_scripts());
     forge.run(shell)?;
 
-    Ok(())
+    Ok(AdminScriptOutputInner::read(shell, output_path)?.into())
 }
 
 pub async fn deploy_erc20(

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/init.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/init.rs
@@ -141,7 +141,7 @@ async fn init_ecosystem(
     let forge_args = init_args.forge_args.clone();
 
     let mut reg_args = RegisterCTMArgsFinal::from((*init_args).clone());
-    register_ctm(&mut reg_args, shell, forge_args, ecosystem_config).await?;
+    register_ctm(&mut reg_args, shell, forge_args, ecosystem_config, false).await?;
 
     Ok(contracts)
 }

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/register_ctm.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/register_ctm.rs
@@ -6,7 +6,7 @@ use super::{
     args::init::{RegisterCTMArgs, RegisterCTMArgsFinal},
     common::register_ctm_on_existing_bh,
 };
-use crate::messages::MSG_REGISTERING_CTM;
+use crate::{commands::chain::utils::display_admin_script_output, messages::MSG_REGISTERING_CTM};
 
 pub async fn run(args: RegisterCTMArgs, shell: &Shell) -> anyhow::Result<()> {
     let ecosystem_config = ZkStackConfig::ecosystem(shell)?;
@@ -29,6 +29,7 @@ pub async fn run(args: RegisterCTMArgs, shell: &Shell) -> anyhow::Result<()> {
         shell,
         forge_args,
         &ecosystem_config,
+        args.only_save_calldata,
     )
     .await?;
 
@@ -40,16 +41,19 @@ pub async fn register_ctm(
     shell: &Shell,
     forge_args: ForgeScriptArgs,
     ecosystem_config: &EcosystemConfig,
+    only_save_calldata: bool,
 ) -> anyhow::Result<()> {
-    register_ctm_on_existing_bh(
+    let output = register_ctm_on_existing_bh(
         shell,
         &forge_args,
         ecosystem_config,
         &init_args.ecosystem.l1_rpc_url,
         None,
-        true,
+        only_save_calldata,
     )
     .await?;
+
+    display_admin_script_output(output);
 
     Ok(())
 }


### PR DESCRIPTION
## What ❔

Adding the ability to save calldata for register-ctm calls (without execution)

## Why ❔

We want to execute it with PUH

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
Yes, it adds a flag `only_save_calldata` to the `register-ctm` command.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
