### PR TITLE
chore: bump foundry

### DIFF
--- a/.github/workflows/build-contract-verifier-template.yml
+++ b/.github/workflows/build-contract-verifier-template.yml
@@ -100,8 +100,8 @@ jobs:
         if: env.BUILD_CONTRACTS == 'true'
         run: |
           mkdir ./foundry-zksync
-          curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/nightly-27360d4c8d12beddbb730dae07ad33a206b38f4b/foundry_nightly_linux_amd64.tar.gz
-          tar zxf foundry_nightly_linux_amd64.tar.gz -C ./foundry-zksync
+          curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-v0.0.29/foundry_zksync_v0.0.29_linux_amd64.tar.gz
+          tar zxf foundry_zksync_v0.0.29_linux_amd64.tar.gz -C ./foundry-zksync
           chmod +x ./foundry-zksync/forge ./foundry-zksync/cast
           echo "$PWD/foundry-zksync" >> $GITHUB_PATH
 

--- a/.github/workflows/build-core-template.yml
+++ b/.github/workflows/build-core-template.yml
@@ -105,8 +105,8 @@ jobs:
         if: env.BUILD_CONTRACTS == 'true'
         run: |
           mkdir ./foundry-zksync
-          curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/nightly-27360d4c8d12beddbb730dae07ad33a206b38f4b/foundry_nightly_linux_amd64.tar.gz
-          tar zxf foundry_nightly_linux_amd64.tar.gz -C ./foundry-zksync
+          curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-v0.0.29/foundry_zksync_v0.0.29_linux_amd64.tar.gz
+          tar zxf foundry_zksync_v0.0.29_linux_amd64.tar.gz -C ./foundry-zksync
           chmod +x ./foundry-zksync/forge ./foundry-zksync/cast
           echo "$PWD/foundry-zksync" >> $GITHUB_PATH
 
@@ -179,8 +179,8 @@ jobs:
         run: |
           mkdir ./foundry-zksync
           # downloading newer version of foundry-zksync since the latest nightly is not working
-          curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-v0.0.24/foundry_zksync_v0.0.24_linux_amd64.tar.gz
-          tar zxf foundry_zksync_v0.0.24_linux_amd64.tar.gz -C ./foundry-zksync
+          curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-v0.0.29/foundry_zksync_v0.0.29_linux_amd64.tar.gz
+          tar zxf foundry_zksync_v0.0.29_linux_amd64.tar.gz -C ./foundry-zksync
           chmod +x ./foundry-zksync/forge
           echo "$PWD/foundry-zksync" >> $GITHUB_PATH
 

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -64,9 +64,12 @@ jobs:
           ci_run run_retried rustup show
 
       - name: Build contracts
+        working-directory: contracts
         run: |
-          ci_run forge --version
-          ci_run zkstack dev contracts
+          ci_run yarn --cwd da-contracts build:foundry
+          ci_run yarn --cwd l1-contracts build:foundry
+          ci_run yarn --cwd l2-contracts build:foundry
+          ci_run yarn --cwd system-contracts build:foundry
 
       - name: Use Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -77,6 +77,16 @@ jobs:
         run: |
           ci_run yarn install
 
+      - name: Clean contracts cache
+        run: |
+          ci_run forge clean --root contracts/da-contracts
+          ci_run yarn --cwd contracts/l1-contracts clean
+          ci_run forge clean --root contracts/l1-contracts
+          ci_run yarn --cwd contracts/l2-contracts clean
+          ci_run forge clean --root contracts/l2-contracts
+          ci_run yarn --cwd contracts/system-contracts clean
+          ci_run forge clean --root contracts/system-contracts
+
       - name: Build da contracts
         run: |
           ci_run yarn --cwd contracts/da-contracts build:foundry

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -63,6 +63,11 @@ jobs:
         run: |
           ci_run run_retried rustup show
 
+      - name: Install yarn dependencies
+        working-directory: contracts
+        run: |
+          ci_run yarn install
+
       - name: Build contracts
         working-directory: contracts
         run: |

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -77,13 +77,26 @@ jobs:
         run: |
           ci_run yarn install
 
-      - name: Build contracts
-        working-directory: contracts
+      - name: Build da contracts
+        working-directory: contracts/da-contracts
         run: |
