### PR TITLE
fix(api): handle NULL protocol_version when replaying batch for traces

### DIFF
--- a/core/node/api_server/src/web3/namespaces/debug.rs
+++ b/core/node/api_server/src/web3/namespaces/debug.rs
@@ -413,21 +413,32 @@ impl DebugNamespace {
             .await
             .context("failed to create L1BatchParamsProvider")?;
 
-        let Some(RestoredL1BatchEnv {
-            l1_batch_env,
-            system_env,
-            pubdata_params,
-            ..
-        }) = l1_batch_params_provider
-            .load_l1_batch_env(&mut connection, l1_batch_number, u32::MAX, chain_id)
+        let Some(mut first_l2_block) = l1_batch_params_provider
+            .load_first_l2_block_in_batch(&mut connection, l1_batch_number)
             .await
-            .context("failed to load L1 batch env")?
+            .context("failed to load first L2 block of L1 batch")?
         else {
             return Err(anyhow::anyhow!(
                 "L1 batch #{l1_batch_number} not found in storage while replaying trace"
             )
             .into());
         };
+
+        // Historical L2 blocks may have a NULL `protocol_version` in the `miniblocks` table (e.g.
+        // blocks predating protocol versioning).
+        if !first_l2_block.has_protocol_version() {
+            first_l2_block.set_protocol_version(protocol_version);
+        }
+
+        let RestoredL1BatchEnv {
+            l1_batch_env,
+            system_env,
+            pubdata_params,
+            ..
+        } = l1_batch_params_provider
+            .load_l1_batch_params(&mut connection, &first_l2_block, u32::MAX, chain_id)
+            .await
+            .context("failed to load L1 batch env")?;
 
         let l2_blocks = connection
             .transactions_dal()


### PR DESCRIPTION
## What

Fixes a failure in the call-trace replay path added in #4816. `debug_traceBlockByNumber` (and `debug_traceTransaction`) error out for historical L2 blocks whose `miniblocks.protocol_version` is NULL:

```
ERROR zksync_node_api_server::web3::metrics: Internal error in method `debug_traceBlockByNumber`:
failed to load L1 batch env: failed loading params for L1 batch #1:
`protocol_version` must be set for L2 block
```

## Why

When stored `call_traces` are missing for a block (common for old blocks where L1 priority-tx traces were never persisted), the handler falls back to replaying the L1 batch. The replay metadata (`get_l2_block_replay_metadata` / `get_tx_trace_metadata`) already resolves a usable protocol version, falling back to `ProtocolVersionId::last_potentially_undefined()` when the column is NULL — the convention used throughout the DAL.

But `replay_l1_batch` discarded that resolved value: it called the combined `load_l1_batch_env`, which re-reads `protocol_version` straight from the L2 block header with **no** fallback and bails when it's NULL. NULL `protocol_version` is normal for early blocks (e.g. batch #1) on nodes whose history predates protocol versioning.

## Fix

Switch `replay_l1_batch` to the two-step `load_first_l2_block_in_batch` → `set_protocol_version` → `load_l1_batch_params` flow — the exact pattern `ExternalIO` already uses for this case ([external_io.rs](https://github.com/matter-labs/zksync-era/blob/main/core/node/node_sync/src/external_io.rs#L220-L245)). The already-resolved version is applied only when the header lacks one (via the existing `has_protocol_version()` / `set_protocol_version()` helpers).

- Fixes both `debug_traceBlockByNumber` and `debug_traceTransaction` (both funnel through `replay_l1_batch`).
- Fully localized to the API namespace; the strict fail-fast behavior of other `load_l1_batch_env` callers (state keeper, vm_runner, airbender) is untouched.

`cargo check -p zksync_node_api_server` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)