### PR TITLE
fix: skip DA commitment decode before v31

### DIFF
--- a/core/lib/eth_client/src/contracts_loader.rs
+++ b/core/lib/eth_client/src/contracts_loader.rs
@@ -185,69 +185,85 @@ pub async fn get_zk_chain_on_chain_params(
     eth_client: &dyn EthInterface,
     diamond_proxy_addr: Address,
 ) -> Result<ZkChainOnChainConfig, ContractCallError> {
-    let abi = getters_facet_contract();
-    let func = abi
-        .function("getDAValidatorPair")
-        .map_err(ContractCallError::Function)?;
-    let encoded_input =
-        func.encode_input(&[])
-            .map_err(|source| ContractCallError::EncodeInput {
-                signature: func.signature(),
-                input: vec![],
-                source,
-            })?;
-    let request = web3::CallRequest {
-        from: None,
-        to: Some(diamond_proxy_addr),
-        data: Some(web3::Bytes(encoded_input)),
-        gas: None,
-        gas_price: None,
-        value: None,
-        transaction_type: None,
-        access_list: None,
-        max_fee_per_gas: None,
-        max_priority_fee_per_gas: None,
-    };
-    let encoded_output = eth_client.call_contract_function(request, None).await?;
-    let output_tokens = func.decode_output(&encoded_output.0).map_err(|source| {
-        ContractCallError::DecodeOutput {
-            signature: func.signature(),
-            output: encoded_output,
-            source,
-        }
-    })?;
+    let protocol_version =
+        get_protocol_version(diamond_proxy_addr, &hyperchain_contract(), eth_client).await?;
+    let protocol_version =
+        ProtocolSemanticVersion::try_from_packed(protocol_version).map_err(|err| {
+            ContractCallError::DetokenizeOutput {
+                signature: "getProtocolVersion():(uint256)".to_owned(),
+                output: vec![],
+                source: web3::contract::Error::InvalidOutputType(format!(
+                    "Failed to unpack protocol version: {err}"
+                )),
+            }
+        })?;
 
-    let l2_da_commitment_scheme = match output_tokens.as_slice() {
-        [Token::Address(_), Token::Uint(value)] if *value <= U256::from(u8::MAX) => {
-            let raw = value.as_u64() as u8;
-            Some(L2DACommitmentScheme::try_from(raw).map_err(|_| {
-                ContractCallError::DetokenizeOutput {
+    let l2_da_commitment_scheme = if protocol_version.minor.is_pre_medium_interop() {
+        None
+    } else {
+        let abi = getters_facet_contract();
+        let func = abi
+            .function("getDAValidatorPair")
+            .map_err(ContractCallError::Function)?;
+        let encoded_input =
+            func.encode_input(&[])
+                .map_err(|source| ContractCallError::EncodeInput {
+                    signature: func.signature(),
+                    input: vec![],
+                    source,
+                })?;
+        let request = web3::CallRequest {
+            from: None,
+            to: Some(diamond_proxy_addr),
+            data: Some(web3::Bytes(encoded_input)),
+            gas: None,
+            gas_price: None,
+            value: None,
+            transaction_type: None,
+            access_list: None,
+            max_fee_per_gas: None,
+            max_priority_fee_per_gas: None,
+        };
+        let encoded_output = eth_client.call_contract_function(request, None).await?;
+        let output_tokens = func.decode_output(&encoded_output.0).map_err(|source| {
+            ContractCallError::DecodeOutput {
+                signature: func.signature(),
+                output: encoded_output,
+                source,
+            }
+        })?;
+
+        match output_tokens.as_slice() {
+            [Token::Address(_), Token::Uint(value)] if *value <= U256::from(u8::MAX) => {
+                let raw = value.as_u64() as u8;
+                Some(L2DACommitmentScheme::try_from(raw).map_err(|_| {
+                    ContractCallError::DetokenizeOutput {
+                        signature: func.signature(),
+                        output: output_tokens.clone(),
+                        source: web3::contract::Error::InvalidOutputType(format!(
+                            "Unsupported L2DACommitmentScheme for Era: {raw}"
+                        )),
+                    }
+                })?)
+            }
+            [Token::Address(_), Token::Uint(raw)] => {
+                return Err(ContractCallError::DetokenizeOutput {
                     signature: func.signature(),
                     output: output_tokens.clone(),
                     source: web3::contract::Error::InvalidOutputType(format!(
-                        "Unsupported L2DACommitmentScheme for Era: {raw}"
+                        "Invalid L2DACommitmentScheme for Era (out of u8 range): {raw}"
                     )),
-                }
-            })?)
-        }
-        [Token::Address(_), Token::Address(_)] => Some(L2DACommitmentScheme::None),
-        [Token::Address(_), Token::Uint(raw)] => {
-            return Err(ContractCallError::DetokenizeOutput {
-                signature: func.signature(),
-                output: output_tokens.clone(),
-                source: web3::contract::Error::InvalidOutputType(format!(
-                    "Invalid L2DACommitmentScheme for Era (out of u8 range): {raw}"
-                )),
-            });
-        }
-        _ => {
-            return Err(ContractCallError::DetokenizeOutput {
-                signature: func.signature(),
-                output: output_tokens,
-                source: web3::contract::Error::InvalidOutputType(
-                    "Unexpected output of getDAValidatorPair".to_owned(),
-                ),
-            });
+                });
+            }
+            _ => {
+                return Err(ContractCallError::DetokenizeOutput {
+                    signature: func.signature(),
+                    output: output_tokens,
+                    source: web3::contract::Error::InvalidOutputType(
+                        "Unexpected output of getDAValidatorPair".to_owned(),
+                    ),
+                });
+            }
         }
     };
 


### PR DESCRIPTION
## What ❔

Gates DA validator pair decoding by protocol version

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
