### PR TITLE
fix(en): surface remote config invariant errors

### DIFF
--- a/core/lib/settlement_layer_data/src/node.rs
+++ b/core/lib/settlement_layer_data/src/node.rs
@@ -276,12 +276,16 @@ const EN_REMOTE_CONFIG_MISSING_BRIDGEHUB_PROXY_ADDR: &str =
 const EN_GATEWAY_CLIENT_REQUIRED: &str =
     "Gateway settlement is selected for EN, but no reachable Gateway RPC client is configured. Set `gateway_rpc_url` / `EN_GATEWAY_URL` explicitly.";
 
+/// Validates that cached EN remote config still carries the bridgehub address
+/// required to build settlement-layer clients.
 fn require_en_bridgehub_proxy_addr(
     bridgehub_proxy_addr: Option<Address>,
 ) -> anyhow::Result<Address> {
     bridgehub_proxy_addr.context(EN_REMOTE_CONFIG_MISSING_BRIDGEHUB_PROXY_ADDR)
 }
 
+/// Validates that Gateway settlement wiring has an initialized Gateway RPC
+/// client before reusing it across EN contract-loading paths.
 fn require_en_gateway_client<'a>(
     gateway_client: Option<&'a Box<DynClient<L2>>>,
 ) -> anyhow::Result<&'a Box<DynClient<L2>>> {

--- a/core/lib/settlement_layer_data/src/node.rs
+++ b/core/lib/settlement_layer_data/src/node.rs
@@ -286,10 +286,9 @@ fn require_en_bridgehub_proxy_addr(
 
 /// Validates that Gateway settlement wiring has an initialized Gateway RPC
 /// client before reusing it across EN contract-loading paths.
-fn require_en_gateway_client(
-    gateway_client: Option<&Box<DynClient<L2>>>,
-) -> anyhow::Result<()> {
-    gateway_client.context(EN_GATEWAY_CLIENT_REQUIRED)
+fn require_en_gateway_client(gateway_client: Option<&Box<DynClient<L2>>>) -> anyhow::Result<()> {
+    gateway_client
+        .context(EN_GATEWAY_CLIENT_REQUIRED)
         .map(|_| ())
 }
 

--- a/core/lib/settlement_layer_data/src/node.rs
+++ b/core/lib/settlement_layer_data/src/node.rs
@@ -271,19 +271,21 @@ impl SettlementLayerData<ENConfig> {
     pub const LAYER_NAME: &'static str = "settlement_layer_en";
 }
 
+const EN_REMOTE_CONFIG_MISSING_BRIDGEHUB_PROXY_ADDR: &str =
+    "remote EN config is missing `l1_bridgehub_proxy_addr`; refresh the main node config or clear the cached EN remote config";
+const EN_GATEWAY_CLIENT_REQUIRED: &str =
+    "Gateway settlement is selected for EN, but no reachable Gateway RPC client is configured. Set `gateway_rpc_url` / `EN_GATEWAY_URL` explicitly.";
+
 fn require_en_bridgehub_proxy_addr(
     bridgehub_proxy_addr: Option<Address>,
 ) -> anyhow::Result<Address> {
-    bridgehub_proxy_addr.context(
-        "remote EN config is missing `l1_bridgehub_proxy_addr`; refresh the main node config or clear the cached EN remote config",
-    )
+    bridgehub_proxy_addr.context(EN_REMOTE_CONFIG_MISSING_BRIDGEHUB_PROXY_ADDR)
 }
 
 fn require_en_gateway_client<'a>(
     gateway_client: Option<&'a Box<DynClient<L2>>>,
-    context: &'static str,
 ) -> anyhow::Result<&'a Box<DynClient<L2>>> {
-    gateway_client.context(context)
+    gateway_client.context(EN_GATEWAY_CLIENT_REQUIRED)
 }
 
 #[async_trait::async_trait]
