### PR TITLE
fix(block_reverter): surface missing timelock context

### DIFF
--- a/core/bin/block_reverter/src/main.rs
+++ b/core/bin/block_reverter/src/main.rs
@@ -114,6 +114,13 @@ enum Command {
     ClearFailedL1Transactions,
 }
 
+fn require_validator_timelock_addr(
+    validator_timelock_addr: Option<Address>,
+) -> anyhow::Result<Address> {
+    validator_timelock_addr
+        .context("validator_timelock_addr not present in settlement-layer contracts")
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let opts = Cli::parse();
@@ -203,10 +210,8 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let sl_diamond_proxy = contracts.chain_contracts_config.diamond_proxy_addr;
-    let sl_validator_timelock = contracts
-        .ecosystem_contracts
-        .validator_timelock_addr
-        .context("validator_timelock_addr not present in settlement-layer contracts")?;
+    let sl_validator_timelock =
+        require_validator_timelock_addr(contracts.ecosystem_contracts.validator_timelock_addr)?;
 
     let config = BlockReverterEthConfig::new(
         &eth_sender,
@@ -398,4 +403,25 @@ async fn main() -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::require_validator_timelock_addr;
+    use zksync_types::Address;
+
+    #[test]
+    fn require_validator_timelock_addr_rejects_missing_value() {
+        let err = require_validator_timelock_addr(None).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "validator_timelock_addr not present in settlement-layer contracts"
+        );
+    }
+
+    #[test]
+    fn require_validator_timelock_addr_accepts_present_value() {
+        let addr = Address::repeat_byte(0x11);
+        assert_eq!(require_validator_timelock_addr(Some(addr)).unwrap(), addr);
+    }
 }

--- a/core/bin/block_reverter/src/main.rs
+++ b/core/bin/block_reverter/src/main.rs
@@ -206,7 +206,7 @@ async fn main() -> anyhow::Result<()> {
     let sl_validator_timelock = contracts
         .ecosystem_contracts
         .validator_timelock_addr
-        .expect("Should be presented");
+        .context("validator_timelock_addr not present in settlement-layer contracts")?;
 
     let config = BlockReverterEthConfig::new(
         &eth_sender,


### PR DESCRIPTION
1. Failure mechanism

`block_reverter` loaded `validator_timelock_addr` from settlement-layer contracts with `expect("Should be presented")` even though the contracts model already exposes that field as `Option<Address>`.

That meant the recovery CLI could panic on incomplete settlement-layer contract config while the normal ETH sender path already returned contextual error for the same condition.

2. Semantic change

This PR:

- routes the check through `require_validator_timelock_addr(...)`
- returns `validator_timelock_addr not present in settlement-layer contracts` instead of panicking
- adds focused unit coverage for both missing and present values

3. Preserved behavior

If `validator_timelock_addr` is present, `block_reverter` still uses the same address.

Only the missing-field path changes: the CLI now returns a contextual error instead of aborting with a raw panic.

4. Evidence

Code paths:
core/bin/block_reverter/src/main.rs
core/node/eth_sender/src/node/aggregator.rs
core/lib/config/src/configs/contracts/ecosystem.rs

The key invariant is already modeled in config and enforced in the ETH sender path, so the recovery CLI should enforce the same contract explicitly.

5. Tests

WSL, Ubuntu 24.04

cargo fmt -p block_reverter --check
cargo check -p block_reverter --bin block_reverter --message-format short
cargo test -p block_reverter tests::require_validator_timelock_addr_rejects_missing_value --bin block_reverter -- --exact --nocapture
cargo test -p block_reverter tests::require_validator_timelock_addr_accepts_present_value --bin block_reverter -- --exact --nocapture