### PR TITLE
fix: Revert "fix: bump foundry-zksync (#4470)"

### DIFF
--- a/.github/workflows/build-contract-verifier-template.yml
+++ b/.github/workflows/build-contract-verifier-template.yml
@@ -100,8 +100,8 @@ jobs:
         if: env.BUILD_CONTRACTS == 'true'
         run: |
           mkdir ./foundry-zksync
-          curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/nightly-63d81adeceb7412682a2b6826f0564614bbbc6cc/foundry_zksync_nightly_linux_amd64.tar.gz
-          tar zxf foundry_zksync_nightly_linux_amd64.tar.gz -C ./foundry-zksync
+          curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/nightly-27360d4c8d12beddbb730dae07ad33a206b38f4b/foundry_nightly_linux_amd64.tar.gz
+          tar zxf foundry_nightly_linux_amd64.tar.gz -C ./foundry-zksync
           chmod +x ./foundry-zksync/forge ./foundry-zksync/cast
           echo "$PWD/foundry-zksync" >> $GITHUB_PATH
 

--- a/.github/workflows/build-core-template.yml
+++ b/.github/workflows/build-core-template.yml
@@ -105,8 +105,8 @@ jobs:
         if: env.BUILD_CONTRACTS == 'true'
         run: |
           mkdir ./foundry-zksync
-          curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/nightly-63d81adeceb7412682a2b6826f0564614bbbc6cc/foundry_zksync_nightly_linux_amd64.tar.gz
-          tar zxf foundry_zksync_nightly_linux_amd64.tar.gz -C ./foundry-zksync
+          curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/nightly-27360d4c8d12beddbb730dae07ad33a206b38f4b/foundry_nightly_linux_amd64.tar.gz
+          tar zxf foundry_nightly_linux_amd64.tar.gz -C ./foundry-zksync
           chmod +x ./foundry-zksync/forge ./foundry-zksync/cast
           echo "$PWD/foundry-zksync" >> $GITHUB_PATH
 

--- a/docker/zk-environment/22.04_amd64_cuda_11_8.Dockerfile
+++ b/docker/zk-environment/22.04_amd64_cuda_11_8.Dockerfile
@@ -84,7 +84,7 @@ RUN cargo install --version=0.8.0 sqlx-cli
 RUN cargo install cargo-nextest
 
 RUN git clone https://github.com/matter-labs/foundry-zksync
-RUN cd foundry-zksync && git reset --hard 63d81adeceb7412682a2b6826f0564614bbbc6cc && cargo build --release --bins
+RUN cd foundry-zksync && git reset --hard 27360d4c8d12beddbb730dae07ad33a206b38f4b && cargo build --release --bins
 RUN mv ./foundry-zksync/target/release/forge /usr/local/cargo/bin/
 RUN mv ./foundry-zksync/target/release/cast /usr/local/cargo/bin/
 

--- a/docker/zk-environment/22.04_amd64_cuda_12.Dockerfile
+++ b/docker/zk-environment/22.04_amd64_cuda_12.Dockerfile
@@ -82,7 +82,7 @@ RUN cargo install --version=0.8.0 sqlx-cli
 RUN cargo install cargo-nextest
 
 RUN git clone https://github.com/matter-labs/foundry-zksync
-RUN cd foundry-zksync && git reset --hard 63d81adeceb7412682a2b6826f0564614bbbc6cc && cargo build --release --bins
+RUN cd foundry-zksync && git reset --hard 27360d4c8d12beddbb730dae07ad33a206b38f4b && cargo build --release --bins
 RUN mv ./foundry-zksync/target/release/forge /usr/local/cargo/bin/
 RUN mv ./foundry-zksync/target/release/cast /usr/local/cargo/bin/
 

--- a/docker/zk-environment/Dockerfile
+++ b/docker/zk-environment/Dockerfile
@@ -47,7 +47,7 @@ RUN cargo install cargo-spellcheck
 RUN cargo install sccache
 
 RUN git clone https://github.com/matter-labs/foundry-zksync
-RUN cd foundry-zksync && git reset --hard 63d81adeceb7412682a2b6826f0564614bbbc6cc && cargo build --release --bins
+RUN cd foundry-zksync && git reset --hard 27360d4c8d12beddbb730dae07ad33a206b38f4b && cargo build --release --bins
 RUN mv ./foundry-zksync/target/release/forge /usr/local/cargo/bin/
 RUN mv ./foundry-zksync/target/release/cast /usr/local/cargo/bin/
 


### PR DESCRIPTION
This reverts commit ec900ccca2e8c8540172a3330214e1a512aaa358.

Bumping of foundry has caused a different bytecode hashes to be producted, which results a failures in genesis (mismatch hashes) and issues with unittests (hashes not matching era-contract ones).

Rolling back for now, until we can find a better solution.