### PR TITLE
fix(zkstack): fix `--update-submodules` flag to accept explicit values

### DIFF
--- a/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/common.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/ecosystem/args/common.rs
@@ -14,7 +14,7 @@ use crate::{
 pub struct CommonEcosystemArgs {
     #[clap(long, default_value_t = false, default_missing_value = "true")]
     pub(crate) zksync_os: bool,
-    #[clap(long, default_value_t = true)]
+    #[clap(long, default_value_t = true, default_missing_value = "true", num_args = 0..=1)]
     pub(crate) update_submodules: bool,
     #[clap(long, default_value_t = false, default_missing_value = "true")]
     pub(crate) skip_contract_compilation_override: bool,


### PR DESCRIPTION
## What ❔

Adds `num_args = 0..=1` to the `update_submodules` clap attribute in `CommonEcosystemArgs`.

Previously, `--update-submodules=false` would fail with "`unexpected value 'false'`". This change allows the flag to accept explicit boolean values while maintaining the default behavior. This wasn't caught in CI, as this flag is only really useful when developing with local contract changes.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
