### PR TITLE
fix(en): remove built-in mainnet Gateway fallback

### DIFF
--- a/core/lib/settlement_layer_data/src/gateway_urls.rs
+++ b/core/lib/settlement_layer_data/src/gateway_urls.rs
@@ -16,11 +16,11 @@ pub static TESTNET_BRIDGEHUB_ADDR: Lazy<Address> =
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DefaultGatewayUrl {
     Testnet,
-    Mainnet,
     Stage,
 }
 
-/// While MatterLabs is the only gateway provider, it's safe to use default parameters for the gateway client.
+/// While MatterLabs is the only gateway provider, testnet and stage still have stable default
+/// parameters for the gateway client.
 /// These URLs serve as fallbacks in case the gateway URL is not specified in the secrets.
 /// This is not defined in JSON, as it's easier to configure the value in secrets
 /// rather than modifying a JSON file.
@@ -29,7 +29,6 @@ impl DefaultGatewayUrl {
         match address {
             addr if addr == *TESTNET_BRIDGEHUB_ADDR => Some(Self::Testnet),
             addr if addr == *STAGE_BRIDGEHUB_ADDR => Some(Self::Stage),
-            addr if addr == *MAINNET_BRIDGEHUB_ADDR => Some(Self::Mainnet),
             _ => None,
         }
     }
@@ -37,9 +36,35 @@ impl DefaultGatewayUrl {
     pub fn to_gateway_url(self) -> SensitiveUrl {
         let url = match self {
             Self::Testnet => "https://rpc.era-gateway-testnet.zksync.dev/",
-            Self::Mainnet => "https://rpc.era-gateway-mainnet.zksync.dev/",
             Self::Stage => "https://rpc.era-gateway-stage.zksync.dev/",
         };
         SensitiveUrl::from_str(url).expect("URL is valid")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DefaultGatewayUrl, MAINNET_BRIDGEHUB_ADDR, STAGE_BRIDGEHUB_ADDR, TESTNET_BRIDGEHUB_ADDR,
+    };
+
+    #[test]
+    fn default_gateway_url_is_available_for_testnet_and_stage() {
+        assert_eq!(
+            DefaultGatewayUrl::from_bridgehub_address(*TESTNET_BRIDGEHUB_ADDR),
+            Some(DefaultGatewayUrl::Testnet)
+        );
+        assert_eq!(
+            DefaultGatewayUrl::from_bridgehub_address(*STAGE_BRIDGEHUB_ADDR),
+            Some(DefaultGatewayUrl::Stage)
+        );
+    }
+
+    #[test]
+    fn mainnet_requires_explicit_gateway_url() {
+        assert_eq!(
+            DefaultGatewayUrl::from_bridgehub_address(*MAINNET_BRIDGEHUB_ADDR),
+            None
+        );
     }
 }