@@ -370,10 +372,7 @@ impl WiringLayer for SettlementLayerData<ENConfig> {
         let (client, bridgehub): (&dyn EthInterface, Address) = match initial_sl_mode {
             SettlementLayer::L1(_) => (&input.eth_client, bridgehub_proxy_addr),
             SettlementLayer::Gateway(_) => (
-                require_en_gateway_client(
-                    l2_eth_client.as_ref(),
-                    "Gateway settlement is selected for EN, but no reachable Gateway RPC client is configured. Set `gateway_rpc_url` / `EN_GATEWAY_URL` explicitly.",
-                )? as &dyn EthInterface,
+                require_en_gateway_client(l2_eth_client.as_ref())? as &dyn EthInterface,
                 L2_BRIDGEHUB_ADDRESS,
             ),
         };
@@ -395,11 +394,7 @@ impl WiringLayer for SettlementLayerData<ENConfig> {
         let sl_client = match sl.settlement_layer() {
             SettlementLayer::L1(_) => SettlementLayerClient::L1(input.eth_client),
             SettlementLayer::Gateway(_) => SettlementLayerClient::Gateway(
-                require_en_gateway_client(
-                    l2_eth_client.as_ref(),
-                    "Gateway settlement is selected for EN, but no reachable Gateway RPC client is configured. Set `gateway_rpc_url` / `EN_GATEWAY_URL` explicitly.",
-                )?
-                .clone(),
+                require_en_gateway_client(l2_eth_client.as_ref())?.clone(),
             ),
         };
 
@@ -429,14 +424,18 @@ mod tests {
     use zksync_basic_types::Address;
     use zksync_web3_decl::client::{DynClient, MockClient, L2};
 
-    use super::{require_en_bridgehub_proxy_addr, require_en_gateway_client};
+    use super::{
+        require_en_bridgehub_proxy_addr, require_en_gateway_client, EN_GATEWAY_CLIENT_REQUIRED,
+        EN_REMOTE_CONFIG_MISSING_BRIDGEHUB_PROXY_ADDR,
+    };
 
     #[test]
     fn en_requires_bridgehub_proxy_addr_in_remote_config() {
         let err = require_en_bridgehub_proxy_addr(None).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("remote EN config is missing `l1_bridgehub_proxy_addr`"));
+        assert_eq!(
+            err.to_string(),
+            EN_REMOTE_CONFIG_MISSING_BRIDGEHUB_PROXY_ADDR
+        );
     }
 
     #[test]
@@ -450,18 +449,17 @@ mod tests {
 
     #[test]
     fn en_requires_gateway_client_for_gateway_settlement() {
-        let err = require_en_gateway_client(None, "missing gateway client").unwrap_err();
-        assert_eq!(err.to_string(), "missing gateway client");
+        let err = require_en_gateway_client(None).unwrap_err();
+        assert_eq!(err.to_string(), EN_GATEWAY_CLIENT_REQUIRED);
     }
 
     #[test]
     fn en_accepts_present_gateway_client() {
         let client = Box::new(MockClient::builder(L2::default()).build()) as Box<DynClient<L2>>;
 
-        let gateway_client =
-            require_en_gateway_client(Some(&client), "missing gateway client").unwrap();
+        let gateway_client = require_en_gateway_client(Some(&client)).unwrap();
         let cloned_client = gateway_client.clone();
 
-        assert_eq!(cloned_client.component(), "unnamed");
+        assert_eq!(cloned_client.component(), client.component());
     }
 }

--- a/core/lib/settlement_layer_data/src/node.rs
+++ b/core/lib/settlement_layer_data/src/node.rs
@@ -287,9 +287,10 @@ fn require_en_bridgehub_proxy_addr(
 /// Validates that Gateway settlement wiring has an initialized Gateway RPC
 /// client before reusing it across EN contract-loading paths.
 fn require_en_gateway_client(
-    gateway_client: Option<&DynClient<L2>>,
-) -> anyhow::Result<&DynClient<L2>> {
+    gateway_client: Option<&Box<DynClient<L2>>>,
+) -> anyhow::Result<()> {
     gateway_client.context(EN_GATEWAY_CLIENT_REQUIRED)
+        .map(|_| ())
 }
 
 #[async_trait::async_trait]
@@ -376,7 +377,8 @@ impl WiringLayer for SettlementLayerData<ENConfig> {
         let (client, bridgehub): (&dyn EthInterface, Address) = match initial_sl_mode {
             SettlementLayer::L1(_) => (&input.eth_client, bridgehub_proxy_addr),
             SettlementLayer::Gateway(_) => (
-                require_en_gateway_client(l2_eth_client.as_ref())? as &dyn EthInterface,
+                require_en_gateway_client(l2_eth_client.as_ref())?;
+                l2_eth_client.as_ref().unwrap().as_ref() as &dyn EthInterface,
                 L2_BRIDGEHUB_ADDRESS,
             ),
         };
@@ -397,9 +399,10 @@ impl WiringLayer for SettlementLayerData<ENConfig> {
         let sl = WorkingSettlementLayer::new(initial_sl_mode, initial_sl_mode);
         let sl_client = match sl.settlement_layer() {
             SettlementLayer::L1(_) => SettlementLayerClient::L1(input.eth_client),
-            SettlementLayer::Gateway(_) => SettlementLayerClient::Gateway(
-                require_en_gateway_client(l2_eth_client.as_ref())?.clone(),
-            ),
+            SettlementLayer::Gateway(_) => {
+                require_en_gateway_client(l2_eth_client.as_ref())?;
+                SettlementLayerClient::Gateway(l2_eth_client.clone().unwrap())
+            }
         };
 
         Ok(Output {
@@ -461,8 +464,8 @@ mod tests {
     fn en_accepts_present_gateway_client() {
         let client = Box::new(MockClient::builder(L2::default()).build()) as Box<DynClient<L2>>;
 
-        let gateway_client = require_en_gateway_client(Some(&client)).unwrap();
-        let cloned_client = gateway_client.clone();
+        require_en_gateway_client(Some(&client)).unwrap();
+        let cloned_client = client.clone();
 
         assert_eq!(cloned_client.component(), client.component());
     }

--- a/core/lib/settlement_layer_data/src/node.rs
+++ b/core/lib/settlement_layer_data/src/node.rs
@@ -271,6 +271,21 @@ impl SettlementLayerData<ENConfig> {
     pub const LAYER_NAME: &'static str = "settlement_layer_en";
 }
 
+fn require_en_bridgehub_proxy_addr(
+    bridgehub_proxy_addr: Option<Address>,
+) -> anyhow::Result<Address> {
+    bridgehub_proxy_addr.context(
+        "remote EN config is missing `l1_bridgehub_proxy_addr`; refresh the main node config or clear the cached EN remote config",
+    )
+}
+
+fn require_en_gateway_client<'a>(
+    gateway_client: Option<&'a Box<DynClient<L2>>>,
+    context: &'static str,
+) -> anyhow::Result<&'a Box<DynClient<L2>>> {
+    gateway_client.context(context)
+}
+
 #[async_trait::async_trait]
 impl WiringLayer for SettlementLayerData<ENConfig> {
     type Input = Input;
@@ -341,22 +356,26 @@ impl WiringLayer for SettlementLayerData<ENConfig> {
             .context("Error occured while getting current SL mode")?
         };
 
+        let bridgehub_proxy_addr =
+            require_en_bridgehub_proxy_addr(remote_config.l1_bridgehub_proxy_addr)?;
+
         let l2_eth_client = get_l2_client(
             &input.eth_client,
-            remote_config.l1_bridgehub_proxy_addr.unwrap(),
+            bridgehub_proxy_addr,
             self.config.chain_id,
             self.config.gateway_rpc_url,
         )
         .await?;
 
         let (client, bridgehub): (&dyn EthInterface, Address) = match initial_sl_mode {
-            SettlementLayer::L1(_) => (
-                &input.eth_client,
-                remote_config.l1_bridgehub_proxy_addr.context(
-                    "missing `bridgehub_proxy_addr` in `l1_chain_contracts.ecosystem_contracts`",
-                )?,
+            SettlementLayer::L1(_) => (&input.eth_client, bridgehub_proxy_addr),
+            SettlementLayer::Gateway(_) => (
+                require_en_gateway_client(
+                    l2_eth_client.as_ref(),
+                    "Gateway settlement is selected for EN, but no reachable Gateway RPC client is configured. Set `gateway_rpc_url` / `EN_GATEWAY_URL` explicitly.",
+                )? as &dyn EthInterface,
+                L2_BRIDGEHUB_ADDRESS,
             ),
-            SettlementLayer::Gateway(_) => (l2_eth_client.as_ref().unwrap(), L2_BRIDGEHUB_ADDRESS),
         };
 
         // There is no need to specify multicall3 for external node
@@ -375,15 +394,13 @@ impl WiringLayer for SettlementLayerData<ENConfig> {
         let sl = WorkingSettlementLayer::new(initial_sl_mode, initial_sl_mode);
         let sl_client = match sl.settlement_layer() {
             SettlementLayer::L1(_) => SettlementLayerClient::L1(input.eth_client),
-            SettlementLayer::Gateway(_) => {
-                // `unwrap()` is safe: `l2_eth_client` is always initialized when `config.gateway_rpc_url` is set,
-                // which is required for `SettlementLayer::Gateway`.
-                SettlementLayerClient::Gateway(
-                    l2_eth_client
-                        .clone()
-                        .expect("Gateway rpc url is not presented"),
-                )
-            }
+            SettlementLayer::Gateway(_) => SettlementLayerClient::Gateway(
+                require_en_gateway_client(
+                    l2_eth_client.as_ref(),
+                    "Gateway settlement is selected for EN, but no reachable Gateway RPC client is configured. Set `gateway_rpc_url` / `EN_GATEWAY_URL` explicitly.",
+                )?
+                .clone(),
+            ),
         };
 
         Ok(Output {
@@ -404,5 +421,47 @@ impl WiringLayer for SettlementLayerData<ENConfig> {
                 remote_config.l1_batch_commit_data_generator_mode,
             ),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zksync_basic_types::Address;
+    use zksync_web3_decl::client::{DynClient, MockClient, L2};
+
+    use super::{require_en_bridgehub_proxy_addr, require_en_gateway_client};
+
+    #[test]
+    fn en_requires_bridgehub_proxy_addr_in_remote_config() {
+        let err = require_en_bridgehub_proxy_addr(None).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("remote EN config is missing `l1_bridgehub_proxy_addr`"));
+    }
+
+    #[test]
+    fn en_accepts_present_bridgehub_proxy_addr() {
+        let bridgehub = Address::repeat_byte(0x11);
+        assert_eq!(
+            require_en_bridgehub_proxy_addr(Some(bridgehub)).unwrap(),
+            bridgehub
+        );
+    }
+
+    #[test]
+    fn en_requires_gateway_client_for_gateway_settlement() {
+        let err = require_en_gateway_client(None, "missing gateway client").unwrap_err();
+        assert_eq!(err.to_string(), "missing gateway client");
+    }
+
+    #[test]
+    fn en_accepts_present_gateway_client() {
+        let client = Box::new(MockClient::builder(L2::default()).build()) as Box<DynClient<L2>>;
+
+        let gateway_client =
+            require_en_gateway_client(Some(&client), "missing gateway client").unwrap();
+        let cloned_client = gateway_client.clone();
+
+        assert_eq!(cloned_client.component(), "unnamed");
     }
 }

--- a/core/lib/settlement_layer_data/src/node.rs
+++ b/core/lib/settlement_layer_data/src/node.rs
@@ -376,11 +376,13 @@ impl WiringLayer for SettlementLayerData<ENConfig> {
 
         let (client, bridgehub): (&dyn EthInterface, Address) = match initial_sl_mode {
             SettlementLayer::L1(_) => (&input.eth_client, bridgehub_proxy_addr),
-            SettlementLayer::Gateway(_) => (
+            SettlementLayer::Gateway(_) => {
                 require_en_gateway_client(l2_eth_client.as_ref())?;
-                l2_eth_client.as_ref().unwrap().as_ref() as &dyn EthInterface,
-                L2_BRIDGEHUB_ADDRESS,
-            ),
+                (
+                    l2_eth_client.as_ref().unwrap().as_ref() as &dyn EthInterface,
+                    L2_BRIDGEHUB_ADDRESS,
+                )
+            }
         };
 
         // There is no need to specify multicall3 for external node

--- a/core/lib/settlement_layer_data/src/node.rs
+++ b/core/lib/settlement_layer_data/src/node.rs
@@ -286,9 +286,9 @@ fn require_en_bridgehub_proxy_addr(
 
 /// Validates that Gateway settlement wiring has an initialized Gateway RPC
 /// client before reusing it across EN contract-loading paths.
-fn require_en_gateway_client<'a>(
-    gateway_client: Option<&'a Box<DynClient<L2>>>,
-) -> anyhow::Result<&'a Box<DynClient<L2>>> {
+fn require_en_gateway_client(
+    gateway_client: Option<&DynClient<L2>>,
+) -> anyhow::Result<&DynClient<L2>> {
     gateway_client.context(EN_GATEWAY_CLIENT_REQUIRED)
 }
 


### PR DESCRIPTION
## What ❔

This PR replaces EN remote-config `unwrap()` / `expect(...)` wiring assumptions with explicit operator-facing errors.

- It requires `l1_bridgehub_proxy_addr` through a helper with actionable context.
- It requires the Gateway client through a helper when EN settles to Gateway.
- It reuses the validated Gateway client for both contract loading and `SettlementLayerClient::Gateway`.
- It adds focused unit tests for both missing and present helper inputs.

## Why ❔

The EN remote-config path already admits incomplete state, but EN wiring still treated several fields as guaranteed.

`RemoteENConfig` stores `l1_bridgehub_proxy_addr` as `Option<Address>`, and `ExternalNodeConfigDal::get_en_remote_config()` can return cached JSON from an older or incomplete fetch. In that state, EN wiring still used `unwrap()` / `expect(...)` on the bridgehub address and derived Gateway client. That turns a recoverable configuration mismatch into a panic during wiring and hides the operator action needed to recover.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

No operational changes.

Operators now get explicit startup errors when cached EN remote config is incomplete or Gateway settlement is selected without a reachable Gateway RPC client.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.

Validation run locally:
- `cargo fmt -p zksync_settlement_layer_data`
- `cargo check -p zksync_settlement_layer_data --lib`
- `cargo test -p zksync_settlement_layer_data --lib`