### PR TITLE
feat(prover): batch_splitter — split sealed batches into two Airbender pieces

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2276,6 +2276,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "batch_splitter"
+version = "29.20.0-non-semver-compat"
+dependencies = [
+ "anyhow",
+ "ciborium",
+ "clap 4.5.40",
+ "serde",
+ "tokio",
+ "tracing",
+ "zksync_airbender_prover_interface",
+ "zksync_airbender_verifier",
+ "zksync_config",
+ "zksync_contracts",
+ "zksync_crypto_primitives",
+ "zksync_dal",
+ "zksync_l1_contract_interface",
+ "zksync_merkle_tree",
+ "zksync_multivm",
+ "zksync_object_store",
+ "zksync_prover_interface",
+ "zksync_types",
+ "zksync_vlog",
+ "zksync_vm_executor",
+ "zksync_vm_interface",
+]
+
+[[package]]
 name = "bech32"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   # Binaries
+  "bin/batch_splitter",
   "bin/block_reverter",
   "bin/contract-verifier",
   "bin/custom_genesis_export",

--- a/core/bin/batch_splitter/Cargo.toml
+++ b/core/bin/batch_splitter/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "batch_splitter"
+description = "Utility to split a sealed L1 batch into two independently-provable Airbender pieces"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish = false
+
+[dependencies]
+zksync_config = { workspace = true, features = ["observability_ext"] }
+zksync_dal.workspace = true
+zksync_object_store.workspace = true
+zksync_types.workspace = true
+zksync_prover_interface.workspace = true
+zksync_airbender_prover_interface.workspace = true
+zksync_airbender_verifier.workspace = true
+zksync_vm_executor.workspace = true
+zksync_vm_interface.workspace = true
+zksync_multivm.workspace = true
+zksync_merkle_tree.workspace = true
+zksync_l1_contract_interface.workspace = true
+zksync_contracts.workspace = true
+zksync_crypto_primitives.workspace = true
+zksync_vlog.workspace = true
+
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }
+tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
+serde.workspace = true
+ciborium.workspace = true

