### PR TITLE
feat(eth_sender): Set fusaka upgrade timestamp

### DIFF
--- a/core/lib/config/src/configs/eth_sender.rs
+++ b/core/lib/config/src/configs/eth_sender.rs
@@ -56,6 +56,7 @@ impl EthConfig {
                 force_use_validator_timelock: false,
                 fusaka_upgrade_block: Some(0),
                 fusaka_upgrade_safety_margin: 0,
+                fusaka_upgrade_timestamp: Some(1),
             },
             gas_adjuster: GasAdjusterConfig {
                 default_priority_fee_per_gas: 1000000000,
@@ -181,8 +182,13 @@ pub struct SenderConfig {
     pub force_use_validator_timelock: bool,
     /// Use fusaka blob tx format if  the block has passed.
     pub fusaka_upgrade_block: Option<u64>,
-    #[config(default_t = 100)]
+    /// Half an hour safety margin
+    #[config(default_t = 1800)]
     pub fusaka_upgrade_safety_margin: u64,
+    /// Use fusaka blob tx format if  the timestamp has passed. Default is mainnet upgrade.
+    /// Use this value if block is not set
+    #[config(default_t = Some(1764798551))]
+    pub fusaka_upgrade_timestamp: Option<u64>,
 }
 
 /// We send precommit if l2_blocks_to_aggregate OR deadline_sec passed since last precommit or beginning of batch.
@@ -309,6 +315,7 @@ mod tests {
                 force_use_validator_timelock: false,
                 fusaka_upgrade_safety_margin: 100,
                 fusaka_upgrade_block: Some(33582142),
+                fusaka_upgrade_timestamp: Some(1),
             },
             gas_adjuster: GasAdjusterConfig {
                 default_priority_fee_per_gas: 20000000000,
@@ -376,6 +383,7 @@ mod tests {
             ETH_SENDER_SENDER_USE_FUSAKA_BLOB_FORMAT="true"
             ETH_SENDER_SENDER_USE_FUSAKA_BLOB_FORMAT="true"
             ETH_SENDER_SENDER_FUSAKA_UPGRADE_BLOCK="33582142"
+            ETH_SENDER_SENDER_FUSAKA_UPGRADE_TIMESTAMP="1"
             ETH_SENDER_SENDER_FUSAKA_UPGRADE_SAFETY_MARGIN="100"
 
         "#;
@@ -416,6 +424,7 @@ mod tests {
             force_use_validator_timelock: false
             fusaka_upgrade_safety_margin: 100
             fusaka_upgrade_block: 33582142
+            fusaka_upgrade_timestamp: 1
             precommit_params:
               l2_blocks_to_aggregate: 1
               deadline: 1 sec
@@ -475,6 +484,7 @@ mod tests {
             force_use_validator_timelock: false
             fusaka_upgrade_safety_margin: 100
             fusaka_upgrade_block: 33582142
+            fusaka_upgrade_timestamp: 1
             precommit_params:
               l2_blocks_to_aggregate: 1
               deadline: 1 sec

--- a/core/lib/eth_client/src/lib.rs
+++ b/core/lib/eth_client/src/lib.rs
@@ -334,4 +334,8 @@ impl dyn BoundEthInterface {
     pub async fn block_number(&self) -> EnrichedClientResult<U64> {
         self.as_ref().block_number().await
     }
+
+    pub async fn block(&self, block_id: BlockId) -> EnrichedClientResult<Option<Block<H256>>> {
+        self.as_ref().block(block_id).await
+    }
 }


### PR DESCRIPTION
## What ❔

Use upgrade timestamp as well as block for switching to fusaka blobs

## Why ❔

Unfortunately ETH foundation doesn't provide the exact block for fusaka, but they have the exact timestamp. So it was decided to use this timestamp and half an hour before and after this as a safety margin 
https://blog.ethereum.org/2025/11/06/fusaka-mainnet-announcement#fusaka-activation

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