-          ci_run yarn --cwd da-contracts build:foundry
-          ci_run yarn --cwd l1-contracts build:foundry
-          ci_run yarn --cwd l2-contracts build:foundry
-          ci_run yarn --cwd system-contracts build:foundry
+          yarn build:foundry
+
+      - name: Build l1 contracts
+        working-directory: contracts/l1-contracts
+        run: |
+          yarn build:foundry
+
+      - name: Build l2 contracts
+        working-directory: contracts/l2-contracts
+        run: |
+          yarn build:foundry
+
+      - name: Build system contracts
+        working-directory: contracts/system-contracts
+        run: |
+          yarn install
+          yarn build:foundry
 
       - name: Check contracts hashes
         working-directory: contracts

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -100,9 +100,8 @@ jobs:
         run: |
           npm install -g yarn
       - name: Check contracts hashes
-        working-directory: contracts
         run: |
-          yarn calculate-hashes:check
+          ci_run sh -c 'cd contracts && yarn calculate-hashes:check'
 
       - name: Download compilers for contract verifier tests
         run: ci_run zkstack contract-verifier init --zksolc-version=v1.5.10 --zkvyper-version=v1.5.4 --solc-version=0.8.26 --vyper-version=v0.3.10 --era-vm-solc-version=0.8.26-1.0.2 --only --chain era

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -65,6 +65,7 @@ jobs:
 
       - name: Build contracts
         run: |
+          ci_run forge --version
           ci_run zkstack dev contracts
 
       - name: Use Node.js

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -29,6 +29,18 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-env
 
+      # TODO: Remove once merged into main
+      - name: (TEMPORARY) Update foundry
+        run: |
+          ci_run curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-v0.0.29/foundry_zksync_v0.0.29_linux_amd64.tar.gz
+          ci_run mkdir ./foundry-temp
+          ci_run tar zxf foundry_zksync_v0.0.29_linux_amd64.tar.gz -C ./foundry-temp
+          ci_run cp ./foundry-temp/forge /usr/local/cargo/bin/forge
+          ci_run cp ./foundry-temp/cast /usr/local/cargo/bin/cast
+          echo "Foundry version after update:"
+          ci_run forge --version
+          ci_run rm -rf ./foundry-temp foundry_zksync_v0.0.29_linux_amd64.tar.gz
+
       # TODO: Remove when we after upgrade of hardhat-plugins
       - name: pre-download compilers
         run: |
@@ -102,6 +114,18 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-env
 
+      # TODO: Remove once merged into main
+      - name: (TEMPORARY) Update foundry
+        run: |
+          ci_run curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-v0.0.29/foundry_zksync_v0.0.29_linux_amd64.tar.gz
+          ci_run mkdir ./foundry-temp
+          ci_run tar zxf foundry_zksync_v0.0.29_linux_amd64.tar.gz -C ./foundry-temp
+          ci_run cp ./foundry-temp/forge /usr/local/cargo/bin/forge
+          ci_run cp ./foundry-temp/cast /usr/local/cargo/bin/cast
+          echo "Foundry version after update:"
+          ci_run forge --version
+          ci_run rm -rf ./foundry-temp foundry_zksync_v0.0.29_linux_amd64.tar.gz
+
       - name: Create and initialize legacy chain
         run: |
           ci_run zkstack chain create \
@@ -174,6 +198,18 @@ jobs:
 
       - name: Setup Environment
         uses: ./.github/actions/setup-env
+
+      # TODO: Remove once merged into main
+      - name: (TEMPORARY) Update foundry
+        run: |
+          ci_run curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-v0.0.29/foundry_zksync_v0.0.29_linux_amd64.tar.gz
+          ci_run mkdir ./foundry-temp
+          ci_run tar zxf foundry_zksync_v0.0.29_linux_amd64.tar.gz -C ./foundry-temp
+          ci_run cp ./foundry-temp/forge /usr/local/cargo/bin/forge
+          ci_run cp ./foundry-temp/cast /usr/local/cargo/bin/cast
+          echo "Foundry version after update:"
+          ci_run forge --version
+          ci_run rm -rf ./foundry-temp foundry_zksync_v0.0.29_linux_amd64.tar.gz
 
       - name: Build test dependencies
         run: |

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -63,6 +63,15 @@ jobs:
         run: |
           ci_run run_retried rustup show
 
+      - name: Use Node.js
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
+        with:
+          node-version: 18.20.8
+
+      - name: Install yarn
+        run: |
+          npm install -g yarn
+
       - name: Install yarn dependencies
         working-directory: contracts
         run: |
