### PR TITLE
feat: adds l1_batch_number to zks_get_l2l1_logproof

### DIFF
--- a/core/lib/types/src/api/mod.rs
+++ b/core/lib/types/src/api/mod.rs
@@ -258,6 +258,9 @@ pub struct L2ToL1LogProof {
     pub id: u32,
     /// The root of the tree.
     pub root: H256,
+    /// The L1 batch number where the log was included.
+    #[serde(rename = "batch_number")]
+    pub l1_batch_number: L1BatchNumber,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/core/node/api_server/src/web3/namespaces/zks.rs
+++ b/core/node/api_server/src/web3/namespaces/zks.rs
@@ -216,6 +216,7 @@ impl ZksNamespace {
                 proof,
                 root: local_root,
                 id: l1_log_index as u32,
+                l1_batch_number,
             }));
         }
 
@@ -287,6 +288,7 @@ impl ZksNamespace {
             proof,
             root,
             id: l1_log_index as u32,
+            l1_batch_number,
         }))
     }
 


### PR DESCRIPTION
## What ❔
- adds l1_batch_number to zks_get_l2l1_logproof
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔
- zksync-os-server returns batch_number with `zks_getL2ToL1LogProof`. Adding the field allows the same SDK to be used for EraVM and zkos use. 

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
