### PR TITLE
docs: Make docs about retention policy  aligned with configs

### DIFF
--- a/docs/src/guides/external-node/08_pruning.md
+++ b/docs/src/guides/external-node/08_pruning.md
@@ -40,7 +40,7 @@ You can enable pruning by setting the environment variable
 EN_PRUNING_ENABLED: 'true'
 ```
 
-By default, the node will keep L1 batch data for 7 days determined by the batch timestamp (always equal to the timestamp
+By default, the node will keep L1 batch data for 4 hours determined by the batch timestamp (always equal to the timestamp
 of the first block in the batch). You can configure the retention period using:
 
 ```yaml


### PR DESCRIPTION
## What ❔

Align docs with retention policy

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
