### PR TITLE
chore: remove temporary bumps

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -52,28 +52,6 @@ runs:
         mkdir -p ./hardhat-nodejs
         ci_localnet_up
 
-    - name: (TEMPORARY) Update Node in ci_run container
-      shell: bash
-      run: |
-        ci_run bash -lc "curl -fsSL https://deb.nodesource.com/setup_20.x | bash -"
-        ci_run apt-get install -y nodejs
-        echo "Node version after update:"
-        ci_run node -v
-        ci_run npm -v
-        (ci_run yarn -v || ci_run npm install -g yarn) && ci_run yarn -v
-
-    - name: (TEMPORARY) Update foundry in ci_run container
-      shell: bash
-      run: |
-        ci_run curl -LO https://github.com/matter-labs/foundry-zksync/releases/download/foundry-zksync-v0.1.5/foundry_zksync_v0.1.5_linux_amd64.tar.gz
-        ci_run mkdir ./foundry-temp
-        ci_run tar zxf foundry_zksync_v0.1.5_linux_amd64.tar.gz -C ./foundry-temp
-        ci_run cp ./foundry-temp/forge /usr/local/cargo/bin/forge
-        ci_run cp ./foundry-temp/cast /usr/local/cargo/bin/cast
-        echo "Foundry version after update:"
-        ci_run forge --version
-        ci_run rm -rf ./foundry-temp foundry_zksync_v0.1.5_linux_amd64.tar.gz
-
     - name: Start sccache servers
       shell: bash
       run: |

--- a/.github/workflows/vm-perf-comparison.yml
+++ b/.github/workflows/vm-perf-comparison.yml
@@ -40,16 +40,6 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-env
 
-      - name: (TEMPORARY) Update Node in ci_run container
-        shell: bash
-        run: |
-          ci_run bash -lc "curl -fsSL https://deb.nodesource.com/setup_20.x | bash -"
-          ci_run apt-get install -y nodejs
-          echo "Node version after update:"
-          ci_run node -v
-          ci_run npm -v
-          (ci_run yarn -v || ci_run npm install -g yarn) && ci_run yarn -v
-
       - name: run benchmarks on base branch
         shell: bash
         run: |

--- a/zkstack_cli/crates/zkstack/build.rs
+++ b/zkstack_cli/crates/zkstack/build.rs
@@ -4,6 +4,7 @@ use anyhow::{anyhow, Context};
 use ethers::contract::Abigen;
 use xshell::{cmd, Shell};
 
+// trigger ci
 const COMPLETION_DIR: &str = "completion";
 
 fn main() -> anyhow::Result<()> {

--- a/zkstack_cli/crates/zkstack/build.rs
+++ b/zkstack_cli/crates/zkstack/build.rs
@@ -4,7 +4,6 @@ use anyhow::{anyhow, Context};
 use ethers::contract::Abigen;
 use xshell::{cmd, Shell};
 
-// trigger ci
 const COMPLETION_DIR: &str = "completion";
 
 fn main() -> anyhow::Result<()> {


### PR DESCRIPTION
## What ❔

Removes the temporary node/foundry version bumps made in https://github.com/matter-labs/zksync-era/pull/4608.
These were needed as docker images are constructed from main. Since the above PR got merged, they are no longer necessary.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
