### PR TITLE
fix(verifier): improve logging

### DIFF
--- a/core/lib/contract_verifier/src/lib.rs
+++ b/core/lib/contract_verifier/src/lib.rs
@@ -795,7 +795,7 @@ impl ContractVerifier {
                 let error_message = match &error {
                     ContractVerifierError::Internal(err) => {
                         // Do not expose the error externally, but log it.
-                        tracing::warn!(request_id, "internal error processing request: {err}");
+                        tracing::warn!(request_id, "internal error processing request: {err:#}");
                         "internal error".to_owned()
                     }
                     _ => error.to_string(),


### PR DESCRIPTION
## What ❔

This change improves verifier internal error logging.

## Why ❔

Currently, only the top-level error is logged. As a result, logs such as `internal error processing request: failed spawning solc` lack detailed information. The updated format prints the full error chain, providing the necessary context for troubleshooting.

## Is this a breaking change?
- [ ] Yes
- [X] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [X] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
