### PR TITLE
fix(consensus): keep interop_fee wire as u64 and add U256->u64 safety checks

### DIFF
--- a/core/lib/dal/src/consensus/conv.rs
+++ b/core/lib/dal/src/consensus/conv.rs
@@ -248,12 +248,7 @@ impl ProtoFmt for Payload {
             interop_roots,
             settlement_layer: read_optional_repr(&r.settlement_layer)
                 .context("settlement_layer")?,
-            interop_fee: r
-                .interop_fee
-                .as_ref()
-                .map(|fee| parse_h256(fee).map(h256_to_u256))
-                .transpose()
-                .context("interop_fee")?,
+            interop_fee: r.interop_fee,
         };
         if this.protocol_version.is_pre_gateway() {
             anyhow::ensure!(
@@ -321,9 +316,7 @@ impl ProtoFmt for Payload {
             pubdata_limit: self.pubdata_limit,
             interop_roots: self.interop_roots.iter().map(ProtoRepr::build).collect(),
             settlement_layer: self.settlement_layer.as_ref().map(ProtoRepr::build),
-            interop_fee: self
-                .interop_fee
-                .map(|fee| u256_to_h256(fee).as_bytes().into()),
+            interop_fee: self.interop_fee,
         };
         match self.protocol_version {
             v if v >= ProtocolVersionId::Version25 => {

--- a/core/lib/dal/src/consensus/mod.rs
+++ b/core/lib/dal/src/consensus/mod.rs
@@ -5,7 +5,7 @@ use zksync_consensus_engine::Last;
 use zksync_consensus_roles::{node, validator};
 use zksync_types::{
     commitment::PubdataParams, ethabi, settlement::SettlementLayer, Address, InteropRoot,
-    L1BatchNumber, ProtocolVersionId, Transaction, H256, U256,
+    L1BatchNumber, ProtocolVersionId, Transaction, H256,
 };
 
 mod conv;
@@ -81,7 +81,7 @@ pub struct Payload {
     pub pubdata_limit: Option<u64>,
     pub interop_roots: Vec<InteropRoot>,
     pub settlement_layer: Option<SettlementLayer>,
-    pub interop_fee: Option<U256>,
+    pub interop_fee: Option<u64>,
 }
 
 impl Payload {

--- a/core/lib/dal/src/consensus/proto/mod.proto
+++ b/core/lib/dal/src/consensus/proto/mod.proto
@@ -53,7 +53,7 @@ message Payload {
   optional uint64 pubdata_limit = 14; // required since v29
   repeated InteropRoot interop_roots = 15; // optional; set for protocol_version >= 29
   optional SettlementLayer settlement_layer = 16; // optional; set for protocol_version >= 31
-  optional bytes interop_fee = 17; // optional; U256; set for protocol_version >= 31
+  optional uint64 interop_fee = 17; // optional; set for protocol_version >= 31
 }
 
 message PubdataParams {

--- a/core/lib/dal/src/consensus/tests.rs
+++ b/core/lib/dal/src/consensus/tests.rs
@@ -12,7 +12,7 @@ use zksync_types::{
     commitment::{L2DACommitmentScheme, L2PubdataValidator, PubdataParams, PubdataType},
     web3::Bytes,
     Execute, ExecuteTransactionCommon, L1BatchNumber, L2ChainId, ProtocolVersionId, SLChainId,
-    Transaction, U256,
+    Transaction,
 };
 
 use super::*;
@@ -89,7 +89,7 @@ fn payload(rng: &mut impl Rng, protocol_version: ProtocolVersionId) -> Payload {
         interop_fee: if protocol_version < ProtocolVersionId::Version29 {
             None
         } else {
-            Some(U256::from_big_endian(&rng.gen::<[u8; 32]>()))
+            Some(rng.gen())
         },
     }
 }

--- a/core/lib/dal/src/models/storage_sync.rs
+++ b/core/lib/dal/src/models/storage_sync.rs
@@ -183,7 +183,11 @@ impl SyncBlock {
             pubdata_limit: self.pubdata_limit,
             interop_roots: self.interop_roots,
             settlement_layer: Some(self.settlement_layer),
-            interop_fee: Some(self.interop_fee),
+            interop_fee: Some(
+                self.interop_fee
+                    .try_into()
+                    .expect("interop_fee doesn't fit consensus u64 wire format"),
+            ),
         }
     }
 }

--- a/core/node/consensus/src/storage/store.rs
+++ b/core/node/consensus/src/storage/store.rs
@@ -55,7 +55,7 @@ fn to_fetched_block(
         pubdata_limit: payload.pubdata_limit,
         interop_roots: payload.interop_roots.clone(),
         settlement_layer: payload.settlement_layer,
-        interop_fee: payload.interop_fee,
+        interop_fee: payload.interop_fee.map(Into::into),
     })
 }
 

--- a/core/node/fee_model/src/node/l1_gas.rs
+++ b/core/node/fee_model/src/node/l1_gas.rs
@@ -84,6 +84,12 @@ impl WiringLayer for L1GasLayer {
             .base_token_ratio_provider
             .unwrap_or_else(|| Arc::<BaseTokenConversionRatio>::default());
 
+        if self.configured_interop_fee > u64::MAX.into() {
+            return Err(WiringError::Configuration(format!(
+                "configured_interop_fee={} doesn't fit consensus u64 wire format",
+                self.configured_interop_fee
+            )));
+        }
         let main_fee_input_provider = Arc::new(MainNodeFeeInputProvider::new(
             input.gas_adjuster.clone(),
             ratio_provider,

--- a/core/node/state_keeper/src/io/mempool.rs
+++ b/core/node/state_keeper/src/io/mempool.rs
@@ -649,6 +649,12 @@ impl MempoolIO {
             } else {
                 self.batch_fee_input_provider.get_interop_fee().await
             };
+            anyhow::ensure!(
+                interop_fee <= u64::MAX.into(),
+                "interop_fee for L1 batch #{} doesn't fit consensus u64 wire format: {}",
+                cursor.l1_batch,
+                interop_fee
+            );
 
             tracing::trace!(
                 "Fee input for L1 batch #{} is {:#?}",


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
