### PR TITLE
fix(verifier): handle raw stored evm bytecode in contract verifier

### DIFF
--- a/core/lib/contract_verifier/src/lib.rs
+++ b/core/lib/contract_verifier/src/lib.rs
@@ -122,6 +122,31 @@ pub struct ContractVerifier {
 }
 
 impl ContractVerifier {
+    fn deployed_evm_bytecode(
+        deployed_contract: &DeployedContractData,
+    ) -> Result<&[u8], ContractVerifierError> {
+        let bytecode_hash = BytecodeHash::try_from(deployed_contract.bytecode_hash)
+            .context("Invalid bytecode hash")?;
+
+        match trim_padded_evm_bytecode(bytecode_hash, &deployed_contract.bytecode) {
+            Ok(bytecode) => Ok(bytecode),
+            Err(err) => {
+                if BytecodeHash::for_raw_evm_bytecode(&deployed_contract.bytecode).value()
+                    == deployed_contract.bytecode_hash
+                {
+                    tracing::warn!(
+                        contract_address = ?deployed_contract.contract_address,
+                        bytecode_hash = ?deployed_contract.bytecode_hash,
+                        "raw EVM bytecode found in factory_deps; using compatibility fallback"
+                    );
+                    Ok(deployed_contract.bytecode.as_slice())
+                } else {
+                    Err(anyhow::format_err!("invalid stored EVM bytecode: {err:#}").into())
+                }
+            }
+        }
+    }
+
     /// Creates a new verifier instance.
     pub async fn new(
         compilation_timeout: Duration,
@@ -261,12 +286,7 @@ impl ContractVerifier {
             .context("unknown bytecode kind")?;
         let deployed_bytecode = match bytecode_marker {
             BytecodeMarker::EraVm => deployed_contract.bytecode.as_slice(),
-            BytecodeMarker::Evm => trim_padded_evm_bytecode(
-                BytecodeHash::try_from(deployed_contract.bytecode_hash)
-                    .context("Invalid bytecode hash")?,
-                &deployed_contract.bytecode,
-            )
-            .context("invalid stored EVM bytecode")?,
+            BytecodeMarker::Evm => Self::deployed_evm_bytecode(&deployed_contract)?,
         };
         let mut deployed_code = deployed_bytecode.to_vec();
         let deployed_identifier =

--- a/core/lib/contract_verifier/src/tests/mod.rs
+++ b/core/lib/contract_verifier/src/tests/mod.rs
@@ -146,6 +146,44 @@ async fn mock_evm_deployment(
     deployed_bytecode: &[u8],
     constructor_args: &[Token],
 ) {
+    let stored_bytecode = pad_evm_bytecode(deployed_bytecode);
+    mock_evm_deployment_with_stored_bytecode(
+        storage,
+        address,
+        creation_bytecode,
+        deployed_bytecode,
+        constructor_args,
+        stored_bytecode,
+    )
+    .await;
+}
+
+async fn mock_raw_evm_deployment(
+    storage: &mut Connection<'_, Core>,
+    address: Address,
+    creation_bytecode: Vec<u8>,
+    deployed_bytecode: &[u8],
+    constructor_args: &[Token],
+) {
+    mock_evm_deployment_with_stored_bytecode(
+        storage,
+        address,
+        creation_bytecode,
+        deployed_bytecode,
+        constructor_args,
+        deployed_bytecode.to_vec(),
+    )
+    .await;
+}
+
+async fn mock_evm_deployment_with_stored_bytecode(
+    storage: &mut Connection<'_, Core>,
+    address: Address,
+    creation_bytecode: Vec<u8>,
+    deployed_bytecode: &[u8],
+    constructor_args: &[Token],
+    stored_bytecode: Vec<u8>,
+) {
     let mut calldata = creation_bytecode;
     calldata.extend_from_slice(&ethabi::encode(constructor_args));
     let deployment = Execute {
@@ -154,9 +192,8 @@ async fn mock_evm_deployment(
         value: 0.into(),
         factory_deps: vec![],
     };
-    let bytecode = pad_evm_bytecode(deployed_bytecode);
-    let bytecode_hash = BytecodeHash::for_evm_bytecode(deployed_bytecode.len(), &bytecode).value();
-    mock_deployment_inner(storage, address, bytecode_hash, bytecode, deployment).await;
+    let bytecode_hash = BytecodeHash::for_raw_evm_bytecode(deployed_bytecode).value();
+    mock_deployment_inner(storage, address, bytecode_hash, stored_bytecode, deployment).await;
 }
 
 async fn mock_deployment_inner(
@@ -556,6 +593,56 @@ async fn verifying_evm_bytecode(contract: TestContract) {
 
         artifacts.clone()
     });
+    let verifier = ContractVerifier::with_resolver(
+        Duration::from_secs(60),
+        pool.clone(),
+        Arc::new(mock_resolver),
+        false,
+    )
+    .await
+    .unwrap();
+
+    let (_stop_sender, stop_receiver) = watch::channel(false);
+    verifier.run(stop_receiver, Some(1)).await.unwrap();
+
+    assert_request_success(&mut storage, request_id, address, &creation_bytecode, &[]).await;
+}
+
+#[tokio::test]
+async fn verifying_evm_with_raw_stored_bytecode() {
+    let pool = ConnectionPool::test_pool().await;
+    let mut storage = pool.connection().await.unwrap();
+    let creation_bytecode = vec![3_u8; 20];
+    let deployed_bytecode = vec![5_u8; 10];
+
+    prepare_storage(&mut storage).await;
+    let address = Address::repeat_byte(1);
+    mock_raw_evm_deployment(
+        &mut storage,
+        address,
+        creation_bytecode.clone(),
+        &deployed_bytecode,
+        &[],
+    )
+    .await;
+    let mut req = test_request(address, COUNTER_CONTRACT);
+    req.compiler_versions = CompilerVersions::Solc {
+        compiler_solc_version: SOLC_VERSION.to_owned(),
+        compiler_zksolc_version: None,
+    };
+    let request_id = storage
+        .contract_verification_dal()
+        .add_contract_verification_request(&req)
+        .await
+        .unwrap();
+
+    let artifacts = CompilationArtifacts {
+        bytecode: creation_bytecode.clone(),
+        deployed_bytecode: Some(deployed_bytecode),
+        abi: counter_contract_abi(),
+        immutable_refs: Default::default(),
+    };
+    let mock_resolver = MockCompilerResolver::solc(move |_| artifacts.clone());
     let verifier = ContractVerifier::with_resolver(
         Duration::from_secs(60),
         pool.clone(),


### PR DESCRIPTION
## What ❔

Fixes EVM contract verification for deployments whose stored runtime bytecode in `factory_deps` is raw instead of padded.

The verifier previously assumed that all stored EVM bytecode could be decoded via `trim_padded_evm_bytecode(...)`. When a contract was persisted with raw EVM runtime bytecode, verification failed in the deployed-bytecode comparison path and surfaced as a generic `internal error`.

This change adds a compatibility path in the verifier:

First, try the existing padded-bytecode decode path.
If that fails, treat the stored bytes as raw EVM bytecode and accept them when `BytecodeHash::for_raw_evm_bytecode(stored_bytes)` matches the stored bytecode hash.
Keep the existing behavior for properly padded bytecode.
The PR also adds a regression test that stores raw EVM runtime bytecode in factory_deps and verifies that the contract still passes verification.

## Why ❔

Fixes #4779 

Mainnet contract verification was failing for some EVM-emulated contracts even when the submitted source and the deployed bytecode were correct. The root cause was a mismatch between verifier assumptions and the bytecode representation stored in the database.

This change makes the verifier robust to both representations while still validating the stored data against the bytecode hash.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

No config changes, flags, or script changes.

This is a verifier-side compatibility fix only. It does not change request formats or compiler resolution behavior.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
