### PR TITLE
fix alloy-consensus that does not compile with latest serde

### DIFF
--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -6190,10 +6190,11 @@ checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.223"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "a505d71960adde88e293da5cb5eda57093379f64e61cf77bf0e6a63af07a7bac"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -6208,10 +6209,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.223"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "20f57cbd357666aa7b3ac84a90b4ea328f1d4ddb6772b430caa5d9e1309bb9e9"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.223"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d428d07faf17e306e699ec1e91996e5a165ba5d6bce5b5155173e91a8a01a56"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -46,8 +46,8 @@ reqwest-middleware = "=0.3.3"
 reqwest-retry = "0.7.0"
 ring = "0.17.8"
 rustls = { version = "0.23.12", features = ["ring"] }
-serde = "1.0"
-serde_json = "1.0"
+serde = "1.0.223"
+serde_json = "1.0.223"
 serde_yaml = "0.9"
 sha3 = "0.10.8"
 sqlx = { version = "0.8.1", default-features = false }

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -47,7 +47,7 @@ reqwest-retry = "0.7.0"
 ring = "0.17.8"
 rustls = { version = "0.23.12", features = ["ring"] }
 serde = "1.0.223"
-serde_json = "1.0.223"
+serde_json = "1.0"
 serde_yaml = "0.9"
 sha3 = "0.10.8"
 sqlx = { version = "0.8.1", default-features = false }

--- a/zkstack_cli/Cargo.lock
+++ b/zkstack_cli/Cargo.lock
@@ -70,9 +70,8 @@ checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
 name = "alloy"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f245ea9ef9be909776941c6c0ce829fb6b79cd6bfafa43762af7a702c4eb8ee4"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -88,6 +87,7 @@ dependencies = [
  "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-trie",
 ]
 
 [[package]]
@@ -103,15 +103,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2179ba839ac532f50279f5da2a6c5047f791f03f6f808b4dfab11327b97902f"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "alloy-trie",
+ "alloy-tx-macros",
  "auto_impl",
  "c-kzg",
  "derive_more 2.0.1",
@@ -119,6 +119,7 @@ dependencies = [
  "k256",
  "once_cell",
  "rand 0.8.5",
+ "secp256k1 0.30.0",
  "serde",
  "serde_with 3.13.0",
  "thiserror 2.0.12",
@@ -126,9 +127,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec6f67bdc62aa277e0ec13c1b1fb396c8a62b65c8e9bd8c1d3583cc6d1a8dd3"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -140,9 +140,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5084cf42388dff75b255308194f9d3e67ae2a93ce7e24262a512cc4043ac1838"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -156,6 +155,7 @@ dependencies = [
  "alloy-transport",
  "futures",
  "futures-util",
+ "serde_json",
  "thiserror 2.0.12",
 ]
 
@@ -226,9 +226,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609515c1955b33af3d78d26357540f68c5551a90ef58fd53def04f2aa074ec43"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -241,20 +240,22 @@ dependencies = [
  "derive_more 2.0.1",
  "either",
  "serde",
+ "serde_with 3.13.0",
  "sha2",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfec8348d97bd624901c6a4b22bb4c24df8a3128fc3d5e42d24f7b79dfa8588"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-serde",
  "alloy-trie",
  "serde",
+ "serde_with 3.13.0",
 ]
 
 [[package]]
@@ -271,12 +272,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3994ab6ff6bdeb5aebe65381a8f6a47534789817570111555e8ac413e242ce06"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
+ "http 1.1.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -285,9 +286,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be3aa020a6d3aa7601185b4c1a7d6f3a5228cb5424352db63064b29a455c891"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -311,9 +311,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498f2ee2eef38a6db0fc810c7bf7daebdf5f2fa8d04adb8bd53e54e91ddbdea3"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -351,9 +350,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6ba76d476f475668925f858cc4db51781f12abdaa4e0274eb57a09f574e869"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -412,15 +410,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6a6985b48a536b47aa0aece56e6a0f49240ce5d33a7f0c94f1b312eda79aa1"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-transport",
  "alloy-transport-http",
- "async-stream",
  "futures",
  "pin-project",
  "reqwest 0.12.9",
@@ -430,16 +426,14 @@ dependencies = [
  "tokio-stream",
  "tower 0.5.2",
  "tracing",
- "tracing-futures",
  "url",
  "wasmtimer",
 ]
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf27873220877cb15125eb6eec2f86c6e9b41473aca85844bd3d9d755bfc0a0"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -449,9 +443,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a40595b927dfb07218459037837dbc8de8500a26024bb6ff0548dd2ccc13e0"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -460,9 +453,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a9f64e0f69cfb6029e2a044519a1bdd44ce9fc334d5315a7b9837f7a6748e5"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -475,14 +467,14 @@ dependencies = [
  "itertools 0.13.0",
  "serde",
  "serde_json",