--- a/core/bin/batch_splitter/README.md
+++ b/core/bin/batch_splitter/README.md
@@ -1,0 +1,98 @@
+# batch_splitter
+
+Splits a **sealed** L1 batch `N` into two independently-provable Airbender pieces, so that batches which Boojum can
+prove but which exceed Airbender's geometry can still be proven by cutting them in half (and, by the caller's retry
+loop, in quarters, eighths, …) until each piece fits.
+
+This tool is **non-invasive**: it never writes to the canonical chain (`l1_batches` / `miniblocks` / `transactions`),
+never re-commits to L1, never re-numbers batches, and never touches the node's Merkle-tree RocksDB. It reads only
+Postgres (MVCC) and immutable object-store blobs, and writes two new object-store blobs the prover loop can pick up.
+
+## Why "split" means "re-execute", not "slice"
+
+A witness input is not sliceable at an L2-block boundary:
+
+- `VMRunWitnessInputData.initial_heap_content` is the bootloader memory for the **whole** batch as a single program.
+- `storage_refunds` / `pubdata_costs` / `merkle_paths` are flat per-VM-op arrays in execution order.
+
+What _is_ per-block is `AirbenderVerifierInput.l2_blocks_execution_data: Vec<L2BlockExecutionData>` (the transactions of
+each L2 block) plus the storage snapshot inside `vm_run_data.witness_block_state`. Those are exactly the inputs an
+execution needs, so each half is produced by **re-running the bootloader over its block range** — the same thing
+`BasicWitnessInputProducer` and `AirbenderVerifierInput::verify()` already do.
+
+## The split
+
+For batch `N` spanning L2 blocks `[first, last]`, cut at `mid = first + ceil(n/2)` (even by block count, whole blocks
+only — see "fictive block" below):
+
+| Field                          | Piece A `[first, mid)`                         | Piece B `[mid, last]`                                          |
+| ------------------------------ | ---------------------------------------------- | -------------------------------------------------------------- |
+| `l2_blocks_execution_data`     | blocks `[first, mid)`                          | blocks `[mid, last]`                                           |
+| `l1_batch_env`                 | = N's (same start, same `previous_batch_hash`) | `previous_batch_hash = root_A`; `first_l2_block` = block `mid` |
+| `system_env`, `pubdata_params` | = N's                                          | = N's                                                          |
+| `vm_run_data`                  | regenerate by re-exec of A                     | regenerate by re-exec of B                                     |
+| `merkle_paths`                 | regenerate from N's multiproof (N-1 state)     | regenerate from N's multiproof (N-1 + A's writes)              |
+| `commitment_input`             | = N's (`prev_*` from batch N-1)                | computed from **piece A's** commitment                         |
+
+`root_A` is piece A's intermediate state root — it is never committed anywhere; it only links the two pieces.
+Composition holds: `old_root_N → root_A` (A) then `root_A → new_root_N` (B) = `old_root_N → new_root_N` (N).
+
+### Built-in correctness self-check
+
+After regenerating B's Merkle paths we get `root_B`. It **must equal batch N's committed root hash**. The tool asserts
+this and fails loudly otherwise — it is a cheap, total check that the re-execution + sparse reconstruction reproduced N
+exactly.
+
+## The hard sub-problems (and how each is handled)
+
+1. **Storage chaining for piece B.** B re-executes from a snapshot that is _N's start state overlaid with A's writes_.
+   We seed B's `StorageSnapshot` from the full-batch `witness_block_state` (a superset of both halves' reads) and
+   overlay the writes from piece A's `FinishedL1Batch.final_execution_state. deduplicated_storage_logs`. The
+   `is_write_initial` flag for B drops any slot piece A inserted (it is no longer a first write). See `reexec.rs`.
+
+2. **Leaf-index assignment.** New (inserted) leaves get enumeration indices `start, start+1, …`. Piece A starts at N's
+   start index (`original merkle_paths.next_enumeration_index()`); piece B continues at `start + (#inserts in A)` — the
+   same order N used, which is why the final root matches. Handled inside `sparse_tree.rs`.
+
+3. **Merkle paths — fully non-invasive.** The tool never touches the node's Merkle-tree RocksDB (opening it would take
+   its lock; snapshotting a live DB races the writer). Instead it reconstructs a sparse binary Merkle tree from batch
+   N's own immutable `WitnessInputMerklePaths` blob (the only non-invasive source of sibling hashes), re-applies A's
+   then B's writes, and regenerates each piece's paths + `root_A`. See `sparse_tree.rs`. Why it works: each touched
+   key's N-1 value comes from its first occurrence in N's proof, and sibling subtrees with no touched leaf are invariant
+   during N (so their hashes can be read from any op). Hashing reuses `Blake2Hasher`'s
+   `hash_leaf`/`hash_branch`/`empty_subtree_hash`, so roots/paths match exactly. Two root self-checks bracket it: the
+   reconstructed N-1 root must equal N's `previous_batch_hash`, and the post-B root must equal N's committed root.
+
+4. **Synthetic commitment for piece B.** `commitment_input` for B needs piece A's Airbender commitment
+   (`prev_batch_commitment`, `prev_aux_hash`, `prev_meta_hash`). This is assembled from A's re-execution output the same
+   way `commitment_generator` does for a real batch (`AirbenderCommitmentComputer` +
+   `L1BatchCommitment::airbender_artifacts`). This is the deepest module and is gated behind `--commitment-chaining`
+   (off by default); without it the tool emits B with `commitment_input: None` (enough to test that each half _fits
+   Airbender's geometry_, which is the immediate goal), and the full commitment chain can be turned on once validated.
+
+## Usage
+
+```
+batch_splitter \
+  --l1-batch <N> \
+  --database-url <postgres://…> \
+  --artifacts-path <object-store-base-path> \
+  --l2-chain-id <id> \
+  [--commitment-chaining]
+```
+
+No tree-DB path is needed — Merkle paths are reconstructed from N's witness blob.
+
+Output: two blobs in the witness-input bucket, `airbender_split_input_{N}_a.cbor` and
+`airbender_split_input_{N}_b.cbor`, each a CBOR-encoded `AirbenderVerifierInput`.
+
+## Key references in the tree
+
+- Full-batch assembly mirrored here: `core/node/airbender_proof_data_handler/src/airbender_request_processor.rs`
+  (`airbender_verifier_input_for_existing_batch`).
+- Re-execution pattern: `core/lib/airbender_verifier/src/lib.rs` (`verify`, `execute_vm`).
+- Witness-data shape: `core/node/vm_runner/src/impls/bwip.rs`.
+- Merkle hashing reused for the sparse reconstruction: `core/lib/merkle_tree/src/hasher/mod.rs` (`Blake2Hasher` as
+  `HashTree`).
+- Airbender commitment: `core/node/commitment_generator/src/{lib,utils}.rs`, `core/lib/types/src/commitment/mod.rs`
+  (`airbender_artifacts`).

--- a/core/bin/batch_splitter/src/blob.rs
+++ b/core/bin/batch_splitter/src/blob.rs
@@ -1,0 +1,54 @@
+//! Object-store wrapper for the two split pieces.
+//!
+//! `AirbenderVerifierInput` is normally assembled on the fly by the
+//! proof-data-handler and never persisted. The split pieces (especially B,
+//! which has no canonical DB row) must be self-contained, so we persist each as
+//! a CBOR `AirbenderVerifierInput` under a dedicated sub-key.
+
+use zksync_airbender_prover_interface::inputs::AirbenderVerifierInput;
+use zksync_object_store::{Bucket, StoredObject, _reexports::BoxedError};
+use zksync_types::L1BatchNumber;
+
+/// Which half of the split a blob holds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Half {
+    /// Blocks `[first, mid)`, proving `old_root_N → root_A`.
+    A,
+    /// Blocks `[mid, last]`, proving `root_A → new_root_N`.
+    B,
+}
+
+impl Half {
+    fn suffix(self) -> &'static str {
+        match self {
+            Half::A => "a",
+            Half::B => "b",
+        }
+    }
+}
+
+/// CBOR-serialized split piece, keyed by `(batch, half)`.
+pub struct SplitPiece(pub AirbenderVerifierInput);
+
+impl StoredObject for SplitPiece {
+    const BUCKET: Bucket = Bucket::WitnessInput;
+    type Key<'a> = (L1BatchNumber, Half);
+
+    fn encode_key(key: Self::Key<'_>) -> String {
+        let (batch, half) = key;
+        format!("airbender_split_input_{}_{}.cbor", batch.0, half.suffix())
+    }
+
+    fn serialize(&self) -> Result<Vec<u8>, BoxedError> {
+        let mut buf = Vec::new();
+        ciborium::into_writer(&self.0, &mut buf)
+            .map_err(|e| BoxedError::from(format!("Failed to serialize SplitPiece: {e}")))?;
+        Ok(buf)
+    }
+
+    fn deserialize(bytes: Vec<u8>) -> Result<Self, BoxedError> {
+        ciborium::from_reader(&bytes[..])
+            .map(Self)
+            .map_err(|e| BoxedError::from(format!("Failed to deserialize SplitPiece: {e}")))
+    }
+}

