### PR TITLE
fix: bump foundry-zksync

### DIFF
--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -181,12 +181,12 @@ jobs:
         run: |
           ci_run curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-v0.0.26/foundry_zksync_v0.0.26_linux_amd64.tar.gz
           ci_run mkdir ./foundry-temp
-          ci_run tar zxf foundry_v0.0.26_linux_amd64.tar.gz -C ./foundry-temp
+          ci_run tar zxf foundry_zksync_v0.0.26_linux_amd64.tar.gz -C ./foundry-temp
           ci_run cp ./foundry-temp/forge /usr/local/cargo/bin/forge
           ci_run cp ./foundry-temp/cast /usr/local/cargo/bin/cast
           echo "Foundry version after update:"
           ci_run forge --version
-          ci_run rm -rf ./foundry-temp foundry_v0.0.26_linux_amd64.tar.gz
+          ci_run rm -rf ./foundry-temp foundry_zksync_v0.0.26_linux_amd64.tar.gz
 
       - name: Build test dependencies
         run: |


### PR DESCRIPTION
## What ❔

Temporarily bumps foundry-zksync version to [v0.0.26](https://github.com/matter-labs/foundry-zksync/releases/tag/foundry-zksync-v0.0.26) for [CI integration tests](https://github.com/matter-labs/zksync-era/blob/2842d753a3d7f8b056fc3293bbfbcb46a758ab6f/.github/workflows/ci-core-reusable.yml#L144-L145).

This temporary fix is needed as CI uses the docker image built from the last run in main. Once merged to main (alongside draft-v30), it should be reverted via bumping the foundry-zksync version in the respective Docker containers, as done in this commit: https://github.com/matter-labs/zksync-era/commit/e05f844415bb9c486c6c23718b21ab13e8e45c00.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
