### PR TITLE
feat(zkstack-cli): add prove & execute wallets 

### DIFF
--- a/zkstack_cli/crates/config/src/forge_interface/register_chain/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/register_chain/input.rs
@@ -59,6 +59,9 @@ pub struct ChainL1Config {
     pub validium_mode: bool,
     pub validator_sender_operator_commit_eth: Address,
     pub validator_sender_operator_blobs_eth: Address,
+    /// Additional validators that can be used for prove & execute (when these are handled by different entities).
+    pub validator_sender_prove_operator: Option<Address>,
+    pub validator_sender_execute_operator: Option<Address>,
     pub base_token_gas_price_multiplier_nominator: u64,
     pub base_token_gas_price_multiplier_denominator: u64,
     pub governance_security_council_address: Address,
@@ -121,6 +124,14 @@ impl RegisterChainL1Config {
                     == L1BatchCommitmentMode::Validium,
                 validator_sender_operator_commit_eth: wallets_config.operator.address,
                 validator_sender_operator_blobs_eth: wallets_config.blob_operator.address,
+                validator_sender_prove_operator: wallets_config
+                    .prove_operator
+                    .as_ref()
+                    .map(|w| w.address),
+                validator_sender_execute_operator: wallets_config
+                    .execute_operator
+                    .as_ref()
+                    .map(|w| w.address),
                 allow_evm_emulator: chain_config.evm_emulator,
             },
             owner_address: wallets_config.governor.address,

--- a/zkstack_cli/crates/config/src/forge_interface/register_chain/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/register_chain/input.rs
@@ -60,8 +60,8 @@ pub struct ChainL1Config {
     pub validator_sender_operator_commit_eth: Address,
     pub validator_sender_operator_blobs_eth: Address,
     /// Additional validators that can be used for prove & execute (when these are handled by different entities).
-    pub validator_sender_prove_operator: Option<Address>,
-    pub validator_sender_execute_operator: Option<Address>,
+    pub validator_sender_operator_prove: Option<Address>,
+    pub validator_sender_operator_execute: Option<Address>,
     pub base_token_gas_price_multiplier_nominator: u64,
     pub base_token_gas_price_multiplier_denominator: u64,
     pub governance_security_council_address: Address,
@@ -124,11 +124,11 @@ impl RegisterChainL1Config {
                     == L1BatchCommitmentMode::Validium,
                 validator_sender_operator_commit_eth: wallets_config.operator.address,
                 validator_sender_operator_blobs_eth: wallets_config.blob_operator.address,
-                validator_sender_prove_operator: wallets_config
+                validator_sender_operator_prove: wallets_config
                     .prove_operator
                     .as_ref()
                     .map(|w| w.address),
-                validator_sender_execute_operator: wallets_config
+                validator_sender_operator_execute: wallets_config
                     .execute_operator
                     .as_ref()
                     .map(|w| w.address),

--- a/zkstack_cli/crates/config/src/forge_interface/register_chain/input.rs
+++ b/zkstack_cli/crates/config/src/forge_interface/register_chain/input.rs
@@ -60,7 +60,9 @@ pub struct ChainL1Config {
     pub validator_sender_operator_commit_eth: Address,
     pub validator_sender_operator_blobs_eth: Address,
     /// Additional validators that can be used for prove & execute (when these are handled by different entities).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub validator_sender_operator_prove: Option<Address>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub validator_sender_operator_execute: Option<Address>,
     pub base_token_gas_price_multiplier_nominator: u64,
     pub base_token_gas_price_multiplier_denominator: u64,

--- a/zkstack_cli/crates/config/src/wallet_creation.rs
+++ b/zkstack_cli/crates/config/src/wallet_creation.rs
@@ -64,5 +64,15 @@ pub fn create_localhost_wallets(
             5,
         )?),
         test_wallet: None,
+        prove_operator: Some(Wallet::from_mnemonic(
+            &eth_mnemonic.test_mnemonic,
+            &base_path,
+            6,
+        )?),
+        execute_operator: Some(Wallet::from_mnemonic(
+            &eth_mnemonic.test_mnemonic,
+            &base_path,
+            7,
+        )?),
     })
 }

--- a/zkstack_cli/crates/config/src/wallets.rs
+++ b/zkstack_cli/crates/config/src/wallets.rs
@@ -10,8 +10,14 @@ use crate::{
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WalletsConfig {
     pub deployer: Option<Wallet>,
+    /// This wallet can be used for any operations (commit, prove, execute, etc.)
     pub operator: Wallet,
+    /// This wallet should be used only for 'commit' when using blobs.
     pub blob_operator: Wallet,
+    /// These are optional wallets, that can be used for prove & execute (when these are handled by different entities).
+    pub prove_operator: Option<Wallet>,
+    pub execute_operator: Option<Wallet>,
+
     pub fee_account: Wallet,
     pub governor: Wallet,
     pub token_multiplier_setter: Option<Wallet>,
@@ -27,6 +33,8 @@ impl WalletsConfig {
             operator: Wallet::random(rng),
             blob_operator: Wallet::random(rng),
             fee_account: Wallet::random(rng),
+            prove_operator: Some(Wallet::random(rng)),
+            execute_operator: Some(Wallet::random(rng)),
             governor: Wallet::random(rng),
             token_multiplier_setter: Some(Wallet::random(rng)),
             test_wallet: None,
@@ -39,6 +47,8 @@ impl WalletsConfig {
             deployer: Some(Wallet::empty()),
             operator: Wallet::empty(),
             blob_operator: Wallet::empty(),
+            prove_operator: None,
+            execute_operator: None,
             fee_account: Wallet::empty(),
             governor: Wallet::empty(),
             token_multiplier_setter: Some(Wallet::empty()),


### PR DESCRIPTION
## What ❔

* Added wallet for prove & execute
* It is optional - so that we are backwards compatible with old configs.

## Why ❔

* it will be used by zkos new sequencer