--- a/core/bin/batch_splitter/src/commitment.rs
+++ b/core/bin/batch_splitter/src/commitment.rs
@@ -1,0 +1,124 @@
+//! Commitment inputs for the two pieces.
+//!
+//! `CommitmentInput` carries the *previous* batch's commitment hashes plus
+//! *this* batch's blob hashes. Mirrors
+//! `airbender_request_processor::airbender_verifier_input_for_existing_batch`
+//! (the blob-hash + prev-commitment assembly), specialized per piece:
+//!
+//! * Piece A: `prev_*` = batch N-1's real Airbender commitment; blob hashes
+//!   from A's own pubdata.
+//! * Piece B: `prev_*` = **piece A's** synthetic commitment; blob hashes from
+//!   B's pubdata. Computing A's commitment is the deepest step and is gated
+//!   behind `--commitment-chaining` (see [`commitment_input_for_b`]).
+
+use zksync_airbender_prover_interface::inputs::{BlobHash, CommitmentInput};
+use zksync_dal::{Connection, Core, CoreDal};
+use zksync_l1_contract_interface::i_executor::commit::kzg::{
+    pubdata_to_blob_commitments, pubdata_to_blob_linear_hashes, pubdata_to_blob_versioned_hashes,
+};
+use zksync_types::{
+    blob::num_blobs_required, commitment::L1BatchCommitmentMode, L1BatchNumber, ProtocolVersionId,
+    H256,
+};
+
+/// Compute a batch's EIP-4844 blob hashes from its pubdata (Validium zeroes
+/// them, matching `commitment_generator`).
+pub fn blob_hashes(
+    pubdata_input: &[u8],
+    version: &ProtocolVersionId,
+    mode: L1BatchCommitmentMode,
+) -> (Vec<BlobHash>, Vec<H256>) {
+    let num_blobs = num_blobs_required(version);
+    let versioned_hashes = pubdata_to_blob_versioned_hashes(num_blobs, pubdata_input);
+
+    let blob_hashes = match mode {
+        L1BatchCommitmentMode::Rollup => {
+            let commitments = pubdata_to_blob_commitments(num_blobs, pubdata_input);
+            let linear_hashes = pubdata_to_blob_linear_hashes(num_blobs, pubdata_input.to_vec());
+            commitments
+                .into_iter()
+                .zip(linear_hashes)
+                .map(|(commitment, linear_hash)| BlobHash {
+                    commitment,
+                    linear_hash,
+                })
+                .collect()
+        }
+        L1BatchCommitmentMode::Validium => vec![BlobHash::default(); num_blobs],
+    };
+    (blob_hashes, versioned_hashes)
+}
+
+/// Piece A starts where batch N does, so its predecessor commitment is batch
+/// N-1's — read exactly as the request processor reads it.
+pub async fn commitment_input_for_a(
+    connection: &mut Connection<'_, Core>,
+    batch: L1BatchNumber,
+    piece_a_pubdata: &[u8],
+    version: &ProtocolVersionId,
+    mode: L1BatchCommitmentMode,
+) -> anyhow::Result<CommitmentInput> {
+    let prev = L1BatchNumber(batch.0.checked_sub(1).context_no_predecessor(batch)?);
+    let prev_commitment = connection
+        .blocks_dal()
+        .get_prev_batch_airbender_commitment_input(prev)
+        .await?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "previous batch {prev} has no Airbender commitment input yet — \
+                 commitment_generator must run before splitting"
+            )
+        })?;
+
+    let (blob_hashes, blob_versioned_hashes) = blob_hashes(piece_a_pubdata, version, mode);
+
+    Ok(CommitmentInput {
+        prev_batch_commitment: prev_commitment.prev_batch_commitment,
+        prev_meta_hash: prev_commitment.meta_parameters_hash,
+        prev_aux_hash: prev_commitment.prev_aux_hash,
+        blob_hashes,
+        blob_versioned_hashes,
+    })
+}
+
+/// Piece B's predecessor is the synthetic intermediate batch A.
+///
+/// When `chaining` is false (the default for geometry-feasibility runs) this
+/// returns `None`: the verifier only requires `Some` for *full* proving, and
+/// `None` is enough to check that each half fits Airbender's geometry.
+///
+/// When `chaining` is true, `prev_*` must be **piece A's Airbender commitment**:
+/// assemble an `L1BatchCommitment` from A's re-execution output (system logs,
+/// state diffs, `AuxCommitments` via `AirbenderCommitmentComputer`, tree data
+/// = `root_A` + A's leaf count) and call
+/// `zksync_types::commitment::L1BatchCommitment::airbender_artifacts()`.
+/// See `core/node/commitment_generator/src/{lib,utils}.rs`. This is the one
+/// piece that cannot be lifted verbatim from existing call sites and is left
+/// unimplemented until validated end-to-end.
+pub fn commitment_input_for_b(
+    chaining: bool,
+    piece_b_pubdata: &[u8],
+    version: &ProtocolVersionId,
+    mode: L1BatchCommitmentMode,
+) -> anyhow::Result<Option<CommitmentInput>> {
+    if !chaining {
+        return Ok(None);
+    }
+    let (_blob_hashes, _blob_versioned_hashes) = blob_hashes(piece_b_pubdata, version, mode);
+    anyhow::bail!(
+        "--commitment-chaining is not yet implemented: computing piece A's Airbender commitment \
+         (prev_* for piece B) requires assembling an L1BatchCommitment from A's outputs. Run \
+         without chaining to produce geometry-feasibility pieces (commitment_input = None)."
+    )
+}
+
+trait NoPredecessor {
+    fn context_no_predecessor(self, batch: L1BatchNumber) -> anyhow::Result<u32>;
+}
+impl NoPredecessor for Option<u32> {
+    fn context_no_predecessor(self, batch: L1BatchNumber) -> anyhow::Result<u32> {
+        self.ok_or_else(|| {
+            anyhow::anyhow!("batch {batch} has no predecessor (only batch 1+ are splittable)")
+        })
+    }
+}

--- a/core/bin/batch_splitter/src/main.rs
+++ b/core/bin/batch_splitter/src/main.rs
@@ -1,0 +1,104 @@
+//! `batch_splitter` — split a sealed L1 batch into two independently-provable
+//! Airbender pieces. See `README.md` for the design and constraints.
+
+use std::path::PathBuf;
+
+use anyhow::Context as _;
+use clap::Parser;
+use zksync_config::ObjectStoreConfig;
+use zksync_dal::{ConnectionPool, Core};
+use zksync_object_store::ObjectStoreFactory;
+use zksync_types::{url::SensitiveUrl, L1BatchNumber, L2ChainId};
+
+mod blob;
+mod commitment;
+mod reexec;
+mod sparse_tree;
+mod split;
+
+use crate::{
+    blob::{Half, SplitPiece},
+    split::{split, SplitParams},
+};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "batch_splitter",
+    about = "Split a sealed L1 batch into two independently-provable Airbender pieces"
+)]
+struct Cli {
+    /// L1 batch number to split.
+    #[arg(long)]
+    l1_batch: u32,
+
+    /// Postgres URL of the node (read-only use).
+    #[arg(long, env = "DATABASE_URL")]
+    database_url: String,
+
+    /// Base path of the file-backed object store holding the batch's witness
+    /// blobs (the witness-input bucket). The two pieces are written back here.
+    #[arg(long)]
+    artifacts_path: PathBuf,
+
+    /// L2 chain id.
+    #[arg(long)]
+    l2_chain_id: u64,
+
+    /// Compute piece A's commitment to chain into piece B's commitment_input.
+    /// Off by default: pieces are produced for geometry-feasibility checks with
+    /// `commitment_input = None` for B (see README).
+    #[arg(long, default_value_t = false)]
+    commitment_chaining: bool,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    let batch = L1BatchNumber(cli.l1_batch);
+
+    let database_url: SensitiveUrl = cli.database_url.parse().context("invalid --database-url")?;
+    let pool = ConnectionPool::<Core>::singleton(database_url)
+        .build()
+        .await
+        .context("failed to build Postgres connection pool")?;
+
+    let object_store_config = ObjectStoreConfig {
+        mode: zksync_config::configs::object_store::ObjectStoreMode::FileBacked {
+            file_backed_base_path: cli.artifacts_path.clone(),
+        },
+        ..ObjectStoreConfig::default()
+    };
+    let blob_store = ObjectStoreFactory::new(object_store_config)
+        .create_store()
+        .await
+        .context("failed to create object store")?;
+
+    let l2_chain_id = L2ChainId::new(cli.l2_chain_id)
+        .map_err(|e| anyhow::anyhow!("invalid --l2-chain-id: {e}"))?;
+
+    let (input_a, input_b) = split(
+        &pool,
+        blob_store.as_ref(),
+        SplitParams {
+            batch,
+            l2_chain_id,
+            commitment_chaining: cli.commitment_chaining,
+        },
+    )
+    .await
+    .with_context(|| format!("failed to split batch {batch}"))?;
+
+    let key_a = blob_store
+        .put((batch, Half::A), &SplitPiece(input_a))
+        .await
+        .context("failed to write piece A")?;
+    let key_b = blob_store
+        .put((batch, Half::B), &SplitPiece(input_b))
+        .await
+        .context("failed to write piece B")?;
+
+    println!("Split batch {batch} into two pieces:");
+    println!("  A: {key_a}");
+    println!("  B: {key_b}");
+    Ok(())
+}

