### PR TITLE
fix(contract-verifier): preserve zksolc standard-json fields and report missing bytecode correctly

### DIFF
--- a/core/lib/contract_verifier/src/compilers/mod.rs
+++ b/core/lib/contract_verifier/src/compilers/mod.rs
@@ -228,7 +228,10 @@ fn parse_standard_json_output(
     };
 
     let Some(bytecode_str) = contract.pointer("/evm/bytecode/object") else {
-        return Err(ContractVerifierError::AbstractContract(contract_name));
+        return Err(ContractVerifierError::MissingCompilerOutput {
+            contract_name,
+            field_path: "/evm/bytecode/object",
+        });
     };
     let bytecode_str = bytecode_str
         .as_str()
@@ -239,7 +242,10 @@ fn parse_standard_json_output(
 
     let deployed_bytecode = if get_deployed_bytecode {
         let Some(bytecode_str) = contract.pointer("/evm/deployedBytecode/object") else {
-            return Err(ContractVerifierError::AbstractContract(contract_name));
+            return Err(ContractVerifierError::MissingCompilerOutput {
+                contract_name,
+                field_path: "/evm/deployedBytecode/object",
+            });
         };
         let bytecode_str = bytecode_str
             .as_str()
@@ -282,4 +288,73 @@ fn is_suppressable_error(message: &str) -> bool {
     // All of them mention `suppressedErrors` in the message, which is a custom
     // `zksolc` configuration, so we use it as a marker.
     message.contains("suppressedErrors")
+}
+
+#[cfg(test)]
+mod parser_tests {
+    use super::parse_standard_json_output;
+    use crate::error::ContractVerifierError;
+
+    #[test]
+    fn reports_missing_creation_bytecode_path() {
+        let output = serde_json::json!({
+            "contracts": {
+                "Counter.sol": {
+                    "Counter": {
+                        "abi": []
+                    }
+                }
+            }
+        });
+
+        let err = parse_standard_json_output(
+            &output,
+            "Counter".to_owned(),
+            "Counter.sol".to_owned(),
+            false,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            ContractVerifierError::MissingCompilerOutput {
+                contract_name,
+                field_path: "/evm/bytecode/object",
+            } if contract_name == "Counter"
+        ));
+    }
+
+    #[test]
+    fn reports_missing_deployed_bytecode_path() {
+        let output = serde_json::json!({
+            "contracts": {
+                "Counter.sol": {
+                    "Counter": {
+                        "abi": [],
+                        "evm": {
+                            "bytecode": {
+                                "object": "00"
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let err = parse_standard_json_output(
+            &output,
+            "Counter".to_owned(),
+            "Counter.sol".to_owned(),
+            true,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            ContractVerifierError::MissingCompilerOutput {
+                contract_name,
+                field_path: "/evm/deployedBytecode/object",
+            } if contract_name == "Counter"
+        ));
+    }
 }

--- a/core/lib/contract_verifier/src/compilers/mod.rs
+++ b/core/lib/contract_verifier/src/compilers/mod.rs
@@ -19,11 +19,17 @@ mod vyper;
 mod zksolc;
 mod zkvyper;
 
+fn default_json_object() -> Value {
+    serde_json::json!({})
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct StandardJson {
     pub language: String,
     pub sources: HashMap<String, Source>,
+    #[serde(flatten, default = "default_json_object")]
+    other: Value,
     #[serde(default)]
     settings: Settings,
 }
@@ -42,7 +48,7 @@ impl Default for Settings {
     fn default() -> Self {
         Self {
             output_selection: None,
-            other: serde_json::json!({}),
+            other: default_json_object(),
         }
     }
 }

--- a/core/lib/contract_verifier/src/compilers/solc.rs
+++ b/core/lib/contract_verifier/src/compilers/solc.rs
@@ -74,6 +74,7 @@ impl Solc {
                 StandardJson {
                     language: "Solidity".to_owned(),
                     sources,
+                    other: serde_json::json!({}),
                     settings,
                 }
             }
@@ -109,6 +110,7 @@ impl Solc {
                 StandardJson {
                     language: "Yul".to_owned(),
                     sources,
+                    other: serde_json::json!({}),
                     settings,
                 }
             }

--- a/core/lib/contract_verifier/src/compilers/vyper.rs
+++ b/core/lib/contract_verifier/src/compilers/vyper.rs
@@ -60,6 +60,7 @@ impl VyperInput {
         StandardJson {
             language: "Vyper".to_owned(),
             sources: sources.collect(),
+            other: serde_json::json!({}),
             settings: Settings {
                 output_selection: Some(serde_json::json!({
                     "*": [ "abi", "evm.bytecode", "evm.deployedBytecode" ],

--- a/core/lib/contract_verifier/src/compilers/zksolc.rs
+++ b/core/lib/contract_verifier/src/compilers/zksolc.rs
@@ -86,16 +86,68 @@ impl ZkSolc {
         }
     }
 
+    fn ensure_selector_outputs(
+        output_selection: &mut serde_json::Value,
+        file_selector: &str,
+        contract_selector: &str,
+        outputs: &[&str],
+    ) {
+        if !output_selection.is_object() {
+            *output_selection = serde_json::json!({});
+        }
+
+        let file_entry = output_selection
+            .as_object_mut()
+            .unwrap()
+            .entry(file_selector.to_owned())
+            .or_insert_with(|| serde_json::json!({}));
+        if !file_entry.is_object() {
+            *file_entry = serde_json::json!({});
+        }
+
+        let contract_entry = file_entry
+            .as_object_mut()
+            .unwrap()
+            .entry(contract_selector.to_owned())
+            .or_insert_with(|| serde_json::json!([]));
+        if !contract_entry.is_array() {
+            *contract_entry = serde_json::json!([]);
+        }
+
+        let selected_outputs = contract_entry.as_array_mut().unwrap();
+        for output in outputs {
+            if !selected_outputs
+                .iter()
+                .any(|value| value.as_str() == Some(output))
+            {
+                selected_outputs.push(serde_json::Value::String((*output).to_owned()));
+            }
+        }
+    }
+
+    fn required_output_selection(
+        existing: Option<serde_json::Value>,
+        file_name: &str,
+        contract_name: &str,
+    ) -> serde_json::Value {
+        let mut output_selection = existing.unwrap_or_else(|| serde_json::json!({}));
+
+        Self::ensure_selector_outputs(&mut output_selection, "*", "*", &["abi", "evm.bytecode"]);
+        Self::ensure_selector_outputs(&mut output_selection, "*", "", &["abi"]);
+        Self::ensure_selector_outputs(
+            &mut output_selection,
+            file_name,
+            contract_name,
+            &["abi", "evm.bytecode"],
+        );
+
+        output_selection
+    }
+
     pub fn build_input(
         req: VerificationIncomingRequest,
     ) -> Result<ZkSolcInput, ContractVerifierError> {
         let (file_name, contract_name) = process_contract_name(&req.contract_name, "sol");
-        let default_output_selection = serde_json::json!({
-            "*": {
-                "*": [ "abi" ],
-                 "": [ "abi" ]
-            }
-        });
 
         match req.source_code_data {
             SourceCodeData::SolSingleFile(source_code) => {
@@ -109,7 +161,11 @@ impl ZkSolc {
                 };
                 let sources = HashMap::from([(file_name.clone(), source)]);
                 let settings = Settings {
-                    output_selection: Some(default_output_selection),
+                    output_selection: Some(Self::required_output_selection(
+                        None,
+                        &file_name,
+                        &contract_name,
+                    )),
                     is_system: req.is_system,
                     force_evmla: req.force_evmla,
                     other: serde_json::json!({
@@ -142,8 +198,11 @@ impl ZkSolc {
                         ));
                     }
                 }
-                // Set default output selection even if it is different in request.
-                compiler_input.settings.output_selection = Some(default_output_selection);
+                compiler_input.settings.output_selection = Some(Self::required_output_selection(
+                    compiler_input.settings.output_selection.take(),
+                    &file_name,
+                    &contract_name,
+                ));
                 Ok(ZkSolcInput::StandardJson {
                     input: compiler_input,
                     contract_name,
@@ -324,6 +383,10 @@ impl Compiler<ZkSolcInput> for ZkSolc {
 mod tests {
     use std::path::PathBuf;
 
+    use zksync_types::contract_verification::api::{
+        CompilerVersions, SourceCodeData, VerificationIncomingRequest,
+    };
+
     use super::*;
 
     #[test]
@@ -356,5 +419,64 @@ mod tests {
 
         zksolc.zksolc_version = "v0.5.1".to_string();
         assert!(!zksolc.is_post_1_5_0(), "v0.5.1");
+    }
+
+    #[test]
+    fn build_input_preserves_existing_standard_json_output_selection() {
+        let req = VerificationIncomingRequest {
+            contract_address: Default::default(),
+            source_code_data: SourceCodeData::StandardJsonInput(
+                serde_json::json!({
+                    "language": "Solidity",
+                    "sources": {
+                        "Counter.sol": {
+                            "content": "contract Counter { function value() external pure returns (uint256) { return 1; } }",
+                        }
+                    },
+                    "settings": {
+                        "outputSelection": {
+                            "*": {
+                                "*": ["storageLayout"],
+                                "": ["ast"]
+                            },
+                            "Counter.sol": {
+                                "Counter": ["abi"]
+                            }
+                        }
+                    }
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+            contract_name: "Counter".to_owned(),
+            compiler_versions: CompilerVersions::Solc {
+                compiler_solc_version: "0.8.27".to_owned(),
+                compiler_zksolc_version: Some("1.5.4".to_owned()),
+            },
+            optimization_used: true,
+            optimizer_mode: None,
+            constructor_arguments: Default::default(),
+            is_system: false,
+            force_evmla: false,
+            evm_specific: Default::default(),
+        };
+
+        let ZkSolcInput::StandardJson { input, .. } = ZkSolc::build_input(req).unwrap() else {
+            panic!("expected standard-json input");
+        };
+
+        assert_eq!(
+            input.settings.output_selection,
+            Some(serde_json::json!({
+                "*": {
+                    "*": ["storageLayout", "abi", "evm.bytecode"],
+                    "": ["ast", "abi"]
+                },
+                "Counter.sol": {
+                    "Counter": ["abi", "evm.bytecode"]
+                }
+            }))
+        );
     }
 }

--- a/core/lib/contract_verifier/src/compilers/zksolc.rs
+++ b/core/lib/contract_verifier/src/compilers/zksolc.rs
@@ -12,8 +12,8 @@ use zksync_types::contract_verification::api::{
 
 use crate::{
     compilers::{
-        default_json_object, has_dangerous_imports, parse_standard_json_output, process_contract_name,
-        sanitize_compiler_stderr, validate_source_paths, Source,
+        default_json_object, has_dangerous_imports, parse_standard_json_output,
+        process_contract_name, sanitize_compiler_stderr, validate_source_paths, Source,
     },
     error::ContractVerifierError,
     resolver::{Compiler, CompilerPaths},
@@ -528,7 +528,13 @@ mod tests {
         };
         let serialized = serde_json::to_value(&input).unwrap();
 
-        assert_eq!(serialized["suppressedErrors"], serde_json::json!(["sendtransfer"]));
-        assert_eq!(serialized["suppressedWarnings"], serde_json::json!(["txorigin"]));
+        assert_eq!(
+            serialized["suppressedErrors"],
+            serde_json::json!(["sendtransfer"])
+        );
+        assert_eq!(
+            serialized["suppressedWarnings"],
+            serde_json::json!(["txorigin"])
+        );
     }
 }

--- a/core/lib/contract_verifier/src/compilers/zksolc.rs
+++ b/core/lib/contract_verifier/src/compilers/zksolc.rs
@@ -12,7 +12,7 @@ use zksync_types::contract_verification::api::{
 
 use crate::{
     compilers::{
-        has_dangerous_imports, parse_standard_json_output, process_contract_name,
+        default_json_object, has_dangerous_imports, parse_standard_json_output, process_contract_name,
         sanitize_compiler_stderr, validate_source_paths, Source,
     },
     error::ContractVerifierError,
@@ -39,6 +39,9 @@ pub(crate) struct StandardJson {
     pub language: String,
     /// The input source code files hashmap.
     pub sources: HashMap<String, Source>,
+    /// Other root-level keys preserved from the original request.
+    #[serde(flatten, default = "default_json_object")]
+    pub other: serde_json::Value,
     /// The compiler settings.
     pub settings: Settings,
 }
@@ -52,10 +55,10 @@ pub(crate) struct Settings {
     /// The output selection filters.
     pub output_selection: Option<serde_json::Value>,
     /// Flag for system compilation mode.
-    #[serde(default)]
+    #[serde(rename = "enableEraVMExtensions", default)]
     pub is_system: bool,
     /// Flag to force `evmla` IR.
-    #[serde(default)]
+    #[serde(rename = "forceEVMLA", default)]
     pub force_evmla: bool,
     /// Other settings (only filled when parsing `StandardJson` input from the request).
     #[serde(flatten)]
@@ -132,13 +135,13 @@ impl ZkSolc {
     ) -> serde_json::Value {
         let mut output_selection = existing.unwrap_or_else(|| serde_json::json!({}));
 
-        Self::ensure_selector_outputs(&mut output_selection, "*", "*", &["abi", "evm.bytecode"]);
+        Self::ensure_selector_outputs(&mut output_selection, "*", "*", &["abi", "evm"]);
         Self::ensure_selector_outputs(&mut output_selection, "*", "", &["abi"]);
         Self::ensure_selector_outputs(
             &mut output_selection,
             file_name,
             contract_name,
-            &["abi", "evm.bytecode"],
+            &["abi", "evm"],
         );
 
         output_selection
@@ -180,6 +183,7 @@ impl ZkSolc {
                     input: StandardJson {
                         language: "Solidity".to_string(),
                         sources,
+                        other: default_json_object(),
                         settings,
                     },
                     contract_name,
@@ -470,13 +474,61 @@ mod tests {
             input.settings.output_selection,
             Some(serde_json::json!({
                 "*": {
-                    "*": ["storageLayout", "abi", "evm.bytecode"],
+                    "*": ["storageLayout", "abi", "evm"],
                     "": ["ast", "abi"]
                 },
                 "Counter.sol": {
-                    "Counter": ["abi", "evm.bytecode"]
+                    "Counter": ["abi", "evm"]
                 }
             }))
         );
+    }
+
+    #[test]
+    fn build_input_preserves_root_level_standard_json_fields() {
+        let req = VerificationIncomingRequest {
+            contract_address: Default::default(),
+            source_code_data: SourceCodeData::StandardJsonInput(
+                serde_json::json!({
+                    "language": "Solidity",
+                    "sources": {
+                        "Counter.sol": {
+                            "content": "contract Counter { function value() external pure returns (uint256) { return 1; } }",
+                        }
+                    },
+                    "suppressedErrors": ["sendtransfer"],
+                    "suppressedWarnings": ["txorigin"],
+                    "settings": {
+                        "outputSelection": {
+                            "*": {
+                                "*": ["abi"]
+                            }
+                        }
+                    }
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+            contract_name: "Counter".to_owned(),
+            compiler_versions: CompilerVersions::Solc {
+                compiler_solc_version: "0.8.27".to_owned(),
+                compiler_zksolc_version: Some("1.5.4".to_owned()),
+            },
+            optimization_used: true,
+            optimizer_mode: None,
+            constructor_arguments: Default::default(),
+            is_system: false,
+            force_evmla: false,
+            evm_specific: Default::default(),
+        };
+
+        let ZkSolcInput::StandardJson { input, .. } = ZkSolc::build_input(req).unwrap() else {
+            panic!("expected standard-json input");
+        };
+        let serialized = serde_json::to_value(&input).unwrap();
+
+        assert_eq!(serialized["suppressedErrors"], serde_json::json!(["sendtransfer"]));
+        assert_eq!(serialized["suppressedWarnings"], serde_json::json!(["txorigin"]));
     }
 }

--- a/core/lib/contract_verifier/src/error.rs
+++ b/core/lib/contract_verifier/src/error.rs
@@ -24,6 +24,11 @@ pub enum ContractVerifierError {
     MissingSource(String),
     #[error("Contract with {0} name is an abstract and thus is not verifiable")]
     AbstractContract(String),
+    #[error("Compiler output for contract {contract_name} is missing required field {field_path}")]
+    MissingCompilerOutput {
+        contract_name: String,
+        field_path: &'static str,
+    },
     #[error("Failed to deserialize standard JSON input")]
     FailedToDeserializeInput,
     #[error("Source path is not allowed: {0}")]

--- a/core/lib/contract_verifier/src/tests/real.rs
+++ b/core/lib/contract_verifier/src/tests/real.rs
@@ -525,7 +525,10 @@ async fn using_zksolc_with_abstract_contract(specify_contract_file: bool) {
     let err = compiler.compile(input).await.unwrap_err();
     assert_matches!(
         err,
-        ContractVerifierError::AbstractContract(name) if name == "ICounter"
+        ContractVerifierError::MissingCompilerOutput {
+            contract_name,
+            field_path: "/evm/bytecode/object",
+        } if contract_name == "ICounter"
     );
 }
 

--- a/core/lib/contract_verifier/src/tests/real.rs
+++ b/core/lib/contract_verifier/src/tests/real.rs
@@ -296,6 +296,36 @@ fn relative_escape_attempt_input() -> serde_json::Map<String, serde_json::Value>
     .clone()
 }
 
+fn root_level_suppression_standard_json_input() -> serde_json::Map<String, serde_json::Value> {
+    serde_json::json!({
+        "language": "Solidity",
+        "sources": {
+            "src/Counter.sol": {
+                "content": r#"
+                    pragma solidity ^0.8.19;
+
+                    contract Counter {
+                        receive() external payable {}
+
+                        function sweep() external {
+                            require(tx.origin == msg.sender);
+                            payable(msg.sender).transfer(address(this).balance);
+                        }
+                    }
+                "#,
+            },
+        },
+        "suppressedErrors": ["sendtransfer"],
+        "suppressedWarnings": ["txorigin"],
+        "settings": {
+            "optimizer": { "enabled": true },
+        },
+    })
+    .as_object()
+    .unwrap()
+    .clone()
+}
+
 async fn compile_standard_json_request(
     compiler_resolver: &EnvCompilerResolver,
     supported_compilers: TestCompilerVersions,
@@ -422,6 +452,33 @@ async fn relative_import_escape_is_still_blocked(bytecode_kind: BytecodeMarker) 
             .iter()
             .all(|err| !err.contains("root:") && !err.contains("/etc/shadow:")),
         "{errors:?}"
+    );
+}
+
+#[tokio::test]
+async fn allows_root_level_standard_json_suppressions_with_zksolc() {
+    let (compiler_resolver, supported_compilers) = real_resolver!();
+
+    let output = compile_standard_json_request(
+        &compiler_resolver,
+        supported_compilers,
+        BytecodeMarker::EraVm,
+        root_level_suppression_standard_json_input(),
+        "src/Counter.sol:Counter",
+    )
+    .await
+    .unwrap();
+
+    assert!(!output.bytecode.is_empty());
+    assert!(
+        output
+            .abi
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| { item["type"] == "function" && item["name"] == "sweep" }),
+        "{:?}",
+        output.abi
     );
 }
 


### PR DESCRIPTION
## What ❔

Fixes contract verification for `zksolc` standard-json inputs that already provide their own `outputSelection` and/or root-level suppression fields.

Changes included:
- preserve caller-provided `outputSelection` instead of overwriting it
- augment `zksolc` standard-json requests with the compiler outputs the verifier actually needs
- preserve root-level standard-json fields such as `suppressedErrors` / `suppressedWarnings`
- use the correct `zksolc` setting names for EraVM extensions / EVMLA
- return a dedicated `MissingCompilerOutput` verifier error instead of reporting missing bytecode as `AbstractContract`

## Why ❔

Fixes #4783

The verifier is currently mutating standard-json input in ways that changes compiler behavior:
- it overwrites user-provided output selection
- it drops root-level suppression fields that affected `zksolc` output
- when bytecode was then missing, the verifier surfaces a misleading `AbstractContract` error

The goal of this change is to make verification respect the submitted compiler input as closely as possible, request only the missing outputs needed by the verifier, and produce an error that reflects the actual failure mode when compiler output is incomplete.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
No config, flag, or script changes are required.

The only behavioral change is in verifier request normalization and error reporting:
- standard-json root-level fields are now preserved
- missing compiler bytecode is now reported as `MissingCompilerOutput`

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.