### PR TITLE
fix: set User-Agent header for coingecko requests

### DIFF
--- a/core/lib/external_price_api/src/coingecko_api.rs
+++ b/core/lib/external_price_api/src/coingecko_api.rs
@@ -17,7 +17,7 @@ pub struct CoinGeckoPriceAPIClient {
 
 const DEFAULT_COINGECKO_API_URL: &str = "https://pro-api.coingecko.com";
 const COINGECKO_AUTH_HEADER: &str = "x-cg-pro-api-key";
-const USER_AGENT_HEADER: &str = "User-Agent";
+const USER_AGENT_HEADER: &str = "user-agent";
 const USER_AGENT_VALUE: &str = "zksync-era-node/0.1 (https://github.com/matter-labs/zksync-era)";
 const ETH_ID: &str = "eth";
 const ZKSYNC_ID: &str = "zksync";
@@ -176,6 +176,7 @@ mod test {
 
             when = when.query_param("contract_addresses", address.clone());
             when = when.query_param("vs_currencies", ETH_ID);
+            when = when.header(USER_AGENT_HEADER, USER_AGENT_VALUE);
             api_key.map(|key| when.header(COINGECKO_AUTH_HEADER, key));
 
             if let Some(p) = price {


### PR DESCRIPTION
## What ❔

Sets User-Agent header for coingecko requests.

## Why ❔

Requests started to fail with 403 status code and message suggesting adding the header.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

None

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
