### PR TITLE
fix(eth_watcher): Do not process upgrades if it's already processed

### DIFF
--- a/core/node/eth_watch/src/event_processors/decentralized_upgrades.rs
+++ b/core/node/eth_watch/src/event_processors/decentralized_upgrades.rs
@@ -97,6 +97,10 @@ impl EventProcessor for DecentralizedUpgradesEventProcessor {
             let latest_protocol_version =
                 ProtocolSemanticVersion::try_from_packed(h256_to_u256(version))
                     .map_err(|err| EventProcessorError::internal(anyhow::anyhow!(err)))?;
+            if latest_protocol_version <= self.last_seen_protocol_version {
+                // This version has been already processed, skip it.
+                continue;
+            }
             if diamond_cuts.is_empty() {
                 return Err(EventProcessorError::internal(anyhow::anyhow!(
                     "No diamond cuts found for protocol version {latest_protocol_version}"


### PR DESCRIPTION
## What ❔

Do not process upgrades if it has already been processed


## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
