### PR TITLE
chore(airbender commit): Refactoring

### DIFF
--- a/core/lib/dal/.sqlx/query-0048d473fc8f7104eb2a05a575627df8e29d985d7e90d53bc94556ee9d7e8e96.json
+++ b/core/lib/dal/.sqlx/query-0048d473fc8f7104eb2a05a575627df8e29d985d7e90d53bc94556ee9d7e8e96.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                l1_batches.meta_parameters_hash,\n                airbender_batch_commitments.commitment AS \"airbender_commitment?\",\n                airbender_batch_commitments.aux_data_hash AS \"airbender_aux_data_hash?\"\n            FROM\n                l1_batches\n            LEFT JOIN airbender_batch_commitments\n                ON airbender_batch_commitments.l1_batch_number = l1_batches.number\n            WHERE\n                l1_batches.number = $1\n                AND l1_batches.is_sealed\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "meta_parameters_hash",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 1,
+        "name": "airbender_commitment?",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 2,
+        "name": "airbender_aux_data_hash?",
+        "type_info": "Bytea"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "0048d473fc8f7104eb2a05a575627df8e29d985d7e90d53bc94556ee9d7e8e96"
+}

--- a/core/lib/dal/.sqlx/query-53951d5015787a682f256c772ab16d83be5f636709486fa6a680a4872d4e1318.json
+++ b/core/lib/dal/.sqlx/query-53951d5015787a682f256c772ab16d83be5f636709486fa6a680a4872d4e1318.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                pubdata_input\n            FROM\n                l1_batches\n            WHERE\n                is_sealed\n                AND number = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pubdata_input",
+        "type_info": "Bytea"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "53951d5015787a682f256c772ab16d83be5f636709486fa6a680a4872d4e1318"
+}

--- a/core/lib/dal/src/blocks_dal.rs
+++ b/core/lib/dal/src/blocks_dal.rs
@@ -58,6 +58,16 @@ pub struct L2ToL1Messages {
     l2_to_l1_messages: Vec<Vec<u8>>,
 }
 
+/// Subset of `AirbenderBatchCommitment` plus `meta_parameters_hash` that the
+/// Airbender V2 prover consumes via `CommitmentInput.prev_*`. Returned by
+/// [`BlocksDal::get_prev_batch_airbender_commitment_input`] in one round-trip.
+#[derive(Debug, Clone, Copy)]
+pub struct PrevBatchAirbenderCommitmentInput {
+    pub meta_parameters_hash: H256,
+    pub prev_batch_commitment: H256,
+    pub prev_aux_hash: H256,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct TxForPrecommit {
     pub l1_batch_number: Option<L1BatchNumber>,
@@ -3126,6 +3136,72 @@ impl BlocksDal<'_, '_> {
                 &r.bootloader_initial_content_commitment,
             ),
         }))
