### PR TITLE
feat(config): allow setting l2_da_commitment_scheme before upgrade

### DIFF
--- a/core/bin/zksync_server/src/main.rs
+++ b/core/bin/zksync_server/src/main.rs
@@ -140,6 +140,7 @@ fn main() -> anyhow::Result<()> {
         l1_sl_contracts: Some(contracts_config.settlement_layer_specific_contracts()),
         eth_proof_manager_contracts: Some(contracts_config.eth_proof_manager_contracts()),
         multicall3: Some(contracts_config.l1.multicall3_addr),
+        config_l2_da_commitment_scheme: contracts_config.l2_da_commitment_scheme,
     };
 
     if opt.genesis {

--- a/core/bin/zksync_server/src/node_builder.rs
+++ b/core/bin/zksync_server/src/node_builder.rs
@@ -108,6 +108,9 @@ pub(crate) struct MainNodeBuilder {
     pub l2_contracts: L2Contracts,
     pub eth_proof_manager_contracts: Option<ProofManagerContracts>,
     pub multicall3: Option<Address>,
+    /// Explicit override for the L2 DA commitment scheme, used before the on-chain getter is
+    /// available (pre medium-interop upgrade) or when the on-chain value is `None`.
+    pub config_l2_da_commitment_scheme: Option<L2DACommitmentScheme>,
 }
 
 impl MainNodeBuilder {
@@ -130,6 +133,13 @@ impl MainNodeBuilder {
     }
 
     pub fn l2_da_commitment_scheme(&self) -> L2DACommitmentScheme {
+        // An explicit override always wins. This lets operators pin the scheme before the
+        // on-chain getter (`getDAValidatorPair`) becomes available, i.e. before the
+        // medium-interop upgrade.
+        if let Some(scheme) = self.config_l2_da_commitment_scheme {
+            return scheme;
+        }
+
         let use_dummy_inclusion_data = self
             .configs
             .da_dispatcher_config

--- a/core/lib/config/src/configs/contracts/chain.rs
+++ b/core/lib/config/src/configs/contracts/chain.rs
@@ -1,4 +1,7 @@
-use smart_config::{ConfigSchema, DescribeConfig, DeserializeConfig};
+use smart_config::{
+    de::{Optional, Serde},
+    ConfigSchema, DescribeConfig, DeserializeConfig,
+};
 use zksync_basic_types::{commitment::L2DACommitmentScheme, Address, H256};
 
 use super::{
@@ -190,6 +193,13 @@ pub struct ContractsConfig {
     // Setting default values to zero(for backwards compatibility)
     #[config(nest, default)]
     pub proof_manager_contracts: ProofManagerContracts,
+    /// Explicit override for the L2 DA commitment scheme.
+    ///
+    /// The scheme is normally read from the chain via `getDAValidatorPair`, but that getter only
+    /// exists from the medium-interop upgrade onwards. This config makes it possible to pin the
+    /// scheme before that upgrade is applied (or when the on-chain value is `None`).
+    #[config(with = Optional(Serde![str]))]
+    pub l2_da_commitment_scheme: Option<L2DACommitmentScheme>,
 }
 
 impl ContractsConfig {
@@ -200,6 +210,7 @@ impl ContractsConfig {
             bridges: BridgesConfig::for_tests(),
             ecosystem_contracts: EcosystemContracts::for_tests(),
             proof_manager_contracts: ProofManagerContracts::for_tests(),
+            l2_da_commitment_scheme: None,
         }
     }
 
@@ -345,6 +356,7 @@ mod tests {
                 proxy_addr: addr("0x35ea7f92f4c5f433efe15284e99c040110cf6297"),
                 proxy_admin_addr: addr("0x35ea7f92f4c5f433efe15284e99c040110cf6297"),
             },
+            l2_da_commitment_scheme: Some(L2DACommitmentScheme::PubdataKeccak256),
         }
     }
 
@@ -386,6 +398,8 @@ mod tests {
             CONTRACTS_PROOF_MANAGER_CONTRACTS_PROOF_MANAGER_ADDR="0x35ea7f92f4c5f433efe15284e99c040110cf6297"
             CONTRACTS_PROOF_MANAGER_CONTRACTS_PROXY_ADDR="0x35ea7f92f4c5f433efe15284e99c040110cf6297"
             CONTRACTS_PROOF_MANAGER_CONTRACTS_PROXY_ADMIN_ADDR="0x35ea7f92f4c5f433efe15284e99c040110cf6297"
+
+            CONTRACTS_L2_DA_COMMITMENT_SCHEME="PubdataKeccak256"
         "#;
         let env = Environment::from_dotenv("test.env", env).unwrap();
 
@@ -442,6 +456,7 @@ mod tests {
               proof_manager_addr: 0x35ea7f92f4c5f433efe15284e99c040110cf6297
               proxy_addr: 0x35ea7f92f4c5f433efe15284e99c040110cf6297
               proxy_admin_addr: 0x35ea7f92f4c5f433efe15284e99c040110cf6297
+            l2_da_commitment_scheme: PubdataKeccak256
         "#;
         let yaml = Yaml::new("test.yml", serde_yaml::from_str(yaml).unwrap()).unwrap();
 

--- a/core/lib/settlement_layer_data/src/node.rs
+++ b/core/lib/settlement_layer_data/src/node.rs
@@ -230,14 +230,26 @@ impl WiringLayer for SettlementLayerData<MainNodeConfig> {
             final_settlement_mode.settlement_layer(),
         );
 
-        if let Some(l2_da_commitment_scheme) = zkchain_on_chain_config.l2_da_commitment_scheme {
-            if l2_da_commitment_scheme == L2DACommitmentScheme::None {
+        match zkchain_on_chain_config.l2_da_commitment_scheme {
+            // The on-chain getter is unavailable before the medium-interop upgrade, so the value
+            // is not present yet. Use the config value so the chain can be configured ahead of
+            // the upgrade.
+            None => {
+                tracing::warn!("L2 DA commitment scheme is not available on-chain (pre-upgrade), falling back to the config value ({:?})", self.config.config_l2_da_commitment_scheme);
+                zkchain_on_chain_config.l2_da_commitment_scheme =
+                    Some(self.config.config_l2_da_commitment_scheme)
+            }
+            Some(L2DACommitmentScheme::None) => {
                 tracing::warn!("L2 DA commitment scheme from on-chain config is None, falling back to the config value");
                 zkchain_on_chain_config.l2_da_commitment_scheme =
                     Some(self.config.config_l2_da_commitment_scheme)
-            } else if l2_da_commitment_scheme != self.config.config_l2_da_commitment_scheme {
+            }
+            Some(l2_da_commitment_scheme)
+                if l2_da_commitment_scheme != self.config.config_l2_da_commitment_scheme =>
+            {
                 tracing::warn!("L2 DA commitment scheme from on-chain config ({l2_da_commitment_scheme:?}) does not match the config value ({:?}), using the on-chain value", self.config.config_l2_da_commitment_scheme);
             }
+            Some(_) => {}
         }
 
         Ok(Output {


### PR DESCRIPTION
## What

Adds an explicit `l2_da_commitment_scheme` config value to `ContractsConfig` so the L2 DA commitment scheme can be set **before** the upgrade that exposes it on-chain.

## Why

`get_zk_chain_on_chain_params` reads the scheme from the chain via `getDAValidatorPair`, but that getter only exists from the medium-interop upgrade onwards. Before the upgrade it returns `None`, and the previous fallback in `SettlementLayerData` only handled the on-chain `Some(L2DACommitmentScheme::None)` case — the fully-`None` (pre-upgrade) case left the value unset. There was also no way to explicitly pin the scheme ahead of the upgrade.

## Changes

- **`ContractsConfig`** ([chain.rs](core/lib/config/src/configs/contracts/chain.rs)): new optional `l2_da_commitment_scheme` field, settable via `CONTRACTS_L2_DA_COMMITMENT_SCHEME` (env) or `contracts.l2_da_commitment_scheme` (yaml). Updated parsing tests.
- **Node builder** ([main.rs](core/bin/zksync_server/src/main.rs), [node_builder.rs](core/bin/zksync_server/src/node_builder.rs)): the explicit override is preferred over the existing DA-client heuristic.
- **`SettlementLayerData`** ([node.rs](core/lib/settlement_layer_data/src/node.rs)): when the on-chain scheme is unavailable (pre-upgrade `None`), the config value is now applied. Existing `Some(None)` fallback and on-chain/config mismatch warning are preserved.

## Precedence

The on-chain value still wins once present and valid post-upgrade; the config acts as a fallback / pre-upgrade pin.

## Testing

- `cargo check` on `zksync_config`, `zksync_settlement_layer_data`, `zksync_server`
- `cargo test -p zksync_config` chain config parsing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)