--- a/core/bin/batch_splitter/src/reexec.rs
+++ b/core/bin/batch_splitter/src/reexec.rs
@@ -1,0 +1,137 @@
+//! Re-execution of one block range of a sealed batch.
+//!
+//! Mirrors `core/lib/airbender_verifier/src/lib.rs` (`verify` / `execute_vm`):
+//! a `StorageSnapshot` seeded from the witness is enough to drive the
+//! bootloader over a list of L2 blocks. We reuse the *full* batch's
+//! `VMRunWitnessInputData` as a template for the fields that are identical
+//! across pieces (system contracts, the superset of used bytecodes) and
+//! override only the five fields that are genuinely per-piece.
+
+use std::collections::HashMap;
+
+use anyhow::Context;
+use zksync_multivm::{
+    interface::{
+        storage::{ReadStorage, StorageSnapshot, StorageView},
+        FinishedL1Batch, L1BatchEnv, L2BlockEnv, SystemEnv, VmFactory, VmInterface, VmInterfaceExt,
+        VmInterfaceHistoryEnabled,
+    },
+    pubdata_builders::pubdata_params_to_builder,
+    vm_latest::HistoryEnabled,
+    LegacyVmInstance,
+};
+use zksync_prover_interface::inputs::VMRunWitnessInputData;
+use zksync_types::{
+    block::L2BlockExecutionData, commitment::PubdataParams,
+    witness_block_state::WitnessStorageState, ProtocolVersionId, Transaction, H256,
+};
+
+/// Result of re-executing one piece.
+pub struct PieceExecution {
+    /// Per-piece witness data ready to drop into an `AirbenderVerifierInput`.
+    pub vm_run_data: VMRunWitnessInputData,
+    /// Raw VM output; the caller needs `final_execution_state` for tree
+    /// instructions (piece A) and storage chaining (piece B → A's writes).
+    pub finished: FinishedL1Batch,
+}
+
+/// Re-execute `blocks` against `storage` (+ `factory_deps`), producing the
+/// piece's witness data. `template` is the full batch's `VMRunWitnessInputData`,
+/// reused for the contract/bytecode fields that don't change between pieces.
+pub fn reexecute_piece(
+    template: &VMRunWitnessInputData,
+    l1_batch_env: L1BatchEnv,
+    system_env: SystemEnv,
+    pubdata_params: PubdataParams,
+    blocks: Vec<L2BlockExecutionData>,
+    storage: HashMap<H256, Option<(H256, u64)>>,
+    factory_deps: HashMap<H256, Vec<u8>>,
+) -> anyhow::Result<PieceExecution> {
+    anyhow::ensure!(!blocks.is_empty(), "cannot re-execute an empty block range");
+
+    let l1_batch_number = l1_batch_env.number;
+    let version = system_env.version;
+
+    let storage_snapshot = StorageSnapshot::new(storage, factory_deps);
+    let storage_view = StorageView::new(storage_snapshot).to_rc_ptr();
+    let vm = LegacyVmInstance::new(l1_batch_env, system_env, storage_view.clone());
+
+    let finished = execute_vm(blocks, vm, pubdata_params, version)?;
+
+    // Read keys + initial-write flags actually observed by *this* piece.
+    let cache = storage_view.borrow().cache();
+    let witness_block_state = WitnessStorageState {
+        read_storage_key: cache.read_storage_keys(),
+        is_write_initial: cache.initial_writes(),
+    };
+
+    let initial_heap_content = finished
+        .final_bootloader_memory
+        .clone()
+        .context("final bootloader memory missing after re-execution")?;
+
+    let vm_run_data = VMRunWitnessInputData {
+        l1_batch_number,
+        // Superset of bytecodes; safe for proving a subrange. Could be pruned
+        // to exactly the bytecodes this piece touched as a later refinement.
+        used_bytecodes: template.used_bytecodes.clone(),
+        initial_heap_content,
+        protocol_version: version,
+        bootloader_code: template.bootloader_code.clone(),
+        default_account_code_hash: template.default_account_code_hash,
+        evm_emulator_code_hash: template.evm_emulator_code_hash,
+        storage_refunds: finished.final_execution_state.storage_refunds.clone(),
+        pubdata_costs: finished.final_execution_state.pubdata_costs.clone(),
+        witness_block_state,
+    };
+
+    Ok(PieceExecution {
+        vm_run_data,
+        finished,
+    })
+}
+
+// --- replicated from airbender_verifier (private there) ---
+
+fn execute_vm<S: ReadStorage>(
+    l2_blocks_execution_data: Vec<L2BlockExecutionData>,
+    mut vm: LegacyVmInstance<S, HistoryEnabled>,
+    pubdata_params: PubdataParams,
+    protocol_version: ProtocolVersionId,
+) -> anyhow::Result<FinishedL1Batch> {
+    let next_l2_blocks_data = l2_blocks_execution_data.iter().skip(1);
+    let l2_blocks_data = l2_blocks_execution_data.iter().zip(next_l2_blocks_data);
+
+    for (l2_block_data, next_l2_block_data) in l2_blocks_data {
+        for tx in &l2_block_data.txs {
+            execute_tx(tx, &mut vm).context("failed to execute transaction in batch_splitter")?;
+        }
+        vm.start_new_l2_block(L2BlockEnv::from_l2_block_data(next_l2_block_data));
+    }
+
+    Ok(vm.finish_batch(pubdata_params_to_builder(pubdata_params, protocol_version)))
+}
+
+fn execute_tx<S: ReadStorage>(
+    tx: &Transaction,
+    vm: &mut LegacyVmInstance<S, HistoryEnabled>,
+) -> anyhow::Result<()> {
+    vm.make_snapshot();
+    if vm
+        .execute_transaction_with_bytecode_compression(tx.clone(), true)
+        .0
+        .is_ok()
+    {
+        vm.pop_snapshot_no_rollback();
+        return Ok(());
+    }
+    vm.rollback_to_the_latest_snapshot();
+    if vm
+        .execute_transaction_with_bytecode_compression(tx.clone(), false)
+        .0
+        .is_err()
+    {
+        anyhow::bail!("compression can't fail if we don't apply it");
+    }
+    Ok(())
+}

