### PR TITLE
fix(consensus): gate settlement_layer/interop_fee on protocol_version >= 31

### DIFF
--- a/core/lib/dal/src/models/storage_sync.rs
+++ b/core/lib/dal/src/models/storage_sync.rs
@@ -182,12 +182,25 @@ impl SyncBlock {
             pubdata_params: self.pubdata_params,
             pubdata_limit: self.pubdata_limit,
             interop_roots: self.interop_roots,
-            settlement_layer: Some(self.settlement_layer),
-            interop_fee: Some(
-                self.interop_fee
-                    .try_into()
-                    .expect("interop_fee doesn't fit consensus u64 wire format"),
-            ),
+            // `settlement_layer` and `interop_fee` are only carried on the wire from
+            // protocol version 31 onwards (see `ProtoRepr::build` for `Payload`). Mirror
+            // that gating here so the locally-derived payload matches the proposed one
+            // during `verify_payload`; otherwise consensus on pre-v31 chains stalls with
+            // an "unexpected payload" mismatch on these two fields.
+            settlement_layer: if self.protocol_version < ProtocolVersionId::Version31 {
+                None
+            } else {
+                Some(self.settlement_layer)
+            },
+            interop_fee: if self.protocol_version < ProtocolVersionId::Version31 {
+                None
+            } else {
+                Some(
+                    self.interop_fee
+                        .try_into()
+                        .expect("interop_fee doesn't fit consensus u64 wire format"),
+                )
+            },
         }
     }
 }


### PR DESCRIPTION
## What

`SyncBlock::into_payload` populates `settlement_layer` and `interop_fee` as `Some(_)` unconditionally, but the consensus wire encoding ([`ProtoRepr::build` for `Payload`](https://github.com/matter-labs/zksync-era/blob/main/core/lib/dal/src/consensus/conv.rs#L318-L327)) strips both to `None` whenever `protocol_version < Version31`. This PR mirrors the same gating in `into_payload` so the two `Payload` representations stay equal.

## Why

`verify_payload` in `core/node/consensus/src/storage/store.rs` compares the proposed payload (decoded off the wire — fields stripped) against the locally-derived payload (via `into_payload` — fields populated). On any pre-v31 chain whose blocks carry `settlement_layer` / `interop_fee` in storage, the comparison can never succeed, and ChonkyBFT rejects every proposal:

```
invalid payload: verify_payload(): unexpected payload:
  got  Payload { ... settlement_layer: None,                  interop_fee: None }
  want Payload { ... settlement_layer: Some(L1(SLChainId(1))), interop_fee: Some(0) }
```

Both sides carry identical `protocol_version: Version29`, identical `hash`, identical transactions — only those two optional fields differ, and they differ purely because of the asymmetric handling between `into_payload` (always `Some`) and `ProtoRepr::build` (`None` if `< Version31`). This is not a binary skew between nodes; even a uniform deployment exhibits it on a pre-v31 chain that has the columns populated.

## Fix

In `SyncBlock::into_payload`, gate `settlement_layer` and `interop_fee` on `protocol_version >= Version31`, matching `ProtoRepr::build`. Round-tripping through proto is now a no-op for both fields, and `verify_payload` succeeds again on v29/v30 chains.

## Test plan

- `cargo check -p zksync_dal` — passes.
- `cargo check -p zksync_node_consensus` — passes.
- Unblocks consensus replicas observed stalling on v29 with `unexpected payload` mismatches on these two fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)