### PR TITLE
docs: update setup and test docs with missing info

### DIFF
--- a/docs/src/guides/development.md
+++ b/docs/src/guides/development.md
@@ -123,6 +123,12 @@ Commands:
 
 ### Running unit tests
 
+Unit tests require preprocessed artifacts from the contracts submodule. These can be prepared by running:
+
+```bash
+zkstack dev contracts
+```
+
 You can run unit tests for the Rust crates in the project by running:
 
 ```bash

--- a/docs/src/guides/setup-dev.md
+++ b/docs/src/guides/setup-dev.md
@@ -41,7 +41,7 @@ npm install -g yarn
 yarn set version 1.22.19
 
 # For running unit tests
-cargo install cargo-nextest
+cargo install cargo-nextest --version 0.9.109 --locked
 # SQL tools
 cargo install sqlx-cli --version 0.8.1
 


### PR DESCRIPTION
## What ❔

Fixes the development setup docs to accurately reflect some missing information
- cargo-nextest must be installed with `--version 0.9.109 --locked` as the latest version does not support rust 1.87
- `zkstack dev contracts` must be run before running unit tests
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Accurate documentation is helpful for new and external contributors to be able to set up a working developer environment

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->
None

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