@@ -76,14 +85,6 @@ jobs:
           ci_run yarn --cwd l2-contracts build:foundry
           ci_run yarn --cwd system-contracts build:foundry
 
-      - name: Use Node.js
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
-        with:
-          node-version: 18.20.8
-
-      - name: Install yarn
-        run: |
-          npm install -g yarn
       - name: Check contracts hashes
         working-directory: contracts
         run: |

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -63,6 +63,34 @@ jobs:
         run: |
           ci_run run_retried rustup show
 
+      - name: Clean all forge artifacts and preprocessing
+        run: |
+          # Clean forge caches
+          ci_run forge clean --root contracts/l1-contracts
+          ci_run forge clean --root contracts/system-contracts
+          ci_run forge clean --root contracts/l2-contracts
+          ci_run forge clean --root contracts/da-contracts
+
+          # Clean preprocessing artifacts and timestamps
+          ci_run rm -rf contracts/system-contracts/contracts-preprocessed
+          ci_run rm -f contracts/system-contracts/last_compilation_preprocessing.timestamp
+          ci_run rm -rf contracts/system-contracts/bootloader/build
+          
+          # Clean zkout directories that other contracts read from
+          ci_run rm -rf contracts/system-contracts/zkout
+          ci_run rm -rf contracts/l1-contracts/zkout
+          ci_run rm -rf contracts/l2-contracts/zkout
+          
+          # Clean out directories
+          ci_run rm -rf contracts/system-contracts/out
+          ci_run rm -rf contracts/l1-contracts/out
+          ci_run rm -rf contracts/l2-contracts/out
+
+      - name: Build contracts
+        run: |
+          ci_run forge --version
+          ci_run zkstack dev contracts
+
       - name: Use Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
         with:
@@ -71,42 +99,10 @@ jobs:
       - name: Install yarn
         run: |
           npm install -g yarn
-
-      - name: Install yarn dependencies
+      - name: Check contracts hashes
         working-directory: contracts
         run: |
-          ci_run yarn install
-
-      - name: Clean contracts cache
-        run: |
-          ci_run forge clean --root contracts/da-contracts
-          ci_run yarn --cwd contracts/l1-contracts clean
-          ci_run forge clean --root contracts/l1-contracts
-          ci_run yarn --cwd contracts/l2-contracts clean
-          ci_run forge clean --root contracts/l2-contracts
-          ci_run yarn --cwd contracts/system-contracts clean
-          ci_run forge clean --root contracts/system-contracts
-
-      - name: Build da contracts
-        run: |
-          ci_run yarn --cwd contracts/da-contracts build:foundry
-
-      - name: Build l1 contracts
-        run: |
-          ci_run yarn --cwd contracts/l1-contracts build:foundry
-
-      - name: Build l2 contracts
-        run: |
-          ci_run yarn --cwd contracts/l2-contracts build:foundry
-
-      - name: Build system contracts
-        run: |
-          ci_run yarn --cwd contracts/system-contracts install
-          ci_run yarn --cwd contracts/system-contracts build:foundry
-
-      - name: Check contracts hashes
-        run: |
-          ci_run yarn --cwd contracts calculate-hashes:check
+          yarn calculate-hashes:check
 
       - name: Download compilers for contract verifier tests
         run: ci_run zkstack contract-verifier init --zksolc-version=v1.5.10 --zkvyper-version=v1.5.4 --solc-version=0.8.26 --vyper-version=v0.3.10 --era-vm-solc-version=0.8.26-1.0.2 --only --chain era

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -78,30 +78,25 @@ jobs:
           ci_run yarn install
 
       - name: Build da contracts
-        working-directory: contracts/da-contracts
         run: |
-          yarn build:foundry
+          ci_run yarn --cwd contracts/da-contracts build:foundry
 
       - name: Build l1 contracts
-        working-directory: contracts/l1-contracts
         run: |
-          yarn build:foundry
+          ci_run yarn --cwd contracts/l1-contracts build:foundry
 
       - name: Build l2 contracts
-        working-directory: contracts/l2-contracts
         run: |
-          yarn build:foundry
+          ci_run yarn --cwd contracts/l2-contracts build:foundry
 
       - name: Build system contracts
-        working-directory: contracts/system-contracts
         run: |
