### PR TITLE
docs: remove stale Gateway mainnet RPC from EN setup

### DIFF
--- a/docs/js/check-external-node-mainnet-gateway-docs.js
+++ b/docs/js/check-external-node-mainnet-gateway-docs.js
@@ -1,0 +1,52 @@
+const fs = require("fs");
+const path = require("path");
+const assert = require("assert");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const mainnetComposePath = path.join(
+    repoRoot,
+    "docs",
+    "src",
+    "guides",
+    "external-node",
+    "docker-compose-examples",
+    "mainnet-external-node-docker-compose.yml"
+);
+const mainnetConfigPath = path.join(
+    repoRoot,
+    "docs",
+    "src",
+    "guides",
+    "external-node",
+    "prepared_configs",
+    "mainnet-config.env"
+);
+const otherChainsGuidePath = path.join(
+    repoRoot,
+    "docs",
+    "src",
+    "guides",
+    "external-node",
+    "11_setup_for_other_chains.md"
+);
+
+const mainnetCompose = fs.readFileSync(mainnetComposePath, "utf8");
+const mainnetConfig = fs.readFileSync(mainnetConfigPath, "utf8");
+const otherChainsGuide = fs.readFileSync(otherChainsGuidePath, "utf8");
+
+assert(
+    !mainnetCompose.includes("EN_GATEWAY_URL"),
+    "mainnet docker-compose example should not set EN_GATEWAY_URL"
+);
+assert(
+    !mainnetConfig.includes("EN_GATEWAY_URL"),
+    "mainnet prepared config should not set EN_GATEWAY_URL"
+);
+assert(
+    otherChainsGuide.includes("Set `EN_GATEWAY_URL` only if the chain operator gave you a reachable Gateway RPC endpoint for that chain."),
+    "other-chains guide should explain when EN_GATEWAY_URL is actually required"
+);
+assert(
+    otherChainsGuide.includes("For ZKsync Era mainnet, the default external-node setup does not need an explicit `EN_GATEWAY_URL`."),
+    "other-chains guide should state that Era mainnet does not need an explicit EN_GATEWAY_URL"
+);

--- a/docs/js/check-external-node-mainnet-gateway-docs.js
+++ b/docs/js/check-external-node-mainnet-gateway-docs.js
@@ -1,56 +1,50 @@
-const fs = require("fs");
-const path = require("path");
-const assert = require("assert");
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
 
-const repoRoot = path.resolve(__dirname, "..", "..");
+const repoRoot = path.resolve(__dirname, '..', '..');
 const mainnetComposePath = path.join(
     repoRoot,
-    "docs",
-    "src",
-    "guides",
-    "external-node",
-    "docker-compose-examples",
-    "mainnet-external-node-docker-compose.yml"
+    'docs',
+    'src',
+    'guides',
+    'external-node',
+    'docker-compose-examples',
+    'mainnet-external-node-docker-compose.yml'
 );
 const mainnetConfigPath = path.join(
     repoRoot,
-    "docs",
-    "src",
-    "guides",
-    "external-node",
-    "prepared_configs",
-    "mainnet-config.env"
+    'docs',
+    'src',
+    'guides',
+    'external-node',
+    'prepared_configs',
+    'mainnet-config.env'
 );
 const otherChainsGuidePath = path.join(
     repoRoot,
-    "docs",
-    "src",
-    "guides",
-    "external-node",
-    "11_setup_for_other_chains.md"
+    'docs',
+    'src',
+    'guides',
+    'external-node',
+    '11_setup_for_other_chains.md'
 );
 
-const mainnetCompose = fs.readFileSync(mainnetComposePath, "utf8");
-const mainnetConfig = fs.readFileSync(mainnetConfigPath, "utf8");
-const otherChainsGuide = fs.readFileSync(otherChainsGuidePath, "utf8");
+const mainnetCompose = fs.readFileSync(mainnetComposePath, 'utf8');
+const mainnetConfig = fs.readFileSync(mainnetConfigPath, 'utf8');
+const otherChainsGuide = fs.readFileSync(otherChainsGuidePath, 'utf8');
 
