### PR TITLE
fix(en): allow missing bridgehub in ecosystem RPC

### DIFF
--- a/core/bin/external_node/src/tests/utils.rs
+++ b/core/bin/external_node/src/tests/utils.rs
@@ -309,7 +309,7 @@ pub(super) fn mock_l2_client(env: &TestEnvironment) -> MockClient<L2> {
         .method("en_whitelistedTokensForAA", || Ok([] as [Address; 0]))
         .method("en_getEcosystemContracts", move || {
             Ok(EcosystemContractsDto {
-                bridgehub_proxy_addr: contracts.ecosystem_contracts.bridgehub_proxy_addr.unwrap(),
+                bridgehub_proxy_addr: contracts.ecosystem_contracts.bridgehub_proxy_addr,
                 state_transition_proxy_addr: contracts
                     .ecosystem_contracts
                     .state_transition_proxy_addr,

--- a/core/lib/settlement_layer_data/src/remote_en_config.rs
+++ b/core/lib/settlement_layer_data/src/remote_en_config.rs
@@ -135,15 +135,14 @@ where
 #[cfg(test)]
 mod tests {
     use zksync_basic_types::{
-        commitment::L1BatchCommitmentMode,
-        protocol_version::ProtocolSemanticVersion,
-        Address, L1ChainId, L2ChainId, H256,
+        commitment::L1BatchCommitmentMode, protocol_version::ProtocolSemanticVersion, Address,
+        L1ChainId, L2ChainId, H256,
     };
+    use zksync_types::api::BridgeAddresses;
     use zksync_web3_decl::{
         client::{DynClient, MockClient, L2},
         types::{EcosystemContractsDto, GenesisConfigDto},
     };
-    use zksync_types::api::BridgeAddresses;
 
     use super::fetch_remote_en_config;
 
@@ -211,6 +210,30 @@ mod tests {
         assert_eq!(
             remote_config.l1_state_transition_proxy_addr,
             Some(Address::repeat_byte(11))
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_remote_en_config_preserves_present_bridgehub_addr() {
+        let remote_config = fetch_remote_en_config(mock_main_node_client(EcosystemContractsDto {
+            bridgehub_proxy_addr: Some(Address::repeat_byte(21)),
+            state_transition_proxy_addr: Some(Address::repeat_byte(11)),
+            message_root_proxy_addr: Some(Address::repeat_byte(12)),
+            transparent_proxy_admin_addr: Address::zero(),
+            l1_bytecodes_supplier_addr: Some(Address::repeat_byte(13)),
+            l1_wrapped_base_token_store: Some(Address::repeat_byte(14)),
+            server_notifier_addr: Some(Address::repeat_byte(15)),
+        }))
+        .await
+        .unwrap();
+
+        assert_eq!(
+            remote_config.l1_bridgehub_proxy_addr,
+            Some(Address::repeat_byte(21))
+        );
+        assert_eq!(
+            remote_config.l1_message_root_proxy_addr,
+            Some(Address::repeat_byte(12))
         );
     }
 }

--- a/core/lib/settlement_layer_data/src/remote_en_config.rs
+++ b/core/lib/settlement_layer_data/src/remote_en_config.rs
@@ -70,7 +70,7 @@ pub(crate) async fn fetch_remote_en_config(
     Ok(RemoteENConfig {
         l1_bridgehub_proxy_addr: l1_ecosystem_contracts
             .as_ref()
-            .map(|a| a.bridgehub_proxy_addr),
+            .and_then(|a| a.bridgehub_proxy_addr),
         l1_state_transition_proxy_addr: l1_ecosystem_contracts
             .as_ref()
             .and_then(|a| a.state_transition_proxy_addr),
@@ -129,5 +129,88 @@ where
             Ok(fallback)
         }
         response => response.context(context),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zksync_basic_types::{
+        commitment::L1BatchCommitmentMode,
+        protocol_version::ProtocolSemanticVersion,
+        Address, L1ChainId, L2ChainId, H256,
+    };
+    use zksync_web3_decl::{
+        client::{DynClient, MockClient, L2},
+        types::{EcosystemContractsDto, GenesisConfigDto},
+    };
+    use zksync_types::api::BridgeAddresses;
+
+    use super::fetch_remote_en_config;
+
+    fn mock_main_node_client(ecosystem_contracts: EcosystemContractsDto) -> Box<DynClient<L2>> {
+        let client = MockClient::builder(L2::default())
+            .method("zks_getBridgeContracts", || {
+                Ok(BridgeAddresses {
+                    l1_shared_default_bridge: Some(Address::repeat_byte(1)),
+                    l2_shared_default_bridge: Some(Address::repeat_byte(3)),
+                    l1_erc20_default_bridge: Some(Address::repeat_byte(4)),
+                    l2_erc20_default_bridge: Some(Address::repeat_byte(3)),
+                    l1_weth_bridge: None,
+                    l2_weth_bridge: None,
+                    l2_legacy_shared_bridge: Some(Address::repeat_byte(5)),
+                })
+            })
+            .method("zks_getTestnetPaymaster", || Ok(Address::repeat_byte(15)))
+            .method("en_getEcosystemContracts", move || {
+                Ok(ecosystem_contracts.clone())
+            })
+            .method("zks_getMainContract", || Ok(Address::repeat_byte(9)))
+            .method("zks_getTimestampAsserter", || {
+                Ok(Some(Address::repeat_byte(6)))
+            })
+            .method("zks_getL2Multicall3", || Ok(Some(Address::repeat_byte(7))))
+            .method("zks_getBaseTokenL1Address", || Ok(Address::repeat_byte(8)))
+            .method("genesis_config", || {
+                Ok(GenesisConfigDto {
+                    protocol_version: ProtocolSemanticVersion::default(),
+                    genesis_root_hash: H256::repeat_byte(1),
+                    rollup_last_leaf_index: 0,
+                    genesis_commitment: H256::repeat_byte(2),
+                    bootloader_hash: H256::repeat_byte(3),
+                    default_aa_hash: H256::repeat_byte(4),
+                    evm_emulator_hash: None,
+                    l1_chain_id: L1ChainId(9),
+                    l2_chain_id: L2ChainId::default(),
+                    snark_wrapper_vk_hash: H256::repeat_byte(5),
+                    fflonk_snark_wrapper_vk_hash: None,
+                    fee_account: Address::repeat_byte(10),
+                    dummy_verifier: false,
+                    l1_batch_commit_data_generator_mode: L1BatchCommitmentMode::default(),
+                })
+            })
+            .build();
+
+        Box::new(client)
+    }
+
+    #[tokio::test]
+    async fn fetch_remote_en_config_allows_missing_bridgehub_addr() {
+        let remote_config = fetch_remote_en_config(mock_main_node_client(EcosystemContractsDto {
+            bridgehub_proxy_addr: None,
+            state_transition_proxy_addr: Some(Address::repeat_byte(11)),
+            message_root_proxy_addr: Some(Address::repeat_byte(12)),
+            transparent_proxy_admin_addr: Address::zero(),
+            l1_bytecodes_supplier_addr: Some(Address::repeat_byte(13)),
+            l1_wrapped_base_token_store: Some(Address::repeat_byte(14)),
+            server_notifier_addr: Some(Address::repeat_byte(15)),
+        }))
+        .await
+        .unwrap();
+
+        assert_eq!(remote_config.l1_bridgehub_proxy_addr, None);
+        assert_eq!(
+            remote_config.l1_state_transition_proxy_addr,
+            Some(Address::repeat_byte(11))
+        );
     }
 }

--- a/core/lib/web3_decl/src/types.rs
+++ b/core/lib/web3_decl/src/types.rs
@@ -410,7 +410,7 @@ pub enum PubSubResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EcosystemContractsDto {
-    pub bridgehub_proxy_addr: Address,
+    pub bridgehub_proxy_addr: Option<Address>,
     pub state_transition_proxy_addr: Option<Address>,
     pub message_root_proxy_addr: Option<Address>,
     pub transparent_proxy_admin_addr: Address,

--- a/core/lib/web3_decl/src/types.rs
+++ b/core/lib/web3_decl/src/types.rs
@@ -593,4 +593,43 @@ mod tests {
             panic!("Failed to parse genesis config with a new name: {}", err)
         });
     }
+
+    #[test]
+    fn ecosystem_contracts_serde_keeps_optional_bridgehub() {
+        let without_bridgehub = EcosystemContractsDto {
+            bridgehub_proxy_addr: None,
+            state_transition_proxy_addr: Some(Address::repeat_byte(0x11)),
+            message_root_proxy_addr: None,
+            transparent_proxy_admin_addr: Address::zero(),
+            l1_bytecodes_supplier_addr: None,
+            l1_wrapped_base_token_store: None,
+            server_notifier_addr: None,
+        };
+        let without_bridgehub_json = serde_json::to_value(&without_bridgehub).unwrap();
+        assert_eq!(
+            without_bridgehub_json["bridgehub_proxy_addr"],
+            serde_json::Value::Null
+        );
+
+        let with_bridgehub = EcosystemContractsDto {
+            bridgehub_proxy_addr: Some(Address::repeat_byte(0x22)),
+            ..without_bridgehub
+        };
+        let with_bridgehub_json = serde_json::to_value(&with_bridgehub).unwrap();
+        assert_eq!(
+            with_bridgehub_json["bridgehub_proxy_addr"],
+            serde_json::json!("0x2222222222222222222222222222222222222222")
+        );
+
+        let restored_without_bridgehub: EcosystemContractsDto =
+            serde_json::from_value(without_bridgehub_json).unwrap();
+        assert!(restored_without_bridgehub.bridgehub_proxy_addr.is_none());
+
+        let restored_with_bridgehub: EcosystemContractsDto =
+            serde_json::from_value(with_bridgehub_json).unwrap();
+        assert_eq!(
+            restored_with_bridgehub.bridgehub_proxy_addr,
+            Some(Address::repeat_byte(0x22))
+        );
+    }
 }

--- a/core/lib/web3_decl/src/types.rs
+++ b/core/lib/web3_decl/src/types.rs
@@ -410,6 +410,8 @@ pub enum PubSubResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EcosystemContractsDto {
+    /// Optional because some EN-backed chains do not expose a bridgehub
+    /// contract on the ecosystem-contracts path.
     pub bridgehub_proxy_addr: Option<Address>,
     pub state_transition_proxy_addr: Option<Address>,
     pub message_root_proxy_addr: Option<Address>,

--- a/core/node/api_server/src/web3/namespaces/en.rs
+++ b/core/node/api_server/src/web3/namespaces/en.rs
@@ -113,8 +113,7 @@ impl EnNamespace {
                 .state
                 .api_config
                 .l1_ecosystem_contracts
-                .bridgehub_proxy_addr
-                .unwrap(),
+                .bridgehub_proxy_addr,
             state_transition_proxy_addr: self
                 .state
                 .api_config


### PR DESCRIPTION
## What ❔

This PR makes `EcosystemContractsDto.bridgehub_proxy_addr` optional, removes the EN ecosystem-RPC `unwrap()`, and lets remote EN config ingestion consume the optional field directly.

- `en_getEcosystemContracts` now returns `null` for `bridgehub_proxy_addr` when bridgehub is absent.
- The rest of the ecosystem-contracts DTO stays unchanged.
- `remote_en_config` keeps preserving the present-address path and now also accepts the missing-address path.
- Added focused RPC / serde / remote-config regression coverage for both `None` and `Some(...)` cases.

## Why ❔

The EN stack already modeled bridgehub as optional, but one RPC path still treated it as guaranteed.

`RemoteENConfig` stores `l1_bridgehub_proxy_addr` as `Option<Address>`, and `zks_getBridgehubContract` already exposed bridgehub as optional. `en_getEcosystemContracts` still called `unwrap()` on the same underlying field, so the API server could admit "bridgehub may be absent" on one path and panic on another path backed by the same config.

## Is this a breaking change?
- [x] Yes
- [ ] No

Downstream consumers must now accept `bridgehub_proxy_addr = null` in the ecosystem-contracts RPC response, and Rust consumers of `EcosystemContractsDto` must handle `Option<Address>` instead of `Address`.

## Operational changes

No node-operator action is required.

Client-side consumers of the ecosystem-contracts RPC and downstream crates using `EcosystemContractsDto` must accept a missing bridgehub value.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.

Validation run locally:
- `cargo fmt -p zksync_settlement_layer_data -p zksync_web3_decl -p zksync_node_api_server`
- `cargo check -p zksync_settlement_layer_data --lib --message-format short`
- `cargo check -p zksync_web3_decl --lib --message-format short`
- `cargo check -p zksync_node_api_server --lib --message-format short`
- `cargo test -p zksync_settlement_layer_data remote_en_config::tests::fetch_remote_en_config_allows_missing_bridgehub_addr --lib -- --exact --nocapture`
- `cargo test -p zksync_settlement_layer_data remote_en_config::tests::fetch_remote_en_config_preserves_present_bridgehub_addr --lib -- --exact --nocapture`
- `cargo test -p zksync_web3_decl types::tests::ecosystem_contracts_serde_keeps_optional_bridgehub --lib -- --exact --nocapture`