### PR TITLE
refactor: add more feature gating to keystore

### DIFF
--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -10019,19 +10019,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zksync_airbender_prover_interface"
-version = "29.15.0-non-semver-compat"
-dependencies = [
- "bincode",
- "serde",
- "serde_with 1.14.0",
- "zksync_object_store",
- "zksync_prover_interface",
- "zksync_types",
- "zksync_vm_interface",
-]
-
-[[package]]
 name = "zksync_basic_types"
 version = "29.15.0-non-semver-compat"
 dependencies = [
@@ -10694,16 +10681,6 @@ dependencies = [
  "vise",
  "zksync_prover_fri_types",
  "zksync_types",
-]
-
-[[package]]
-name = "zksync_prover_input_encoder"
-version = "25.2.0"
-dependencies = [
- "bincode",
- "clap 4.5.37",
- "serde_json",
- "zksync_airbender_prover_interface",
 ]
 
 [[package]]

--- a/prover/crates/bin/vk_setup_data_generator_server_fri/Cargo.toml
+++ b/prover/crates/bin/vk_setup_data_generator_server_fri/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 zksync_prover_fri_types.workspace = true
-zksync_prover_keystore.workspace = true
+zksync_prover_keystore = { workspace = true, features = ["circuit-prover"] }
 zksync_utils.workspace = true
 zkevm_test_harness.workspace = true
 circuit_definitions = { workspace = true, features = ["log_tracing"] }

--- a/prover/crates/lib/keystore/Cargo.toml
+++ b/prover/crates/lib/keystore/Cargo.toml
@@ -13,8 +13,8 @@ categories.workspace = true
 zksync_basic_types.workspace = true
 zksync_utils.workspace = true
 zksync_prover_fri_types.workspace = true
-zksync_witness_generator_service.workspace = true
-zksync_circuit_prover_service.workspace = true
+zksync_witness_generator_service = { workspace = true, optional = true }
+zksync_circuit_prover_service = { workspace = true, optional = true }
 zkevm_test_harness.workspace = true
 zksync_types.workspace = true
 circuit_definitions = { workspace = true, features = ["log_tracing"] }
@@ -37,6 +37,11 @@ futures = { workspace = true, features = ["compat"] }
 
 [features]
 default = []
-# feature to not compile era-bellman-cuda, but to be able to use GPU features
-gpu-light = ["dep:shivini", "dep:boojum-cuda"]
-gpu = ["dep:shivini", "dep:fflonk-gpu", "dep:boojum-cuda", "dep:proof-compression-gpu"]
+# Enables setup data loading (CPU proving) via zksync_circuit_prover_service.
+# Pulls in shivini -> CUDA transitive dependency.
+circuit-prover = ["dep:zksync_circuit_prover_service"]
+# Enables the VerificationKeyManager trait impl via zksync_witness_generator_service.
+witness-gen-service = ["dep:zksync_witness_generator_service"]
+# Feature to not compile era-bellman-cuda, but to be able to use GPU features.
+gpu-light = ["circuit-prover", "dep:shivini", "dep:boojum-cuda"]
+gpu = ["gpu-light", "witness-gen-service", "dep:fflonk-gpu", "dep:proof-compression-gpu"]

--- a/prover/crates/lib/keystore/src/keystore.rs
+++ b/prover/crates/lib/keystore/src/keystore.rs
@@ -29,6 +29,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 #[cfg(any(feature = "gpu", feature = "gpu-light"))]
 use shivini::boojum::field::goldilocks::GoldilocksField;
 use zkevm_test_harness::data_source::{in_memory_data_source::InMemoryDataSource, SetupDataSource};
+#[cfg(feature = "circuit-prover")]
 use zksync_circuit_prover_service::types::setup_data::GoldilocksProverSetupData;
 #[cfg(any(feature = "gpu", feature = "gpu-light"))]
 use zksync_circuit_prover_service::types::setup_data::{
@@ -413,6 +414,7 @@ impl Keystore {
     // Setup keys
     //
 
+    #[cfg(feature = "circuit-prover")]
     pub fn load_cpu_setup_data_for_circuit_type(
         &self,
         key: ProverServiceDataKey,

--- a/prover/crates/lib/keystore/src/lib.rs
+++ b/prover/crates/lib/keystore/src/lib.rs
@@ -5,8 +5,13 @@ use serde::{Deserialize, Serialize};
 
 pub mod commitment_utils;
 pub mod keystore;
+/// Setup data generation for CPU and GPU proving. Requires `circuit-prover` feature.
+#[cfg(feature = "circuit-prover")]
 pub mod setup_data_generator;
 pub mod utils;
+/// [`keystore::Keystore`] implementation of the `VerificationKeyManager` trait.
+/// Requires `witness-gen-service` feature.
+#[cfg(feature = "witness-gen-service")]
 pub mod witness_generator;
 
 #[cfg(feature = "gpu")]


### PR DESCRIPTION
## What ❔

Make zksync_circuit_prover_service and zksync_witness_generator_service optional dependencies in zksync_prover_keystore, gated behind new circuit-prover and witness-gen-service feature flags.                                                    
                                                            
gpu-light implies circuit-prover, and gpu implies both, so existing consumers with GPU features are unaffected.

## Why ❔

zksync_prover_keystore unconditionally pulls in zksync_circuit_prover_service → shivini → boojum-cuda → era_cudart_sys, requiring the CUDA toolkit at build time.

Consumers that only need verification key loading, finalization hints, and commitment utilities (e.g. witness generators) should not require a GPU toolchain to compile.

This is relevant for ZK Chain operators who want to build and run witness generation on CPU-only machines separately from GPU proving infrastructure.

## Is this a breaking change?
- [X] Yes
- [ ] No

Consumers of zksync_prover_keystore that use setup_data_generator (e.g. CPUSetupDataGenerator, load_cpu_setup_data_for_circuit_type) without enabling gpu or gpu-light must now add features = ["circuit-prover"]. Consumers that use the witness_generator module (the VerificationKeyManager trait impl) must add features = 
["witness-gen-service"]. Consumers that already use gpu or gpu-light require no changes.

## Operational changes

New feature flags on zksync_prover_keystore:                                          
- circuit-prover — enables zksync_circuit_prover_service dep, setup_data_generator
  module, and load_cpu_setup_data_for_circuit_type                                      
- witness-gen-service — enables zksync_witness_generator_service dep and
  witness_generator module                                                              
- gpu-light now implies circuit-prover                                                
- gpu now implies witness-gen-service (in addition to existing gpu-light)

## Checklist

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
