### PR TITLE
fix(en): add index for fetching precommits

### DIFF
--- a/core/lib/dal/migrations/20250929121423_index_for_fetching_precommits.down.sql
+++ b/core/lib/dal/migrations/20250929121423_index_for_fetching_precommits.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS miniblocks_number_precommit_not_null;

--- a/core/lib/dal/migrations/20250929121423_index_for_fetching_precommits.up.sql
+++ b/core/lib/dal/migrations/20250929121423_index_for_fetching_precommits.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS miniblocks_number_precommit_not_null ON miniblocks ( number )
+WHERE eth_precommit_tx_id IS NOT NULL;


### PR DESCRIPTION
## What ❔

Add one more index for supporting precommits query 
## Why ❔

En restart takes a long time
## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
