### PR TITLE
feat: updated genesis to match 0.29.6

### DIFF
--- a/etc/env/file_based/genesis.yaml
+++ b/etc/env/file_based/genesis.yaml
@@ -2,8 +2,8 @@
 # note: this is not the root, but blake_hash(root, index, number, prev hashes, timestamp) -
 #  it's used in place of root in zksync os. It's called `state_commitment`
 #  (don't confuse it with `commitment` which is about pudata etc)
-# Updated to match zksync-v0.29.5
-genesis_root: "0x8ffc4046cfb3c1d91dbd541dcf0202c23ac355df020f6b5edb2e6cb93525871c"
+# Updated to match zksync-v0.29.6
+genesis_root: "0xc346a158cce093e99ab65a95c884a26629d0e4f8d00ae20bbca4bfc4b204eec2"
 genesis_rollup_leaf_index: 0
 genesis_batch_commitment: "0x0000000000000000000000000000000000000000000000000000000000000001"
 genesis_protocol_version: 29


### PR DESCRIPTION
## What ❔

Updated genesis hash to match zkos-0.29.6.

# Instructions on how to do it:

```shell
COMMIT_CHANGES=true ZKSYNC_OS_SERVER_TAG=origin/main ERA_CONTRACTS_TAG=zkos-v0.29.6  ZKSYNC_ERA_STACK_CLI_TAG=origin/main  ./update.sh
```


This generated changes in genesis.json + state.json.

Now changing the code in repos/zksync-os-server (that already has this new genesis.json) - to print the commitment.
Then starting anvil + the server.

```shell
anvil --load-state zkos-l1-state.json
# and in separate terminal (from repos/zksync-os-server)
# cleanup DB just in case
rm -rf db/

cargo run
```

This should crash (with different hash) - but that's ok - we have to 'only' pick up the hash that we printed in the step above.

Got the hash:
```
[node/bin/src/batcher/util.rs:38:5] &state_commitment = 0xc346a158cce093e99ab65a95c884a26629d0e4f8d00ae20bbca4bfc4b204eec2
```

updated zksync-os-integration branch.

And re-run again:

```shell
COMMIT_CHANGES=true ZKSYNC_OS_SERVER_TAG=origin/main ERA_CONTRACTS_TAG=zkos-v0.29.6  ZKSYNC_ERA_STACK_CLI_TAG=origin/main  ./update.sh
```

