### PR TITLE
fix(en): allow to disable sanity checks for commitment generation

### DIFF
--- a/core/bin/external_node/src/node_builder.rs
+++ b/core/bin/external_node/src/node_builder.rs
@@ -271,8 +271,11 @@ impl ExternalNodeBuilder {
 
     fn add_commitment_generator_layer(mut self) -> anyhow::Result<Self> {
         let config = &self.config.local.commitment_generator;
-        let layer =
-            CommitmentGeneratorLayer::default().with_max_parallelism(config.max_parallelism);
+        let layer = CommitmentGeneratorLayer::default()
+            .with_max_parallelism(config.max_parallelism)
+            // For external node, we need to disable all sanity checks, because it will allow to generate wrong commitments,
+            // which will eventually lead to consistency errors and node will revert the incorrect state.
+            .disable_sanity_checks();
         self.node.add_layer(layer);
         Ok(self)
     }

--- a/core/lib/types/src/commitment/tests/mod.rs
+++ b/core/lib/types/src/commitment/tests/mod.rs
@@ -17,7 +17,7 @@ fn run_test(test_name: &str) {
     let contents = read_to_string(format!("src/commitment/tests/{test_name}.json")).unwrap();
     let commitment_test: CommitmentTest = serde_json::from_str(&contents).unwrap();
 
-    let commitment = L1BatchCommitment::new(commitment_test.input).unwrap();
+    let commitment = L1BatchCommitment::new(commitment_test.input, true).unwrap();
 
     assert_eq!(
         commitment.pass_through_data,

--- a/core/node/commitment_generator/src/lib.rs
+++ b/core/node/commitment_generator/src/lib.rs
@@ -43,16 +43,18 @@ pub struct CommitmentGenerator {
     connection_pool: ConnectionPool<Core>,
     health_updater: HealthUpdater,
     parallelism: NonZeroU32,
+    disable_sanity_checks: bool,
 }
 
 impl CommitmentGenerator {
     /// Creates a commitment generator with the provided mode.
-    pub fn new(connection_pool: ConnectionPool<Core>) -> Self {
+    pub fn new(connection_pool: ConnectionPool<Core>, disable_sanity_checks: bool) -> Self {
         Self {
             computer: Arc::new(RealCommitmentComputer),
             connection_pool,
             health_updater: ReactiveHealthCheck::new("commitment_generator").1,
             parallelism: Self::default_parallelism(),
+            disable_sanity_checks,
         }
     }
 
@@ -337,7 +339,7 @@ impl CommitmentGenerator {
 
         let latency =
             METRICS.generate_commitment_latency_stage[&CommitmentStage::Calculate].start();
-        let mut commitment = L1BatchCommitment::new(input)?;
+        let mut commitment = L1BatchCommitment::new(input, self.disable_sanity_checks)?;
         self.post_process_commitment(&mut commitment, commitment_mode);
         let artifacts = commitment.artifacts()?;
         let latency = latency.observe();

--- a/core/node/commitment_generator/src/node/commitment_generator.rs
+++ b/core/node/commitment_generator/src/node/commitment_generator.rs
@@ -17,6 +17,7 @@ use crate::CommitmentGenerator;
 #[derive(Debug, Default)]
 pub struct CommitmentGeneratorLayer {
     max_parallelism: Option<NonZero<u32>>,
+    disable_sanity_checks: bool,
 }
 
 #[derive(Debug, FromContext)]
@@ -37,6 +38,11 @@ impl CommitmentGeneratorLayer {
         self.max_parallelism = max_parallelism;
         self
     }
+
+    pub fn disable_sanity_checks(mut self) -> Self {
+        self.disable_sanity_checks = true;
+        self
+    }
 }
 
 #[async_trait::async_trait]
@@ -55,7 +61,8 @@ impl WiringLayer for CommitmentGeneratorLayer {
             .get();
         let main_pool = input.master_pool.get_custom(pool_size).await?;
 
-        let mut commitment_generator = CommitmentGenerator::new(main_pool);
+        let mut commitment_generator =
+            CommitmentGenerator::new(main_pool, self.disable_sanity_checks);
         if let Some(max_parallelism) = self.max_parallelism {
             commitment_generator.set_max_parallelism(max_parallelism);
         }

--- a/core/node/commitment_generator/src/tests/mod.rs
+++ b/core/node/commitment_generator/src/tests/mod.rs
@@ -95,7 +95,7 @@ impl CommitmentComputer for MockCommitmentComputer {
 }
 
 fn create_commitment_generator(pool: ConnectionPool<Core>) -> CommitmentGenerator {
-    let mut generator = CommitmentGenerator::new(pool);
+    let mut generator = CommitmentGenerator::new(pool, false);
     generator.computer = Arc::new(MockCommitmentComputer {
         delay: Duration::from_millis(20),
     });

--- a/core/node/fee_model/src/l1_gas_price/blob_base_fee_predictor.rs
+++ b/core/node/fee_model/src/l1_gas_price/blob_base_fee_predictor.rs
@@ -152,7 +152,7 @@ mod tests {
 
         let cap = predict_blob_fee_cap(blobs_total, l1_blocks_total, l1_blob_base_fee);
         // Expect only safety margin applied to base fee = 1
-        let expected = ((1u128 * SAFETY_BPS as u128) / 10_000u128) as u64;
+        let expected = ((SAFETY_BPS as u128) / 10_000u128) as u64;
         assert_eq!(
             cap, expected,
             "fee cap should equal base fee * safety when no backlog"

--- a/core/node/genesis/src/lib.rs
+++ b/core/node/genesis/src/lib.rs
@@ -218,7 +218,7 @@ pub fn make_genesis_batch_params(
         base_system_contract_hashes,
         protocol_version,
     );
-    let block_commitment = L1BatchCommitment::new(commitment_input)?;
+    let block_commitment = L1BatchCommitment::new(commitment_input, true)?;
     let commitment = block_commitment.hash()?.commitment;
 
     Ok((


### PR DESCRIPTION
## What ❔

Disabling sanity checks for commitment generation


## Why ❔

Our external node is designed around commitment generation and verification. Now it's possible to be in a situation, that we have incorrect block and we can't revert it, because we don't have a commitment for it. 

EN is not able to produce any commitment => EN can't verify the commitment => EN can't revert incorrect block. 


## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