+assert(!mainnetCompose.includes('EN_GATEWAY_URL'), 'mainnet docker-compose example should not set EN_GATEWAY_URL');
+assert(!mainnetConfig.includes('EN_GATEWAY_URL'), 'mainnet prepared config should not set EN_GATEWAY_URL');
 assert(
-    !mainnetCompose.includes("EN_GATEWAY_URL"),
-    "mainnet docker-compose example should not set EN_GATEWAY_URL"
-);
-assert(
-    !mainnetConfig.includes("EN_GATEWAY_URL"),
-    "mainnet prepared config should not set EN_GATEWAY_URL"
+    otherChainsGuide.includes(
+        'Set `EN_GATEWAY_URL` only if the chain operator gave you a reachable Gateway RPC endpoint for that chain.'
+    ),
+    'other-chains guide should explain when EN_GATEWAY_URL is actually required'
 );
 assert(
     otherChainsGuide.includes(
-        "Set `EN_GATEWAY_URL` only if the chain operator gave you a reachable Gateway RPC endpoint for that chain."
+        'For ZKsync Era mainnet, the default external-node setup does not need an explicit `EN_GATEWAY_URL`.'
     ),
-    "other-chains guide should explain when EN_GATEWAY_URL is actually required"
-);
-assert(
-    otherChainsGuide.includes(
-        "For ZKsync Era mainnet, the default external-node setup does not need an explicit `EN_GATEWAY_URL`."
-    ),
-    "other-chains guide should state that Era mainnet does not need an explicit EN_GATEWAY_URL"
+    'other-chains guide should state that Era mainnet does not need an explicit EN_GATEWAY_URL'
 );

--- a/docs/js/check-external-node-mainnet-gateway-docs.js
+++ b/docs/js/check-external-node-mainnet-gateway-docs.js
@@ -43,10 +43,14 @@ assert(
     "mainnet prepared config should not set EN_GATEWAY_URL"
 );
 assert(
-    otherChainsGuide.includes("Set `EN_GATEWAY_URL` only if the chain operator gave you a reachable Gateway RPC endpoint for that chain."),
+    otherChainsGuide.includes(
+        "Set `EN_GATEWAY_URL` only if the chain operator gave you a reachable Gateway RPC endpoint for that chain."
+    ),
     "other-chains guide should explain when EN_GATEWAY_URL is actually required"
 );
 assert(
-    otherChainsGuide.includes("For ZKsync Era mainnet, the default external-node setup does not need an explicit `EN_GATEWAY_URL`."),
+    otherChainsGuide.includes(
+        "For ZKsync Era mainnet, the default external-node setup does not need an explicit `EN_GATEWAY_URL`."
+    ),
     "other-chains guide should state that Era mainnet does not need an explicit EN_GATEWAY_URL"
 );

--- a/docs/src/guides/external-node/11_setup_for_other_chains.md
+++ b/docs/src/guides/external-node/11_setup_for_other_chains.md
@@ -1,7 +1,6 @@
 # Steps to modify the docker-compose files to support Other Chains
 
-Below are the steps for adjusting ZKsync Era docker-compose files from [here](00_quick_start.md) to support chains other
-than ZKsync Era.
+Below are the steps for adjusting ZKsync Era docker-compose files from [here](00_quick_start.md) to support chains other than ZKsync Era.
 
 ```admonish note
 If you want to run Node for a given chain, you can first ask the company hosting the chains for the Dockerfiles.

--- a/docs/src/guides/external-node/11_setup_for_other_chains.md
+++ b/docs/src/guides/external-node/11_setup_for_other_chains.md
@@ -1,6 +1,7 @@
 # Steps to modify the docker-compose files to support Other Chains
 
-Below are the steps for adjusting ZKsync Era docker-compose files from [here](00_quick_start.md) to support chains other than ZKsync Era.
+Below are the steps for adjusting ZKsync Era docker-compose files from [here](00_quick_start.md) to support chains other
+than ZKsync Era.
 
 ```admonish note
 If you want to run Node for a given chain, you can first ask the company hosting the chains for the Dockerfiles.
@@ -36,7 +37,8 @@ Set `EN_GATEWAY_URL` only if the chain operator gave you a reachable Gateway RPC
 
 For ZKsync Era mainnet, the default external-node setup does not need an explicit `EN_GATEWAY_URL`.
 