--- a/core/lib/settlement_layer_data/src/lib.rs
+++ b/core/lib/settlement_layer_data/src/lib.rs
@@ -35,6 +35,15 @@ pub enum SettlementLayerError {
     Internal(#[from] anyhow::Error),
 }
 
+const MAINNET_GATEWAY_FALLBACK_REMOVED_WARN: &str =
+    "No Gateway RPC URL was configured for the Era mainnet bridgehub. The built-in mainnet Gateway fallback was removed because the public endpoint is unavailable. Configure `gateway_rpc_url` / `EN_GATEWAY_URL` explicitly before using Gateway settlement.";
+const GATEWAY_SETTLEMENT_ACTIVE_REQUIRES_CLIENT: &str =
+    "Gateway settlement is active, but no reachable Gateway RPC client is configured. Set `gateway_rpc_url` / `EN_GATEWAY_URL` explicitly.";
+const GATEWAY_MIGRATION_FINISH_REQUIRES_CLIENT: &str =
+    "Gateway settlement is required to finish migration, but no reachable Gateway RPC client is configured. Set `gateway_rpc_url` / `EN_GATEWAY_URL` explicitly.";
+const GATEWAY_NOTIFICATION_REQUIRES_CLIENT: &str =
+    "Gateway migration notification requires a reachable Gateway RPC client, but none is configured. Set `gateway_rpc_url` / `EN_GATEWAY_URL` explicitly.";
+
 async fn get_l2_client(
     eth_client: &dyn EthInterface,
     bridgehub_address: Address,
@@ -77,12 +86,7 @@ async fn get_l2_client_unchecked(
             None
         }
     } else if l1_bridgehub_address == *gateway_urls::MAINNET_BRIDGEHUB_ADDR {
-        tracing::warn!(
-            "No Gateway RPC URL was configured for the Era mainnet bridgehub. \
-             The built-in mainnet Gateway fallback was removed because the public \
-             endpoint is unavailable. Configure `gateway_rpc_url` / `EN_GATEWAY_URL` \
-             explicitly before using Gateway settlement."
-        );
+        tracing::warn!(MAINNET_GATEWAY_FALLBACK_REMOVED_WARN);
         None
     } else {
         tracing::warn!(
@@ -167,8 +171,7 @@ pub async fn current_settlement_layer(
     let gateway_client = match settlement_mode_from_l1 {
         SettlementLayer::Gateway(_) => Some(require_gateway_client(
             gateway_client,
-            "Gateway settlement is active, but no reachable Gateway RPC client is configured. \
-             Set `gateway_rpc_url` / `EN_GATEWAY_URL` explicitly.",
+            GATEWAY_SETTLEMENT_ACTIVE_REQUIRES_CLIENT,
         )?),
         SettlementLayer::L1(_) => gateway_client,
     };
@@ -216,8 +219,7 @@ pub async fn current_settlement_layer(
             SettlementLayer::L1(_) => {
                 let gateway_client = require_gateway_client(
                     gateway_client,
-                    "Gateway settlement is required to finish migration, but no reachable \
-                     Gateway RPC client is configured. Set `gateway_rpc_url` / `EN_GATEWAY_URL` explicitly.",
+                    GATEWAY_MIGRATION_FINISH_REQUIRES_CLIENT,
                 )?;
                 let chain_id = gateway_client
                     .fetch_chain_id()
@@ -237,11 +239,8 @@ pub async fn current_settlement_layer(
 
     let target_settlement_mode = match latest_gateway_migration_notification {
         Some(GatewayMigrationNotification::ToGateway) => {
-            let gateway_client = require_gateway_client(
-                gateway_client,
-                "Gateway migration notification requires a reachable Gateway RPC client, \
-                 but none is configured. Set `gateway_rpc_url` / `EN_GATEWAY_URL` explicitly.",
-            )?;
+            let gateway_client =
+                require_gateway_client(gateway_client, GATEWAY_NOTIFICATION_REQUIRES_CLIENT)?;
             let chain_id = gateway_client
                 .fetch_chain_id()
                 .await
@@ -261,4 +260,32 @@ pub async fn current_settlement_layer(
     let mut layer = WorkingSettlementLayer::new(final_settlement_mode, target_settlement_mode);
     layer.set_migration_in_progress(!use_settlement_mode_from_l1);
     Ok(layer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        gateway_urls, get_l2_client_unchecked, require_gateway_client,
+        GATEWAY_SETTLEMENT_ACTIVE_REQUIRES_CLIENT, MAINNET_GATEWAY_FALLBACK_REMOVED_WARN,
+    };
+
+    #[tokio::test]
+    async fn mainnet_gateway_fallback_now_requires_explicit_url() {
+        let gateway_client =
+            get_l2_client_unchecked(None, *gateway_urls::MAINNET_BRIDGEHUB_ADDR).await;
+        assert!(gateway_client.unwrap().is_none());
+    }
+
+    #[test]
+    fn require_gateway_client_returns_actionable_error() {
+        let err =
+            require_gateway_client(None, GATEWAY_SETTLEMENT_ACTIVE_REQUIRES_CLIENT).unwrap_err();
+        assert_eq!(err.to_string(), GATEWAY_SETTLEMENT_ACTIVE_REQUIRES_CLIENT);
+    }
+
+    #[test]
+    fn mainnet_gateway_warning_contract_mentions_operator_action() {
+        assert!(MAINNET_GATEWAY_FALLBACK_REMOVED_WARN.contains("Era mainnet bridgehub"));
+        assert!(MAINNET_GATEWAY_FALLBACK_REMOVED_WARN.contains("EN_GATEWAY_URL"));
+    }
 }

--- a/core/lib/settlement_layer_data/src/lib.rs
+++ b/core/lib/settlement_layer_data/src/lib.rs
@@ -76,6 +76,14 @@ async fn get_l2_client_unchecked(
         } else {
             None
         }
+    } else if l1_bridgehub_address == *gateway_urls::MAINNET_BRIDGEHUB_ADDR {
+        tracing::warn!(
+            "No Gateway RPC URL was configured for the Era mainnet bridgehub. \
+             The built-in mainnet Gateway fallback was removed because the public \
+             endpoint is unavailable. Configure `gateway_rpc_url` / `EN_GATEWAY_URL` \
+             explicitly before using Gateway settlement."
+        );
+        None
     } else {
         tracing::warn!(
             "No client was found for gateway, you are working in none \
@@ -83,6 +91,13 @@ async fn get_l2_client_unchecked(
         );
         None
     })
+}
+
+fn require_gateway_client<'a>(
+    gateway_client: Option<&'a dyn EthInterface>,
+    context: &'static str,
+) -> anyhow::Result<&'a dyn EthInterface> {
+    gateway_client.context(context)
 }
 
 // Gateway has different rules for pubdata and gas space.
@@ -149,6 +164,15 @@ pub async fn current_settlement_layer(
     )
     .await?;
 
+    let gateway_client = match settlement_mode_from_l1 {
+        SettlementLayer::Gateway(_) => Some(require_gateway_client(
+            gateway_client,
+            "Gateway settlement is active, but no reachable Gateway RPC client is configured. \
+             Set `gateway_rpc_url` / `EN_GATEWAY_URL` explicitly.",
+        )?),
+        SettlementLayer::L1(_) => gateway_client,
+    };
+
     let (sl_client, bridge_hub_address) = match settlement_mode_from_l1 {
         SettlementLayer::L1(_) => (
             l1_client,
@@ -157,10 +181,7 @@ pub async fn current_settlement_layer(
                 .bridgehub_proxy_addr
                 .expect("Bridgehub address should always be presented"),
         ),
-        SettlementLayer::Gateway(_) => (
-            gateway_client.expect("No gateway url was provided"),
-            L2_BRIDGEHUB_ADDRESS,
-        ),
+        SettlementLayer::Gateway(_) => (gateway_client.unwrap(), L2_BRIDGEHUB_ADDRESS),
     };
 
     // Load chain contracts from sl
@@ -193,8 +214,12 @@ pub async fn current_settlement_layer(
         // If it's impossible to use settlement_mode_from_l1 server have to use the opposite settlement_layer
         match settlement_mode_from_l1 {
             SettlementLayer::L1(_) => {
+                let gateway_client = require_gateway_client(
+                    gateway_client,
+                    "Gateway settlement is required to finish migration, but no reachable \
+                     Gateway RPC client is configured. Set `gateway_rpc_url` / `EN_GATEWAY_URL` explicitly.",
+                )?;
                 let chain_id = gateway_client
-                    .expect("No gateway url was provided")
                     .fetch_chain_id()
                     .await
                     .map_err(ContractCallError::from)?;
@@ -212,8 +237,12 @@ pub async fn current_settlement_layer(
 
     let target_settlement_mode = match latest_gateway_migration_notification {
         Some(GatewayMigrationNotification::ToGateway) => {
+            let gateway_client = require_gateway_client(
+                gateway_client,
+                "Gateway migration notification requires a reachable Gateway RPC client, \
+                 but none is configured. Set `gateway_rpc_url` / `EN_GATEWAY_URL` explicitly.",
+            )?;
             let chain_id = gateway_client
-                .expect("No gateway url was provided")
                 .fetch_chain_id()
                 .await
                 .map_err(ContractCallError::from)?;


### PR DESCRIPTION
## What ❔

1. Remove the built-in Era mainnet Gateway fallback from `zksync_settlement_layer_data`.
2. Keep the default Gateway URL mapping for testnet and stage.
3. Replace the generic Gateway-client `expect(...)` paths with explicit operator-facing errors.
4. Keep the new Gateway error strings centralized in `core/lib/settlement_layer_data/src/lib.rs` so the operator-facing contract stays consistent across settlement and migration paths.

## Why ❔

Issue: https://github.com/matter-labs/zksync-era/issues/4822

The old mainnet fallback still mapped the Era mainnet bridgehub to `https://rpc.era-gateway-mainnet.zksync.dev/`.

That endpoint is no longer reachable. The fallback did not give operators a working default. It selected a dead URL and deferred the failure until the node actually needed Gateway connectivity.

Live checks on 2026-05-30 narrowed the failure mode:

- `en_getInteropFee` against `https://zksync2-mainnet.zksync.io` returned HTTP 403 with JSON-RPC `-32601` and `rpc method is not whitelisted`.
- The same public endpoint still returned HTTP 200 for `zks_getBridgeContracts`, `zks_getBaseTokenL1Address`, and `zks_getTimestampAsserter`, and returned HTTP 200 with `result: null` for `zks_getL2Multicall3`.
- A live fetch to `https://rpc.era-gateway-mainnet.zksync.dev/` failed on 2026-05-30, matching the report in #4822.

This patch makes that failure mode explicit. Era mainnet now requires an intentional Gateway RPC configuration, while testnet and stage keep their existing defaults.

## Is this a breaking change?
- [x] Yes
- [ ] No

## Operational changes

1. If you run EN against Era mainnet and rely on Gateway settlement or Gateway migration flows, you now need to set `gateway_rpc_url` or `EN_GATEWAY_URL` explicitly.
2. Testnet and stage behavior stays the same.
3. The new error messages point operators at the missing Gateway RPC configuration instead of panicking with `expect(...)`.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.

Validation run in WSL:

- `cargo fmt -p zksync_settlement_layer_data`
- `cargo check -p zksync_settlement_layer_data --lib`
- `cargo test -p zksync_settlement_layer_data --lib`
- `zkstack --ignore-prerequisites dev fmt rustfmt --check`
- `zkstack --ignore-prerequisites dev lint -t rs --check`