--- a/core/bin/batch_splitter/src/sparse_tree.rs
+++ b/core/bin/batch_splitter/src/sparse_tree.rs
@@ -1,0 +1,308 @@
+//! Non-invasive Merkle-path regeneration via a sparse binary Merkle tree
+//! reconstructed from batch N's own `WitnessInputMerklePaths` blob.
+//!
+//! We never touch the node's Merkle-tree RocksDB. The only sibling-hash source
+//! is N's already-persisted, immutable multiproof (object store). From it we
+//! rebuild the N-1 tree state restricted to the leaves N touched, then re-apply
+//! piece A's writes (→ `root_A` + A's paths) and piece B's writes (→ `root_B` +
+//! B's paths) on the same tree.
+//!
+//! ## Why this works
+//! * **N-1 leaf values:** each touched key's *first* occurrence in N carries its
+//!   pre-N value (`value_read`) and enumeration index — i.e., its N-1 state.
+//! * **Boundary siblings:** a sibling subtree containing no touched leaf never
+//!   changes during N, so its hash is identical in every op's proof and equals
+//!   its N-1 value. We record those "off-trie" siblings; on-trie nodes are
+//!   recomputed from the touched leaves.
+//! * **Leaf indices:** existing keys keep their N-1 index; new keys get
+//!   sequential indices from N's start index, continuing across A→B — the same
+//!   order N used, which is why the final root matches.
+//!
+//! ## Hashing
+//! The zkSync tree stores nodes 16-ary, but its proofs are the binarized
+//! 256-level tree using `Blake2Hasher::{hash_leaf, hash_branch,
+//! empty_subtree_hash}`. We reuse those exact primitives, so roots and paths
+//! match byte-for-byte.
+//!
+//! ## Self-checks
+//! [`SparseMerkle::build`] asserts the reconstructed N-1 root equals the batch's
+//! `previous_batch_hash`; the caller asserts the post-B root equals N's
+//! committed root. Together they validate the whole reconstruction.
+//!
+//! ## Known limitation (guarded)
+//! A key that existed at N-1 but whose *only* interaction in N is a no-op update
+//! (same value, which the tree omits from the witness) and is never read won't
+//! appear in N's multiproof, so we'd misclassify it as absent. If a piece writes
+//! such a key non-trivially the post-B root won't match N's and the self-check
+//! fails loudly rather than emitting a bad witness. This is rare in practice.
+
+use std::collections::{HashMap, HashSet};
+
+use zksync_crypto_primitives::hasher::blake2::Blake2Hasher;
+use zksync_merkle_tree::HashTree;
+use zksync_prover_interface::inputs::{StorageLogMetadata, WitnessInputMerklePaths};
+use zksync_types::{StorageLog, H256, U256};
+
+const TREE_DEPTH: usize = 256;
+
+#[derive(Clone, Copy)]
+struct Leaf {
+    value: H256,
+    leaf_index: u64,
+}
+
+pub struct SparseMerkle {
+    hasher: Blake2Hasher,
+    /// Touched keys (sorted, unique) — defines the "on-trie" region.
+    sorted_keys: Vec<U256>,
+    /// Current leaf state (starts at N-1, evolves as pieces are applied).
+    leaves: HashMap<U256, Leaf>,
+    /// Off-trie sibling hashes (invariant during N), keyed by (level, prefix).
+    boundary: HashMap<(u16, U256), H256>,
+    /// Current hashes of on-trie internal nodes (level >= 1), incl. the root.
+    nodes: HashMap<(u16, U256), H256>,
+    /// Next enumeration index for inserts; persists across A→B.
+    next_index: u64,
+}
+
+impl SparseMerkle {
+    /// Reconstruct the N-1 tree from N's multiproof and verify its root.
+    ///
+    /// * `orig` — batch N's `WitnessInputMerklePaths`.
+    /// * `old_root` — N's `previous_batch_hash` (the N-1 root).
+    /// * `start_index` — N's start enumeration index
+    ///   (`orig.next_enumeration_index()`).
+    pub fn build(
+        orig: &WitnessInputMerklePaths,
+        old_root: H256,
+        start_index: u64,
+    ) -> anyhow::Result<Self> {
+        let logs: Vec<StorageLogMetadata> = orig.clone().into_merkle_paths().collect();
+
+        // Pass 1: touched keys and their N-1 leaf state (first occurrence).
+        let mut leaves: HashMap<U256, Leaf> = HashMap::new();
+        let mut sorted_keys: Vec<U256> = Vec::new();
+        let mut seen: HashSet<U256> = HashSet::new();
+        for m in &logs {
+            let key = m.leaf_hashed_key;
+            if !seen.insert(key) {
+                continue;
+            }
+            sorted_keys.push(key);
+            // Existed at N-1 iff: a non-first write (Updated) or a read that hit
+            // a leaf (enumeration index != 0). Inserts / ReadMissingKey => absent.
+            let existed = if m.is_write {
+                !m.first_write
+            } else {
+                m.leaf_enumeration_index != 0
+            };
+            if existed {
+                leaves.insert(
+                    key,
+                    Leaf {
+                        value: H256(m.value_read),
+                        leaf_index: m.leaf_enumeration_index,
+                    },
+                );
+            }
+        }
+        sorted_keys.sort_unstable();
+
+        let mut me = Self {
+            hasher: Blake2Hasher,
+            sorted_keys,
+            leaves,
+            boundary: HashMap::new(),
+            nodes: HashMap::new(),
+            next_index: start_index,
+        };
+
+        // Pass 2: record off-trie boundary siblings from the (full) proofs.
+        for m in &logs {
+            anyhow::ensure!(
+                m.merkle_paths.len() == TREE_DEPTH,
+                "expected a full {TREE_DEPTH}-hash path after de-compaction, got {}",
+                m.merkle_paths.len()
+            );
+            let key = m.leaf_hashed_key;
+            for (d, sibling) in m.merkle_paths.iter().enumerate() {
+                let sib_prefix = (key >> d) ^ U256::one();
+                if !me.on_trie(d as u16, sib_prefix) {
+                    me.boundary
+                        .entry((d as u16, sib_prefix))
+                        .or_insert_with(|| H256(*sibling));
+                }
+            }
+        }
+
+        // Build the on-trie node hashes for N-1 and verify the root.
+        let root = me.compute(TREE_DEPTH as u16, U256::zero());
+        anyhow::ensure!(
+            root == old_root,
+            "reconstructed N-1 root {root:?} != batch's previous_batch_hash {old_root:?}; \
+             multiproof reconstruction is wrong",
+        );
+        Ok(me)
+    }
+
+    /// Apply one piece's storage logs, returning its witness paths and the
+    /// resulting root. The witness's start index is the current `next_index`,
+    /// which advances as inserts are applied (so a subsequent piece continues
+    /// from the right index).
+    pub fn process_piece(
+        &mut self,
+        logs: &[StorageLog],
+    ) -> anyhow::Result<(WitnessInputMerklePaths, H256)> {
+        let mut witness = WitnessInputMerklePaths::new(self.next_index);
+        for log in logs {
+            if let Some(meta) = self.apply(log) {
+                witness.push_merkle_path(meta);
+            }
+        }
+        Ok((witness, self.current_root()))
+    }
+
+    fn apply(&mut self, log: &StorageLog) -> Option<StorageLogMetadata> {
+        let key = log.key.hashed_key_u256();
+        if log.is_write() {
+            let value = log.value;
+            let (first_write, leaf_index, value_read) = match self.leaves.get(&key).copied() {
+                Some(leaf) => {
+                    if leaf.value == value {
+                        // No-op update: the tree omits these from the witness.
+                        return None;
+                    }
+                    (false, leaf.leaf_index, leaf.value)
+                }
+                None => {
+                    let idx = self.next_index;
+                    self.next_index += 1;
+                    (true, idx, H256::zero())
+                }
+            };
+            self.leaves.insert(key, Leaf { value, leaf_index });
+            let (siblings, root) = self.recompute_path(key);
+            Some(StorageLogMetadata {
+                root_hash: root.0,
+                is_write: true,
+                first_write,
+                merkle_paths: siblings.iter().map(|h| h.0).collect(),
+                leaf_hashed_key: key,
+                leaf_enumeration_index: leaf_index,
+                value_written: value.0,
+                value_read: value_read.0,
+            })
+        } else {
+            let (leaf_index, value_read) = match self.leaves.get(&key) {
+                Some(leaf) => (leaf.leaf_index, leaf.value),
+                None => (0, H256::zero()),
+            };
+            let siblings = self.read_path(key);
+            Some(StorageLogMetadata {
+                root_hash: self.current_root().0,
+                is_write: false,
+                first_write: false,
+                merkle_paths: siblings.iter().map(|h| h.0).collect(),
+                leaf_hashed_key: key,
+                leaf_enumeration_index: leaf_index,
+                value_written: [0_u8; 32],
+                value_read: value_read.0,
+            })
+        }
+    }
+
+    /// Update the nodes along `key`'s path after its leaf changed; returns the
+    /// per-level sibling hashes (depth 0..256) and the new root.
+    fn recompute_path(&mut self, key: U256) -> (Vec<H256>, H256) {
+        let mut siblings = Vec::with_capacity(TREE_DEPTH);
+        let mut node = self.leaf_hash(key);
+        for d in 0..TREE_DEPTH {
+            let prefix_d = key >> d;
+            let sib = self.node_at(d as u16, prefix_d ^ U256::one());
+            siblings.push(sib);
+            node = if (prefix_d & U256::one()).is_zero() {
+                self.hasher.hash_branch(&node, &sib)
+            } else {
+                self.hasher.hash_branch(&sib, &node)
+            };
+            self.nodes.insert(((d + 1) as u16, key >> (d + 1)), node);
+        }
+        (siblings, node)
+    }
+
+    /// Sibling hashes along `key`'s path without mutating the tree (for reads).
+    fn read_path(&self, key: U256) -> Vec<H256> {
+        (0..TREE_DEPTH)
+            .map(|d| self.node_at(d as u16, (key >> d) ^ U256::one()))
+            .collect()
+    }
+
+    /// Current hash of any node, reading the live `nodes`/`leaves`/`boundary`.
+    fn node_at(&self, level: u16, prefix: U256) -> H256 {
+        if level == 0 {
+            return self.leaf_hash(prefix);
+        }
+        if self.on_trie(level, prefix) {
+            *self
+                .nodes
+                .get(&(level, prefix))
+                .expect("on-trie node must be present after build")
+        } else {
+            self.boundary
+                .get(&(level, prefix))
+                .copied()
+                .unwrap_or_else(|| self.hasher.empty_subtree_hash(level as usize))
+        }
+    }
+
+    fn current_root(&self) -> H256 {
+        *self
+            .nodes
+            .get(&(TREE_DEPTH as u16, U256::zero()))
+            .expect("root must be present after build")
+    }
+
+    fn leaf_hash(&self, key: U256) -> H256 {
+        match self.leaves.get(&key) {
+            Some(leaf) => self.hasher.hash_leaf(&leaf.value, leaf.leaf_index),
+            None => self.hasher.empty_subtree_hash(0),
+        }
+    }
+
+    /// Recursively compute (and memoize) an on-trie node hash during build.
+    fn compute(&mut self, level: u16, prefix: U256) -> H256 {
+        if level == 0 {
+            return self.leaf_hash(prefix);
+        }
+        if !self.on_trie(level, prefix) {
+            return self
+                .boundary
+                .get(&(level, prefix))
+                .copied()
+                .unwrap_or_else(|| self.hasher.empty_subtree_hash(level as usize));
+        }
+        if let Some(h) = self.nodes.get(&(level, prefix)) {
+            return *h;
+        }
+        let left = self.compute(level - 1, prefix << 1);
+        let right = self.compute(level - 1, (prefix << 1) | U256::one());
+        let h = self.hasher.hash_branch(&left, &right);
+        self.nodes.insert((level, prefix), h);
+        h
+    }
+
+    /// Whether the subtree at `(level, prefix)` contains any touched key.
+    fn on_trie(&self, level: u16, prefix: U256) -> bool {
+        if self.sorted_keys.is_empty() {
+            return false;
+        }
+        if level as usize >= TREE_DEPTH {
+            return true;
+        }
+        let level = level as usize;
+        let low = prefix << level;
+        let high = low + ((U256::one() << level) - U256::one());
+        let idx = self.sorted_keys.partition_point(|k| *k < low);
+        idx < self.sorted_keys.len() && self.sorted_keys[idx] <= high
+    }
+}