-If your chain settles to Gateway and you do not have a provider-supplied Gateway RPC URL yet, ask the company hosting the chain for the correct endpoint before enabling the setting.
+If your chain settles to Gateway and you do not have a provider-supplied Gateway RPC URL yet, ask the company hosting
+the chain for the correct endpoint before enabling the setting.
 
 ## 4. Update snapshots recovery settings
 

--- a/docs/src/guides/external-node/11_setup_for_other_chains.md
+++ b/docs/src/guides/external-node/11_setup_for_other_chains.md
@@ -29,9 +29,17 @@ where `0x144` is the chain ID (324 in decimal)
 
 ## 2. Update `EN_MAIN_NODE_URL`
 
-The `EN_MAIN_NODE_URL` The EN_MAIN_NODE_URL environment variable should point to the main node URL of the target chain
+The `EN_MAIN_NODE_URL` environment variable should point to the main node URL of the target chain.
 
-## 3. Update snapshots recovery settings
+## 3. Configure `EN_GATEWAY_URL` only when your chain actually settles to Gateway
+
+Set `EN_GATEWAY_URL` only if the chain operator gave you a reachable Gateway RPC endpoint for that chain.
+
+For ZKsync Era mainnet, the default external-node setup does not need an explicit `EN_GATEWAY_URL`.
+
+If your chain settles to Gateway and you do not have a provider-supplied Gateway RPC URL yet, ask the company hosting the chain for the correct endpoint before enabling the setting.
+
+## 4. Update snapshots recovery settings
 
 Snapshots recovery is a feature that allows faster Node startup at the cost of no transaction history. By default the
 ZKsync Era docker-compose file has this feature enabled, but it's only recommended to use if the Node first startup time

--- a/docs/src/guides/external-node/docker-compose-examples/mainnet-external-node-docker-compose.yml
+++ b/docs/src/guides/external-node/docker-compose-examples/mainnet-external-node-docker-compose.yml
@@ -94,7 +94,6 @@ services:
       EN_PROMETHEUS_PORT: 3322
       EN_ETH_CLIENT_URL: https://ethereum-rpc.publicnode.com
       EN_MAIN_NODE_URL: https://zksync2-mainnet.zksync.io
-      EN_GATEWAY_URL: https://rpc.era-gateway-mainnet.zksync.dev
       EN_L1_CHAIN_ID: 1
       EN_L2_CHAIN_ID: 324
       EN_PRUNING_ENABLED: true

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "utils": "yarn workspace utils",
     "fmt:check": "prettier --check \"**.{js,jsx,ts,tsx,vue,md}\" --cache",
     "fmt": "prettier --write \"**.{js,jsx,ts,tsx,vue,md}\" --cache",
+    "test:docs:external-node-mainnet-gateway": "node docs/js/check-external-node-mainnet-gateway-docs.js",
     "highlevel-test-tools": "yarn workspace highlevel-test-tools"
   },
   "devDependencies": {


### PR DESCRIPTION
## What ❔

This PR removes the stale `EN_GATEWAY_URL` line from the Era mainnet external-node docker example and updates the docs to say that operators should set `EN_GATEWAY_URL` only when their chain actually settles to Gateway and they have a reachable provider-supplied endpoint.

## Why ❔

The mainnet external-node example still pointed at `https://rpc.era-gateway-mainnet.zksync.dev`, and that hostname no longer resolves.

Live checks on 2026-05-29 narrowed the scope of the docs fix:

- `Resolve-DnsName rpc.era-gateway-mainnet.zksync.dev` returned no answer records.
- `eth_call getSettlementLayer()` against the Era main contract `0x32400084c286cf3e17e7b677ea9583e60a000324` on Ethereum mainnet returned the zero address.

That means the default Era mainnet EN path does not currently need an explicit Gateway RPC URL, so the docs should not advertise a dead one.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

- This is a docs-only change.
- Operators should set `EN_GATEWAY_URL` only for chains that actually settle to Gateway and only when the chain host provided a reachable endpoint.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.

Validation run locally:
- `git diff --check`

Fixes #4822