### PR TITLE
fix(eth_proof_manager): fixed prover query and add logs

### DIFF
--- a/core/lib/dal/src/eth_proof_manager_dal.rs
+++ b/core/lib/dal/src/eth_proof_manager_dal.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use sqlx::QueryBuilder;
+use sqlx::{QueryBuilder, Row};
 use zksync_db_connection::{
     connection::Connection, error::DalResult, instrument::InstrumentExt,
     utils::pg_interval_from_duration,
@@ -337,15 +337,43 @@ impl EthProofManagerDal<'_, '_> {
         .into_iter()
         .map(|row| L1BatchNumber(row.l1_batch_number as u32))
         .collect();
-        let mut query_builder = QueryBuilder::new(
-            "UPDATE proof_generation_details SET status='unpicked', proving_mode = 'prover_cluster', updated_at = NOW() WHERE (status='unpicked' AND updated_at < NOW() - "
-        );
-
-        query_builder.push_bind(picking_timeout);
-        query_builder.push("::INTERVAL)");
 
         if !batches.is_empty() {
-            query_builder.push(" OR l1_batch_number IN (");
+            tracing::info!(
+                "Fallbacking batches in eth_proof_manager: {:?}",
+                batches
+            );
+        }
+
+        // Move batches that exceeded picking_timeout to prover_cluster
+        let timed_out_batches: Vec<L1BatchNumber> = sqlx::query(
+            "UPDATE proof_generation_details \
+             SET status = 'unpicked', proving_mode = 'prover_cluster', updated_at = NOW() \
+             WHERE status = 'unpicked' \
+                 AND proving_mode = 'proving_network' \
+                 AND updated_at < NOW() - $1::INTERVAL \
+             RETURNING l1_batch_number",
+        )
+        .bind(&picking_timeout)
+        .map(|row: sqlx::postgres::PgRow| {
+            L1BatchNumber(row.get::<i64, _>("l1_batch_number") as u32)
+        })
+        .instrument("move_unpicked_batches_to_prover_cluster")
+        .fetch_all(&mut transaction)
+        .await?;
+
+        if !timed_out_batches.is_empty() {
+            tracing::info!(
+                "Moved batches to prover_cluster due to picking_timeout: {:?}",
+                timed_out_batches
+            );
+        }
+
+        // Move batches that were fallbacked in eth_proof_manager to prover_cluster
+        if !batches.is_empty() {
+            let mut query_builder: QueryBuilder<'_, sqlx::Postgres> = QueryBuilder::new(
+                "UPDATE proof_generation_details SET status='unpicked', proving_mode = 'prover_cluster', updated_at = NOW() WHERE l1_batch_number IN ("
+            );
 
             for (index, batch) in batches.iter().enumerate() {
                 query_builder.push_bind(i64::from(batch.0));
@@ -355,15 +383,18 @@ impl EthProofManagerDal<'_, '_> {
             }
 
             query_builder.push(")");
+
+            query_builder
+                .build()
+                .instrument("move_fallbacked_batches_to_prover_cluster")
+                .execute(&mut transaction)
+                .await?;
+
+            tracing::info!(
+                "Moved eth_proof_manager fallbacked batches to prover_cluster in proof_generation_details: {:?}",
+                batches
+            );
         }
-
-        let result = query_builder
-            .build()
-            .instrument("move_batches_to_fallback")
-            .execute(&mut transaction)
-            .await?;
-
-        tracing::info!("Moved {} batches to fallback", result.rows_affected());
 
         transaction.commit().await?;
 
@@ -371,8 +402,12 @@ impl EthProofManagerDal<'_, '_> {
     }
 
     pub async fn fallback_batch(&mut self, batch_number: L1BatchNumber) -> DalResult<()> {
+        tracing::info!(
+            "Fallbacking single batch {} to prover cluster",
+            batch_number
+        );
         let mut transaction = self.storage.start_transaction().await?;
-        sqlx::query!(
+        let eth_rows = sqlx::query!(
             r#"
             UPDATE eth_proof_manager SET status = $1, updated_at = NOW()
             WHERE l1_batch_number = $2
@@ -384,6 +419,13 @@ impl EthProofManagerDal<'_, '_> {
         .with_arg("batch_number", &batch_number)
         .execute(&mut transaction)
         .await?;
+
+        if eth_rows.rows_affected() == 0 {
+            tracing::warn!(
+                "Batch {} had no eth_proof_manager entry to fallback",
+                batch_number
+            );
+        }
 
         sqlx::query!(
             r#"
@@ -398,6 +440,12 @@ impl EthProofManagerDal<'_, '_> {
         .await?;
 
         transaction.commit().await?;
+
+        tracing::info!(
+            "Batch {} fallbacked to prover cluster (eth_proof_manager rows: {})",
+            batch_number,
+            eth_rows.rows_affected()
+        );
 
         Ok(())
     }

--- a/core/lib/dal/src/eth_proof_manager_dal.rs
+++ b/core/lib/dal/src/eth_proof_manager_dal.rs
@@ -339,10 +339,7 @@ impl EthProofManagerDal<'_, '_> {
         .collect();
 
         if !batches.is_empty() {
-            tracing::info!(
-                "Fallbacking batches in eth_proof_manager: {:?}",
-                batches
-            );
+            tracing::info!("Fallbacking batches in eth_proof_manager: {:?}", batches);
         }
 
         // Move batches that exceeded picking_timeout to prover_cluster
@@ -355,9 +352,9 @@ impl EthProofManagerDal<'_, '_> {
              RETURNING l1_batch_number",
         )
         .bind(&picking_timeout)
-        .map(|row: sqlx::postgres::PgRow| {
-            L1BatchNumber(row.get::<i64, _>("l1_batch_number") as u32)
-        })
+        .map(
+            |row: sqlx::postgres::PgRow| L1BatchNumber(row.get::<i64, _>("l1_batch_number") as u32),
+        )
         .instrument("move_unpicked_batches_to_prover_cluster")
         .fetch_all(&mut transaction)
         .await?;

--- a/core/node/eth_proof_manager/src/sender/submit_proof_request.rs
+++ b/core/node/eth_proof_manager/src/sender/submit_proof_request.rs
@@ -69,8 +69,10 @@ impl ProofRequestSubmitter {
     }
 
     pub async fn loop_iteration(&self) -> anyhow::Result<()> {
+        tracing::info!("Looking for a batch to submit proof request for");
         let batch_id = self.processor.lock_batch_for_proving_network().await?;
         if let Some(batch_id) = batch_id {
+            tracing::info!("Locked batch {} for proving network", batch_id);
             match self.submit_request(batch_id).await {
                 Ok(_) => {
                     tracing::info!("Submitted proof request for batch {}", batch_id);
@@ -88,6 +90,7 @@ impl ProofRequestSubmitter {
                         .eth_proof_manager_dal()
                         .fallback_batch(batch_id)
                         .await?;
+                    tracing::info!("Batch {} fallbacked to prover cluster", batch_id);
                 }
             }
         } else {
@@ -98,12 +101,19 @@ impl ProofRequestSubmitter {
     }
 
     pub async fn submit_request(&self, batch_id: L1BatchNumber) -> anyhow::Result<()> {
+        tracing::info!(
+            "Fetching proof generation data from blob store for batch {}",
+            batch_id
+        );
         let proof_generation_data = self
             .processor
             .proof_generation_data_for_existing_batch(batch_id)
             .await?;
 
-        tracing::info!("Need to send proof request for batch {}", batch_id);
+        tracing::info!(
+            "Uploading public witness inputs to blob store for batch {}",
+            batch_id
+        );
 
         let witness_input_data =
             PublicWitnessInputData::new(proof_generation_data.witness_input_data.clone());
@@ -127,6 +137,10 @@ impl ProofRequestSubmitter {
             key
         );
 
+        tracing::info!(
+            "Inserting batch {} into eth_proof_manager with witness URL",
+            batch_id
+        );
         self.connection_pool
             .connection()
             .await?

--- a/core/node/proof_data_handler/src/proof_router.rs
+++ b/core/node/proof_data_handler/src/proof_router.rs
@@ -48,7 +48,15 @@ impl ProofRouter {
                 )
                 .await?;
 
-            tracing::info!("Fallbacked {} batches with timeouts: acknowledgment timeout: {:?} and proving timeout: {:?}", amount, self.acknowledgment_timeout, self.proving_timeout);
+            if amount > 0 {
+                tracing::info!(
+                    "Fallbacked {} batches with timeouts: acknowledgment: {:?}, proving: {:?}, picking: {:?}",
+                    amount,
+                    self.acknowledgment_timeout,
+                    self.proving_timeout,
+                    self.picking_timeout
+                );
+            }
 
             METRICS.fallbacked_batches.inc_by(amount as u64);
 


### PR DESCRIPTION
## What ❔

  Summary                                                                                                                                                                       
                                                                                                                                                                                
  - Fix fallback_batches() in eth_proof_manager_dal prematurely moving batches from proving_network to prover_cluster in proof_generation_details when their prerequisites      
  aren't ready yet                                                                                                                                                              
  - Add proving_mode = 'proving_network' filter to the picking timeout query so it only fallbacks batches actually in the proving network path
  - Split the combined proof_generation_details fallback query into two separate queries (picking timeout vs eth_proof_manager fallback) for clear observability                
  - Add detailed logging across the eth proof manager sender, fallback paths, and proof router                                                                                  
                                                                                                                                                                                
  Problem                                                                                                                                                                       
                                                                                                                                                                                
  The fallback_batches() method runs a secondary UPDATE on proof_generation_details that moves any batch with status='unpicked' older than picking_timeout (5 min) to           
  proving_mode = 'prover_cluster'. This query did not filter on proving_mode, so it also caught batches that were simply waiting for prerequisites (blob URLs, l1_batch
  metadata) to be populated.                                                                                                                                                    
                                                            
  Once moved to prover_cluster, lock_batch_for_proving_network() would never pick the batch (it filters on proving_mode = 'proving_network'). The batch would then wait for the 
  5h proof_generation_timeout re-pick in lock_batch_for_proving() before being processed.
                                                                                                                                                                                
  This was completely invisible in logs — no error, no fallback log, no mention of the affected batch number.                                                                   
   
  Evidence                                                                                                                                                                      
                                                            
  Batch 58064 (and previously 57421):                                                                                                                                           
  - Created in proof_generation_details at 21:12, prerequisites not yet ready
  - fallback_batches() moved it to prover_cluster after 5 min picking timeout                                                                                                   
  - lock_batch_for_proving_network() never returned it — sender skipped from 58063 to 58065
  - Batch sat orphaned until lock_batch_for_proving() re-picked it at 02:12 (+5h)                                                                                               
  - Zero logs from the eth proof manager mentioning batch 58064                                                                                                                 
                                                                     

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