-          yarn install
-          yarn build:foundry
+          ci_run yarn --cwd contracts/system-contracts install
+          ci_run yarn --cwd contracts/system-contracts build:foundry
 
       - name: Check contracts hashes
-        working-directory: contracts
         run: |
-          yarn calculate-hashes:check
+          ci_run yarn --cwd contracts calculate-hashes:check
 
       - name: Download compilers for contract verifier tests
         run: ci_run zkstack contract-verifier init --zksolc-version=v1.5.10 --zkvyper-version=v1.5.4 --solc-version=0.8.26 --vyper-version=v0.3.10 --era-vm-solc-version=0.8.26-1.0.2 --only --chain era

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -29,18 +29,6 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-env
 
-      # TODO: Remove once merged into main
-      - name: (TEMPORARY) Update foundry
-        run: |
-          ci_run curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-v0.0.29/foundry_zksync_v0.0.29_linux_amd64.tar.gz
-          ci_run mkdir ./foundry-temp
-          ci_run tar zxf foundry_zksync_v0.0.29_linux_amd64.tar.gz -C ./foundry-temp
-          ci_run cp ./foundry-temp/forge /usr/local/cargo/bin/forge
-          ci_run cp ./foundry-temp/cast /usr/local/cargo/bin/cast
-          echo "Foundry version after update:"
-          ci_run forge --version
-          ci_run rm -rf ./foundry-temp foundry_zksync_v0.0.29_linux_amd64.tar.gz
-
       # TODO: Remove when we after upgrade of hardhat-plugins
       - name: pre-download compilers
         run: |
@@ -58,6 +46,20 @@ jobs:
             wget -nv -O "./hardhat-nodejs/compilers-v2/$compiler/${compiler}-v${version}" "https://github.com/matter-labs/${compiler}-bin/releases/download/v${version}/${compiler}-linux-amd64-musl-v${version}"
             chmod +x "./hardhat-nodejs/compilers-v2/$compiler/${compiler}-v${version}"
           done
+
+      # TODO: Remove once merged into main
+      - name: (TEMPORARY) Update foundry
+        run: |
+          ci_run rm -rf ~/.foundry/cache
+          ci_run rm -rf ~/.foundry/zksolc-bin
+          ci_run curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-v0.0.29/foundry_zksync_v0.0.29_linux_amd64.tar.gz
+          ci_run mkdir ./foundry-temp
+          ci_run tar zxf foundry_zksync_v0.0.29_linux_amd64.tar.gz -C ./foundry-temp
+          ci_run cp ./foundry-temp/forge /usr/local/cargo/bin/forge
+          ci_run cp ./foundry-temp/cast /usr/local/cargo/bin/cast
+          echo "Foundry version after update:"
+          ci_run forge --version
+          ci_run rm -rf ./foundry-temp foundry_zksync_v0.0.29_linux_amd64.tar.gz
 
       - name: Init
         run: |

--- a/.github/workflows/vm-perf-to-prometheus.yml
+++ b/.github/workflows/vm-perf-to-prometheus.yml
@@ -26,6 +26,18 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-env
 
+      # TODO: Remove once merged into main
+      - name: (TEMPORARY) Update foundry
+        run: |
+          ci_run curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-v0.0.29/foundry_zksync_v0.0.29_linux_amd64.tar.gz
+          ci_run mkdir ./foundry-temp
+          ci_run tar zxf foundry_zksync_v0.0.29_linux_amd64.tar.gz -C ./foundry-temp
+          ci_run cp ./foundry-temp/forge /usr/local/cargo/bin/forge
+          ci_run cp ./foundry-temp/cast /usr/local/cargo/bin/cast
+          echo "Foundry version after update:"
+          ci_run forge --version
+          ci_run rm -rf ./foundry-temp foundry_zksync_v0.0.29_linux_amd64.tar.gz
+
       - name: build contracts
         run: |
           ci_run zkstack dev contracts


### PR DESCRIPTION
## What ❔

Bumps foundry-zksync to v0.0.29. This is a sister PR to https://github.com/matter-labs/era-contracts/pull/1715

For some workflows a temporary fix is needed as CI uses the docker image built from the last run in main. Once merged to main (alongside draft-v30), it should be reverted via bumping the foundry-zksync version in the respective Docker containers, as done in this commit: https://github.com/matter-labs/zksync-era/commit/e05f844415bb9c486c6c23718b21ab13e8e45c00. These are marked as `(TEMPORARY) Update foundry`.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
