### PR TITLE
ci: Build prover e2e tests for all CUDA ARCHs

### DIFF
--- a/prover/crates/bin/prover_autoscaler/src/main.rs
+++ b/prover/crates/bin/prover_autoscaler/src/main.rs
@@ -29,7 +29,7 @@ impl std::str::FromStr for AutoscalerType {
         match s {
             "scaler" => Ok(AutoscalerType::Scaler),
             "agent" => Ok(AutoscalerType::Agent),
-            other => Err(format!("{} is not a valid AutoscalerType ", other)),
+            other => Err(format!("{} is not a valid AutoscalerType", other)),
         }
     }
 }


### PR DESCRIPTION
## What ❔

Build prover e2e tests for all CUDA ARCHs.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To being able to run on any GPU available from L4,A100,H100 list.
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.

ref ZKD-3043