+    }
+
+    /// Returns the three previous-batch hashes the Airbender V2 prover needs in
+    /// its `CommitmentInput`, fetched in a single round-trip by joining
+    /// `l1_batches` with `airbender_batch_commitments`. Returns `None` if
+    /// either side hasn't been populated yet (commitment_generator must run
+    /// before Airbender V2 proving).
+    pub async fn get_prev_batch_airbender_commitment_input(
+        &mut self,
+        prev_number: L1BatchNumber,
+    ) -> DalResult<Option<PrevBatchAirbenderCommitmentInput>> {
+        let row = sqlx::query!(
+            r#"
+            SELECT
+                l1_batches.meta_parameters_hash,
+                airbender_batch_commitments.commitment AS "airbender_commitment?",
+                airbender_batch_commitments.aux_data_hash AS "airbender_aux_data_hash?"
+            FROM
+                l1_batches
+            LEFT JOIN airbender_batch_commitments
+                ON airbender_batch_commitments.l1_batch_number = l1_batches.number
+            WHERE
+                l1_batches.number = $1
+                AND l1_batches.is_sealed
+            "#,
+            i64::from(prev_number.0)
+        )
+        .instrument("get_prev_batch_airbender_commitment_input")
+        .with_arg("prev_number", &prev_number)
+        .fetch_optional(self.storage)
+        .await?;
+
+        Ok(row.and_then(|r| {
+            Some(PrevBatchAirbenderCommitmentInput {
+                meta_parameters_hash: H256::from_slice(&r.meta_parameters_hash?),
+                prev_batch_commitment: H256::from_slice(&r.airbender_commitment?),
+                prev_aux_hash: H256::from_slice(&r.airbender_aux_data_hash?),
+            })
+        }))
+    }
+
+    /// Single-column read of `l1_batches.pubdata_input`. Avoids the extra
+    /// `l2_to_l1_logs` query that `get_l1_batch_header` does when the caller
+    /// only needs the pubdata blob (e.g. to derive KZG blob hashes).
+    pub async fn get_l1_batch_pubdata_input(
+        &mut self,
+        number: L1BatchNumber,
+    ) -> DalResult<Option<Vec<u8>>> {
+        let row = sqlx::query!(
+            r#"
+            SELECT
+                pubdata_input
+            FROM
+                l1_batches
+            WHERE
+                is_sealed
+                AND number = $1
+            "#,
+            i64::from(number.0)
+        )
+        .instrument("get_l1_batch_pubdata_input")
+        .with_arg("number", &number)
+        .fetch_optional(self.storage)
+        .await?;
+
+        Ok(row.and_then(|r| r.pubdata_input))
     }
 
     pub async fn get_l1_batch_tree_data(

--- a/core/lib/dal/src/blocks_dal.rs
+++ b/core/lib/dal/src/blocks_dal.rs
@@ -23,7 +23,8 @@ use zksync_types::{
         StorageOracleInfo, UnsealedL1BatchHeader,
     },
     commitment::{
-        AirbenderBatchCommitment, L1BatchCommitmentArtifacts, L1BatchWithMetadata, PubdataParams,
+        AirbenderBatchCommitment, L1BatchCommitmentArtifacts, L1BatchWithMetadata,
+        PrevBatchAirbenderCommitmentInput, PubdataParams,
     },
     l2_to_l1_log::{BatchAndChainMerklePath, UserL2ToL1Log},
     settlement::SettlementLayer,
@@ -32,9 +33,7 @@ use zksync_types::{
 };
 use zksync_vm_interface::CircuitStatistic;
 
-pub use crate::models::storage_block::{
-    L1BatchMetadataError, L1BatchWithOptionalMetadata, PrevBatchAirbenderCommitmentInput,
-};
+pub use crate::models::storage_block::{L1BatchMetadataError, L1BatchWithOptionalMetadata};
 use crate::{
     models::{
         bigdecimal_to_u256, parse_protocol_version,

--- a/core/lib/dal/src/blocks_dal.rs
+++ b/core/lib/dal/src/blocks_dal.rs
@@ -32,14 +32,16 @@ use zksync_types::{
 };
 use zksync_vm_interface::CircuitStatistic;
 
-pub use crate::models::storage_block::{L1BatchMetadataError, L1BatchWithOptionalMetadata};
+pub use crate::models::storage_block::{
+    L1BatchMetadataError, L1BatchWithOptionalMetadata, PrevBatchAirbenderCommitmentInput,
+};
 use crate::{
     models::{
         bigdecimal_to_u256, parse_protocol_version,
         storage_block::{
             from_settlement_layer, CommonStorageL1BatchHeader, StorageL1Batch,
-            StorageL1BatchHeader, StorageL2BlockHeader, StoragePubdataParams,
-            UnsealedStorageL1Batch,
+            StorageL1BatchHeader, StorageL2BlockHeader, StoragePrevBatchAirbenderCommitmentInput,
+            StoragePubdataParams, UnsealedStorageL1Batch,
         },
         storage_eth_tx::L2BlockWithEthTx,
         storage_event::StorageL2ToL1Log,
@@ -56,16 +58,6 @@ pub struct BlocksDal<'a, 'c> {
 
 pub struct L2ToL1Messages {
     l2_to_l1_messages: Vec<Vec<u8>>,
-}
-
-/// Subset of `AirbenderBatchCommitment` plus `meta_parameters_hash` that the
-/// Airbender V2 prover consumes via `CommitmentInput.prev_*`. Returned by
-/// [`BlocksDal::get_prev_batch_airbender_commitment_input`] in one round-trip.
-#[derive(Debug, Clone, Copy)]
-pub struct PrevBatchAirbenderCommitmentInput {
-    pub meta_parameters_hash: H256,
-    pub prev_batch_commitment: H256,
-    pub prev_aux_hash: H256,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -3140,14 +3132,15 @@ impl BlocksDal<'_, '_> {
 
     /// Returns the three previous-batch hashes the Airbender V2 prover needs in
     /// its `CommitmentInput`, fetched in a single round-trip by joining
-    /// `l1_batches` with `airbender_batch_commitments`. Returns `None` if
-    /// either side hasn't been populated yet (commitment_generator must run
-    /// before Airbender V2 proving).
+    /// `l1_batches` with `airbender_batch_commitments`. Returns `None` if the
+    /// batch row is missing or either commitment side hasn't been populated yet
+    /// (commitment_generator must run before Airbender V2 proving).
     pub async fn get_prev_batch_airbender_commitment_input(
         &mut self,
         prev_number: L1BatchNumber,
     ) -> DalResult<Option<PrevBatchAirbenderCommitmentInput>> {
-        let row = sqlx::query!(
+        let Some(row) = sqlx::query_as!(
+            StoragePrevBatchAirbenderCommitmentInput,
             r#"
             SELECT
                 l1_batches.meta_parameters_hash,
@@ -3166,15 +3159,14 @@ impl BlocksDal<'_, '_> {
         .instrument("get_prev_batch_airbender_commitment_input")
         .with_arg("prev_number", &prev_number)
         .fetch_optional(self.storage)
-        .await?;
+        .await?
+        else {
+            return Ok(None);
+        };
 
-        Ok(row.and_then(|r| {
-            Some(PrevBatchAirbenderCommitmentInput {
-                meta_parameters_hash: H256::from_slice(&r.meta_parameters_hash?),
-                prev_batch_commitment: H256::from_slice(&r.airbender_commitment?),
-                prev_aux_hash: H256::from_slice(&r.airbender_aux_data_hash?),
-            })
-        }))
+        // Missing columns map to `None` at the DAL boundary — caller treats
+        // this the same as a missing row (commitment_generator hasn't run yet).
+        Ok(row.try_into().ok())
     }
 
     /// Single-column read of `l1_batches.pubdata_input`. Avoids the extra

--- a/core/lib/dal/src/models/storage_block.rs
+++ b/core/lib/dal/src/models/storage_block.rs
@@ -750,6 +750,44 @@ impl ResolvedL1BatchForL2Block {
     }
 }
 
+/// Subset of previous-batch commitment artifacts the Airbender V2 prover
+/// consumes via `CommitmentInput.prev_*`. Joined from `l1_batches`
+/// (`meta_parameters_hash`) and `airbender_batch_commitments` in a single
+/// query — see [`crate::BlocksDal::get_prev_batch_airbender_commitment_input`].
+#[derive(Debug, Clone, Copy)]
+pub struct PrevBatchAirbenderCommitmentInput {
+    pub meta_parameters_hash: H256,
+    pub prev_batch_commitment: H256,
+    pub prev_aux_hash: H256,
+}
+
+pub(crate) struct StoragePrevBatchAirbenderCommitmentInput {
+    pub meta_parameters_hash: Option<Vec<u8>>,
+    pub airbender_commitment: Option<Vec<u8>>,
+    pub airbender_aux_data_hash: Option<Vec<u8>>,
+}
+
+impl TryFrom<StoragePrevBatchAirbenderCommitmentInput> for PrevBatchAirbenderCommitmentInput {
+    type Error = L1BatchMetadataError;
+
+    fn try_from(row: StoragePrevBatchAirbenderCommitmentInput) -> Result<Self, Self::Error> {
+        Ok(Self {
+            meta_parameters_hash: H256::from_slice(
+                &row.meta_parameters_hash
+                    .ok_or(L1BatchMetadataError::Incomplete("meta_parameters_hash"))?,
+            ),
+            prev_batch_commitment: H256::from_slice(
+                &row.airbender_commitment
+                    .ok_or(L1BatchMetadataError::Incomplete("airbender.commitment"))?,
+            ),
+            prev_aux_hash: H256::from_slice(
+                &row.airbender_aux_data_hash
+                    .ok_or(L1BatchMetadataError::Incomplete("airbender.aux_data_hash"))?,
+            ),
+        })
+    }
+}
+
 pub(crate) struct StoragePubdataParams {
     pub l2_da_validator_address: Option<Vec<u8>>,
     pub l2_da_commitment_scheme: Option<i32>,

--- a/core/lib/dal/src/models/storage_block.rs
+++ b/core/lib/dal/src/models/storage_block.rs
@@ -9,7 +9,8 @@ use zksync_types::{
     api,
     block::{CommonL1BatchHeader, L1BatchHeader, L2BlockHeader, UnsealedL1BatchHeader},
     commitment::{
-        L1BatchMetaParameters, L1BatchMetadata, L2DACommitmentScheme, PubdataParams, PubdataType,
+        L1BatchMetaParameters, L1BatchMetadata, L2DACommitmentScheme,
+        PrevBatchAirbenderCommitmentInput, PubdataParams, PubdataType,
     },
     eth_sender::EthTxFinalityStatus,
     fee_model::BatchFeeInput,
@@ -748,17 +749,6 @@ impl ResolvedL1BatchForL2Block {
     pub fn expected_l1_batch(&self) -> L1BatchNumber {
         self.block_l1_batch.unwrap_or(self.pending_l1_batch)
     }
-}
-
-/// Subset of previous-batch commitment artifacts the Airbender V2 prover
-/// consumes via `CommitmentInput.prev_*`. Joined from `l1_batches`
-/// (`meta_parameters_hash`) and `airbender_batch_commitments` in a single
-/// query — see [`crate::BlocksDal::get_prev_batch_airbender_commitment_input`].
-#[derive(Debug, Clone, Copy)]
-pub struct PrevBatchAirbenderCommitmentInput {
-    pub meta_parameters_hash: H256,
-    pub prev_batch_commitment: H256,
-    pub prev_aux_hash: H256,
 }
 
 pub(crate) struct StoragePrevBatchAirbenderCommitmentInput {

--- a/core/lib/l1_contract_interface/src/i_executor/commit/kzg/mod.rs
+++ b/core/lib/l1_contract_interface/src/i_executor/commit/kzg/mod.rs
@@ -1,5 +1,4 @@
 pub use kzg::{pubdata_to_blob_commitments, KzgInfo, ZK_SYNC_BYTES_PER_BLOB};
-
 use zksync_types::{web3::keccak256, H256};
 
 /// Compute the EIP-4844 versioned hash for each blob in `pubdata_input`.

--- a/core/lib/types/src/commitment/mod.rs
+++ b/core/lib/types/src/commitment/mod.rs
@@ -357,6 +357,15 @@ pub struct PrevBatchAirbenderCommitmentInput {
     pub prev_aux_hash: H256,
 }
 
+/// Selects which `aux_commitments` variant of a `PostBoojum` auxiliary output
+/// to serialize/hash. Used internally to share the serialization path between
+/// the default (Boojum) hash and the Airbender hash.
+#[derive(Debug, Clone, Copy)]
+enum AuxCommitmentsVariant {
+    Boojum,
+    Airbender,
+}
+
 /// Block Output produced by Virtual Machine
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(test, derive(Serialize, Deserialize))]
@@ -375,6 +384,11 @@ pub enum L1BatchAuxiliaryOutput {
         state_diffs_compressed: Vec<u8>,
         state_diffs_hash: H256,
         aux_commitments: AuxCommitments,
+        /// Airbender-shape `aux_commitments`, kept here to derive a parallel
+        /// `aux_data_hash`/commitment without recomputing the rest of the
+        /// auxiliary output. `None` when only the Boojum variant is available.
+        #[cfg_attr(test, serde(default))]
+        airbender_aux_commitments: Option<AuxCommitments>,
         blob_hashes: Vec<BlobHash>,
         aggregation_root: H256,
         local_root: H256,
@@ -428,10 +442,14 @@ impl L1BatchAuxiliaryOutput {
                 common: common_input,
                 system_logs,
                 state_diffs,
-                aux_commitments,
+                aux_commitments_both,
                 blob_hashes,
                 aggregation_root,
             } => {
+                let AuxCommitmentsBoth {
+                    boojum: aux_commitments,
+                    airbender: airbender_aux_commitments,
+                } = aux_commitments_both;
                 let l2_l1_logs_compressed = serialize_commitments(&common_input.l2_to_l1_logs);
                 let merkle_tree_leaves = l2_l1_logs_compressed
                     .chunks(UserL2ToL1Log::SERIALIZED_SIZE)
@@ -512,6 +530,7 @@ impl L1BatchAuxiliaryOutput {
                     state_diffs_compressed,
                     state_diffs_hash,
                     aux_commitments,
+                    airbender_aux_commitments,
                     blob_hashes,
                     local_root,
                     aggregation_root,
@@ -546,6 +565,14 @@ impl L1BatchAuxiliaryOutput {
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {
+        self.to_bytes_for(AuxCommitmentsVariant::Boojum)
+    }
+
+    /// Serializes the auxiliary output using either the Boojum or Airbender
+    /// `aux_commitments` stored on the `PostBoojum` variant. Pre-Boojum ignores
+    /// the choice. Panics if `Airbender` is requested but the Airbender variant
+    /// is not populated — callers should pre-check via [`Self::airbender_hash`].
+    fn to_bytes_for(&self, variant: AuxCommitmentsVariant) -> Vec<u8> {
         let mut result = Vec::new();
 
         match self {
@@ -565,9 +592,16 @@ impl L1BatchAuxiliaryOutput {
                 system_logs_linear_hash,
                 state_diffs_hash,
                 aux_commitments,
+                airbender_aux_commitments,
                 blob_hashes,
                 ..
             } => {
+                let aux_commitments = match variant {
+                    AuxCommitmentsVariant::Boojum => aux_commitments,
+                    AuxCommitmentsVariant::Airbender => airbender_aux_commitments
+                        .as_ref()
+                        .expect("airbender aux commitments are not populated"),
+                };
                 result.extend(system_logs_linear_hash.as_bytes());
                 result.extend(state_diffs_hash.as_bytes());
                 result.extend(
@@ -591,10 +625,33 @@ impl L1BatchAuxiliaryOutput {
         H256::from_slice(&keccak256(&self.to_bytes()))
     }
 
+    /// Hash of the auxiliary output computed with the stored Airbender-shape
+    /// `aux_commitments`. Returns `None` for pre-Boojum batches or when the
+    /// Airbender variant was not populated.
+    pub fn airbender_hash(&self) -> Option<H256> {
+        self.airbender_aux_commitments()?;
+        Some(H256::from_slice(&keccak256(
+            &self.to_bytes_for(AuxCommitmentsVariant::Airbender),
+        )))
+    }
+
     pub fn common(&self) -> &L1BatchAuxiliaryCommonOutput {
         match self {
             Self::PreBoojum { common, .. } => common,
             Self::PostBoojum { common, .. } => common,
+        }
+    }
+
+    /// Airbender-shape `aux_commitments` stored alongside the Boojum variant
+    /// on `PostBoojum` outputs. Returns `None` for pre-Boojum batches or when
+    /// the Airbender variant was not populated.
+    pub fn airbender_aux_commitments(&self) -> Option<AuxCommitments> {
+        match self {
+            Self::PreBoojum { .. } => None,
+            Self::PostBoojum {
+                airbender_aux_commitments,
+                ..
+            } => *airbender_aux_commitments,
         }
     }
 }
@@ -734,22 +791,56 @@ impl L1BatchCommitment {
         }
     }
 
-    pub fn hash(&self) -> Result<L1BatchCommitmentHash, CommitmentValidationError> {
-        let mut result = vec![];
+    /// Computes the commitment hash for the chosen `aux_commitments` variant.
+    /// Panics if `Airbender` is requested but the Airbender variant is not
+    /// populated — callers should pre-check via [`Self::airbender_artifacts`].
+    fn hash_for(
+        &self,
+        variant: AuxCommitmentsVariant,
+    ) -> Result<L1BatchCommitmentHash, CommitmentValidationError> {
+        let auxiliary_output_hash = match variant {
+            AuxCommitmentsVariant::Boojum => self.auxiliary_output.hash(),
+            AuxCommitmentsVariant::Airbender => self
+                .auxiliary_output
+                .airbender_hash()
+                .expect("airbender aux commitments are not populated"),
+        };
         let pass_through_data_hash = self.pass_through_data.hash()?;
-        result.extend_from_slice(pass_through_data_hash.as_bytes());
-        let metadata_hash = self.meta_parameters.hash();
-        result.extend_from_slice(metadata_hash.as_bytes());
-        let auxiliary_output_hash = self.auxiliary_output.hash();
-        result.extend_from_slice(auxiliary_output_hash.as_bytes());
-        let hash = keccak256(&result);
-        let commitment = H256::from_slice(&hash);
+        let meta_parameters_hash = self.meta_parameters.hash();
+        let mut buf = Vec::with_capacity(32 * 3);
+        buf.extend_from_slice(pass_through_data_hash.as_bytes());
+        buf.extend_from_slice(meta_parameters_hash.as_bytes());
+        buf.extend_from_slice(auxiliary_output_hash.as_bytes());
+        let commitment = H256::from_slice(&keccak256(&buf));
         Ok(L1BatchCommitmentHash {
             pass_through_data: pass_through_data_hash,
             aux_output: auxiliary_output_hash,
-            meta_parameters: metadata_hash,
+            meta_parameters: meta_parameters_hash,
             commitment,
         })
+    }
+
+    pub fn hash(&self) -> Result<L1BatchCommitmentHash, CommitmentValidationError> {
+        self.hash_for(AuxCommitmentsVariant::Boojum)
+    }
+
+    /// Builds the Airbender-shape commitment for this batch, reusing the
+    /// already-computed `pass_through_data` and `meta_parameters` and hashing
+    /// the auxiliary output with the Airbender variant of `aux_commitments`.
+    /// Returns `None` for pre-Boojum batches.
+    pub fn airbender_artifacts(
+        &self,
+    ) -> Result<Option<AirbenderBatchCommitment>, CommitmentValidationError> {
+        let Some(aux) = self.auxiliary_output.airbender_aux_commitments() else {
+            return Ok(None);
+        };
+        let commitment_hash = self.hash_for(AuxCommitmentsVariant::Airbender)?;
+        Ok(Some(AirbenderBatchCommitment {
+            commitment: commitment_hash.commitment,
+            aux_data_hash: commitment_hash.aux_output,
+            events_queue_commitment: aux.events_queue_commitment,
+            bootloader_initial_content_commitment: aux.bootloader_initial_content_commitment,
+        }))
     }
 
     pub fn artifacts(&self) -> Result<L1BatchCommitmentArtifacts, CommitmentValidationError> {
@@ -792,6 +883,34 @@ pub struct AuxCommitments {
     pub bootloader_initial_content_commitment: H256,
 }
 
+/// Both Boojum and Airbender variants of the auxiliary commitments for a single
+/// L1 batch. Airbender uses lighter math for two of the four sub-hashes; the
+/// other two come out identical. `airbender` is `None` when only the Boojum
+/// variant is available (e.g. legacy fixtures without the Airbender commitment).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(test, derive(Serialize, Deserialize))]
+pub struct AuxCommitmentsBoth {
+    pub boojum: AuxCommitments,
+    pub airbender: Option<AuxCommitments>,
+}
+
+/// Deserializes a flat [`AuxCommitments`] JSON object into [`AuxCommitmentsBoth`]
+/// with the Airbender variant set to `None`. Used by tests to keep the
+/// pre-Airbender `aux_commitments` field shape in fixture files.
+#[cfg(test)]
+fn deserialize_aux_commitments_both_legacy<'de, D>(
+    deserializer: D,
+) -> Result<AuxCommitmentsBoth, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let boojum = AuxCommitments::deserialize(deserializer)?;
+    Ok(AuxCommitmentsBoth {
+        boojum,
+        airbender: None,
+    })
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(test, derive(Serialize, Deserialize))]
 pub struct CommitmentCommonInput {
@@ -816,7 +935,14 @@ pub enum CommitmentInput {
         common: CommitmentCommonInput,
         system_logs: Vec<SystemL2ToL1Log>,
         state_diffs: Vec<StateDiffRecord>,
-        aux_commitments: AuxCommitments,
+        #[cfg_attr(
+            test,
+            serde(
+                rename = "aux_commitments",
+                deserialize_with = "deserialize_aux_commitments_both_legacy"
+            )
+        )]
+        aux_commitments_both: AuxCommitmentsBoth,
         blob_hashes: Vec<BlobHash>,
         aggregation_root: H256,
     },
@@ -852,13 +978,17 @@ impl CommitmentInput {
                 repeated_writes: Vec::new(),
             }
         } else {
+            let zero_aux = AuxCommitments {
+                events_queue_commitment: H256::zero(),
+                bootloader_initial_content_commitment: H256::zero(),
+            };
             Self::PostBoojum {
                 common: commitment_common_input,
                 system_logs: Vec::new(),
                 state_diffs: Vec::new(),
-                aux_commitments: AuxCommitments {
-                    events_queue_commitment: H256::zero(),
-                    bootloader_initial_content_commitment: H256::zero(),
+                aux_commitments_both: AuxCommitmentsBoth {
+                    boojum: zero_aux,
+                    airbender: Some(zero_aux),
                 },
                 blob_hashes: {
                     let num_blobs = num_blobs_required(&protocol_version);

--- a/core/lib/types/src/commitment/mod.rs
+++ b/core/lib/types/src/commitment/mod.rs
@@ -346,6 +346,17 @@ pub struct AirbenderBatchCommitment {
     pub bootloader_initial_content_commitment: H256,
 }
 
+/// Subset of previous-batch commitment artifacts the Airbender V2 prover
+/// consumes via `CommitmentInput.prev_*`. Aggregated from `l1_batches`
+/// (`meta_parameters_hash`) and `airbender_batch_commitments` (commitment +
+/// `aux_data_hash`) in a single DAL query.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct PrevBatchAirbenderCommitmentInput {
+    pub meta_parameters_hash: H256,
+    pub prev_batch_commitment: H256,
+    pub prev_aux_hash: H256,
+}
+
 /// Block Output produced by Virtual Machine
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(test, derive(Serialize, Deserialize))]

--- a/core/node/airbender_proof_data_handler/src/airbender_request_processor.rs
+++ b/core/node/airbender_proof_data_handler/src/airbender_request_processor.rs
@@ -216,54 +216,40 @@ impl AirbenderRequestProcessor {
         }
 
         // Prev-batch hashes from L1 settlement of batch N-1. For batch 1 we
-        // read the genesis batch (#0) metadata, which `genesis::insert_genesis_batch`
-        // populates at chain bootstrap — so batch 1 is provable. Batch 0 itself has
-        // no predecessor and isn't a valid proving target.
+        // read the genesis batch (#0) commitments, which
+        // `genesis::insert_genesis_batch` populates at chain bootstrap — so
+        // batch 1 is provable. Batch 0 itself has no predecessor and isn't a
+        // valid proving target. The Airbender variant uses lighter
+        // aux-commitment math (zero events queue + Blake2 bootloader heap), so
+        // its `commitment` and `aux_data_hash` differ from Boojum's;
+        // `meta_parameters_hash` matches and is read from the regular
+        // `l1_batches` row in the same query.
         let prev_number = L1BatchNumber(l1_batch_number.0.checked_sub(1).ok_or_else(|| {
             AirbenderProcessorError::GeneralError(anyhow::anyhow!(
                 "batch {l1_batch_number} has no predecessor (only batch 1+ are provable)"
             ))
         })?);
-        let prev_metadata = connection
+        let prev_commitment_input = connection
             .blocks_dal()
-            .get_l1_batch_metadata(prev_number)
+            .get_prev_batch_airbender_commitment_input(prev_number)
             .await?
             .ok_or_else(|| {
                 AirbenderProcessorError::GeneralError(anyhow::anyhow!(
-                    "previous batch {prev_number} has no committed metadata yet — \
-                     commitment_generator must run before Airbender V2 proving"
-                ))
-            })?;
-        // The Airbender variant uses lighter aux-commitment math (zero events
-        // queue + Blake2 bootloader heap), so its `commitment` and
-        // `aux_data_hash` differ from Boojum's. `meta_parameters_hash` matches
-        // and is read from the regular `l1_batches` row above.
-        let prev_airbender = connection
-            .blocks_dal()
-            .get_airbender_batch_commitment(prev_number)
-            .await?
-            .ok_or_else(|| {
-                AirbenderProcessorError::GeneralError(anyhow::anyhow!(
-                    "previous batch {prev_number} has no Airbender commitment yet — \
+                    "previous batch {prev_number} has no Airbender commitment input yet — \
                      commitment_generator must run before Airbender V2 proving"
                 ))
             })?;
 
         // Blob hashes + EIP-4844 versioned hashes from VM pubdata via KZG.
-        let header = connection
+        let pubdata_input = connection
             .blocks_dal()
-            .get_l1_batch_header(l1_batch_number)
+            .get_l1_batch_pubdata_input(l1_batch_number)
             .await?
             .ok_or_else(|| {
                 AirbenderProcessorError::GeneralError(anyhow::anyhow!(
-                    "L1BatchHeader missing for batch {l1_batch_number}"
+                    "pubdata_input missing for batch {l1_batch_number}"
                 ))
             })?;
-        let pubdata_input = header.pubdata_input.ok_or_else(|| {
-            AirbenderProcessorError::GeneralError(anyhow::anyhow!(
-                "L1BatchHeader is missing pubdata_input for batch {l1_batch_number}"
-            ))
-        })?;
         let num_blobs = num_blobs_required(&system_env.version);
 
         let commitments = pubdata_to_blob_commitments(num_blobs, &pubdata_input);
@@ -280,9 +266,9 @@ impl AirbenderRequestProcessor {
             .collect::<Vec<_>>();
 
         let commitment_input = CommitmentInput {
-            prev_batch_commitment: prev_airbender.commitment,
-            prev_meta_hash: prev_metadata.metadata.meta_parameters_hash,
-            prev_aux_hash: prev_airbender.aux_data_hash,
+            prev_batch_commitment: prev_commitment_input.prev_batch_commitment,
+            prev_meta_hash: prev_commitment_input.meta_parameters_hash,
+            prev_aux_hash: prev_commitment_input.prev_aux_hash,
             blob_hashes,
             blob_versioned_hashes: versioned_hashes,
         };

--- a/core/node/commitment_generator/src/lib.rs
+++ b/core/node/commitment_generator/src/lib.rs
@@ -48,17 +48,18 @@ struct CommitmentArtifactsBoth {
 }
 
 /// Pre-built commitment inputs for a single batch. `boojum` is always present;
-/// `airbender` only exists for post-Boojum batches. The Airbender aux is kept
-/// alongside its input so the downstream `AirbenderBatchCommitment` can read
-/// it without re-matching on the enum.
+/// `airbender` only exists for post-Boojum batches.
 struct PreparedCommitmentInputs {
     boojum: CommitmentInput,
-    airbender: Option<AirbenderPreparedInput>,
+    airbender: Option<CommitmentInput>,
 }
 
-struct AirbenderPreparedInput {
-    input: CommitmentInput,
-    aux: AuxCommitments,
+fn zero_blob_commitments(input: &mut CommitmentInput) {
+    if let CommitmentInput::PostBoojum { blob_hashes, .. } = input {
+        for hashes in blob_hashes {
+            hashes.commitment = H256::zero();
+        }
+    }
 }
 
 mod metrics;
@@ -392,17 +393,11 @@ impl CommitmentGenerator {
 
             PreparedCommitmentInputs {
                 boojum,
-                airbender: Some(AirbenderPreparedInput {
-                    input: airbender_input,
-                    aux: aux_commitments_both.airbender,
-                }),
+                airbender: Some(airbender_input),
             }
         };
 
-        self.tweak_input(&mut prepared.boojum, commitment_mode);
-        if let Some(airbender) = prepared.airbender.as_mut() {
-            self.tweak_input(&mut airbender.input, commitment_mode);
-        }
+        self.tweak_input(&mut prepared, commitment_mode);
         Ok(prepared)
     }
 
@@ -430,16 +425,23 @@ impl CommitmentGenerator {
         // batches return `None` and aren't persisted.
         let airbender = prepared
             .airbender
-            .map(|ab| {
-                let mut commitment =
-                    L1BatchCommitment::new(ab.input, self.disable_sanity_checks)?;
+            .map(|input| {
+                let aux = match &input {
+                    CommitmentInput::PostBoojum {
+                        aux_commitments, ..
+                    } => *aux_commitments,
+                    CommitmentInput::PreBoojum { .. } => {
+                        unreachable!("airbender variant is built only for post-Boojum batches")
+                    }
+                };
+                let mut commitment = L1BatchCommitment::new(input, self.disable_sanity_checks)?;
                 self.post_process_commitment(&mut commitment, commitment_mode);
                 let artifacts = commitment.artifacts()?;
                 anyhow::Ok(AirbenderBatchCommitment {
                     commitment: artifacts.commitment_hash.commitment,
                     aux_data_hash: artifacts.commitment_hash.aux_output,
-                    events_queue_commitment: ab.aux.events_queue_commitment,
-                    bootloader_initial_content_commitment: ab.aux
+                    events_queue_commitment: aux.events_queue_commitment,
+                    bootloader_initial_content_commitment: aux
                         .bootloader_initial_content_commitment,
                 })
             })
@@ -520,17 +522,18 @@ impl CommitmentGenerator {
         Ok(())
     }
 
-    fn tweak_input(&self, input: &mut CommitmentInput, commitment_mode: L1BatchCommitmentMode) {
-        match (commitment_mode, input) {
-            (L1BatchCommitmentMode::Rollup, _) => {
-                // Do nothing
-            }
-            (L1BatchCommitmentMode::Validium, CommitmentInput::PostBoojum { blob_hashes, .. }) => {
-                for hashes in blob_hashes {
-                    hashes.commitment = H256::zero();
-                }
-            }
-            (L1BatchCommitmentMode::Validium, _) => { /* Do nothing */ }
+    fn tweak_input(
+        &self,
+        prepared: &mut PreparedCommitmentInputs,
+        commitment_mode: L1BatchCommitmentMode,
+    ) {
+        if commitment_mode == L1BatchCommitmentMode::Rollup {
+            return;
+        }
+        // Validium: zero out the blob commitments in both variants.
+        zero_blob_commitments(&mut prepared.boojum);
+        if let Some(airbender) = prepared.airbender.as_mut() {
+            zero_blob_commitments(airbender);
         }
     }
 

--- a/core/node/commitment_generator/src/lib.rs
+++ b/core/node/commitment_generator/src/lib.rs
@@ -13,9 +13,9 @@ use zksync_multivm::zk_evm_latest::ethereum_types::U256;
 use zksync_types::{
     blob::num_blobs_required,
     commitment::{
-        AirbenderBatchCommitment, AuxCommitments, BlobHash, CommitmentCommonInput, CommitmentInput,
-        L1BatchAuxiliaryOutput, L1BatchCommitment, L1BatchCommitmentArtifacts,
-        L1BatchCommitmentMode,
+        AirbenderBatchCommitment, AuxCommitments, AuxCommitmentsBoth, BlobHash,
+        CommitmentCommonInput, CommitmentInput, L1BatchAuxiliaryOutput, L1BatchCommitment,
+        L1BatchCommitmentArtifacts, L1BatchCommitmentMode,
     },
     h256_to_u256,
     writes::{InitialStorageWrite, RepeatedStorageWrite, StateDiffRecord},
@@ -30,14 +30,6 @@ use crate::{
     },
 };
 
-/// Both Boojum and Airbender variants of the auxiliary commitments for a single
-/// L1 batch. Airbender uses lighter math for two of the four sub-hashes; the
-/// other two come out identical.
-struct AuxCommitmentsBoth {
-    boojum: AuxCommitments,
-    airbender: AuxCommitments,
-}
-
 /// Both Boojum and Airbender variants of the per-batch commitment artifacts.
 /// `boojum` holds everything zksync-era already persisted in `l1_batches`.
 /// `airbender` holds the four hashes that go into `airbender_batch_commitments`,
@@ -45,13 +37,6 @@ struct AuxCommitmentsBoth {
 struct CommitmentArtifactsBoth {
     boojum: L1BatchCommitmentArtifacts,
     airbender: Option<AirbenderBatchCommitment>,
-}
-
-/// Pre-built commitment inputs for a single batch. `boojum` is always present;
-/// `airbender` only exists for post-Boojum batches.
-struct PreparedCommitmentInputs {
-    boojum: CommitmentInput,
-    airbender: Option<CommitmentInput>,
 }
 
 fn zero_blob_commitments(input: &mut CommitmentInput) {
@@ -211,7 +196,7 @@ impl CommitmentGenerator {
 
         Ok(AuxCommitmentsBoth {
             boojum: boojum_aux,
-            airbender: airbender_aux,
+            airbender: Some(airbender_aux),
         })
     }
 
@@ -220,7 +205,7 @@ impl CommitmentGenerator {
         &self,
         l1_batch_number: L1BatchNumber,
         commitment_mode: L1BatchCommitmentMode,
-    ) -> anyhow::Result<PreparedCommitmentInputs> {
+    ) -> anyhow::Result<CommitmentInput> {
         tracing::info!("Started preparing commitment input for L1 batch #{l1_batch_number}");
 
         let mut connection = self
@@ -291,13 +276,10 @@ impl CommitmentGenerator {
                 }
             }
 
-            PreparedCommitmentInputs {
-                boojum: CommitmentInput::PreBoojum {
-                    common,
-                    initial_writes,
-                    repeated_writes,
-                },
-                airbender: None,
+            CommitmentInput::PreBoojum {
+                common,
+                initial_writes,
+                repeated_writes,
             }
         } else {
             let aux_commitments_both = self
@@ -374,26 +356,13 @@ impl CommitmentGenerator {
                 read_aggregation_root(&mut connection, l1_batch_number).await?
             };
 
-            let boojum = CommitmentInput::PostBoojum {
-                common: common.clone(),
-                system_logs: header.system_logs.clone(),
-                state_diffs: state_diffs.clone(),
-                aux_commitments: aux_commitments_both.boojum,
-                blob_hashes: blob_hashes.clone(),
-                aggregation_root,
-            };
-            let airbender_input = CommitmentInput::PostBoojum {
+            CommitmentInput::PostBoojum {
                 common,
                 system_logs: header.system_logs,
                 state_diffs,
-                aux_commitments: aux_commitments_both.airbender,
+                aux_commitments_both,
                 blob_hashes,
                 aggregation_root,
-            };
-
-            PreparedCommitmentInputs {
-                boojum,
-                airbender: Some(airbender_input),
             }
         };
 
@@ -417,35 +386,12 @@ impl CommitmentGenerator {
         let latency =
             METRICS.generate_commitment_latency_stage[&CommitmentStage::Calculate].start();
 
-        let mut commitment = L1BatchCommitment::new(prepared.boojum, self.disable_sanity_checks)?;
+        let mut commitment = L1BatchCommitment::new(prepared, self.disable_sanity_checks)?;
         self.post_process_commitment(&mut commitment, commitment_mode);
+        // Both variants are derived from the same `L1BatchCommitment`, so any
+        // post-processing on `auxiliary_output` applies to both hashes.
         let boojum_artifacts = commitment.artifacts()?;
-
-        // Only post-Boojum batches have an Airbender variant; pre-Boojum
-        // batches return `None` and aren't persisted.
-        let airbender = prepared
-            .airbender
-            .map(|input| {
-                let aux = match &input {
-                    CommitmentInput::PostBoojum {
-                        aux_commitments, ..
-                    } => *aux_commitments,
-                    CommitmentInput::PreBoojum { .. } => {
-                        unreachable!("airbender variant is built only for post-Boojum batches")
-                    }
-                };
-                let mut commitment = L1BatchCommitment::new(input, self.disable_sanity_checks)?;
-                self.post_process_commitment(&mut commitment, commitment_mode);
-                let artifacts = commitment.artifacts()?;
-                anyhow::Ok(AirbenderBatchCommitment {
-                    commitment: artifacts.commitment_hash.commitment,
-                    aux_data_hash: artifacts.commitment_hash.aux_output,
-                    events_queue_commitment: aux.events_queue_commitment,
-                    bootloader_initial_content_commitment: aux
-                        .bootloader_initial_content_commitment,
-                })
-            })
-            .transpose()?;
+        let airbender = commitment.airbender_artifacts()?;
 
         let latency = latency.observe();
         tracing::debug!(
@@ -522,19 +468,12 @@ impl CommitmentGenerator {
         Ok(())
     }
 
-    fn tweak_input(
-        &self,
-        prepared: &mut PreparedCommitmentInputs,
-        commitment_mode: L1BatchCommitmentMode,
-    ) {
+    fn tweak_input(&self, prepared: &mut CommitmentInput, commitment_mode: L1BatchCommitmentMode) {
         if commitment_mode == L1BatchCommitmentMode::Rollup {
             return;
         }
-        // Validium: zero out the blob commitments in both variants.
-        zero_blob_commitments(&mut prepared.boojum);
-        if let Some(airbender) = prepared.airbender.as_mut() {
-            zero_blob_commitments(airbender);
-        }
+        // Validium: zero out the blob commitments.
+        zero_blob_commitments(prepared);
     }
 
     fn post_process_commitment(

--- a/core/node/commitment_generator/src/lib.rs
+++ b/core/node/commitment_generator/src/lib.rs
@@ -47,31 +47,18 @@ struct CommitmentArtifactsBoth {
     airbender: Option<AirbenderBatchCommitment>,
 }
 
-/// Returns a copy of `input` with `aux_commitments` replaced by `aux`. Used to
-/// derive the Airbender-shape input from the Boojum input without re-fetching
-/// upstream data. Pre-Boojum is unreachable because the caller only invokes
-/// this when an Airbender `aux` is available, which never happens for pre-Boojum.
-fn override_aux_commitments(input: CommitmentInput, aux: AuxCommitments) -> CommitmentInput {
-    match input {
-        CommitmentInput::PostBoojum {
-            common,
-            system_logs,
-            state_diffs,
-            blob_hashes,
-            aggregation_root,
-            ..
-        } => CommitmentInput::PostBoojum {
-            common,
-            system_logs,
-            state_diffs,
-            aux_commitments: aux,
-            blob_hashes,
-            aggregation_root,
-        },
-        CommitmentInput::PreBoojum { .. } => {
-            unreachable!("Airbender variant only applies to post-Boojum batches")
-        }
-    }
+/// Pre-built commitment inputs for a single batch. `boojum` is always present;
+/// `airbender` only exists for post-Boojum batches. The Airbender aux is kept
+/// alongside its input so the downstream `AirbenderBatchCommitment` can read
+/// it without re-matching on the enum.
+struct PreparedCommitmentInputs {
+    boojum: CommitmentInput,
+    airbender: Option<AirbenderPreparedInput>,
+}
+
+struct AirbenderPreparedInput {
+    input: CommitmentInput,
+    aux: AuxCommitments,
 }
 
 mod metrics;
@@ -232,7 +219,7 @@ impl CommitmentGenerator {
         &self,
         l1_batch_number: L1BatchNumber,
         commitment_mode: L1BatchCommitmentMode,
-    ) -> anyhow::Result<(CommitmentInput, Option<AuxCommitments>)> {
+    ) -> anyhow::Result<PreparedCommitmentInputs> {
         tracing::info!("Started preparing commitment input for L1 batch #{l1_batch_number}");
 
         let mut connection = self
@@ -279,7 +266,7 @@ impl CommitmentGenerator {
             .await?;
         drop(connection);
 
-        let (mut input, airbender_aux) = if protocol_version.is_pre_boojum() {
+        let mut prepared = if protocol_version.is_pre_boojum() {
             let mut initial_writes = Vec::new();
             let mut repeated_writes = Vec::new();
             for (key, value) in touched_slots.into_iter().sorted_by_key(|(key, _)| *key) {
@@ -303,14 +290,14 @@ impl CommitmentGenerator {
                 }
             }
 
-            (
-                CommitmentInput::PreBoojum {
+            PreparedCommitmentInputs {
+                boojum: CommitmentInput::PreBoojum {
                     common,
                     initial_writes,
                     repeated_writes,
                 },
-                None, // Airbender variant only applies to post-Boojum batches.
-            )
+                airbender: None,
+            }
         } else {
             let aux_commitments_both = self
                 .calculate_aux_commitments(header.number, protocol_version)
@@ -386,21 +373,37 @@ impl CommitmentGenerator {
                 read_aggregation_root(&mut connection, l1_batch_number).await?
             };
 
-            (
-                CommitmentInput::PostBoojum {
-                    common,
-                    system_logs: header.system_logs,
-                    state_diffs,
-                    aux_commitments: aux_commitments_both.boojum,
-                    blob_hashes,
-                    aggregation_root,
-                },
-                Some(aux_commitments_both.airbender),
-            )
+            let boojum = CommitmentInput::PostBoojum {
+                common: common.clone(),
+                system_logs: header.system_logs.clone(),
+                state_diffs: state_diffs.clone(),
+                aux_commitments: aux_commitments_both.boojum,
+                blob_hashes: blob_hashes.clone(),
+                aggregation_root,
+            };
+            let airbender_input = CommitmentInput::PostBoojum {
+                common,
+                system_logs: header.system_logs,
+                state_diffs,
+                aux_commitments: aux_commitments_both.airbender,
+                blob_hashes,
+                aggregation_root,
+            };
+
+            PreparedCommitmentInputs {
+                boojum,
+                airbender: Some(AirbenderPreparedInput {
+                    input: airbender_input,
+                    aux: aux_commitments_both.airbender,
+                }),
+            }
         };
 
-        self.tweak_input(&mut input, commitment_mode);
-        Ok((input, airbender_aux))
+        self.tweak_input(&mut prepared.boojum, commitment_mode);
+        if let Some(airbender) = prepared.airbender.as_mut() {
+            self.tweak_input(&mut airbender.input, commitment_mode);
+        }
+        Ok(prepared)
     }
 
     #[tracing::instrument(skip(self))]
@@ -412,33 +415,31 @@ impl CommitmentGenerator {
 
         let latency =
             METRICS.generate_commitment_latency_stage[&CommitmentStage::PrepareInput].start();
-        let (input, airbender_aux) = self.prepare_input(l1_batch_number, commitment_mode).await?;
+        let prepared = self.prepare_input(l1_batch_number, commitment_mode).await?;
         let latency = latency.observe();
         tracing::debug!("Prepared commitment input for L1 batch #{l1_batch_number} in {latency:?}");
 
         let latency =
             METRICS.generate_commitment_latency_stage[&CommitmentStage::Calculate].start();
 
-        // Boojum artifacts (existing path, unchanged).
-        let mut commitment = L1BatchCommitment::new(input.clone(), self.disable_sanity_checks)?;
+        let mut commitment = L1BatchCommitment::new(prepared.boojum, self.disable_sanity_checks)?;
         self.post_process_commitment(&mut commitment, commitment_mode);
         let boojum_artifacts = commitment.artifacts()?;
 
-        // Airbender artifacts: same input but with `aux_commitments` swapped to
-        // the Airbender variant. Only post-Boojum batches have an Airbender
-        // variant; pre-Boojum batches return `None` and aren't persisted.
-        let airbender = airbender_aux
-            .map(|airbender_aux| {
-                let airbender_input = override_aux_commitments(input, airbender_aux);
-                let mut airbender_commitment =
-                    L1BatchCommitment::new(airbender_input, self.disable_sanity_checks)?;
-                self.post_process_commitment(&mut airbender_commitment, commitment_mode);
-                let airbender_artifacts = airbender_commitment.artifacts()?;
+        // Only post-Boojum batches have an Airbender variant; pre-Boojum
+        // batches return `None` and aren't persisted.
+        let airbender = prepared
+            .airbender
+            .map(|ab| {
+                let mut commitment =
+                    L1BatchCommitment::new(ab.input, self.disable_sanity_checks)?;
+                self.post_process_commitment(&mut commitment, commitment_mode);
+                let artifacts = commitment.artifacts()?;
                 anyhow::Ok(AirbenderBatchCommitment {
-                    commitment: airbender_artifacts.commitment_hash.commitment,
-                    aux_data_hash: airbender_artifacts.commitment_hash.aux_output,
-                    events_queue_commitment: airbender_aux.events_queue_commitment,
-                    bootloader_initial_content_commitment: airbender_aux
+                    commitment: artifacts.commitment_hash.commitment,
+                    aux_data_hash: artifacts.commitment_hash.aux_output,
+                    events_queue_commitment: ab.aux.events_queue_commitment,
+                    bootloader_initial_content_commitment: ab.aux
                         .bootloader_initial_content_commitment,
                 })
             })

--- a/core/node/genesis/src/utils.rs
+++ b/core/node/genesis/src/utils.rs
@@ -11,7 +11,7 @@ use zksync_system_constants::{DEFAULT_ERA_CHAIN_ID, ETHEREUM_ADDRESS};
 use zksync_types::{
     block::{DeployedContract, L1BatchTreeData},
     bytecode::BytecodeHash,
-    commitment::{AirbenderBatchCommitment, L1BatchCommitment},
+    commitment::L1BatchCommitment,
     get_code_key, get_known_code_key, get_system_context_init_logs, h256_to_u256,
     tokens::{TokenInfo, TokenMetadata},
     u256_to_h256,
@@ -163,18 +163,13 @@ pub(super) async fn save_genesis_l1_batch_metadata(
         .save_l1_batch_commitment_artifacts(L1BatchNumber(0), &commitment_artifacts)
         .await?;
 
-    // Genesis batch's `aux_commitments` are zero in both variants
-    // (`events_queue_commitment` and `bootloader_initial_content_commitment`
-    // are zero per `CommitmentInput::for_genesis_batch`), so the Airbender
-    // variant's `commitment` and `aux_data_hash` match Boojum's exactly.
-    // Persist them here so the V2 producer can read batch 0's row when
-    // building V2 input for batch 1.
-    let airbender_genesis = AirbenderBatchCommitment {
-        commitment: commitment_artifacts.commitment_hash.commitment,
-        aux_data_hash: commitment_artifacts.commitment_hash.aux_output,
-        events_queue_commitment: H256::zero(),
-        bootloader_initial_content_commitment: H256::zero(),
-    };
+    // Genesis batch's `aux_commitments` are zero in both variants, so the
+    // Airbender variant's `commitment` and `aux_data_hash` match Boojum's
+    // exactly. Persist them here so the V2 producer can read batch 0's row
+    // when building V2 input for batch 1.
+    let airbender_genesis = commitment
+        .airbender_artifacts()?
+        .expect("genesis batch is post-Boojum");
     transaction
         .blocks_dal()
         .save_airbender_batch_commitment(L1BatchNumber(0), &airbender_genesis)


### PR DESCRIPTION
## What ❔

Refactors the airbender commitment pipeline so a single `L1BatchCommitment` carries both the Boojum-shape and Airbender-shape `aux_commitments` and exposes the two derived commitments side-by-side. Replaces the v1 path where airbender commitment was computed via a separate helper with duplicated inputs.

Key changes in `zksync_types::commitment`:
- `L1BatchAuxiliaryOutput::PostBoojum` gains `airbender_aux_commitments: Option<AuxCommitments>` so the parallel `aux_data_hash` / commitment can be derived without recomputing the rest of the auxiliary output.
- New `AuxCommitmentsBoth { boojum, airbender }` struct carrying both variants.
- **Breaking:** `CommitmentInput::PostBoojum.aux_commitments` changes type from `AuxCommitments` to `AuxCommitmentsBoth`. The field name is preserved; external pattern-matches/constructors on the variant need the type update.
- New public API: `L1BatchAuxiliaryOutput::airbender_hash` / `airbender_aux_commitments`, `L1BatchCommitment::airbender_artifacts` (returns an `AirbenderBatchCommitment`).
- Serialization of the auxiliary output is shared between Boojum and Airbender via `post_boojum_aux_bytes` — the caller picks which `&AuxCommitments` to feed in, no implicit variant flag.

Downstream:
- `commitment_generator` now computes and persists both commitments per batch (Boojum in `l1_batches`, Airbender in the new `airbender_batch_commitments` table populated by `save_airbender_batch_commitment`).
- `genesis::utils` persists the airbender row for batch 0 (zero aux on both variants → values collapse to the Boojum row).
- `airbender_prover_interface` consumes the new `AirbenderBatchCommitment` shape; `airbender_request_processor` passes commitment + aux_data_hash from the parallel table.

## Why ❔

The v1 design assembled airbender commitment inputs from a separate helper that re-derived data already present in the commitment pipeline; the airbender prover needed a fragile path through duplicated fields. Consolidating both variants on `L1BatchCommitment` means:
- One source of truth for `pass_through_data` and `meta_parameters` — the airbender artifact reuses them and only swaps the auxiliary output hash.
- The airbender row in `airbender_batch_commitments` is computed alongside the existing Boojum row in `commitment_generator`, so the prover reads a stable per-batch commitment from the DB instead of rebuilding inputs.

## Is this a breaking change?
- [x] Yes
- [ ] No

Public API affected: `zksync_types::commitment::CommitmentInput::PostBoojum.aux_commitments` now holds `AuxCommitmentsBoth` (was `AuxCommitments`). Anything in a downstream crate that constructs or destructures this variant must wrap the inner value as `AuxCommitmentsBoth { boojum, airbender }`.

## Operational changes

- New migration `add_airbender_batch_commitments` adds a sibling table to `l1_batches`. Backfill is not required for new chains; existing chains will have the airbender row populated forward from the first batch processed under this version (genesis-row insertion happens on chain init).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] Code has been formatted via \`zkstack dev fmt\` and \`zkstack dev lint\`.