### PR TITLE
fix(api_server): guard missing post-gateway aggregation roots

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -14632,6 +14632,7 @@ dependencies = [
  "reqwest 0.12.22",
  "serde",
  "serde_json",
+ "sqlx",
  "strum 0.26.3",
  "tempfile",
  "test-casing",

--- a/core/node/api_server/Cargo.toml
+++ b/core/node/api_server/Cargo.toml
@@ -64,6 +64,7 @@ zk_evm_1_5_0.workspace = true
 zksync_node_genesis.workspace = true
 zksync_node_test_utils.workspace = true
 zksync_test_contracts.workspace = true
+sqlx.workspace = true
 
 assert_matches.workspace = true
 http-body-util.workspace = true

--- a/core/node/api_server/src/web3/namespaces/zks.rs
+++ b/core/node/api_server/src/web3/namespaces/zks.rs
@@ -1,3 +1,4 @@
+use anyhow::Context as _;
 use zksync_crypto_primitives::hasher::{keccak::KeccakHasher, Hasher};
 use zksync_dal::{Connection, Core, CoreDal, DalError};
 use zksync_mini_merkle_tree::MiniMerkleTree;
@@ -231,7 +232,7 @@ impl ZksNamespace {
         let aggregated_root = batch_with_metadata
             .metadata
             .aggregation_root
-            .expect("`aggregation_root` must be present for post-gateway branch");
+            .context("missing `aggregation_root` for post-gateway L2->L1 log proof")?;
         let root = KeccakHasher.compress(&local_root, &aggregated_root);
 
         let mut log_leaf_proof = proof;

--- a/core/node/api_server/src/web3/namespaces/zks.rs
+++ b/core/node/api_server/src/web3/namespaces/zks.rs
@@ -178,6 +178,9 @@ impl ZksNamespace {
         U64::from(*self.state.api_config.l1_chain_id)
     }
 
+    /// Builds an L2->L1 log proof for a sealed batch and upgrades the local
+    /// Merkle proof with post-gateway metadata when the batch was executed
+    /// through Gateway.
     async fn get_l2_to_l1_log_proof_inner(
         &self,
         storage: &mut Connection<'_, Core>,

--- a/core/node/api_server/src/web3/tests/mod.rs
+++ b/core/node/api_server/src/web3/tests/mod.rs
@@ -21,12 +21,13 @@ use zksync_node_test_utils::{
     l1_batch_metadata_to_commitment_artifacts, prepare_recovery_snapshot,
 };
 use zksync_system_constants::{
-    SYSTEM_CONTEXT_ADDRESS, SYSTEM_CONTEXT_CURRENT_L2_BLOCK_INFO_POSITION,
+    L1_MESSENGER_ADDRESS, SYSTEM_CONTEXT_ADDRESS, SYSTEM_CONTEXT_CURRENT_L2_BLOCK_INFO_POSITION,
 };
+use zksync_types::l2_to_l1_log::{L2ToL1Log, UserL2ToL1Log};
 use zksync_types::{
     aggregated_operations::L1BatchAggregatedActionType,
     api,
-    api::{BlockNumber, BlockStatus, TransactionStatus},
+    api::{BlockNumber, BlockStatus, InteropMode, TransactionStatus},
     block::{pack_block_info, L2BlockHasher, L2BlockHeader, UnsealedL1BatchHeader},
     bytecode::{
         testonly::{PADDED_EVM_BYTECODE, PROCESSED_EVM_BYTECODE},
@@ -1447,6 +1448,77 @@ impl HttpTest for HttpServerBatchStatusTest {
 #[tokio::test]
 async fn http_server_batch_statuses() {
     test_http_server(HttpServerBatchStatusTest).await;
+}
+
+#[derive(Debug)]
+struct L2ToL1LogProofWithoutAggregationRootTest;
+
+#[async_trait]
+impl HttpTest for L2ToL1LogProofWithoutAggregationRootTest {
+    async fn test(
+        &self,
+        client: &DynClient<L2>,
+        pool: &ConnectionPool<Core>,
+    ) -> anyhow::Result<()> {
+        let mut storage = pool.connection().await?;
+        let l1_batch_number = L1BatchNumber(1);
+        let l2_block_number = L2BlockNumber(1);
+        let tx = create_l2_transaction(10, 200);
+        let tx_hash = tx.hash();
+        let tx_results = vec![mock_execute_transaction(tx.into())];
+
+        store_l2_block(&mut storage, l2_block_number, &tx_results).await?;
+        seal_l1_batch(&mut storage, l1_batch_number).await?;
+
+        let log = UserL2ToL1Log(L2ToL1Log {
+            shard_id: 0,
+            is_service: false,
+            tx_number_in_block: 0,
+            sender: L1_MESSENGER_ADDRESS,
+            key: H256::from_low_u64_be(11),
+            value: H256::from_low_u64_be(19),
+        });
+        let logs = vec![(
+            IncludedTxLocation {
+                tx_hash,
+                tx_index_in_l2_block: 0,
+            },
+            vec![&log],
+        )];
+        storage
+            .events_dal()
+            .save_user_l2_to_l1_logs(l2_block_number, &logs)
+            .await?;
+
+        sqlx::query(
+            r#"
+            UPDATE l1_batches
+            SET aggregation_root = NULL
+            WHERE number = $1
+            "#,
+        )
+        .bind(i64::from(l1_batch_number.0))
+        .execute(storage.conn())
+        .await?;
+        drop(storage);
+
+        let err = client
+            .get_l2_to_l1_log_proof(tx_hash, Some(0), Some(InteropMode::ProofBasedGateway))
+            .await
+            .unwrap_err();
+        assert_matches!(
+            err,
+            ClientError::Call(err)
+                if err.code() == ErrorCode::InternalError.code()
+                    && err.message().contains("Internal error")
+        );
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn getting_l2_to_l1_log_proof_without_aggregation_root() {
+    test_http_server(L2ToL1LogProofWithoutAggregationRootTest).await;
 }
 
 #[derive(Debug)]

--- a/core/node/api_server/src/web3/tests/mod.rs
+++ b/core/node/api_server/src/web3/tests/mod.rs
@@ -27,7 +27,7 @@ use zksync_types::l2_to_l1_log::{L2ToL1Log, UserL2ToL1Log};
 use zksync_types::{
     aggregated_operations::L1BatchAggregatedActionType,
     api,
-    api::{BlockNumber, BlockStatus, InteropMode, TransactionStatus},
+    api::{BlockNumber, BlockStatus, TransactionStatus},
     block::{pack_block_info, L2BlockHasher, L2BlockHeader, UnsealedL1BatchHeader},
     bytecode::{
         testonly::{PADDED_EVM_BYTECODE, PROCESSED_EVM_BYTECODE},
@@ -1489,6 +1489,10 @@ impl HttpTest for L2ToL1LogProofWithoutAggregationRootTest {
             .events_dal()
             .save_user_l2_to_l1_logs(l2_block_number, &logs)
             .await?;
+        storage
+            .transactions_dal()
+            .mark_txs_as_executed_in_l1_batch(l1_batch_number, &[tx_hash])
+            .await?;
 
         sqlx::query(
             r#"
@@ -1503,7 +1507,7 @@ impl HttpTest for L2ToL1LogProofWithoutAggregationRootTest {
         drop(storage);
 
         let err = client
-            .get_l2_to_l1_log_proof(tx_hash, Some(0), Some(InteropMode::ProofBasedGateway))
+            .get_l2_to_l1_log_proof(tx_hash, Some(0), None)
             .await
             .unwrap_err();
         assert_matches!(


### PR DESCRIPTION
## What ❔

This PR replaces the post-gateway `aggregation_root` `expect()` in `zks_getL2ToL1LogProof` with contextual error propagation.

- Pre-gateway proofs stay unchanged.
- Post-gateway proofs with a present `aggregation_root` stay unchanged.
- Only the missing-field path changes, from panic to structured internal failure.
- Added a regression test that clears `aggregation_root` in a sealed batch and asserts the RPC call now fails as an internal error.

## Why ❔

`aggregation_root` is optional in storage, so the API path can legitimately observe batch metadata that exists but still lacks that post-gateway-only field.

The post-gateway proof branch still used `expect()` for `aggregation_root`. That made a DB-representable state crash the RPC path instead of returning a structured internal error. The regression test also needed one fixture correction: the transaction must be marked as executed in the L1 batch before the proof lookup, otherwise the test exits earlier with `Ok(None)` and never reaches the guarded branch.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

No operational changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.

Validation run locally:
- `cargo fmt --manifest-path core/Cargo.toml --all`
- `cargo check -p zksync_node_api_server --lib --message-format short`
- `cargo test -p zksync_node_api_server web3::tests::getting_l2_to_l1_log_proof_without_aggregation_root -- --exact --nocapture`