### PR TITLE
fix: change HARD_CODED_CHAIN_ID / L2ChainId::default() from 270 to 0

### DIFF
--- a/core/lib/basic_types/src/lib.rs
+++ b/core/lib/basic_types/src/lib.rs
@@ -225,7 +225,9 @@ impl FromStr for L2ChainId {
 
 impl Default for L2ChainId {
     fn default() -> Self {
-        Self(270)
+        // 0 is the sentinel "uninitialized" chain ID used before L2GenesisUpgradeTx sets the real value.
+        // Chain ID 0 is rejected by the L1 Bridgehub (ZeroChainId), so it can never be a real deployed chain.
+        Self::zero()
     }
 }
 

--- a/core/node/node_sync/src/validate_chain_ids_task.rs
+++ b/core/node/node_sync/src/validate_chain_ids_task.rs
@@ -171,6 +171,7 @@ impl ValidateChainIdsTask {
 
 #[cfg(test)]
 mod tests {
+    use zksync_system_constants::DEFAULT_ERA_CHAIN_ID;
     use zksync_types::U64;
     use zksync_web3_decl::client::{MockClient, L1};
 
@@ -182,13 +183,13 @@ mod tests {
             .method("eth_chainId", || Ok(U64::from(9)))
             .build();
         let main_node_client = MockClient::builder(L2::default())
-            .method("eth_chainId", || Ok(U64::from(270)))
+            .method("eth_chainId", || Ok(U64::from(DEFAULT_ERA_CHAIN_ID)))
             .method("zks_L1ChainId", || Ok(U64::from(3)))
             .build();
 
         let validation_task = ValidateChainIdsTask::new(
             L1ChainId(3), // << mismatch with the Ethereum client
-            L2ChainId::from(270u32),
+            L2ChainId::from(DEFAULT_ERA_CHAIN_ID),
             Box::new(eth_client.clone()),
             Box::new(main_node_client.clone()),
         );
@@ -205,7 +206,7 @@ mod tests {
 
         let validation_task = ValidateChainIdsTask::new(
             L1ChainId(9), // << mismatch with the main node client
-            L2ChainId::from(270),
+            L2ChainId::from(DEFAULT_ERA_CHAIN_ID),
             Box::new(eth_client.clone()),
             Box::new(main_node_client),
         );
@@ -220,13 +221,13 @@ mod tests {
         );
 
         let main_node_client = MockClient::builder(L2::default())
-            .method("eth_chainId", || Ok(U64::from(270)))
+            .method("eth_chainId", || Ok(U64::from(DEFAULT_ERA_CHAIN_ID)))
             .method("zks_L1ChainId", || Ok(U64::from(9)))
             .build();
 
         let validation_task = ValidateChainIdsTask::new(
             L1ChainId(9),
-            L2ChainId::from(271), // << mismatch with the main node client
+            L2ChainId::from(DEFAULT_ERA_CHAIN_ID + 1), // << mismatch with the main node client
             Box::new(eth_client),
             Box::new(main_node_client),
         );
@@ -247,13 +248,13 @@ mod tests {
             .method("eth_chainId", || Ok(U64::from(9)))
             .build();
         let main_node_client = MockClient::builder(L2::default())
-            .method("eth_chainId", || Ok(U64::from(270)))
+            .method("eth_chainId", || Ok(U64::from(DEFAULT_ERA_CHAIN_ID)))
             .method("zks_L1ChainId", || Ok(U64::from(9)))
             .build();
 
         let validation_task = ValidateChainIdsTask::new(
             L1ChainId(9),
-            L2ChainId::from(270u32),
+            L2ChainId::from(DEFAULT_ERA_CHAIN_ID),
             Box::new(eth_client),
             Box::new(main_node_client),
         );

--- a/core/node/node_sync/src/validate_chain_ids_task.rs
+++ b/core/node/node_sync/src/validate_chain_ids_task.rs
@@ -188,7 +188,7 @@ mod tests {
 
         let validation_task = ValidateChainIdsTask::new(
             L1ChainId(3), // << mismatch with the Ethereum client
-            L2ChainId::default(),
+            L2ChainId::from(270u32),
             Box::new(eth_client.clone()),
             Box::new(main_node_client.clone()),
         );
@@ -253,7 +253,7 @@ mod tests {
 
         let validation_task = ValidateChainIdsTask::new(
             L1ChainId(9),
-            L2ChainId::default(),
+            L2ChainId::from(270u32),
             Box::new(eth_client),
             Box::new(main_node_client),
         );

--- a/core/tests/loadnext/src/config.rs
+++ b/core/tests/loadnext/src/config.rs
@@ -191,7 +191,6 @@ fn default_seed() -> Option<String> {
 }
 
 fn default_l2_chain_id() -> u64 {
-    // 270 for Rinkeby
     let result = L2ChainId::default().as_u64();
     tracing::info!("Using default L2_CHAIN_ID: {result}");
     result


### PR DESCRIPTION
## Summary

- `HARD_CODED_CHAIN_ID = 270` in `system-contracts/contracts/Constants.sol` collides with an actual chain deployed on the **stage** ecosystem.
- Changed the sentinel to `0` in both the contracts submodule and the server's `L2ChainId::default()`.
- Chain ID `0` is already rejected by `_validateChainParams` in `BridgehubBase.sol` via `ZeroChainId`, so no additional assertion is needed.

**Depends on contracts PR:** https://github.com/matter-labs/era-contracts/pull/2083

## Chain IDs queried

```
# Mainnet (Ethereum mainnet)
cast call 0x303a465B659cBB0ab36eE643eA362c509EEb5213 "getAllZKChainChainIDs()(uint256[])" --rpc-url https://eth.llamarpc.com
# → [324, 388, 50104, 543210, 2741, 325, 61166, 1345, 9637, 320, 232, 1217, 2904, 375, 51888, 9075, 30715, 5010405, 2787, 30716]

# Stage (Sepolia)
cast call 0x236D1c3Ff32Bd0Ca26b72Af287E895627c0478cE "getAllZKChainChainIDs()(uint256[])" --rpc-url https://sepolia.gateway.tenderly.co
# → [270, 271, 272, 273, 275, 276, 277, 278, 37111, 6474, 6475, 11123, 1381491, 299, 399, 499, 123, 333, 334, 335, 2702, 2705, 2700, 2800]

# Testnet (Sepolia)
cast call 0xc4fd2580c3487bba18d63f50301020132342fdbd "getAllZKChainChainIDs()(uint256[])" --rpc-url https://sepolia.gateway.tenderly.co
# → [8022832, 8022833, 36900, 42111, 7567979, 531050204, 788621, 1401, 2905, 8022834, 17986, 29538, 17218, 278701, 17219, 1326, 1327, 4221, 88288, 579028, 579029]
```

Chain ID `270` is present on **stage**.

## Changes

- `contracts` submodule bumped to era-contracts `fix/evm-1221-hard-coded-chain-id-zero` (PR #2083)
- `core/lib/basic_types/src/lib.rs`: `L2ChainId::default()` now returns `Self::zero()` (chain ID 0)
- `core/node/node_sync/src/validate_chain_ids_task.rs`: two tests that paired `L2ChainId::default()` with hardcoded `270` mock responses updated to use `L2ChainId::from(270u32)` explicitly
- `core/tests/loadnext/src/config.rs`: removed stale `// 270 for Rinkeby` comment

## Test plan

- [x] `cargo test -p zksync_basic_types` — 30 passed
- [x] `cargo test -p zksync_types` — 55 passed
- [x] `cargo test -p zksync_node_sync -- validate_chain` — 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)