### PR TITLE
fix(block_reverter): surface missing timelock context

### DIFF
--- a/core/bin/block_reverter/src/main.rs
+++ b/core/bin/block_reverter/src/main.rs
@@ -114,6 +114,13 @@ enum Command {
     ClearFailedL1Transactions,
 }
 
+fn require_validator_timelock_addr(
+    validator_timelock_addr: Option<Address>,
+) -> anyhow::Result<Address> {
+    validator_timelock_addr
+        .context("validator_timelock_addr not present in settlement-layer contracts")
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let opts = Cli::parse();
@@ -203,10 +210,8 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let sl_diamond_proxy = contracts.chain_contracts_config.diamond_proxy_addr;
-    let sl_validator_timelock = contracts
-        .ecosystem_contracts
-        .validator_timelock_addr
-        .context("validator_timelock_addr not present in settlement-layer contracts")?;
+    let sl_validator_timelock =
+        require_validator_timelock_addr(contracts.ecosystem_contracts.validator_timelock_addr)?;
 
     let config = BlockReverterEthConfig::new(
         &eth_sender,
@@ -398,4 +403,25 @@ async fn main() -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::require_validator_timelock_addr;
+    use zksync_types::Address;
+
+    #[test]
+    fn require_validator_timelock_addr_rejects_missing_value() {
+        let err = require_validator_timelock_addr(None).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "validator_timelock_addr not present in settlement-layer contracts"
+        );
+    }
+
+    #[test]
+    fn require_validator_timelock_addr_accepts_present_value() {
+        let addr = Address::repeat_byte(0x11);
+        assert_eq!(require_validator_timelock_addr(Some(addr)).unwrap(), addr);
+    }
 }

--- a/core/bin/block_reverter/src/main.rs
+++ b/core/bin/block_reverter/src/main.rs
@@ -206,7 +206,7 @@ async fn main() -> anyhow::Result<()> {
     let sl_validator_timelock = contracts
         .ecosystem_contracts
         .validator_timelock_addr
-        .expect("Should be presented");
+        .context("validator_timelock_addr not present in settlement-layer contracts")?;
 
     let config = BlockReverterEthConfig::new(
         &eth_sender,


### PR DESCRIPTION
1. Failure mechanism

`block_reverter` still treated `validator_timelock_addr` as guaranteed even though the settlement-layer contracts model already exposes it as optional.

The same field already gets explicit error handling in the normal ETH sender wiring:

core/node/eth_sender/src/node/aggregator.rs
`validator_timelock_addr.context("validator_timelock_addr not present in SL contracts")?`

But the block reverter CLI still used:

core/bin/block_reverter/src/main.rs
`validator_timelock_addr.expect("Should be presented")`

That meant the operational recovery path could still panic with an unhelpful message instead of returning an actionable config / contract-loading error.

2. Semantic change

This patch replaces the `expect(...)` with `context(...)` in `block_reverter` and routes the check through a tiny helper so the missing-field behavior is unit tested directly.

3. Preserved behavior

If the settlement-layer contracts include `validator_timelock_addr`, behavior is unchanged.
If the field is missing, the CLI now exits with a contextual error instead of panicking.

4. Evidence

Code path:
core/bin/block_reverter/src/main.rs
core/node/eth_sender/src/node/aggregator.rs
core/lib/config/src/configs/contracts/ecosystem.rs

The key point is that the field type is `Option<Address>` in the contracts model, so the recovery CLI should not assume it is impossible for it to be absent.

5. Tests

WSL, Ubuntu 24.04

cargo fmt -p block_reverter --check
cargo check -p block_reverter --bin block_reverter --message-format short
cargo test -p block_reverter tests::require_validator_timelock_addr_rejects_missing_value --bin block_reverter -- --exact --nocapture
cargo test -p block_reverter tests::require_validator_timelock_addr_accepts_present_value --bin block_reverter -- --exact --nocapture