### PR TITLE
fix(contract-verifier): Paths for solc compiler

### DIFF
--- a/core/lib/contract_verifier/src/compilers/solc.rs
+++ b/core/lib/contract_verifier/src/compilers/solc.rs
@@ -303,7 +303,6 @@ impl Compiler<SolcInput> for Solc {
             .arg("--standard-json")
             .arg("--allow-paths")
             .arg(compile_dir.path())
-            .current_dir(compile_dir.path())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())


### PR DESCRIPTION
## What ❔

When spawning solc we provide relative path to compiler, then set current dir to temporary artifacts directory. I believe that it breaks relative path to compiler binary. This PR removes setting current_dir to temporary one.