### PR TITLE
fix(consensus): omit interop_fee for pre-v31 payloads

### DIFF
--- a/core/lib/dal/src/consensus/conv.rs
+++ b/core/lib/dal/src/consensus/conv.rs
@@ -315,8 +315,16 @@ impl ProtoFmt for Payload {
             },
             pubdata_limit: self.pubdata_limit,
             interop_roots: self.interop_roots.iter().map(ProtoRepr::build).collect(),
-            settlement_layer: self.settlement_layer.as_ref().map(ProtoRepr::build),
-            interop_fee: self.interop_fee,
+            settlement_layer: if self.protocol_version < ProtocolVersionId::Version31 {
+                None
+            } else {
+                self.settlement_layer.as_ref().map(ProtoRepr::build)
+            },
+            interop_fee: if self.protocol_version < ProtocolVersionId::Version31 {
+                None
+            } else {
+                self.interop_fee
+            },
         };
         match self.protocol_version {
             v if v >= ProtocolVersionId::Version25 => {

--- a/core/lib/dal/src/consensus/tests.rs
+++ b/core/lib/dal/src/consensus/tests.rs
@@ -81,12 +81,12 @@ fn payload(rng: &mut impl Rng, protocol_version: ProtocolVersionId) -> Payload {
             Some(rng.gen())
         },
         interop_roots: (1..10).map(|_| interop_root(rng)).collect(),
-        settlement_layer: if protocol_version < ProtocolVersionId::Version29 {
+        settlement_layer: if protocol_version < ProtocolVersionId::Version31 {
             None
         } else {
             Some(SettlementLayer::L1(SLChainId(rng.gen::<u64>())))
         },
-        interop_fee: if protocol_version < ProtocolVersionId::Version29 {
+        interop_fee: if protocol_version < ProtocolVersionId::Version31 {
             None
         } else {
             Some(rng.gen())


### PR DESCRIPTION
## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
