### PR TITLE
docs: docs mismatch review draft-v31

### DIFF
--- a/docs/src/guides/advanced/11_compression.md
+++ b/docs/src/guides/advanced/11_compression.md
@@ -72,7 +72,7 @@ validation, and compressing it.
 
 For bytecode to be considered valid it must satisfy the following:
 
-1. Bytecode length must be less than 2097120 ((2^16 - 1) \* 32) bytes.
+1. Bytecode length must be at most 2097120 ((2^16 - 1) \* 32) bytes
 2. Bytecode length must be a multiple of 32.
 3. Number of words cannot be even.
 

--- a/docs/src/specs/contracts/chain_management/admin_role.md
+++ b/docs/src/specs/contracts/chain_management/admin_role.md
@@ -20,7 +20,7 @@ Generally all the functionality of chain admin should be treated with maximal se
 
 ### Setting validators for a chain
 
-The admin of a chain can call `ValidatorTimelock` on the settlement layer to add or remove validators, i.e. addresses that have the right to `commit`/`verify`/`execute` batches etc.
+The admin of a chain can call `ValidatorTimelock` on the settlement layer to add or remove validators via  `addValidator`/`removeValidator` (which grant/revoke all six per-chain roles at once), or assign individual roles granularly via `addValidatorRoles`/`removeValidatorRoles` i.e. for an addresses to have the right to commit/verify/execute batches.
 
 The system is protected against malicious validators, they can never steal funds from users. However, this role is still relatively powerful: If the DA layer is not reliable, and a batch does get executed, the funds may be frozen. This is why the chains should be [cautious about DA layers that they use](#setting-da-layer). Note, that on L1 the `ValidatorTimelock` has 3h delay, while on Gateway this timelock will not be present.
 

--- a/docs/src/specs/contracts/chain_management/bridgehub.md
+++ b/docs/src/specs/contracts/chain_management/bridgehub.md
@@ -15,7 +15,7 @@ Note sure what CTM is? Check our the [overview](./chain_type_manager.md).
 
 > This document will not cover how ZK Gateway works, you can check it out in [a separate doc](../gateway/overview.md). 
 
-The Bridgehub is the contract where new chains can [register](./chain_genesis.md). The Bridgehub also serves as an AssetHandler for chains when migrating chains between settlement layers, read more about it [here](../gateway/chain_migration.md).
+The Bridgehub is the contract where new chains can [register](./chain_genesis.md). Chain migration between settlement layers is handled by dedicated `ChainAssetHandler` contracts (`L1ChainAssetHandler` on L1, `L2ChainAssetHandler` as an L2 predeploy at `0x1000a`), not by the Bridgehub directly. The Bridgehub retains only helper hooks (`forwardedBridgeBurnSetSettlementLayer`, `forwardedBridgeMint`) gated `onlyChainAssetHandler`. Read more about chain migration [here](../gateway/chain_migration.md).
 
 Overall, it is the main registry for all the contracts. Note, that a clone of Bridgehub is also deployed on each L2 chain, it is used to start interop txs by checking that the chain is active. It is also used on settlement layers such as Gateway. All the in all, the architecture of the entire ecosystem can be seen below:
 

--- a/docs/src/specs/contracts/chain_management/bridgehub.md
+++ b/docs/src/specs/contracts/chain_management/bridgehub.md
@@ -15,7 +15,7 @@ Note sure what CTM is? Check our the [overview](./chain_type_manager.md).
 
 > This document will not cover how ZK Gateway works, you can check it out in [a separate doc](../gateway/overview.md). 
 
-The Bridgehub is the contract where new chains can [register](./chain_genesis.md). Chain migration between settlement layers is handled by dedicated `ChainAssetHandler` contracts (`L1ChainAssetHandler` on L1, `L2ChainAssetHandler` as an L2 predeploy at `0x1000a`), not by the Bridgehub directly. The Bridgehub retains only helper hooks (`forwardedBridgeBurnSetSettlementLayer`, `forwardedBridgeMint`) gated `onlyChainAssetHandler`. Read more about chain migration [here](../gateway/chain_migration.md).
+The Bridgehub is the contract where new chains can [register](./chain_genesis.md). Chain migration between settlement layers is handled by dedicated `ChainAssetHandler` contracts (`L1ChainAssetHandler` on L1, `L2ChainAssetHandler` as an L2 predeploy at `0x1000a`), not by the Bridgehub directly. The Bridgehub retains only helper hooks gated `onlyChainAssetHandler` (`forwardedBridgeBurnSetSettlementLayer`, `forwardedBridgeMint`, `forwardedBridgeConfirmTransferResult`, and `registerNewZKChain`). Read more about chain migration [here](../gateway/chain_migration.md).
 
 Overall, it is the main registry for all the contracts. Note, that a clone of Bridgehub is also deployed on each L2 chain, it is used to start interop txs by checking that the chain is active. It is also used on settlement layers such as Gateway. All the in all, the architecture of the entire ecosystem can be seen below:
 

--- a/docs/src/specs/contracts/chain_management/chain_type_manager.md
+++ b/docs/src/specs/contracts/chain_management/chain_type_manager.md
@@ -62,7 +62,7 @@ In the current release, each chain will be an instance of ZKsync Era and so the 
 
 In case of an emergency, the [security council](https://blog.zknation.io/introducing-zk-nation/) has the ability to freeze the ecosystem and conduct an emergency upgrade.
 
-In case we are aware that some of the committed batches on a chain are dangerous to be executed, the CTM can call `revertBatches` on that chain. This is performed by the CTM owner — the governance-controlled Protocol Upgrade Handler — typically as part of a freeze and emergency upgrade. This action does not lead to funds being lost, so it is considered suitable for the partially trusted role of the admin of the ChainTypeManager.
+In case we are aware that some of the committed batches on a chain are dangerous to be executed, the CTM can call `revertBatches` on that chain. This is performed by the CTM owner — the governance-controlled Protocol Upgrade Handler — typically as part of a freeze and emergency upgrade. This action does not lead to funds being lost.
 
 ### Issues & caveats
 

--- a/docs/src/specs/contracts/chain_management/chain_type_manager.md
+++ b/docs/src/specs/contracts/chain_management/chain_type_manager.md
@@ -62,7 +62,7 @@ In the current release, each chain will be an instance of ZKsync Era and so the 
 
 In case of an emergency, the [security council](https://blog.zknation.io/introducing-zk-nation/) has the ability to freeze the ecosystem and conduct an emergency upgrade.
 
-In case we are aware that some of the committed batches on a chain are dangerous to be executed, the CTM can call `revertBatches` on that chain. For faster reaction, the admin of the ChainTypeManager has the ability to do so without waiting for govenrnace approval that may take a lot of time. This action does not lead to funds being lost, so it is considered suitable for the partially trusted role of the admin of the ChainTypeManager.
+In case we are aware that some of the committed batches on a chain are dangerous to be executed, the CTM can call `revertBatches` on that chain. This is performed by the CTM owner — the governance-controlled Protocol Upgrade Handler — typically as part of a freeze and emergency upgrade. This action does not lead to funds being lost, so it is considered suitable for the partially trusted role of the admin of the ChainTypeManager.
 
 ### Issues & caveats
 

--- a/docs/src/specs/contracts/chain_management/chain_type_manager.md
+++ b/docs/src/specs/contracts/chain_management/chain_type_manager.md
@@ -62,7 +62,7 @@ In the current release, each chain will be an instance of ZKsync Era and so the 
 
 In case of an emergency, the [security council](https://blog.zknation.io/introducing-zk-nation/) has the ability to freeze the ecosystem and conduct an emergency upgrade.
 
-In case we are aware that some of the committed batches on a chain are dangerous to be executed, the CTM can call `revertBatches` on that chain. This is performed by the CTM owner — the governance-controlled Protocol Upgrade Handler — typically as part of a freeze and emergency upgrade. This action does not lead to funds being lost.
+In case we are aware that some of the committed batches on a chain are dangerous to be executed, the CTM can call `revertBatches` on that chain. This is performed by the CTM owner — the governance-controlled Protocol Upgrade Handler — typically as part of a freeze and emergency upgrade. This action does not lead to funds being lost. Note that reverting batches is not exclusive to the CTM: the underlying `revertBatchesSharedBridge` function on the chain is callable by both the CTM and the chain's validators (via the `REVERTER_ROLE` on the ValidatorTimelock), so a chain's operator can also revert its own not-yet-executed batches.
 
 ### Issues & caveats
 

--- a/docs/src/specs/contracts/chain_management/overview.md
+++ b/docs/src/specs/contracts/chain_management/overview.md
@@ -77,8 +77,7 @@ be able to leverage them when available).
   - `ChainTypeRegistry` The chain type is shared for multiple chains, so initialization and upgrades have to be the same for all
     chains. Registration is not permissionless but happens based on the registrations in the bridgehub’s `Registry`. At
     registration a `DiamondProxy` is deployed and initialized with the appropriate `Facets` for each ZK Chain.
-  - `Facets` and `Verifier` are shared across chains that relies on the same chain type: `Base`, `Executor` , `Getters`, `Admin`
-    , `Mailbox.`The `Verifier` is the contract that actually verifies the proof, and is called by the `Executor`.
+  - `Facets` and `Verifier` are shared across chains that use the same chain type. The chain diamond is initialized with `Admin`, `Getters`, `Mailbox`, `Committer`, `Executor`, and `Migrator` facets. `ZKChainBase` is an inherited base contract, not a diamond facet. The `Committer` handles batch precommit/commit logic, including L2 log processing and batch commitment creation. The `Executor` handles proving, executing, and reverting batches, and calls the `Verifier` during proof validation. The `Migrator` handles settlement-layer migration logic
   - Upgrade Mechanism The system requires all chains to be up-to-date with the latest implementation, so whenever an
     update is needed, we have to “force” each chain to update, but due to decentralization, we have to give each chain a
     time frame. This is done in the update mechanism contract, this is where the bootloader and system contracts are

--- a/docs/src/specs/contracts/gateway/chain_migration.md
+++ b/docs/src/specs/contracts/gateway/chain_migration.md
@@ -2,15 +2,15 @@
 
 ## Ecosystem Setup
 
-Chain migration reuses lots of logic from standard custom asset bridging which is enabled by the AssetRouter. The easiest way to imagine is that ZKChains are NFTs that are being migrated from one chain to another. Just like in case of the NFT contract, an CTM is assumed to have an `assetId := keccak256(abi.encode(L1_CHAIN_ID, address(ctmDeployer), bytes32(uint256(uint160(_ctmAddress)))))`. I.e. these are all assets with ADT = ctmDeployer contract on L1.
+Chain migration reuses lots of logic from standard custom asset bridging which is enabled by the AssetRouter. The easiest way to imagine is that ZKChains are NFTs that are being migrated from one chain to another. Just like in case of the NFT contract, an CTM is assumed to have an `assetId := keccak256(abi.encode(block.chainid, address(ctmDeploymentTracker), bytes32(uint256(uint160(_ctmAddress)))))`. I.e. these are all assets with ADT = ctmDeploymentTracker contract on L1.
 
-CTMDeployer is a very lightweight contract used to facilitate chain migration. Its main purpose is to serve as formal asset deployment tracker for CTMs. It serves two purposes:
+CTMDeploymentTracker is a very lightweight contract used to facilitate chain migration. Its main purpose is to serve as formal asset deployment tracker for CTMs. It serves two purposes:
 
-- Assign bridgehub as the asset handler for the “asset” of the CTM on the supported settlement layer.
+- Register the `ChainAssetHandler` (via `registerCTMAssetOnL1`) as the asset handler for the 'asset' of the CTM on the supported settlement layer.
 
-Currently, it can only be done by the owner of the CTMDeployer, but in the future, this method can become either permissionless or callable by the CTM owner.
+Currently, it can only be done by the owner of the CTMDeploymentTracker, but in the future, this method can become either permissionless or callable by the CTM owner.
 
-- Tell bridgehub which address on the L2 should serve as the L2 representation of the CTM on L1. Currently, it can only be done by the owner of the CTMDeployer, but in the future, this method can become callable by the CTM owner.
+- Tell bridgehub which address on the L2 should serve as the L2 representation of the CTM on L1. Currently, it can only be done by the owner of the CTMDeploymentTracker, but in the future, this method can become callable by the CTM owner.
 
 ![image.png](./img/ctm_gw_registration.png)
 

--- a/docs/src/specs/contracts/gateway/l2_gw_l1_messaging.md
+++ b/docs/src/specs/contracts/gateway/l2_gw_l1_messaging.md
@@ -109,10 +109,10 @@ If the settlement layer of the chain is the chain itself, we can just end here b
 
 If the chain is not a settlement layer of itself, we then need to calculate:
 
-- `BatchRootLeaf = keccak256(BATCH_LEAF_HASH_PADDING, SettledRootOfBatch, batch_number).`
+- `BatchRootLeaf = keccak256(BATCH_LEAF_PADDING, SettledRootOfBatch, batch_number).`
 - Consume one element from the `_proofs` array to get the mask for the merkle path of the batch leaf in the chain id tree.
 - Consume `batchLeafProofLen` elements to construct the `ChainIdRoot`
-- After that, we calculate the `chainIdLeaf = keccak256(CHAIN_ID_LEAF_PADDING, chainIdRoot, chainId`
+- After that, we calculate the `chainIdLeaf = keccak256(CHAIN_ID_LEAF_PADDING, chainIdRoot, chainId`)
 
 Now, we have the _supposed_ `chainIdRoot` for the chain inside its settlement layer. The only thing left to prove is that this root belonged to some batch of the settlement layer.
 

--- a/docs/src/specs/contracts/gateway/l2_gw_l1_messaging.md
+++ b/docs/src/specs/contracts/gateway/l2_gw_l1_messaging.md
@@ -30,11 +30,11 @@ The structure has the following recursive format:
 - `settledMessageRoot = keccak256(LocalRoot, AggregatedRoot)`
 - `LocalRoot` — the root of the binary merkle tree over `UserLog[]`. (the same as the one we have now). It only contains messages from the current batch.
 - `AggregatedRoot` — the root of the binary merkle tree over `ChainIdLeaf[]`.
-- `ChainIdLeaf = keccak256(CHAIN_ID_LEAF_PADDING, chain_id, ChainIdRoot`)
+- `ChainIdLeaf = keccak256(CHAIN_ID_LEAF_PADDING, ChainIdRoot, chain_id)`
 - `CHAIN_ID_LEAF_PADDING` — it is a constant padding, needed to ensure that the preimage of the ChainIdLeaf is larger than 64 bytes and so it can not be an internal node.
 - `chain_id` — the chain id of the chain the batches of which are aggregated.
 - `ChainIdRoot` = the root of the binary merkle tree `BatchRootLeaf[]`.
-- `BatchRootLeaf = keccak256(BATCH_LEAF_HASH_PADDING, batch_number, SettledRootOfBatch).`
+- `BatchRootLeaf = keccak256(BATCH_LEAF_PADDING, SettledRootOfBatch, batch_number).`
 
 In other words, we get the recursive structure, where for leaves of it, i.e. chains that do not aggregate any other chains, have empty `AggregatedRoot`.
 

--- a/docs/src/specs/contracts/gateway/l2_gw_l1_messaging.md
+++ b/docs/src/specs/contracts/gateway/l2_gw_l1_messaging.md
@@ -97,9 +97,13 @@ This function will be internally used by the existing `_proveL2LogInclusion` fun
 
 We want to avoid breaking changes to SDKs, so we will modify the `zks_getL2ToL1LogProof` to return the data in the following format (the results of it are directly passed into the `proveL2LeafInclusion` method, so returned value must be supported by the contract):
 
-First `bytes32` corresponds to the metadata of the proof. The zero-th byte should tell the version of the metadata and must be equal to the `SUPPORTED_PROOF_METADATA_VERSION` (a constant of `0x01`).
+The first `bytes32` element of the proof encodes the proof metadata, laid out byte by byte (byte 0 being the most significant):
 
-Then, it should contain the number of 32-byte words that are needed to restore the current `BatchRootLeaf` , i.e. `logLeafProofLen` (it is called this way as it proves that a leaf belongs to the `SettledRootOfBatch`). The second byte contains the `batchLeafProofLen` . It is the length of the merkle path to prove that the `BatchRootLeaf` belonged to the `ChainIdRoot` .
+- byte 0 — metadata version; must equal `SUPPORTED_PROOF_METADATA_VERSION` (a constant of `0x01`).
+- byte 1 — `logLeafProofLen`: the number of 32-byte words needed to restore the current `BatchRootLeaf` (named this way because it proves a leaf belongs to the `SettledRootOfBatch`).
+- byte 2 — `batchLeafProofLen`: the length of the Merkle path proving that the `BatchRootLeaf` belongs to the `ChainIdRoot`.
+- byte 3 — `finalProofNode`: whether this proof is the last link in the chain of recursive settlement-layer proofs.
+- bytes 4–31 — zero.
 
 Then, the following happens:
 
@@ -178,7 +182,7 @@ In order to ease the server migration, we support legacy format of L2→L1 logs 
 
 To differentiate between legacy format and the one, the following approach is used;
 
-- Except for the first 3 bytes the first word in the new format contains 0s, which is unlikely in the old format, where leaves are hashed.
-- I.e. if the last 29 bytes are zeroes, then it is assumed to be the new format and vice versa.
+- Except for the first 4 bytes the first word in the new format contains 0s, which is unlikely in the old format, where leaves are hashed.
+- I.e. if the last 28 bytes are zeroes, then it is assumed to be the new format and vice versa.
 
 In the next release the old format will be removed.

--- a/docs/src/specs/contracts/settlement_contracts/data_availability/custom_da.md
+++ b/docs/src/specs/contracts/settlement_contracts/data_availability/custom_da.md
@@ -65,4 +65,4 @@ This allows for a general-purpose solution that ensures DA consistency and verif
    - `L2_DA_VALIDATOR_OUTPUT_HASH_KEY` (the commitment) 
 
 4. L1 verification  
-	On L1 the Executor facet will call L1 DA validator, providing it with chain ID and batch number of the chain for which the DA must be verified, along with `l2DAValidatorOutputHash`, `operatorDAInput` and `_maxBlobsSupported` value. It's then L1 DA Validator job to verify the correctness of the DA on L1.
+	On L1 the Committer facet calls the L1 DA validator during batch commitment, providing it with chain ID and batch number of the chain for which the DA must be verified, along with `l2DAValidatorOutputHash`, `operatorDAInput` and `_maxBlobsSupported` value. It's then L1 DA Validator job to verify the correctness of the DA on L1.

--- a/docs/src/specs/contracts/settlement_contracts/data_availability/pubdata.md
+++ b/docs/src/specs/contracts/settlement_contracts/data_availability/pubdata.md
@@ -194,7 +194,7 @@ all concatenated together to yield the final compressed version.
 
 For bytecode to be considered valid it must satisfy the following:
 
-1. Bytecode length must be less than 2097120 ((2^16 - 1) \* 32) bytes.
+1. Bytecode length must be at most 2097120 ((2^16 - 1) \* 32) bytes
 2. Bytecode length must be a multiple of 32.
 3. Number of 32-byte words cannot be even.
 

--- a/docs/src/specs/contracts/settlement_contracts/data_availability/pubdata.md
+++ b/docs/src/specs/contracts/settlement_contracts/data_availability/pubdata.md
@@ -13,8 +13,8 @@ pre-Boojum system these are represented as separate fields while for boojum they
 array. Once 4844 gets integrated this bytes array will move from being part of the calldata to blob data.
 
 While the structure of the pubdata changes, the way in which one can go about pulling the information will remain the
-same. Basically, we just need to filter all of the transactions to the L1 ZKsync contract for only the `commitBatches`
-transactions where the proposed block has been referenced by a corresponding `executeBatches` call (the reason for this
+same. Basically, we just need to filter all of the transactions to the L1 ZKsync contract for only the `commitBatchesSharedBridge`
+transactions where the proposed block has been referenced by a corresponding `executeBatchesSharedBridge` call (the reason for this
 is that a committed or even proven block can be reverted but an executed one cannot). Once we have all the committed
 batches that have been executed, we then will pull the transaction input and the relevant fields, applying them in order
 to reconstruct the current state of L2.
@@ -65,7 +65,7 @@ natively by VM _system_ logs. Here is a short comparison table for better unders
 | Emitted by VM via an opcode.                                                                                    | VM knows nothing about them.                                                                                                                                                                                                        |
 | Consistency and correctness is enforced by the verifier on L1 (i.e. their hash is part of the block commitment. | Consistency and correctness is enforced by the L1Messenger system contract. The correctness of the behavior of the L1Messenger is enforced implicitly by prover in a sense that it proves the correctness of the execution overall. |
 | We don’t calculate their Merkle root.                                                                           | We calculate their Merkle root on the L1Messenger system contract.                                                                                                                                                                  |
-| We have constant small number of those.                                                                         | We can have as much as possible as long as the commitBatches function on L1 remains executable (it is the job of the operator to ensure that only such transactions are selected)                                                   |
+| We have constant small number of those.                                                                         | We can have as much as possible as long as the commitBatchesSharedBridge function on L1 remains executable (it is the job of the operator to ensure that only such transactions are selected)                                                   |
 | In EIP4844 they will remain part of the calldata.                                                               | In EIP4844 they will become part of the blobs.                                                                                                                                                                                      |
 
 #### Backwards-compatibility
@@ -429,7 +429,7 @@ With Boojum, the interface for committing batches is the following one:
 /// @param bootloaderHeapInitialContentsHash Hash of the initial contents of the bootloader heap. In practice it serves as the commitment to the transactions in the batch.
 /// @param eventsQueueStateHash Hash of the events queue state. In practice it serves as the commitment to the events in the batch.
 /// @param systemLogs concatenation of all L2 -> L1 system logs in the batch
-/// @param totalL2ToL1Pubdata Total pubdata committed to as part of bootloader run. Contents are: l2Tol1Logs <> l2Tol1Messages <> publishedBytecodes <> stateDiffs
+/// @param operatorDAInput The data-availability input provided by the operator, processed by the L1DAValidator. Its contents depend on the DA mode (for rollups: the state-diff hash, the pubdata, and blob commitment data).
 struct CommitBatchInfo {
   uint64 batchNumber;
   uint64 timestamp;
@@ -440,7 +440,7 @@ struct CommitBatchInfo {
   bytes32 bootloaderHeapInitialContentsHash;
   bytes32 eventsQueueStateHash;
   bytes systemLogs;
-  bytes totalL2ToL1Pubdata;
+  bytes operatorDAInput;
 }
 
 ```

--- a/docs/src/specs/contracts/settlement_contracts/data_availability/standard_pubdata_format.md
+++ b/docs/src/specs/contracts/settlement_contracts/data_availability/standard_pubdata_format.md
@@ -291,6 +291,6 @@ struct CommitBatchInfo {
   bytes32 bootloaderHeapInitialContentsHash;
   bytes32 eventsQueueStateHash;
   bytes systemLogs;
-  bytes operatorDAInput;;
+  bytes operatorDAInput;
 }
 ```

--- a/docs/src/specs/contracts/settlement_contracts/data_availability/standard_pubdata_format.md
+++ b/docs/src/specs/contracts/settlement_contracts/data_availability/standard_pubdata_format.md
@@ -11,7 +11,7 @@ Pubdata in ZKsync can be divided up into 4 categories:
 3. Smart Contract Bytecodes  
 4. Storage Writes  
 
-Using data corresponding to these 4 facets across all executed batches, we’re able to reconstruct the full state of L2. To restore the state we just need to filter all of the transactions to the L1 ZKsync contract for only the `commitBatches` transactions where the proposed block has been referenced by a corresponding `executeBatches` call (the reason for this is that a committed or even proven block can be reverted but an executed one cannot). Once we have all the committed batches that have been executed, we will then pull the transaction input and the relevant fields, applying them in order to reconstruct the current state of L2.
+Using data corresponding to these 4 facets across all executed batches, we’re able to reconstruct the full state of L2. To restore the state we just need to filter all of the transactions to the L1 ZKsync contract for only the `commitBatchesSharedBridge` transactions where the proposed block has been referenced by a corresponding `executeBatchesSharedBridge` call (the reason for this is that a committed or even proven block can be reverted but an executed one cannot). Once we have all the committed batches that have been executed, we will then pull the transaction input and the relevant fields, applying them in order to reconstruct the current state of L2.
 
 ## L2→L1 communication
 
@@ -24,7 +24,7 @@ We will now refer to the logs that are created by users and Merklized as _user_ 
 | Emitted by VM via an opcode.                                                                                    | VM knows nothing about them.                                                                                                                                                                                                        |
 | Consistency and correctness are enforced by the verifier on L1 (i.e. their hash is part of the block commitment). | Consistency and correctness is enforced by the L1Messenger system contract. The correctness of the behavior of the L1Messenger is enforced implicitly by the prover in the sense that it proves the correctness of the execution overall. |
 | We don’t calculate their Merkle root.                                                                           | We calculate their Merkle root on the L1Messenger system contract.                                                                                                                                                                  |
-| There is a constant small number of these logs.                                                                 | We can have as many as possible as long as the commitBatches function on L1 remains executable (it is the job of the operator to ensure that only such transactions are selected).                                                   |
+| There is a constant small number of these logs.                                                                 | We can have as many as possible as long as the commitBatchesSharedBridge function on L1 remains executable (it is the job of the operator to ensure that only such transactions are selected).                                                   |
 | In EIP-4844 they will remain part of the calldata.                                                              | In EIP-4844 they will become part of the blobs.                                                                                                                                                                                     |
 
 ### Backwards-compatibility
@@ -280,7 +280,7 @@ The interface for committing batches is the following:
 /// @param bootloaderHeapInitialContentsHash Hash of the initial contents of the bootloader heap. In practice it serves as the commitment to the transactions in the batch.
 /// @param eventsQueueStateHash Hash of the events queue state. In practice it serves as the commitment to the events in the batch.
 /// @param systemLogs Concatenation of all L2→L1 system logs in the batch
-/// @param totalL2ToL1Pubdata Total pubdata committed to as part of bootloader run. Contents are: l2Tol1Logs <> l2Tol1Messages <> publishedBytecodes <> stateDiffs
+/// @param operatorDAInput The data-availability input provided by the operator, processed by the L1DAValidator. Its contents depend on the DA mode (for rollups: the state-diff hash, the pubdata, and blob commitment data).
 struct CommitBatchInfo {
   uint64 batchNumber;
   uint64 timestamp;
@@ -291,6 +291,6 @@ struct CommitBatchInfo {
   bytes32 bootloaderHeapInitialContentsHash;
   bytes32 eventsQueueStateHash;
   bytes systemLogs;
-  bytes totalL2ToL1Pubdata;
+  bytes operatorDAInput;;
 }
 ```

--- a/docs/src/specs/contracts/settlement_contracts/data_availability/standard_pubdata_format.md
+++ b/docs/src/specs/contracts/settlement_contracts/data_availability/standard_pubdata_format.md
@@ -126,7 +126,7 @@ Each 8-byte word from the chunked bytecode is assigned a 2-byte index (constrain
 
 For bytecode to be considered valid, it must satisfy the following:
 
-1. Bytecode length must be less than 2097120 ((2^16 – 1) * 32) bytes.  
+1. Bytecode length must be at most 2097120 ((2^16 - 1) \* 32) bytes 
 2. Bytecode length must be a multiple of 32.  
 3. Number of 32-byte words cannot be even.  
 

--- a/docs/src/specs/contracts/settlement_contracts/data_availability/standard_pubdata_format.md
+++ b/docs/src/specs/contracts/settlement_contracts/data_availability/standard_pubdata_format.md
@@ -244,7 +244,7 @@ Note that values like `initial_value`, `address`, and `key` are not used in the 
 #### **L1**
 
 1. During block commitment, the standard DA protocol follows and the `L1DAValidator` is responsible for checking that the operator has provided the preimage for the `_totalPubdata`. More on how this is checked can be seen [here](./rollup_da.md).  
-2. The block commitment [includes](https://github.com/matter-labs/era-contracts/blob/b43cf6b3b069c85aec3cd61d33dd3ae2c462c896/l1-contracts/contracts/state-transition/chain-deps/facets/Executor.sol#L550) _the hash of the `stateDiffs`_. Thus, ZKP verification will fail if the provided stateDiffs hash is not correct.  
+2. The block commitment [includes](https://github.com/matter-labs/era-contracts/blob/fdb60be1a49f5f0a371fc24b747cf5bdea1b1f74/l1-contracts/contracts/state-transition/chain-deps/facets/Committer.sol#L367-L373) _the hash of the `stateDiffs`_. Thus, ZKP verification will fail if the provided stateDiffs hash is not correct.  
 
 It is a secure construction because the proof can be verified only if both the execution was correct and the hash of the `stateDiffs` is correct. This means that the `L2DAValidator` library indeed received the array of correct `stateDiffs` and, assuming the `L2DAValidator` is working correctly, double-checked that the compression is in the correct format, while L1 contracts at the commit stage double-checked that the operator provided the preimage for the compressed state diffs.
 

--- a/docs/src/specs/contracts/settlement_contracts/priority_queue/l1_l2_communication/l1_to_l2.md
+++ b/docs/src/specs/contracts/settlement_contracts/priority_queue/l1_l2_communication/l1_to_l2.md
@@ -17,12 +17,7 @@ between system and user logs.
 
 ### Initiation
 
-A new priority operation can be appended by calling the
-[requestL2Transaction](https://github.com/code-423n4/2023-10-zksync/blob/ef99273a8fdb19f5912ca38ba46d6bd02071363d/code/contracts/ethereum/contracts/zksync/facets/Mailbox.sol#L236)
-method on L1. This method will perform several checks for the transaction, making sure that it is processable and
-provides enough fee to compensate the operator for this transaction. Then, this transaction will be
-[appended](https://github.com/code-423n4/2023-10-zksync/blob/ef99273a8fdb19f5912ca38ba46d6bd02071363d/code/contracts/ethereum/contracts/zksync/facets/Mailbox.sol#L369C1-L369C1)
-to the priority queue.
+A new priority operation is submitted by calling [`Bridgehub.requestL2TransactionDirect`](https://github.com/matter-labs/era-contracts/blob/draft-v31/l1-contracts/contracts/core/bridgehub/L1Bridgehub.sol#L152) or [`Bridgehub.requestL2TransactionTwoBridges`](https://github.com/matter-labs/era-contracts/blob/draft-v31/l1-contracts/contracts/core/bridgehub/L1Bridgehub.sol#L206) on L1. These route through to [`Mailbox.bridgehubRequestL2Transaction`](https://github.com/matter-labs/era-contracts/blob/draft-v31/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol#L126) (gated `onlyBridgehub`), which performs several checks on the transaction (processability, sufficient fee) and appends it to the priority tree. Service transactions can be submitted via [`requestL2ServiceTransaction`](https://github.com/matter-labs/era-contracts/blob/draft-v31/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol#L400). The legacy `requestL2Transaction` method still exists on the Mailbox as an Era-only shim and is marked for removal.
 
 ### Bootloader
 

--- a/docs/src/specs/contracts/settlement_contracts/priority_queue/l1_l2_communication/l2_to_l1.md
+++ b/docs/src/specs/contracts/settlement_contracts/priority_queue/l1_l2_communication/l2_to_l1.md
@@ -29,7 +29,7 @@ Where:
 - `key` and `value` are just two 32-byte values that could be used to carry some data with the log.
 
 The hashed array of these opcodes is then included into the
-[batch commitment](https://github.com/matter-labs/era-contracts/blob/main/l1-contracts/contracts/state-transition/chain-deps/facets/Executor.sol#L663).
+[batch commitment](https://github.com/matter-labs/era-contracts/blob/fdb60be1a49f5f0a371fc24b747cf5bdea1b1f74/l1-contracts/contracts/state-transition/chain-deps/facets/Committer.sol#L791-L797).
 Because of that we know that if the proof verifies, then the L2→L1 logs provided by the operator were correct, so we can
 use that fact to produce more complex structures. Before Boojum such logs were also Merklized within the circuits and so
 the Merkle tree’s root hash was included into the batch commitment also.

--- a/docs/src/specs/contracts/settlement_contracts/priority_queue/priority-queue.md
+++ b/docs/src/specs/contracts/settlement_contracts/priority_queue/priority-queue.md
@@ -2,46 +2,20 @@
 
 ## Overview of the current implementation
 
-The priority tree is the live mechanism for handling L1→L2 priority operations. `Mailbox._writePriorityOpHash` appends each new priority op into `s.priorityTree` (an incremental Merkle tree), and batch execution verifies priority ops via Merkle proofs (`s.riorityTree.processBatch`) over `PriorityOpsBatchInfo` against historical roots.
-
-### Inserting new operations
-
-The queue is implemented as a [library](https://github.com/matter-labs/era-contracts/blob/b43cf6b3b069c85aec3cd61d33dd3ae2c462c896/l1-contracts/contracts/state-transition/libraries/PriorityQueue.sol#L22).
-For each incoming priority operation, we simply `pushBack` its hash, expiration and layer2Tip.
-
-### Checking validity
-
-When a new batch is executed, we need to check that operations that were executed there match the operations in the priority queue. The batch header contains `numberOfLayer1Txs` and `priorityOperationsHash` which is a rolling hash of all priority operations that were executed in the batch. Bootloader check that this hash indeed corresponds to all priority operations that have been executed in that batch. The contract only checks that this hash matches the operations stored in the queue:
-
-```solidity
-/// @dev Pops the priority operations from the priority queue and returns a rolling hash of operations
-function _collectOperationsFromPriorityQueue(uint256 _nPriorityOps) internal returns (bytes32 concatHash) {
-    concatHash = EMPTY_STRING_KECCAK;
-
-    for (uint256 i = 0; i < _nPriorityOps; i = i.uncheckedInc()) {
-        PriorityOperation memory priorityOp = s.priorityQueue.popFront();
-        concatHash = keccak256(abi.encode(concatHash, priorityOp.canonicalTxHash));
-    }
-}
-
-bytes32 priorityOperationsHash = _collectOperationsFromPriorityQueue(_storedBatch.numberOfLayer1Txs);
-require(priorityOperationsHash == _storedBatch.priorityOperationsHash); // priority operations hash does not match to expected
-```
-
-As can be seen, this is done in `O(n)` compute, where `n` is the number of priority operations in the batch.
+The priority tree is the live mechanism for handling L1→L2 priority operations. `Mailbox._writePriorityOpHash` appends each new priority op into `s.priorityTree` (an incremental Merkle tree), and batch execution verifies priority ops via Merkle proofs (`s.priorityTree.processBatch`) over `PriorityOpsBatchInfo` against historical roots.
 
 ## Motivation for migration to Merkle Tree
 
-Since we will be introducing Gateway, we will need to support one more operation:
+Gateway was introduced, requiring support for one more operation:
 
 - migrating priority queue from L1 to Gateway (and back)
 
 Current implementation takes `O(n)` space and is vulnerable to spam attacks during migration
 (e.g. an attacker can insert a lot of priority operations and we won't be able to migrate all of them due to gas limits).
 
-Hence, we need an implementation with a small (constant- or log-size) space imprint that we can migrate to Gateway and back that would still allow us to perform the other 2 operations.
+Hence, we required an implementation with a small (constant- or log-size) space imprint that could be migrated to Gateway and back that would still allow us to perform the other 2 operations.
 
-Merkle tree of priority operations is perfect for this since we can simply migrate the latest root hash to Gateway and back.
+Merkle tree of priority operations is perfect for this since the latest root hash can simply be migrated to Gateway and back.
 
 - It can still efficiently (in `O(height)`) insert new operations.
 - It can also still efficiently (in `O(n)` compute and `O(n + height)` calldata) check that the batch’s `priorityOperationsHash` corresponds to the operations from the queue.
@@ -53,7 +27,7 @@ The implementation details are described below.
 ### FAQ
 
 - Q: Why can't we just migrate the rolling hash of the operations in the existing priority queue?
-- A: The rolling hash is not enough to check that the operations from the executed batch are indeed from the priority queue. We would need to store all historical rolling hashes, which would be `O(n)` space and would not solve the spam attack problem.
+- A: The rolling hash is not enough to check that the operations from the executed batch are indeed from the priority queue. That would have required storing all historical rolling hashes, which would have been `O(n)` space and would have not solve the spam attack problem.
 
 ## Implementation
 
@@ -66,7 +40,7 @@ The implementation consists of two parts:
 
 On the contracts, the Merkle tree is implemented as an Incremental (append-only) Merkle Tree ([example implementation](https://github.com/tornadocash/tornado-core/blob/master/contracts/MerkleTreeWithHistory.sol)), meaning that it can efficiently (in `O(height)` compute) append new elements to the right, while only storing `O(height)` nodes at all times.
 
-It will also be dynamically sized, meaning that it will double in size when the current size is not enough to store the new element.
+It is also dynamically sized, meaning that it doubles in size when the current size is not enough to store the new element.
 
 ### Server
 
@@ -74,7 +48,7 @@ On the server, the Merkle tree is implemented as an extension of `MiniMerkleTree
 
 It has the following properties:
 
-- in-memory: the tree will be stored in memory and will be rebuilt on each restart (details below).
+- in-memory: the tree is stored in memory and is rebuilt on each restart (details below).
 - dynamically sized (to match the contracts implementation)
 - append-only (to match the contracts implementation)
 
@@ -88,10 +62,10 @@ Note: If even rebuilding it once becomes a problem, it can be easily mitigated b
 
 ### Caching
 
-**Why do we need caching?** After a batch is successfully executed, we will no longer need to have the ability to generate merkle paths for those operations. This means that we can save space and compute by only fully storing the operations that are not yet executed, and caching the leaves
+**Why do we need caching?** After a batch is successfully executed, we no longer need to have the ability to generate merkle paths for those operations. This means that we can save space and compute by only fully storing the operations that are not yet executed, and caching the leaves
 corresponding to the already executed operations.
 
-We will only cache some prefix of the tree, meaning nodes in the interval [0; N) where N is the number of executed priority operations. The cache will store the rightmost cached left-child node on each level of the tree (see diagrams).
+We only cache some prefix of the tree, meaning nodes in the interval [0; N) where N is the number of executed priority operations. The cache stores the rightmost cached left-child node on each level of the tree (see diagrams).
 
 ![Untitled](./img/PQ1.png)
 
@@ -99,7 +73,7 @@ We will only cache some prefix of the tree, meaning nodes in the interval [0; N)
 
 ![Untitled](./img/PQ3.png)
 
-This means that we are not be able to generate merkle proofs for the cached nodes (and since they are already executed, we don't need to). This structure allows us to save a lot of space, since it only takes up `O(height)` space instead of linear space for all executed operations. This is a big optimization since there are currently 3.2M total operations but <10 non-executed operations in the mainnet priority queue, which means most of the tree will be cached.
+This means that we are not be able to generate merkle proofs for the cached nodes (and since they are already executed, we don't need to). This structure allows us to save a lot of space, since it only takes up `O(height)` space instead of linear space for all executed operations. This is a big optimization since there are currently 3.2M total operations but <10 non-executed operations in the mainnet priority queue, which means most of the tree caches.
 
 This also means we don’t really have to store non-leaf nodes other than cache, since we can calculate merkle root / merkle paths in `O(n)` where `n` is the number of non-executed operations (and not total number of operations), and since `n` is so small, it is really fast.
 
@@ -107,15 +81,15 @@ This also means we don’t really have to store non-leaf nodes other than cache,
 
 On the contracts, appending a new operation to the tree is done by simply calling `append` on the Incremental Merkle Tree, which will update at most `height` slots. Actually, it works almost exactly like the cache described above. Once again: [tornado-cash implementation](https://github.com/tornadocash/tornado-core/blob/1ef6a263ac6a0e476d063fcb269a9df65a1bd56a/contracts/MerkleTreeWithHistory.sol#L68).
 
-On the server, `eth_watch` will listen for `NewPriorityRequest` events as it does now, and will append the new operation to the tree on the server.
+On the server, `eth_watch` listens for `NewPriorityRequest` events as it does now, and appends the new operation to the tree on the server.
 
 ### Checking validity
 
-To check that the executed batch indeed took its priority operations from the queue, we have to make sure that if we take first `numberOfL1Txs` non-executed operations from the tree, their rolling hash will match `priorityOperationsHash` . Since will not be storing the hashes of these operations onchain anymore, we provide them as calldata. Additionally in calldata, we should provide merkle proofs for the **first and last** operations in that batch (hence `O(n + height)` calldata). This will make it possible to prove onchain that that contiguous interval of hashes indeed exists in the merkle tree.
+To check that the executed batch indeed took its priority operations from the queue, we have to make sure that if we take first `numberOfL1Txs` non-executed operations from the tree, their rolling hash matches `priorityOperationsHash` . Since we don't store the hashes of these operations onchain anymore, we provide them as calldata. Additionally in calldata, we should provide merkle proofs for the **first and last** operations in that batch (hence `O(n + height)` calldata). This makes it possible to prove onchain that that contiguous interval of hashes indeed exists in the merkle tree.
 
-This can be done simply by constructing the part of the tree above this interval using the provided paths to first and last elements of the interval checking that computed merkle root matches with stored one (in `O(n)` where `n` is number of priority operations in a batch). We will also need to track the `index` of the first unexecuted operation onchain to properly calculate the merkle root and ensure that batches don’t execute some operations out of order or multiple times.
+This can be done simply by constructing the part of the tree above this interval using the provided paths to first and last elements of the interval checking that computed merkle root matches with stored one (in `O(n)` where `n` is number of priority operations in a batch). We also need to track the `index` of the first unexecuted operation onchain to properly calculate the merkle root and ensure that batches don’t execute some operations out of order or multiple times.
 
-We will also need to prove that the rolling hash of provided hashes matches with `priorityOperationsHash` which is also `O(n)`
+We also need to prove that the rolling hash of provided hashes matches with `priorityOperationsHash` which is also `O(n)`
 
 It is important to note that we store some number of historical root hashes, since the Merkle tree on the server might lag behind the contracts a bit, and hence merkle paths generated on the server-side might become invalid if we compare them to the latest root hash on the contracts. These historical root hashes are not necessary to migrate to and from Gateway though.
 

--- a/docs/src/specs/contracts/settlement_contracts/priority_queue/priority-queue.md
+++ b/docs/src/specs/contracts/settlement_contracts/priority_queue/priority-queue.md
@@ -1,6 +1,6 @@
-# Priority Queue to Merkle Tree
+# Priority Operations: Merkle Tree
 
-## Overview of the current implementation
+## Overview
 
 The priority tree is the live mechanism for handling L1→L2 priority operations. `Mailbox._writePriorityOpHash` appends each new priority op into `s.priorityTree` (an incremental Merkle tree), and batch execution verifies priority ops via Merkle proofs (`s.priorityTree.processBatch`) over `PriorityOpsBatchInfo` against historical roots.
 
@@ -11,7 +11,7 @@ Gateway was introduced, requiring support for one more operation:
 - migrating priority queue from L1 to Gateway (and back)
 
 Current implementation takes `O(n)` space and is vulnerable to spam attacks during migration
-(e.g. an attacker can insert a lot of priority operations and we won't be able to migrate all of them due to gas limits).
+(e.g. an attacker can insert a lot of priority operations and migration of all of them would have been impossible due to gas limits).
 
 Hence, we required an implementation with a small (constant- or log-size) space imprint that could be migrated to Gateway and back that would still allow us to perform the other 2 operations.
 
@@ -27,7 +27,7 @@ The implementation details are described below.
 ### FAQ
 
 - Q: Why can't we just migrate the rolling hash of the operations in the existing priority queue?
-- A: The rolling hash is not enough to check that the operations from the executed batch are indeed from the priority queue. That would have required storing all historical rolling hashes, which would have been `O(n)` space and would have not solve the spam attack problem.
+- A: The rolling hash is not enough to check that the operations from the executed batch are indeed from the priority queue. That would have required storing all historical rolling hashes, which would have been `O(n)` space and would not have solve the spam attack problem.
 
 ## Implementation
 
@@ -73,13 +73,13 @@ We only cache some prefix of the tree, meaning nodes in the interval [0; N) wher
 
 ![Untitled](./img/PQ3.png)
 
-This means that we are not be able to generate merkle proofs for the cached nodes (and since they are already executed, we don't need to). This structure allows us to save a lot of space, since it only takes up `O(height)` space instead of linear space for all executed operations. This is a big optimization since there are currently 3.2M total operations but <10 non-executed operations in the mainnet priority queue, which means most of the tree caches.
+This means that we are not able to generate merkle proofs for the cached nodes (and since they are already executed, we don't need to). This structure allows us to save a lot of space, since it only takes up `O(height)` space instead of linear space for all executed operations. This is a big optimization since there are currently 3.2M total operations but <10 non-executed operations in the mainnet priority queue, which means most of the tree is cached.
 
 This also means we don’t really have to store non-leaf nodes other than cache, since we can calculate merkle root / merkle paths in `O(n)` where `n` is the number of non-executed operations (and not total number of operations), and since `n` is so small, it is really fast.
 
 ### Adding new operations
 
-On the contracts, appending a new operation to the tree is done by simply calling `append` on the Incremental Merkle Tree, which will update at most `height` slots. Actually, it works almost exactly like the cache described above. Once again: [tornado-cash implementation](https://github.com/tornadocash/tornado-core/blob/1ef6a263ac6a0e476d063fcb269a9df65a1bd56a/contracts/MerkleTreeWithHistory.sol#L68).
+On the contracts, appending a new operation to the tree is done by simply calling `append` on the Incremental Merkle Tree, which updates at most `height` slots. Actually, it works almost exactly like the cache described above. Once again: [tornado-cash implementation](https://github.com/tornadocash/tornado-core/blob/1ef6a263ac6a0e476d063fcb269a9df65a1bd56a/contracts/MerkleTreeWithHistory.sol#L68).
 
 On the server, `eth_watch` listens for `NewPriorityRequest` events as it does now, and appends the new operation to the tree on the server.
 

--- a/docs/src/specs/contracts/settlement_contracts/priority_queue/priority-queue.md
+++ b/docs/src/specs/contracts/settlement_contracts/priority_queue/priority-queue.md
@@ -2,22 +2,7 @@
 
 ## Overview of the current implementation
 
-Priority queue is a data structure in Era contracts that is used to handle L1->L2 priority operations. It supports the following:
-
-- inserting a new operation into the end of the queue
-- checking that an newly executed batch executed some n first priority operations from the queue (and not some other ones) in correct order
-
-The queue itself only stores the following:
-
-```solidity
-struct PriorityOperation {
-  bytes32 canonicalTxHash;
-  uint64 expirationTimestamp;
-  uint192 layer2Tip;
-}
-```
-
-of which we only care about the canonical hash.
+The priority tree is the live mechanism for handling L1→L2 priority operations. `Mailbox._writePriorityOpHash` appends each new priority op into `s.priorityTree` (an incremental Merkle tree), and batch execution verifies priority ops via Merkle proofs (`s.riorityTree.processBatch`) over `PriorityOpsBatchInfo` against historical roots.
 
 ### Inserting new operations
 
@@ -72,22 +57,22 @@ The implementation details are described below.
 
 ## Implementation
 
-The implementation will consist of two parts:
+The implementation consists of two parts:
 
 - Merkle tree on L1 contracts, to replace the existing priority queue (while still supporting the existing operations)
 - Merkle tree off-chain on the server, to generate the merkle proofs for the executed priority operations.
 
 ### Contracts
 
-On the contracts, the Merkle tree will be implemented as an Incremental (append-only) Merkle Tree ([example implementation](https://github.com/tornadocash/tornado-core/blob/master/contracts/MerkleTreeWithHistory.sol)), meaning that it can efficiently (in `O(height)` compute) append new elements to the right, while only storing `O(height)` nodes at all times.
+On the contracts, the Merkle tree is implemented as an Incremental (append-only) Merkle Tree ([example implementation](https://github.com/tornadocash/tornado-core/blob/master/contracts/MerkleTreeWithHistory.sol)), meaning that it can efficiently (in `O(height)` compute) append new elements to the right, while only storing `O(height)` nodes at all times.
 
 It will also be dynamically sized, meaning that it will double in size when the current size is not enough to store the new element.
 
 ### Server
 
-On the server, the Merkle tree will be implemented as an extension of `MiniMerkleTree` currently used for L2->L1 logs.
+On the server, the Merkle tree is implemented as an extension of `MiniMerkleTree` currently used for L2->L1 logs.
 
-It will have the following properties:
+It has the following properties:
 
 - in-memory: the tree will be stored in memory and will be rebuilt on each restart (details below).
 - dynamically sized (to match the contracts implementation)
@@ -114,7 +99,7 @@ We will only cache some prefix of the tree, meaning nodes in the interval [0; N)
 
 ![Untitled](./img/PQ3.png)
 
-This means that we will not be able to generate merkle proofs for the cached nodes (and since they are already executed, we don't need to). This structure allows us to save a lot of space, since it only takes up `O(height)` space instead of linear space for all executed operations. This is a big optimization since there are currently 3.2M total operations but <10 non-executed operations in the mainnet priority queue, which means most of the tree will be cached.
+This means that we are not be able to generate merkle proofs for the cached nodes (and since they are already executed, we don't need to). This structure allows us to save a lot of space, since it only takes up `O(height)` space instead of linear space for all executed operations. This is a big optimization since there are currently 3.2M total operations but <10 non-executed operations in the mainnet priority queue, which means most of the tree will be cached.
 
 This also means we don’t really have to store non-leaf nodes other than cache, since we can calculate merkle root / merkle paths in `O(n)` where `n` is the number of non-executed operations (and not total number of operations), and since `n` is so small, it is really fast.
 
@@ -122,14 +107,19 @@ This also means we don’t really have to store non-leaf nodes other than cache,
 
 On the contracts, appending a new operation to the tree is done by simply calling `append` on the Incremental Merkle Tree, which will update at most `height` slots. Actually, it works almost exactly like the cache described above. Once again: [tornado-cash implementation](https://github.com/tornadocash/tornado-core/blob/1ef6a263ac6a0e476d063fcb269a9df65a1bd56a/contracts/MerkleTreeWithHistory.sol#L68).
 
-On the server, `eth_watch` will listen for `NewPriorityOperation` events as it does now, and will append the new operation to the tree on the server.
+On the server, `eth_watch` will listen for `NewPriorityRequest` events as it does now, and will append the new operation to the tree on the server.
 
 ### Checking validity
 
-To check that the executed batch indeed took its priority operations from the queue, we have to make sure that if we take first `numberOfL1Txs` non-executed operations from the tree, their rolling hash will match `priorityOperationsHash` . Since will not be storing the hashes of these operations onchain anymore, we will have to provide them as calldata. Additionally in calldata, we should provide merkle proofs for the **first and last** operations in that batch (hence `O(n + height)` calldata). This will make it possible to prove onchain that that contiguous interval of hashes indeed exists in the merkle tree.
+To check that the executed batch indeed took its priority operations from the queue, we have to make sure that if we take first `numberOfL1Txs` non-executed operations from the tree, their rolling hash will match `priorityOperationsHash` . Since will not be storing the hashes of these operations onchain anymore, we provide them as calldata. Additionally in calldata, we should provide merkle proofs for the **first and last** operations in that batch (hence `O(n + height)` calldata). This will make it possible to prove onchain that that contiguous interval of hashes indeed exists in the merkle tree.
 
 This can be done simply by constructing the part of the tree above this interval using the provided paths to first and last elements of the interval checking that computed merkle root matches with stored one (in `O(n)` where `n` is number of priority operations in a batch). We will also need to track the `index` of the first unexecuted operation onchain to properly calculate the merkle root and ensure that batches don’t execute some operations out of order or multiple times.
 
 We will also need to prove that the rolling hash of provided hashes matches with `priorityOperationsHash` which is also `O(n)`
 
-It is important to note that we should store some number of historical root hashes, since the Merkle tree on the server might lag behind the contracts a bit, and hence merkle paths generated on the server-side might become invalid if we compare them to the latest root hash on the contracts. These historical root hashes are not necessary to migrate to and from Gateway though.
+It is important to note that we store some number of historical root hashes, since the Merkle tree on the server might lag behind the contracts a bit, and hence merkle paths generated on the server-side might become invalid if we compare them to the latest root hash on the contracts. These historical root hashes are not necessary to migrate to and from Gateway though.
+
+
+## Legacy: Priority Queue
+
+Previously, priority operations were stored in a linear queue (PriorityQueue library) using `pushBack`/`popFront`, with batch execution verifying ops via a rolling hash loop. This was replaced by the Merkle tree to support Gateway migration. The old library remains in storage as `s.__DEPRECATED_priorityQueue` but is no longer in the request/execute path.

--- a/docs/src/specs/l1_smart_contracts.md
+++ b/docs/src/specs/l1_smart_contracts.md
@@ -261,8 +261,8 @@ When the validator calls `commitBatchesSharedBridge`, the same calldata will be 
 through `call` where it invokes the `CommitterFacet` through `delegatecall`), and also a timestamp is assigned to these
 batches to track the time these batches are committed by the validator to enforce a delay between committing and
 execution of batches. Then, the validator can prove the already committed batches regardless of the mentioned timestamp,
-and again the same calldata (related to the `proveBatches` function) will be propagated to the ZKsync contract. After
-the `delay` is elapsed, the validator is allowed to call `executeBatches` to propagate the same calldata to ZKsync
+and again the same calldata (related to the `proveBatchesSharedBridge` function) will be propagated to the ZKsync contract. After
+the `delay` is elapsed, the validator is allowed to call `executeBatchesSharedBridge` to propagate the same calldata to ZKsync
 contract.
 
 The execution delay is dynamically read from the contract's `executionDelay()` function by the node, eliminating the

--- a/docs/src/specs/l1_smart_contracts.md
+++ b/docs/src/specs/l1_smart_contracts.md
@@ -232,6 +232,7 @@ Each upgrade consists of two steps:
     of upgrade.
 
 Please note, that both the Owner and Security council can cancel the upgrade before its execution.
+Please note that the cancel function is owner-only; however, the Security Council is able to cancel the upgrade before its execution through the Protocol Upgrade Handler (the owner) emergency path.
 
 The diagram below outlines the complete journey from the initiation of an operation to its execution.
 

--- a/docs/src/specs/l1_smart_contracts.md
+++ b/docs/src/specs/l1_smart_contracts.md
@@ -247,11 +247,18 @@ investigation and mitigation before resuming normal operations.
 It is a temporary solution to prevent any significant impact of the validator hot key leakage, while the network is in
 the Alpha stage.
 
-This contract consists of four main functions `commitBatches`, `proveBatches`, `executeBatches`, and `revertBatches`,
-which can be called only by the validator.
+ValidatorTimelock uses per-chain role-based access control with six operational roles, each gating the corresponding `*SharedBridge` entry point:
+- `precommitSharedBridge` → `PRECOMMITTER_ROLE`
+- `commitBatchesSharedBridge` → `COMMITTER_ROLE`
+- `revertBatchesSharedBridge` → `REVERTER_ROLE`
+- `proveBatchesSharedBridge` → `PROVER_ROLE`
+- `executeBatchesSharedBridge` → `EXECUTOR_ROLE`
+- `upgradeChainFromVersion` → `UPGRADER_ROLE`
 
-When the validator calls `commitBatches`, the same calldata will be propagated to the ZKsync contract (`DiamondProxy`
-through `call` where it invokes the `ExecutorFacet` through `delegatecall`), and also a timestamp is assigned to these
+The `addValidator`/`removeValidator` helpers grant or revoke all roles at once; `addValidatorRoles`/`removeValidatorRoles` allow granular per-role assignment.
+
+When the validator calls `commitBatchesSharedBridge`, the same calldata will be propagated to the ZKsync contract (`DiamondProxy`
+through `call` where it invokes the `CommitterFacet` through `delegatecall`), and also a timestamp is assigned to these
 batches to track the time these batches are committed by the validator to enforce a delay between committing and
 execution of batches. Then, the validator can prove the already committed batches regardless of the mentioned timestamp,
 and again the same calldata (related to the `proveBatches` function) will be propagated to the ZKsync contract. After

--- a/docs/src/specs/l1_smart_contracts.md
+++ b/docs/src/specs/l1_smart_contracts.md
@@ -116,15 +116,19 @@ found [here](./contracts/settlement_contracts/data_availability/pubdata.md).
 
 ### Committer and Executor facets
 
-These contracts accept L2 batches, enforces data availability and checks the validity of zk-proofs. The state transition pipeline is split into three stages:
+These contracts accept L2 batches, enforces data availability and checks the validity of zk-proofs. The state transition
+pipeline is split into three stages:
 
-- `commitBatchesSharedBridge` - check L2 batch timestamp, process the L2 logs, save data for a batch, and prepare data for zk-proof.
+- `commitBatchesSharedBridge` - check L2 batch timestamp, process the L2 logs, save data for a batch, and prepare data
+  for zk-proof.
 - `proveBatchesSharedBridge` - validate zk-proof.
-- `executeBatchesSharedBridge` - finalize the state, marking L1 -> L2 communication processing, and saving Merkle tree with L2 logs.
+- `executeBatchesSharedBridge` - finalize the state, marking L1 -> L2 communication processing, and saving Merkle tree
+  with L2 logs.
 
 These stages are divided by contracts as:
 
-- `Committer` handles `precommitSharedBridge` and `commitBatchesSharedBridge`, including batch metadata checks, L2 log processing, DA validation inputs, and batch commitment creation.
+- `Committer` handles `precommitSharedBridge` and `commitBatchesSharedBridge`, including batch metadata checks, L2 log
+  processing, DA validation inputs, and batch commitment creation.
 - `Executor` handles proof validation, batch execution, and batch reverts.
 
 Each L2 -> L1 system log will have a key that is part of the following:
@@ -231,7 +235,8 @@ Each upgrade consists of two steps:
   - Instant upgrade. Scheduled operations can be executed at any moment. Only the Security Council can perform this type
     of upgrade.
 
-Please note that the cancel function is owner-only; however, the Security Council is able to cancel the upgrade before its execution through the Protocol Upgrade Handler (the owner) emergency path.
+Please note that the cancel function is owner-only; however, the Security Council is able to cancel the upgrade before
+its execution through the Protocol Upgrade Handler (the owner) emergency path.
 
 The diagram below outlines the complete journey from the initiation of an operation to its execution.
 
@@ -247,7 +252,9 @@ investigation and mitigation before resuming normal operations.
 It is a temporary solution to prevent any significant impact of the validator hot key leakage, while the network is in
 the Alpha stage.
 
-ValidatorTimelock uses per-chain role-based access control with six operational roles, each gating the corresponding `*SharedBridge` entry point:
+ValidatorTimelock uses per-chain role-based access control with six operational roles, each gating the corresponding
+`*SharedBridge` entry point:
+
 - `precommitSharedBridge` → `PRECOMMITTER_ROLE`
 - `commitBatchesSharedBridge` → `COMMITTER_ROLE`
 - `revertBatchesSharedBridge` → `REVERTER_ROLE`
@@ -255,15 +262,16 @@ ValidatorTimelock uses per-chain role-based access control with six operational 
 - `executeBatchesSharedBridge` → `EXECUTOR_ROLE`
 - `upgradeChainFromVersion` → `UPGRADER_ROLE`
 
-The `addValidator`/`removeValidator` helpers grant or revoke all roles at once; `addValidatorRoles`/`removeValidatorRoles` allow granular per-role assignment.
+The `addValidator`/`removeValidator` helpers grant or revoke all roles at once;
+`addValidatorRoles`/`removeValidatorRoles` allow granular per-role assignment.
 
-When the validator calls `commitBatchesSharedBridge`, the same calldata will be propagated to the ZKsync contract (`DiamondProxy`
-through `call` where it invokes the `CommitterFacet` through `delegatecall`), and also a timestamp is assigned to these
-batches to track the time these batches are committed by the validator to enforce a delay between committing and
-execution of batches. Then, the validator can prove the already committed batches regardless of the mentioned timestamp,
-and again the same calldata (related to the `proveBatchesSharedBridge` function) will be propagated to the ZKsync contract. After
-the `delay` is elapsed, the validator is allowed to call `executeBatchesSharedBridge` to propagate the same calldata to ZKsync
-contract.
+When the validator calls `commitBatchesSharedBridge`, the same calldata will be propagated to the ZKsync contract
+(`DiamondProxy` through `call` where it invokes the `CommitterFacet` through `delegatecall`), and also a timestamp is
+assigned to these batches to track the time these batches are committed by the validator to enforce a delay between
+committing and execution of batches. Then, the validator can prove the already committed batches regardless of the
+mentioned timestamp, and again the same calldata (related to the `proveBatchesSharedBridge` function) will be propagated
+to the ZKsync contract. After the `delay` is elapsed, the validator is allowed to call `executeBatchesSharedBridge` to
+propagate the same calldata to ZKsync contract.
 
 The execution delay is dynamically read from the contract's `executionDelay()` function by the node, eliminating the
 need for manual configuration management.

--- a/docs/src/specs/l1_smart_contracts.md
+++ b/docs/src/specs/l1_smart_contracts.md
@@ -231,7 +231,6 @@ Each upgrade consists of two steps:
   - Instant upgrade. Scheduled operations can be executed at any moment. Only the Security Council can perform this type
     of upgrade.
 
-Please note, that both the Owner and Security council can cancel the upgrade before its execution.
 Please note that the cancel function is owner-only; however, the Security Council is able to cancel the upgrade before its execution through the Protocol Upgrade Handler (the owner) emergency path.
 
 The diagram below outlines the complete journey from the initiation of an operation to its execution.

--- a/docs/src/specs/l1_smart_contracts.md
+++ b/docs/src/specs/l1_smart_contracts.md
@@ -116,13 +116,13 @@ found [here](./contracts/settlement_contracts/data_availability/pubdata.md).
 
 ### Committer and Executor facets
 
-The state transition pipeline is split into three stages:
+These contracts accept L2 batches, enforces data availability and checks the validity of zk-proofs. The state transition pipeline is split into three stages:
 
 - `commitBatchesSharedBridge` - check L2 batch timestamp, process the L2 logs, save data for a batch, and prepare data for zk-proof.
 - `proveBatchesSharedBridge` - validate zk-proof.
 - `executeBatchesSharedBridge` - finalize the state, marking L1 -> L2 communication processing, and saving Merkle tree with L2 logs.
 
-These stages are divided across two contracts:
+These stages are divided by contracts as:
 
 - `Committer` handles `precommitSharedBridge` and `commitBatchesSharedBridge`, including batch metadata checks, L2 log processing, DA validation inputs, and batch commitment creation.
 - `Executor` handles proof validation, batch execution, and batch reverts.

--- a/docs/src/specs/l1_smart_contracts.md
+++ b/docs/src/specs/l1_smart_contracts.md
@@ -114,15 +114,18 @@ L2 -> L1 communication, in contrast to L1 -> L2 communication, is based only on 
 the transaction execution on L1. The full description of the mechanism for sending information from L2 to L1 can be
 found [here](./contracts/settlement_contracts/data_availability/pubdata.md).
 
-### ExecutorFacet
+### Committer and Executor facets
 
-A contract that accepts L2 batches, enforces data availability and checks the validity of zk-proofs.
+The state transition pipeline is split into three stages:
 
-The state transition is divided into three stages:
+- `commitBatchesSharedBridge` - check L2 batch timestamp, process the L2 logs, save data for a batch, and prepare data for zk-proof.
+- `proveBatchesSharedBridge` - validate zk-proof.
+- `executeBatchesSharedBridge` - finalize the state, marking L1 -> L2 communication processing, and saving Merkle tree with L2 logs.
 
-- `commitBatches` - check L2 batch timestamp, process the L2 logs, save data for a batch, and prepare data for zk-proof.
-- `proveBatches` - validate zk-proof.
-- `executeBatches` - finalize the state, marking L1 -> L2 communication processing, and saving Merkle tree with L2 logs.
+These stages are divided across two contracts:
+
+- `Committer` handles `precommitSharedBridge` and `commitBatchesSharedBridge`, including batch metadata checks, L2 log processing, DA validation inputs, and batch commitment creation.
+- `Executor` handles proof validation, batch execution, and batch reverts.
 
 Each L2 -> L1 system log will have a key that is part of the following:
 

--- a/docs/src/specs/l1_smart_contracts.md
+++ b/docs/src/specs/l1_smart_contracts.md
@@ -235,8 +235,9 @@ Each upgrade consists of two steps:
   - Instant upgrade. Scheduled operations can be executed at any moment. Only the Security Council can perform this type
     of upgrade.
 
-Please note that the cancel function is owner-only; however, the Security Council is able to cancel the upgrade before
-its execution through the Protocol Upgrade Handler (the owner) emergency path.
+Please note that the cancel function is owner-only, so the Security Council cannot unilaterally cancel a scheduled
+operation. A cancellation can still be executed through the owner — the Protocol Upgrade Handler — whose emergency
+upgrade path requires approvals from the Security Council, the Guardians, and the ZK Foundation together.
 
 The diagram below outlines the complete journey from the initiation of an operation to its execution.
 


### PR DESCRIPTION
## What ❔

Fixes of the docs vs implementation mismatch and accuracy review, taking the current contracts implementation as the source of truth for small nits. Issues fixed (check internal report):
```
#1. Diamond facet set is stale — Executor was split into Committer/Executor/Migrator
#2. ValidatorTimelock no longer has a single "validator" role with 4 functions — it is per-chain RBAC with 6 operational roles
#7. priority-queue.md frames the Merkle-tree migration as future work, but the priority tree is the live mechanism
#9. l1_to_l2.md points at requestL2Transaction as the priority-op entry point; the canonical entry is bridgehubRequestL2Transaction
#12. Bridgehub is no longer the asset handler for chains — a dedicated ChainAssetHandler is
#22. CommitBatchInfo's last field is operatorDAInput, not totalL2ToL1Pubdata
#26. Functions commitBatches/executeBatches no longer exist — entry points are the *SharedBridge variants
#28 — BatchRootLeaf/ChainIdLeaf hashing: argument order reversed and stale constant name
#M-1 Security council cannot cancel scheduled governance ops
#29. Proof metadata layout is off by one byte and the legacy-format discrimination
```

Work intentionally left pending from protocol:
- Interop docs rework
- Priority mode missing docs
- blob/pubdata guides (09 & 10) stale

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No