+ "serde_with 3.13.0",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-serde"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4dba6ff08916bc0a9cbba121ce21f67c0b554c39cf174bc7b9df6c651bd3c3b"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -491,9 +483,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c580da7f00f3999e44e327223044d6732358627f93043e22d92c583f6583556"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -506,9 +497,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00f0f07862bd8f6bc66c953660693c5903062c2c9d308485b2a6eee411089e7"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -595,11 +585,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1f1a55f9ff9a48aa0b4a8c616803754620010fbb266edae2f4548f4304373b"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-json-rpc",
+ "alloy-primitives",
+ "auto_impl",
  "base64 0.22.1",
  "derive_more 2.0.1",
  "futures",
@@ -617,9 +608,8 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171b3d8824b6697d6c8325373ec410d230b6c59ce552edfbfabe4e7b8a26aac3"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -632,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
+checksum = "e3412d52bb97c6c6cc27ccc28d4e6e8cf605469101193b50b0bd5813b1f990b5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -644,6 +634,18 @@ dependencies = [
  "serde",
  "smallvec",
  "tracing",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "1.0.30"
+source = "git+https://github.com/alloy-rs/alloy?rev=6cdfb187dc44eae8aba5d9d7887e29368ca22838#6cdfb187dc44eae8aba5d9d7887e29368ca22838"
+dependencies = [
+ "alloy-primitives",
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1075,6 +1077,22 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -1742,6 +1760,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,6 +1798,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "strsim 0.11.1",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +1830,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.104",
 ]
@@ -2987,6 +3041,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -4194,13 +4257,14 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nybbles"
-version = "0.3.4"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
+checksum = "f0418987d1aaed324d95b4beffc93635e19be965ed5d63ec07a35980fe3b71a4"
 dependencies = [
  "alloy-rlp",
- "const-hex",
+ "cfg-if",
  "proptest",
+ "ruint",
  "serde",
  "smallvec",
 ]
@@ -5554,7 +5618,19 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "secp256k1-sys",
+ "secp256k1-sys 0.8.1",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.5",
+ "secp256k1-sys 0.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -5562,6 +5638,15 @@ name = "secp256k1-sys"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
@@ -5649,10 +5734,11 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.223"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "a505d71960adde88e293da5cb5eda57093379f64e61cf77bf0e6a63af07a7bac"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -5667,10 +5753,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.215"
+name = "serde_core"
+version = "1.0.223"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "20f57cbd357666aa7b3ac84a90b4ea328f1d4ddb6772b430caa5d9e1309bb9e9"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.223"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d428d07faf17e306e699ec1e91996e5a165ba5d6bce5b5155173e91a8a01a56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6904,8 +6999,6 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "futures",
- "futures-task",
  "pin-project",
  "tracing",
 ]
@@ -8036,7 +8129,7 @@ dependencies = [
  "blake2",
  "hex",
  "rand 0.8.5",
- "secp256k1",
+ "secp256k1 0.27.0",
  "serde",
  "serde_json",
  "sha2",

--- a/zkstack_cli/Cargo.toml
+++ b/zkstack_cli/Cargo.toml
@@ -36,7 +36,7 @@ zksync_consensus_crypto = "=0.13"
 
 # External dependencies
 anyhow = "1.0.82"
-alloy = "0.14.0"
+alloy = { git = "https://github.com/alloy-rs/alloy", rev = "6cdfb187dc44eae8aba5d9d7887e29368ca22838" }
 clap = { version = "4.4", features = ["derive", "wrap_help", "string"] }
 clap_complete = "4.5.33"
 dirs = "5.0.1"
@@ -51,7 +51,7 @@ lazy_static = "1.4.0"
 once_cell = "1.19.0"
 prost = "0.12.1"
 rand = "0.8.5"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.223", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 sqlx = { version = "0.8.1", features = [


### PR DESCRIPTION
## What ❔

Added fix for alloy - https://github.com/alloy-rs/alloy/pull/2875
Note: rev should be replaced with version when alloy will create a new release.
Also use latest serde

## Why ❔

Currently zkstack-cli cannot compile with current crate dependencies.
Command `cargo install --path zkstack_cli/crates/zkstack --force` fails
## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
<img width="1713" height="134" alt="image" src="https://github.com/user-attachments/assets/ab0be593-2634-44dc-9e37-141c750c0a87" />

