### PR TITLE
chore: increase LOOK_BACK_BLOCK_RANGE to 2.5 mil

### DIFF
--- a/core/node/eth_watch/src/client.rs
+++ b/core/node/eth_watch/src/client.rs
@@ -87,7 +87,7 @@ pub trait EthClient: 'static + fmt::Debug + Send + Sync {
 }
 
 // This constant is used for reading auxiliary events
-const LOOK_BACK_BLOCK_RANGE: u64 = 1_000_000;
+const LOOK_BACK_BLOCK_RANGE: u64 = 2_500_000;
 pub const RETRY_LIMIT: usize = 5;
 const TOO_MANY_RESULTS_INFURA: &str = "query returned more than";
 const TOO_MANY_RESULTS_ALCHEMY: &str = "response size exceeded";


### PR DESCRIPTION
## What ❔

Increase LOOK_BACK_BLOCK_RANGE to 2_500_000

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
