### PR TITLE
fix(zkstack): use vm_option in args properly

### DIFF
--- a/zkstack_cli/crates/zkstack/src/commands/chain/args/create.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/args/create.rs
@@ -7,7 +7,9 @@ use slugify_rs::slugify;
 use strum::{Display, EnumIter, IntoEnumIterator};
 use zkstack_cli_common::{Prompt, PromptConfirm, PromptSelect};
 use zkstack_cli_config::forge_interface::deploy_ecosystem::output::Erc20Token;
-use zkstack_cli_types::{BaseToken, L1BatchCommitmentMode, L1Network, ProverMode, WalletCreation};
+use zkstack_cli_types::{
+    BaseToken, L1BatchCommitmentMode, L1Network, ProverMode, VMOption, WalletCreation,
+};
 use zksync_basic_types::H160;
 
 use crate::{
@@ -88,6 +90,11 @@ impl ChainCreateArgs {
         l1_network: &L1Network,
         possible_erc20: Vec<Erc20Token>,
     ) -> anyhow::Result<ChainCreateArgsFinal> {
+        let vm_option = if self.zksync_os {
+            VMOption::ZKSyncOsVM
+        } else {
+            VMOption::EraVM
+        };
         let mut chain_name = self
             .chain_name
             .unwrap_or_else(|| Prompt::new(MSG_CHAIN_NAME_PROMPT).ask());
@@ -247,6 +254,7 @@ impl ChainCreateArgs {
             legacy_bridge: self.legacy_bridge,
             evm_emulator,
             tight_ports: self.tight_ports,
+            vm_option,
         })
     }
 }
@@ -264,6 +272,7 @@ pub struct ChainCreateArgsFinal {
     pub legacy_bridge: bool,
     pub evm_emulator: bool,
     pub tight_ports: bool,
+    pub vm_option: VMOption,
 }
 
 #[derive(Debug, Clone, EnumIter, Display, PartialEq, Eq)]

--- a/zkstack_cli/crates/zkstack/src/commands/chain/create.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/create.rs
@@ -7,7 +7,6 @@ use zkstack_cli_config::{
     create_local_configs_dir, create_wallets, traits::SaveConfigWithBasePath, ChainConfig,
     EcosystemConfig, GenesisConfig, ZkStackConfig, GENESIS_FILE,
 };
-use zkstack_cli_types::VMOption;
 use zksync_basic_types::L2ChainId;
 
 use crate::{
@@ -30,12 +29,6 @@ pub async fn create(
     ecosystem_config: &mut EcosystemConfig,
     shell: &Shell,
 ) -> anyhow::Result<()> {
-    let vm_option = if args.zksync_os {
-        VMOption::ZKSyncOsVM
-    } else {
-        VMOption::EraVM
-    };
-
     let tokens = ecosystem_config.get_erc20_tokens();
     let args = args
         .fill_values_with_prompt(
@@ -51,7 +44,7 @@ pub async fn create(
     let spinner = Spinner::new(MSG_CREATING_CHAIN_CONFIGURATIONS_SPINNER);
     let name = args.chain_name.clone();
     let set_as_default = args.set_as_default;
-    create_chain_inner(args, ecosystem_config, shell, vm_option).await?;
+    create_chain_inner(args, ecosystem_config, shell).await?;
     if set_as_default {
         ecosystem_config.set_default_chain(name);
         ecosystem_config.save_with_base_path(shell, ".")?;
@@ -67,8 +60,8 @@ pub(crate) async fn create_chain_inner(
     args: ChainCreateArgsFinal,
     ecosystem_config: &EcosystemConfig,
     shell: &Shell,
-    vm_option: VMOption,
 ) -> anyhow::Result<()> {
+    let vm_option = args.vm_option;
     if args.legacy_bridge {
         logger::warn("WARNING!!! You are creating a chain with legacy bridge, use it only for testing compatibility")
     }

--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/create.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/create.rs
@@ -5,7 +5,6 @@ use zkstack_cli_config::{
     create_local_configs_dir, create_wallets, get_default_era_chain_id,
     traits::SaveConfigWithBasePath, EcosystemConfig, EcosystemConfigFromFileError, ZkStackConfig,
 };
-use zkstack_cli_types::VMOption;
 
 use crate::{
     commands::{
@@ -93,8 +92,7 @@ async fn create(args: EcosystemCreateArgs, shell: &Shell) -> anyhow::Result<()> 
     spinner.finish();
 
     let spinner = Spinner::new(MSG_CREATING_DEFAULT_CHAIN_SPINNER);
-    // By default, do not use zksync os for the ecosystem chain
-    create_chain_inner(chain_config, &ecosystem_config, shell, VMOption::EraVM).await?;
+    create_chain_inner(chain_config, &ecosystem_config, shell).await?;
     spinner.finish();
 
     if args.start_containers {


### PR DESCRIPTION
## What ❔

Allow create zksync_os chain by default 

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