--- a/core/bin/batch_splitter/src/split.rs
+++ b/core/bin/batch_splitter/src/split.rs
@@ -1,0 +1,243 @@
+//! Orchestration: load batch N, split its blocks in half, re-execute and
+//! regenerate witnesses for each half, and assemble two
+//! `AirbenderVerifierInput`s. Loading mirrors
+//! `airbender_request_processor::airbender_verifier_input_for_existing_batch`.
+//!
+//! Order matters: piece B's execution depends on `root_A` (its
+//! `previous_batch_hash`), and `root_A` comes from applying piece A to the
+//! reconstructed sparse tree. So the flow is: re-exec A → sparse.process A →
+//! root_A → re-exec B → sparse.process B (which feeds the `root_B ==
+//! new_root_N` self-check).
+
+use std::collections::HashMap;
+
+use anyhow::Context;
+use zksync_airbender_prover_interface::inputs::AirbenderVerifierInput;
+use zksync_dal::{ConnectionPool, Core, CoreDal};
+use zksync_multivm::interface::{FinishedL1Batch, L2BlockEnv};
+use zksync_object_store::ObjectStore;
+use zksync_prover_interface::inputs::{VMRunWitnessInputData, WitnessInputMerklePaths};
+use zksync_types::{
+    commitment::L1BatchCommitmentMode, u256_to_h256, L1BatchNumber, L2ChainId, H256,
+};
+use zksync_vm_executor::storage::{L1BatchParamsProvider, RestoredL1BatchEnv};
+
+use crate::{commitment, reexec, sparse_tree::SparseMerkle};
+
+pub struct SplitParams {
+    pub batch: L1BatchNumber,
+    pub l2_chain_id: L2ChainId,
+    pub commitment_chaining: bool,
+}
+
+pub async fn split(
+    pool: &ConnectionPool<Core>,
+    blob_store: &dyn ObjectStore,
+    params: SplitParams,
+) -> anyhow::Result<(AirbenderVerifierInput, AirbenderVerifierInput)> {
+    let SplitParams {
+        batch,
+        l2_chain_id,
+        commitment_chaining,
+    } = params;
+
+    let mut connection = pool.connection_tagged("batch_splitter").await?;
+
+    // --- 1. Load the full batch's witness components (as the prover would) ---
+    let vm_run_data: VMRunWitnessInputData = blob_store
+        .get(batch)
+        .await
+        .context("failed to load VMRunWitnessInputData")?;
+    let merkle_paths: WitnessInputMerklePaths = blob_store
+        .get(batch)
+        .await
+        .context("failed to load WitnessInputMerklePaths")?;
+    let start_enumeration_index = merkle_paths.next_enumeration_index();
+
+    let l2_blocks = connection
+        .transactions_dal()
+        .get_l2_blocks_to_execute_for_l1_batch(batch)
+        .await?;
+    anyhow::ensure!(
+        l2_blocks.len() >= 2,
+        "batch {batch} has {} L2 block(s); need at least 2 to split",
+        l2_blocks.len()
+    );
+
+    let l1_batch_params_provider = L1BatchParamsProvider::new(&mut connection).await?;
+    let RestoredL1BatchEnv {
+        system_env,
+        l1_batch_env,
+        pubdata_params,
+        ..
+    } = l1_batch_params_provider
+        .load_l1_batch_env(&mut connection, batch, u32::MAX, l2_chain_id)
+        .await?
+        .with_context(|| format!("envs missing for batch {batch}"))?;
+    let version = system_env.version;
+    let commitment_mode: L1BatchCommitmentMode = pubdata_params.pubdata_type().into();
+
+    let expected_new_root: H256 = connection
+        .blocks_dal()
+        .get_l1_batch_tree_data(batch)
+        .await?
+        .with_context(|| format!("tree data (root hash) missing for batch {batch}"))?
+        .hash;
+
+    // --- 2. Split the block list in half (whole blocks; fictive block → B) ---
+    let mid = l2_blocks.len().div_ceil(2);
+    let blocks_a = l2_blocks[..mid].to_vec();
+    let blocks_b = l2_blocks[mid..].to_vec();
+    tracing::info!(
+        "splitting batch {batch} ({} blocks) at index {mid}: A blocks {}..{}, B blocks {}..{}",
+        l2_blocks.len(),
+        blocks_a.first().map(|b| b.number.0).unwrap_or_default(),
+        blocks_a.last().map(|b| b.number.0).unwrap_or_default(),
+        blocks_b.first().map(|b| b.number.0).unwrap_or_default(),
+        blocks_b.last().map(|b| b.number.0).unwrap_or_default(),
+    );
+
+    // --- 3. Shared factory deps + the batch-start storage snapshot ---
+    let factory_deps: HashMap<H256, Vec<u8>> = vm_run_data
+        .used_bytecodes
+        .iter()
+        .map(|(hash, code)| (u256_to_h256(*hash), code.clone().into_flattened()))
+        .collect();
+    let start_storage = batch_start_storage(&vm_run_data);
+
+    // --- 4. Re-execute piece A from the batch start ---
+    let exec_a = reexec::reexecute_piece(
+        &vm_run_data,
+        l1_batch_env.clone(),
+        system_env.clone(),
+        pubdata_params,
+        blocks_a.clone(),
+        start_storage.clone(),
+        factory_deps.clone(),
+    )
+    .context("re-execution of piece A failed")?;
+    let logs_a = exec_a
+        .finished
+        .final_execution_state
+        .deduplicated_storage_logs
+        .clone();
+
+    // --- 5. Reconstruct the N-1 tree from N's multiproof; regenerate A's paths.
+    //        Non-invasive: uses only the immutable witness blob, no tree DB. ---
+    let old_root = l1_batch_env
+        .previous_batch_hash
+        .context("batch N has no previous_batch_hash")?;
+    let mut sparse = SparseMerkle::build(&merkle_paths, old_root, start_enumeration_index)?;
+    let (merkle_paths_a, root_a) = sparse.process_piece(&logs_a)?;
+
+    // --- 6. Re-execute piece B from (start + A's writes) with prev = root_A ---
+    let storage_b = overlay_writes(start_storage, &exec_a.finished);
+    let mut l1_batch_env_b = l1_batch_env.clone();
+    l1_batch_env_b.first_l2_block = L2BlockEnv::from_l2_block_data(&blocks_b[0]);
+    l1_batch_env_b.previous_batch_hash = Some(root_a);
+
+    let exec_b = reexec::reexecute_piece(
+        &vm_run_data,
+        l1_batch_env_b.clone(),
+        system_env.clone(),
+        pubdata_params,
+        blocks_b.clone(),
+        storage_b,
+        factory_deps,
+    )
+    .context("re-execution of piece B failed")?;
+    let logs_b = exec_b
+        .finished
+        .final_execution_state
+        .deduplicated_storage_logs
+        .clone();
+
+    // --- 7. Regenerate B's paths; self-check root_B == new_root_N ---
+    let (merkle_paths_b, root_b) = sparse.process_piece(&logs_b)?;
+    anyhow::ensure!(
+        root_b == expected_new_root,
+        "self-check failed: replayed root_B {root_b:?} != batch {batch} committed root \
+         {expected_new_root:?}; the sparse reconstruction or leaf-index assignment is wrong",
+    );
+
+    // --- 8. Commitment inputs ---
+    let pubdata_a = exec_a
+        .finished
+        .pubdata_input
+        .clone()
+        .context("piece A produced no pubdata")?;
+    let pubdata_b = exec_b
+        .finished
+        .pubdata_input
+        .clone()
+        .context("piece B produced no pubdata")?;
+
+    let ci_a = commitment::commitment_input_for_a(
+        &mut connection,
+        batch,
+        &pubdata_a,
+        &version,
+        commitment_mode,
+    )
+    .await?;
+    let ci_b = commitment::commitment_input_for_b(
+        commitment_chaining,
+        &pubdata_b,
+        &version,
+        commitment_mode,
+    )?;
+
+    // --- 9. Assemble the two self-contained inputs ---
+    let input_a = AirbenderVerifierInput {
+        vm_run_data: exec_a.vm_run_data,
+        merkle_paths: merkle_paths_a,
+        l2_blocks_execution_data: blocks_a,
+        l1_batch_env,
+        system_env: system_env.clone(),
+        pubdata_params,
+        commitment_input: Some(ci_a),
+    };
+    let input_b = AirbenderVerifierInput {
+        vm_run_data: exec_b.vm_run_data,
+        merkle_paths: merkle_paths_b,
+        l2_blocks_execution_data: blocks_b,
+        l1_batch_env: l1_batch_env_b,
+        system_env,
+        pubdata_params,
+        commitment_input: ci_b,
+    };
+
+    Ok((input_a, input_b))
+}
+
+/// Batch-start storage snapshot, exactly as `AirbenderVerifierInput::verify`
+/// builds it: read slots with dummy non-zero enum indices, plus initial-write
+/// slots as `None`.
+fn batch_start_storage(vm_run_data: &VMRunWitnessInputData) -> HashMap<H256, Option<(H256, u64)>> {
+    let reads = vm_run_data
+        .witness_block_state
+        .read_storage_key
+        .iter()
+        .enumerate()
+        .map(|(i, (key, value))| (key.hashed_key(), Some((*value, i as u64 + 1))));
+    let initial_writes = vm_run_data
+        .witness_block_state
+        .is_write_initial
+        .iter()
+        .filter_map(|(key, initial)| initial.then_some((key.hashed_key(), None)));
+    reads.chain(initial_writes).collect()
+}
+
+/// Overlay piece A's writes onto the start snapshot so piece B sees post-A
+/// state. A non-zero enum index marks the slot as non-initial for B.
+fn overlay_writes(
+    mut storage: HashMap<H256, Option<(H256, u64)>>,
+    finished_a: &FinishedL1Batch,
+) -> HashMap<H256, Option<(H256, u64)>> {
+    for log in &finished_a.final_execution_state.deduplicated_storage_logs {
+        if log.is_write() {
+            storage.insert(log.key.hashed_key(), Some((log.value, 1)));
+        }
+    }
+    storage
+}


