### PR TITLE
fix(job_processor): drop high-cardinality job_id metric label

### DIFF
--- a/core/lib/queued_job_processor/src/lib.rs
+++ b/core/lib/queued_job_processor/src/lib.rs
@@ -14,8 +14,8 @@ const ATTEMPT_BUCKETS: Buckets = Buckets::exponential(1.0..=64.0, 2.0);
 #[derive(Debug, Metrics)]
 #[metrics(prefix = "job_processor")]
 struct JobProcessorMetrics {
-    #[metrics(labels = ["service_name", "job_id"])]
-    max_attempts_reached: LabeledFamily<(&'static str, String), Counter, 2>,
+    #[metrics(labels = ["service_name"])]
+    max_attempts_reached: LabeledFamily<&'static str, Counter>,
     #[metrics(labels = ["service_name"], buckets = ATTEMPT_BUCKETS)]
     attempts: LabeledFamily<&'static str, Histogram<usize>>,
 }
@@ -116,7 +116,7 @@ pub trait JobProcessor: Sync + Send {
         let attempts = self.get_job_attempts(&job_id).await?;
         let max_attempts = self.max_attempts();
         if attempts == max_attempts {
-            METRICS.max_attempts_reached[&(Self::SERVICE_NAME, format!("{job_id:?}"))].inc();
+            METRICS.max_attempts_reached[&Self::SERVICE_NAME].inc();
             tracing::error!(
                 "Max attempts ({max_attempts}) reached for {} job {:?}",
                 Self::SERVICE_NAME,


### PR DESCRIPTION
## Problem
`max_attempts_reached` was labeled by `format!("{job_id:?}")`:

```rust
max_attempts_reached: LabeledFamily<(&'static str, String), Counter, 2>,
...
METRICS.max_attempts_reached[&(Self::SERVICE_NAME, format!("{job_id:?}"))].inc();
```

`job_id` is per-job (effectively monotonic), so every distinct job that exhausted its retries minted a **permanent** time series in the metrics registry, growing its memory without bound over the process lifetime (classic Prometheus cardinality anti-pattern). It's a slow leak — failure-path only — but unbounded.

## Fix
Aggregate the counter per `service_name` only, mirroring the sibling `attempts` metric. The job id is still recorded in the adjacent `tracing::error!`, so no diagnostic information is lost.

## Risk
Minimal. Any dashboard/alert that grouped this counter by `job_id` would need updating, but per-job-id breakdown of a max-attempts counter is not a useful aggregation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)