### PR TITLE
chore: force-release core 31.0.0 and prover 26.0.0

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -3838,3 +3838,5 @@
 * **circuits:** update circuits+vk for invalid memory access issue ([#1496](https://github.com/matter-labs/zksync-2-dev/issues/1496)) ([d84a73a](https://github.com/matter-labs/zksync-2-dev/commit/d84a73a3b54688f808be590e13fc4995666e3068))
 * **db:** create index to reduce load from prover_jobs table ([#1251](https://github.com/matter-labs/zksync-2-dev/issues/1251)) ([500f03a](https://github.com/matter-labs/zksync-2-dev/commit/500f03ac753f243e6e525639bc02e28987dcc7dd))
 * **gas_adjuster:** Sub 1 from the last block number for fetching  base_fee_history ([#1483](https://github.com/matter-labs/zksync-2-dev/issues/1483)) ([0af2f42](https://github.com/matter-labs/zksync-2-dev/commit/0af2f42b8c7c4635a18af01250213390c2424de9))
+
+<!-- release-please: force core 31.0.0 -->

--- a/core/bin/external_node/src/node_builder.rs
+++ b/core/bin/external_node/src/node_builder.rs
@@ -649,6 +649,7 @@ impl ExternalNodeBuilder {
             match component {
                 Component::HttpApi => {
                     self = self
+                        .add_sync_state_updater_layer()?
                         .add_bridge_addresses_updater_layer()?
                         .add_mempool_cache_layer()?
                         .add_tree_api_client_layer()?
@@ -658,6 +659,7 @@ impl ExternalNodeBuilder {
                 }
                 Component::WsApi => {
                     self = self
+                        .add_sync_state_updater_layer()?
                         .add_bridge_addresses_updater_layer()?
                         .add_mempool_cache_layer()?
                         .add_tree_api_client_layer()?
@@ -695,7 +697,6 @@ impl ExternalNodeBuilder {
                     // Main tasks
                     self = self
                         .add_state_keeper_layer()?
-                        .add_sync_state_updater_layer()?
                         .add_consensus_layer()?
                         .add_pruning_layer()?
                         .add_consistency_checker_layer()?

--- a/core/bin/external_node/src/node_builder.rs
+++ b/core/bin/external_node/src/node_builder.rs
@@ -649,7 +649,6 @@ impl ExternalNodeBuilder {
             match component {
                 Component::HttpApi => {
                     self = self
-                        .add_sync_state_updater_layer()?
                         .add_bridge_addresses_updater_layer()?
                         .add_mempool_cache_layer()?
                         .add_tree_api_client_layer()?
@@ -659,7 +658,6 @@ impl ExternalNodeBuilder {
                 }
                 Component::WsApi => {
                     self = self
-                        .add_sync_state_updater_layer()?
                         .add_bridge_addresses_updater_layer()?
                         .add_mempool_cache_layer()?
                         .add_tree_api_client_layer()?
@@ -697,6 +695,7 @@ impl ExternalNodeBuilder {
                     // Main tasks
                     self = self
                         .add_state_keeper_layer()?
+                        .add_sync_state_updater_layer()?
                         .add_consensus_layer()?
                         .add_pruning_layer()?
                         .add_consistency_checker_layer()?

--- a/prover/CHANGELOG.md
+++ b/prover/CHANGELOG.md
@@ -1301,3 +1301,5 @@
 
 * **api:** Fix bytes deserialization by bumping web3 crate version  ([#2240](https://github.com/matter-labs/zksync-2-dev/issues/2240)) ([59ef24a](https://github.com/matter-labs/zksync-2-dev/commit/59ef24afa6ceddf506a9ac7c4b1e9fc292311095))
 * **prover:** Panics in `send_report` will make provers crash ([#2273](https://github.com/matter-labs/zksync-2-dev/issues/2273)) ([85974d3](https://github.com/matter-labs/zksync-2-dev/commit/85974d3f9482307e0dbad0ec179e80886dafa42e))
+
+<!-- release-please: force prover 26.0.0 -->


### PR DESCRIPTION
Forces release-please to cut the next releases at specific versions:

- **core**: 29.20.0 → **31.0.0**
- **prover**: 25.3.0 → **26.0.0**

Each commit carries a `Release-As:` footer and touches a file inside the respective component directory so release-please attributes the override to the correct component.

Once merged to `main`, the release-please workflow will open the corresponding release PRs at these versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)