### PR DESCRIPTION
## Why

Boojum can prove heavier batches than Airbender's geometry allows. To migrate such batches to Airbender we want to: prove the whole batch, and on failure split it into two pieces and prove each — recursively, until each piece fits Airbender's geometry.

This PR adds a `batch_splitter` binary (`core/bin/batch_splitter`) that splits a **sealed** L1 batch `N` into two independently-provable `AirbenderVerifierInput` pieces.

## What it does

For batch `N` spanning L2 blocks `[first, last]`, it cuts at the midpoint (even by block count, whole blocks only) into piece **A** `[first, mid)` and piece **B** `[mid, last]`, such that `old_root_N →(A) root_A →(B) new_root_N`.

- **Witness-input level, not a slice.** A witness input is one bootloader program; the per-op arrays can't be cut at a block boundary. So each half is **re-executed** over its block range (mirroring `BasicWitnessInputProducer` / `AirbenderVerifierInput::verify`), seeded from the in-witness storage snapshot (piece B overlaid with A's writes).
- **Non-invasive.** Reads only Postgres (MVCC) and immutable object-store blobs; **never** writes the canonical chain, re-commits to L1, re-numbers batches, or touches the Merkle-tree RocksDB.
- **Merkle paths from N's own multiproof.** Sibling hashes come from batch N's immutable `WitnessInputMerklePaths` blob — the only non-invasive source. A sparse binary Merkle tree is reconstructed from it (N-1 leaf values from each key's first occurrence; off-trie siblings are invariant during N), then A's and B's writes are re-applied to regenerate each piece's paths + `root_A`. Hashing reuses `Blake2Hasher`'s `hash_leaf`/`hash_branch`/`empty_subtree_hash`, so roots/paths match exactly.
- **Output.** Two self-contained `AirbenderVerifierInput` CBOR blobs (`airbender_split_input_{N}_a.cbor` / `_b.cbor`).

## Correctness self-checks

Two root checks bracket the reconstruction and fail loudly rather than emitting a bad witness:
1. reconstructed N-1 root == N's `previous_batch_hash`;
2. post-B root == N's committed root hash.

## Scope / follow-ups

- **Commitment chaining for piece B** (computing piece A's synthetic Airbender commitment) is gated behind `--commitment-chaining`. Off by default, B is emitted with `commitment_input = None`, which is enough to verify each half **fits Airbender's geometry** — the immediate goal. The full `L1BatchCommitment` assembly for the intermediate batch is the one piece left for a follow-up (clearly isolated in `commitment.rs`).
- **Validation:** the binary builds and is type-checked; the next step is a run on a real heavy batch to exercise the root self-checks (empirical proof the reconstruction is exact). Not yet run against live data.

See `core/bin/batch_splitter/README.md` for the full design.

## Usage

```
batch_splitter --l1-batch <N> --database-url <pg> --artifacts-path <object-store> --l2-chain-id <id> [--commitment-chaining]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)