### PR TITLE
feat(airbender): emit read_proofs binding reverted-frame reads to old_root_hash

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -13460,6 +13460,7 @@ dependencies = [
  "zksync_node_framework",
  "zksync_object_store",
  "zksync_prover_interface",
+ "zksync_shared_resources",
  "zksync_types",
  "zksync_vm_executor",
 ]

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -13473,6 +13473,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 1.14.0",
+ "zksync_crypto_primitives",
+ "zksync_merkle_tree",
  "zksync_object_store",
  "zksync_prover_interface",
  "zksync_types",

--- a/core/bin/zksync_server/src/node_builder.rs
+++ b/core/bin/zksync_server/src/node_builder.rs
@@ -891,7 +891,9 @@ impl MainNodeBuilder {
                     self = self.add_proof_data_handler_layer()?;
                 }
                 Component::AirbenderProofDataHandler => {
-                    self = self.add_airbender_proof_data_handler_layer()?;
+                    self = self
+                        .add_tree_api_client_layer()?
+                        .add_airbender_proof_data_handler_layer()?;
                 }
                 Component::Consensus => {
                     self = self.add_consensus_layer()?;

--- a/core/lib/airbender_prover_interface/Cargo.toml
+++ b/core/lib/airbender_prover_interface/Cargo.toml
@@ -22,3 +22,5 @@ bincode.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+zksync_merkle_tree.workspace = true
+zksync_crypto_primitives.workspace = true

--- a/core/lib/airbender_prover_interface/src/inputs.rs
+++ b/core/lib/airbender_prover_interface/src/inputs.rs
@@ -68,3 +68,53 @@ pub struct AirbenderVerifierInput {
     #[serde(default)]
     pub read_proofs: Vec<ReadProof>,
 }
+
+#[cfg(test)]
+mod tests {
+    use zksync_crypto_primitives::hasher::blake2::Blake2Hasher;
+    use zksync_merkle_tree::{MerkleTree, PatchSet, TreeEntry, TreeEntryWithProof};
+    use zksync_types::{H256, U256};
+
+    use super::ReadProof;
+
+    #[test]
+    fn read_proof_roundtrips_a_real_tree_proof() {
+        // Build a one-leaf tree; capture root + proofs for a present and an absent key.
+        let mut tree = MerkleTree::new(PatchSet::default()).unwrap();
+        let present = U256::from(0x1111u64);
+        let absent = U256::from(0x2222u64);
+        let value = H256::from_low_u64_be(0x42);
+        let root = tree
+            .extend(vec![TreeEntry::new(present, 1, value)])
+            .unwrap()
+            .root_hash;
+        let entries = tree.entries_with_proofs(0, &[present, absent]).unwrap();
+
+        // Map each tree proof into our ReadProof exactly as the handler does.
+        let to_read_proof = |key: U256, e: &TreeEntryWithProof| ReadProof {
+            hashed_key: key,
+            value: e.base.value,
+            enumeration_index: e.base.leaf_index,
+            merkle_path: e.merkle_path.clone(),
+        };
+        let present_rp = to_read_proof(present, &entries[0]);
+        let absent_rp = to_read_proof(absent, &entries[1]);
+
+        // Reconstruct the tree proof from our ReadProof and confirm it still folds to root.
+        for rp in [&present_rp, &absent_rp] {
+            let reconstructed = TreeEntryWithProof {
+                base: TreeEntry::new(rp.hashed_key, rp.enumeration_index, rp.value),
+                merkle_path: rp.merkle_path.clone(),
+            };
+            reconstructed
+                .verify(&Blake2Hasher, root)
+                .expect("ReadProof must reconstruct a valid proof");
+        }
+
+        // Sanity: the present slot carries the value/index; the absent slot is empty (index 0, value 0).
+        assert_eq!(present_rp.value, value);
+        assert_eq!(present_rp.enumeration_index, 1);
+        assert_eq!(absent_rp.enumeration_index, 0);
+        assert!(absent_rp.value.is_zero());
+    }
+}

--- a/core/lib/airbender_prover_interface/src/inputs.rs
+++ b/core/lib/airbender_prover_interface/src/inputs.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 use zksync_prover_interface::inputs::{VMRunWitnessInputData, WitnessInputMerklePaths};
-use zksync_types::{block::L2BlockExecutionData, commitment::PubdataParams, H256};
+use zksync_types::{block::L2BlockExecutionData, commitment::PubdataParams, H256, U256};
 use zksync_vm_interface::{L1BatchEnv, SystemEnv};
 
 /// Wire-format mirror of `zksync_types::commitment::BlobHash`.
@@ -33,6 +33,22 @@ pub struct CommitmentInput {
     pub blob_versioned_hashes: Vec<H256>,
 }
 
+/// A Merkle proof of a single storage slot's pre-batch state against
+/// `old_root_hash`, for a slot the committed `merkle_paths` omits (a read inside
+/// a reverted frame, or a reverted initial write). Wire-format mirror of the
+/// verifier's `ReadProof`; field order is load-bearing for bincode.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReadProof {
+    /// Hashed storage key (little-endian `U256`, matching `TreeEntry`).
+    pub hashed_key: U256,
+    /// Pre-state value; zero for an empty/absent slot.
+    pub value: H256,
+    /// Enumeration index; 0 for an empty/initial slot.
+    pub enumeration_index: u64,
+    /// Merkle path from the leaf to `old_root_hash`.
+    pub merkle_path: Vec<H256>,
+}
+
 /// Data fed to the Airbender verifier.
 ///
 /// `commitment_input` is `Some` when the producer can populate it (i.e., the
@@ -47,4 +63,8 @@ pub struct AirbenderVerifierInput {
     pub system_env: SystemEnv,
     pub pubdata_params: PubdataParams,
     pub commitment_input: Option<CommitmentInput>,
+    /// Proofs (vs `old_root_hash`) for view-domain slots absent from
+    /// `merkle_paths`. Empty when every read the VM makes is committed.
+    #[serde(default)]
+    pub read_proofs: Vec<ReadProof>,
 }

--- a/core/lib/airbender_verifier/src/lib.rs
+++ b/core/lib/airbender_verifier/src/lib.rs
@@ -379,6 +379,7 @@ mod tests {
             )
             .unwrap(),
             commitment_input: None,
+            read_proofs: vec![],
         };
         let serialized =
             serde_json::to_vec(&tvi).expect("Failed to serialize AirbenderVerifierInput.");

--- a/core/node/airbender_proof_data_handler/Cargo.toml
+++ b/core/node/airbender_proof_data_handler/Cargo.toml
@@ -19,6 +19,7 @@ zksync_l1_contract_interface.workspace = true
 zksync_node_framework.workspace = true
 zksync_object_store = { workspace = true, features = ["node_framework"] }
 zksync_prover_interface.workspace = true
+zksync_shared_resources.workspace = true
 zksync_airbender_prover_interface.workspace = true
 zksync_types.workspace = true
 zksync_vm_executor.workspace = true

--- a/core/node/airbender_proof_data_handler/src/airbender_request_processor.rs
+++ b/core/node/airbender_proof_data_handler/src/airbender_request_processor.rs
@@ -22,6 +22,7 @@ use zksync_prover_interface::{
     inputs::{VMRunWitnessInputData, WitnessInputMerklePaths},
     outputs::L1BatchProofForL1,
 };
+use zksync_shared_resources::tree::TreeApiClient;
 use zksync_types::{
     blob::num_blobs_required, commitment::L1BatchCommitmentMode, L1BatchNumber, L2ChainId,
 };
@@ -38,6 +39,9 @@ pub(crate) struct AirbenderRequestProcessor {
     pool: ConnectionPool<Core>,
     config: AirbenderProofDataHandlerConfig,
     l2_chain_id: L2ChainId,
+    // Held for upcoming read-proof fetching at batch N-1; not yet used.
+    #[allow(dead_code)]
+    tree_api_client: Arc<dyn TreeApiClient>,
 }
 
 impl AirbenderRequestProcessor {
@@ -46,12 +50,14 @@ impl AirbenderRequestProcessor {
         pool: ConnectionPool<Core>,
         config: AirbenderProofDataHandlerConfig,
         l2_chain_id: L2ChainId,
+        tree_api_client: Arc<dyn TreeApiClient>,
     ) -> Self {
         Self {
             blob_store,
             pool,
             config,
             l2_chain_id,
+            tree_api_client,
         }
     }
 

--- a/core/node/airbender_proof_data_handler/src/airbender_request_processor.rs
+++ b/core/node/airbender_proof_data_handler/src/airbender_request_processor.rs
@@ -25,7 +25,7 @@ use zksync_prover_interface::{
     inputs::{VMRunWitnessInputData, WitnessInputMerklePaths},
     outputs::L1BatchProofForL1,
 };
-use zksync_shared_resources::tree::TreeApiClient;
+use zksync_shared_resources::tree::{TreeApiClient, TreeEntryWithProof};
 use zksync_types::{
     blob::num_blobs_required, commitment::L1BatchCommitmentMode,
     witness_block_state::WitnessStorageState, L1BatchNumber, L2ChainId, U256,
@@ -329,8 +329,6 @@ impl AirbenderRequestProcessor {
         // Bind every slot the VM reads to `old_root_hash`: for view-domain slots
         // the committed `merkle_paths` omits (reverted-frame reads), fetch a
         // Merkle proof against the tree at N-1 (= old_root_hash for batch N).
-        // `gap` is kept past the `get_proofs` call because the returned proofs
-        // carry no key — we recover each `hashed_key` from the request order.
         let gap = read_proof_gap(&vm_run_data.witness_block_state, &merkle_paths);
         let read_proofs = if gap.is_empty() {
             Vec::new()
@@ -345,22 +343,7 @@ impl AirbenderRequestProcessor {
                         gap.len()
                     ))
                 })?;
-            if entries.len() != gap.len() {
-                return Err(AirbenderProcessorError::GeneralError(anyhow::anyhow!(
-                    "tree returned {} proofs for {} requested read-proof slots",
-                    entries.len(),
-                    gap.len()
-                )));
-            }
-            gap.into_iter()
-                .zip(entries)
-                .map(|(hashed_key, e)| ReadProof {
-                    hashed_key,
-                    value: e.value,
-                    enumeration_index: e.index,
-                    merkle_path: e.merkle_path,
-                })
-                .collect()
+            read_proofs_from_entries(gap, entries).map_err(AirbenderProcessorError::GeneralError)?
         };
 
         Ok(AirbenderVerifierInput {
@@ -690,6 +673,32 @@ fn read_proof_gap(
         .collect()
 }
 
+/// Pair tree proofs with the hashed keys they were requested for, into
+/// `ReadProof`s. `entries` come back from `get_proofs` in request order and carry
+/// no key, so we recover each `hashed_key` from `gap` by position; the length
+/// guard rejects a malformed (out-of-contract) tree response.
+fn read_proofs_from_entries(
+    gap: Vec<U256>,
+    entries: Vec<TreeEntryWithProof>,
+) -> anyhow::Result<Vec<ReadProof>> {
+    anyhow::ensure!(
+        entries.len() == gap.len(),
+        "tree returned {} proofs for {} requested read-proof slots",
+        entries.len(),
+        gap.len()
+    );
+    Ok(gap
+        .into_iter()
+        .zip(entries)
+        .map(|(hashed_key, e)| ReadProof {
+            hashed_key,
+            value: e.value,
+            enumeration_index: e.index,
+            merkle_path: e.merkle_path,
+        })
+        .collect())
+}
+
 #[cfg(test)]
 mod tests {
     use zksync_prover_interface::inputs::StorageLogMetadata;
@@ -741,5 +750,39 @@ mod tests {
             !gap.contains(&a.hashed_key_u256()),
             "a should NOT be in gap (already in merkle_paths)"
         );
+    }
+
+    #[test]
+    fn read_proofs_from_entries_pairs_by_position_and_guards_length() {
+        let gap = vec![U256::from(0xaau64), U256::from(0xbbu64)];
+        let entries = vec![
+            TreeEntryWithProof {
+                value: H256::from_low_u64_be(0x11),
+                index: 5,
+                merkle_path: vec![H256::zero()],
+            },
+            // An absent (empty) slot: value 0, index 0.
+            TreeEntryWithProof {
+                value: H256::zero(),
+                index: 0,
+                merkle_path: vec![H256::repeat_byte(2)],
+            },
+        ];
+
+        let rps = read_proofs_from_entries(gap.clone(), entries.clone()).unwrap();
+        assert_eq!(rps.len(), 2);
+        // Each ReadProof recovers its key from gap by position and copies the
+        // proof's value/index/path verbatim.
+        for i in 0..2 {
+            assert_eq!(rps[i].hashed_key, gap[i]);
+            assert_eq!(rps[i].value, entries[i].value);
+            assert_eq!(rps[i].enumeration_index, entries[i].index);
+            assert_eq!(rps[i].merkle_path, entries[i].merkle_path);
+        }
+
+        // A length mismatch (malformed tree response) errors rather than silently
+        // truncating / mispairing.
+        let short = vec![entries.into_iter().next().unwrap()];
+        assert!(read_proofs_from_entries(gap, short).is_err());
     }
 }

--- a/core/node/airbender_proof_data_handler/src/airbender_request_processor.rs
+++ b/core/node/airbender_proof_data_handler/src/airbender_request_processor.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::{
+    collections::{BTreeSet, HashSet},
+    sync::Arc,
+};
 
 use anyhow::Context;
 use axum::{extract::Path, Json};
@@ -24,7 +27,8 @@ use zksync_prover_interface::{
 };
 use zksync_shared_resources::tree::TreeApiClient;
 use zksync_types::{
-    blob::num_blobs_required, commitment::L1BatchCommitmentMode, L1BatchNumber, L2ChainId, U256,
+    blob::num_blobs_required, commitment::L1BatchCommitmentMode,
+    witness_block_state::WitnessStorageState, L1BatchNumber, L2ChainId, U256,
 };
 use zksync_vm_executor::storage::{L1BatchParamsProvider, RestoredL1BatchEnv};
 
@@ -325,6 +329,8 @@ impl AirbenderRequestProcessor {
         // Bind every slot the VM reads to `old_root_hash`: for view-domain slots
         // the committed `merkle_paths` omits (reverted-frame reads), fetch a
         // Merkle proof against the tree at N-1 (= old_root_hash for batch N).
+        // `gap` is kept past the `get_proofs` call because the returned proofs
+        // carry no key — we recover each `hashed_key` from the request order.
         let gap = read_proof_gap(&vm_run_data.witness_block_state, &merkle_paths);
         let read_proofs = if gap.is_empty() {
             Vec::new()
@@ -659,18 +665,19 @@ impl AirbenderRequestProcessor {
 
 /// Hashed keys the verifier needs read-proofs for: every slot the operator's
 /// witness exposes to the VM (`read_storage_key` ∪ `is_write_initial`) that the
-/// committed `merkle_paths` does not already prove. Sorted for a reproducible
-/// request order so the returned proofs pair up by position.
+/// committed `merkle_paths` does not already prove. Returned in sorted order for
+/// determinism; the caller pairs proofs back by position, which is safe because
+/// `TreeApiClient::get_proofs` preserves request order.
 fn read_proof_gap(
-    witness_block_state: &zksync_types::witness_block_state::WitnessStorageState,
+    witness_block_state: &WitnessStorageState,
     merkle_paths: &WitnessInputMerklePaths,
 ) -> Vec<U256> {
-    let in_paths: std::collections::HashSet<U256> = merkle_paths
+    let in_paths: HashSet<U256> = merkle_paths
         .merkle_paths
         .iter()
         .map(|log| log.leaf_hashed_key)
         .collect();
-    let mut domain: std::collections::BTreeSet<U256> = std::collections::BTreeSet::new();
+    let mut domain: BTreeSet<U256> = BTreeSet::new();
     for k in witness_block_state.read_storage_key.keys() {
         domain.insert(k.hashed_key_u256());
     }

--- a/core/node/airbender_proof_data_handler/src/airbender_request_processor.rs
+++ b/core/node/airbender_proof_data_handler/src/airbender_request_processor.rs
@@ -684,7 +684,10 @@ fn read_proof_gap(
     for k in witness_block_state.is_write_initial.keys() {
         domain.insert(k.hashed_key_u256());
     }
-    domain.into_iter().filter(|k| !in_paths.contains(k)).collect()
+    domain
+        .into_iter()
+        .filter(|k| !in_paths.contains(k))
+        .collect()
 }
 
 #[cfg(test)]
@@ -696,8 +699,12 @@ mod tests {
 
     #[test]
     fn read_proof_gap_excludes_merkle_path_slots_includes_reverted() {
-        let k =
-            |n: u64| StorageKey::new(AccountTreeId::new(Address::from_low_u64_be(n)), H256::zero());
+        let k = |n: u64| {
+            StorageKey::new(
+                AccountTreeId::new(Address::from_low_u64_be(n)),
+                H256::zero(),
+            )
+        };
         let a = k(1);
         let b = k(2);
         let c = k(3);

--- a/core/node/airbender_proof_data_handler/src/airbender_request_processor.rs
+++ b/core/node/airbender_proof_data_handler/src/airbender_request_processor.rs
@@ -9,7 +9,7 @@ use zksync_airbender_prover_interface::{
         SubmitAirbenderProofResponse, SubmitAirbenderSnarkProofRequest,
         SubmitAirbenderSnarkProofResponse,
     },
-    inputs::{AirbenderVerifierInput, BlobHash, CommitmentInput},
+    inputs::{AirbenderVerifierInput, BlobHash, CommitmentInput, ReadProof},
     outputs::{L1BatchAirbenderProofForL1, L1BatchAirbenderSnarkProofForL1},
 };
 use zksync_config::configs::AirbenderProofDataHandlerConfig;
@@ -24,7 +24,7 @@ use zksync_prover_interface::{
 };
 use zksync_shared_resources::tree::TreeApiClient;
 use zksync_types::{
-    blob::num_blobs_required, commitment::L1BatchCommitmentMode, L1BatchNumber, L2ChainId,
+    blob::num_blobs_required, commitment::L1BatchCommitmentMode, L1BatchNumber, L2ChainId, U256,
 };
 use zksync_vm_executor::storage::{L1BatchParamsProvider, RestoredL1BatchEnv};
 
@@ -39,8 +39,6 @@ pub(crate) struct AirbenderRequestProcessor {
     pool: ConnectionPool<Core>,
     config: AirbenderProofDataHandlerConfig,
     l2_chain_id: L2ChainId,
-    // Held for upcoming read-proof fetching at batch N-1; not yet used.
-    #[allow(dead_code)]
     tree_api_client: Arc<dyn TreeApiClient>,
 }
 
@@ -324,6 +322,41 @@ impl AirbenderRequestProcessor {
             blob_versioned_hashes: versioned_hashes,
         };
 
+        // Bind every slot the VM reads to `old_root_hash`: for view-domain slots
+        // the committed `merkle_paths` omits (reverted-frame reads), fetch a
+        // Merkle proof against the tree at N-1 (= old_root_hash for batch N).
+        let gap = read_proof_gap(&vm_run_data.witness_block_state, &merkle_paths);
+        let read_proofs = if gap.is_empty() {
+            Vec::new()
+        } else {
+            let entries = self
+                .tree_api_client
+                .get_proofs(prev_number, gap.clone())
+                .await
+                .map_err(|e| {
+                    AirbenderProcessorError::GeneralError(anyhow::anyhow!(
+                        "tree get_proofs(N-1={prev_number}) for {} read-proof slots failed: {e}",
+                        gap.len()
+                    ))
+                })?;
+            if entries.len() != gap.len() {
+                return Err(AirbenderProcessorError::GeneralError(anyhow::anyhow!(
+                    "tree returned {} proofs for {} requested read-proof slots",
+                    entries.len(),
+                    gap.len()
+                )));
+            }
+            gap.into_iter()
+                .zip(entries)
+                .map(|(hashed_key, e)| ReadProof {
+                    hashed_key,
+                    value: e.value,
+                    enumeration_index: e.index,
+                    merkle_path: e.merkle_path,
+                })
+                .collect()
+        };
+
         Ok(AirbenderVerifierInput {
             vm_run_data,
             merkle_paths,
@@ -332,7 +365,7 @@ impl AirbenderRequestProcessor {
             system_env,
             pubdata_params,
             commitment_input: Some(commitment_input),
-            read_proofs: Vec::new(),
+            read_proofs,
         })
     }
 
@@ -621,5 +654,78 @@ impl AirbenderRequestProcessor {
         );
 
         Ok(Json(SubmitAirbenderSnarkProofResponse::Success))
+    }
+}
+
+/// Hashed keys the verifier needs read-proofs for: every slot the operator's
+/// witness exposes to the VM (`read_storage_key` ∪ `is_write_initial`) that the
+/// committed `merkle_paths` does not already prove. Sorted for a reproducible
+/// request order so the returned proofs pair up by position.
+fn read_proof_gap(
+    witness_block_state: &zksync_types::witness_block_state::WitnessStorageState,
+    merkle_paths: &WitnessInputMerklePaths,
+) -> Vec<U256> {
+    let in_paths: std::collections::HashSet<U256> = merkle_paths
+        .merkle_paths
+        .iter()
+        .map(|log| log.leaf_hashed_key)
+        .collect();
+    let mut domain: std::collections::BTreeSet<U256> = std::collections::BTreeSet::new();
+    for k in witness_block_state.read_storage_key.keys() {
+        domain.insert(k.hashed_key_u256());
+    }
+    for k in witness_block_state.is_write_initial.keys() {
+        domain.insert(k.hashed_key_u256());
+    }
+    domain.into_iter().filter(|k| !in_paths.contains(k)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use zksync_prover_interface::inputs::StorageLogMetadata;
+    use zksync_types::{AccountTreeId, Address, StorageKey, H256};
+
+    use super::*;
+
+    #[test]
+    fn read_proof_gap_excludes_merkle_path_slots_includes_reverted() {
+        let k =
+            |n: u64| StorageKey::new(AccountTreeId::new(Address::from_low_u64_be(n)), H256::zero());
+        let a = k(1);
+        let b = k(2);
+        let c = k(3);
+        let mut wbs = zksync_types::witness_block_state::WitnessStorageState::default();
+        wbs.read_storage_key.insert(a, H256::zero());
+        wbs.read_storage_key.insert(b, H256::zero());
+        wbs.is_write_initial.insert(c, true);
+
+        let mut mp = WitnessInputMerklePaths::new(0);
+        // Build a StorageLogMetadata whose leaf_hashed_key == a.hashed_key_u256();
+        // only leaf_hashed_key matters for the gap computation.
+        let log_a = StorageLogMetadata {
+            root_hash: [0u8; 32],
+            is_write: false,
+            first_write: false,
+            merkle_paths: vec![[0u8; 32]],
+            leaf_hashed_key: a.hashed_key_u256(),
+            leaf_enumeration_index: 1,
+            value_written: [0u8; 32],
+            value_read: [0u8; 32],
+        };
+        mp.push_merkle_path(log_a);
+
+        let gap = read_proof_gap(&wbs, &mp);
+        assert!(
+            gap.contains(&b.hashed_key_u256()),
+            "b should be in gap (read, not in merkle_paths)"
+        );
+        assert!(
+            gap.contains(&c.hashed_key_u256()),
+            "c should be in gap (is_write_initial, not in merkle_paths)"
+        );
+        assert!(
+            !gap.contains(&a.hashed_key_u256()),
+            "a should NOT be in gap (already in merkle_paths)"
+        );
     }
 }

--- a/core/node/airbender_proof_data_handler/src/airbender_request_processor.rs
+++ b/core/node/airbender_proof_data_handler/src/airbender_request_processor.rs
@@ -326,6 +326,7 @@ impl AirbenderRequestProcessor {
             system_env,
             pubdata_params,
             commitment_input: Some(commitment_input),
+            read_proofs: Vec::new(),
         })
     }
 

--- a/core/node/airbender_proof_data_handler/src/lib.rs
+++ b/core/node/airbender_proof_data_handler/src/lib.rs
@@ -17,6 +17,7 @@ use zksync_airbender_prover_interface::api::{
 use zksync_config::configs::AirbenderProofDataHandlerConfig;
 use zksync_dal::{ConnectionPool, Core};
 use zksync_object_store::ObjectStore;
+use zksync_shared_resources::tree::TreeApiClient;
 use zksync_types::L2ChainId;
 
 mod airbender_request_processor;
@@ -31,11 +32,18 @@ pub async fn run_server(
     blob_store: Arc<dyn ObjectStore>,
     connection_pool: ConnectionPool<Core>,
     l2_chain_id: L2ChainId,
+    tree_api_client: Arc<dyn TreeApiClient>,
     mut stop_receiver: watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
     let bind_address = SocketAddr::from(([0, 0, 0, 0], config.http_port));
     tracing::info!("Starting proof data handler server on {bind_address}");
-    let app = create_proof_processing_router(blob_store, connection_pool, config, l2_chain_id);
+    let app = create_proof_processing_router(
+        blob_store,
+        connection_pool,
+        config,
+        l2_chain_id,
+        tree_api_client,
+    );
 
     let listener = tokio::net::TcpListener::bind(bind_address)
         .await
@@ -58,9 +66,15 @@ fn create_proof_processing_router(
     connection_pool: ConnectionPool<Core>,
     config: AirbenderProofDataHandlerConfig,
     l2_chain_id: L2ChainId,
+    tree_api_client: Arc<dyn TreeApiClient>,
 ) -> Router {
-    let processor =
-        AirbenderRequestProcessor::new(blob_store, connection_pool, config.clone(), l2_chain_id);
+    let processor = AirbenderRequestProcessor::new(
+        blob_store,
+        connection_pool,
+        config.clone(),
+        l2_chain_id,
+        tree_api_client,
+    );
 
     Router::new()
         .route(

--- a/core/node/airbender_proof_data_handler/src/node.rs
+++ b/core/node/airbender_proof_data_handler/src/node.rs
@@ -12,6 +12,7 @@ use zksync_node_framework::{
     FromContext, IntoContext,
 };
 use zksync_object_store::ObjectStore;
+use zksync_shared_resources::tree::TreeApiClient;
 use zksync_types::L2ChainId;
 
 /// Wiring layer for proof data handler server.
@@ -25,6 +26,7 @@ pub struct AirbenderProofDataHandlerLayer {
 pub struct Input {
     master_pool: PoolResource<MasterPool>,
     object_store: Arc<dyn ObjectStore>,
+    tree_api_client: Option<Arc<dyn TreeApiClient>>,
 }
 
 #[derive(Debug, IntoContext)]
@@ -57,12 +59,18 @@ impl WiringLayer for AirbenderProofDataHandlerLayer {
     async fn wire(self, input: Self::Input) -> Result<Self::Output, WiringError> {
         let main_pool = input.master_pool.get().await?;
         let blob_store = input.object_store;
+        let tree_api_client = input.tree_api_client.ok_or_else(|| {
+            WiringError::Configuration(
+                "Tree API client is required for the airbender proof data handler".into(),
+            )
+        })?;
 
         let task = AirbenderProofDataHandlerTask {
             proof_data_handler_config: self.proof_data_handler_config,
             blob_store,
             main_pool,
             l2_chain_id: self.l2_chain_id,
+            tree_api_client,
         };
 
         Ok(Output { task })
@@ -75,6 +83,7 @@ pub struct AirbenderProofDataHandlerTask {
     blob_store: Arc<dyn ObjectStore>,
     main_pool: ConnectionPool<Core>,
     l2_chain_id: L2ChainId,
+    tree_api_client: Arc<dyn TreeApiClient>,
 }
 
 #[async_trait::async_trait]
@@ -89,6 +98,7 @@ impl Task for AirbenderProofDataHandlerTask {
             self.blob_store,
             self.main_pool,
             self.l2_chain_id,
+            self.tree_api_client,
             stop_receiver.0,
         )
         .await

--- a/core/node/airbender_proof_data_handler/src/tests.rs
+++ b/core/node/airbender_proof_data_handler/src/tests.rs
@@ -339,6 +339,7 @@ async fn submit_airbender_proof_failure_marks_batch_failed() {
         db_conn_pool.clone(),
         test_config(),
         L2ChainId::default(),
+        test_tree_api_client(),
     );
 
     let response =
@@ -373,6 +374,7 @@ async fn submit_airbender_proof_failure_rejects_when_not_picked() {
         db_conn_pool,
         test_config(),
         L2ChainId::default(),
+        test_tree_api_client(),
     );
 
     let response =
@@ -400,6 +402,7 @@ async fn submit_airbender_snark_proof_failure_reverts_to_generated() {
         db_conn_pool.clone(),
         test_config(),
         L2ChainId::default(),
+        test_tree_api_client(),
     );
 
     let response =
@@ -425,6 +428,7 @@ async fn snark_inputs_returns_no_content_when_empty() {
         db_conn_pool,
         test_config(),
         L2ChainId::default(),
+        test_tree_api_client(),
     );
 
     let response = app
@@ -487,6 +491,7 @@ async fn snark_inputs_returns_fri_proof_and_locks_for_snark() {
         db_conn_pool.clone(),
         test_config(),
         L2ChainId::default(),
+        test_tree_api_client(),
     );
 
     let response = app
@@ -545,6 +550,7 @@ async fn snark_inputs_rolls_back_lock_when_fri_proof_missing_in_gcs() {
         db_conn_pool.clone(),
         test_config(),
         L2ChainId::default(),
+        test_tree_api_client(),
     );
 
     let response = app
@@ -592,6 +598,7 @@ async fn submit_snark_proof_succeeds_when_picked_for_snark() {
         db_conn_pool.clone(),
         test_config(),
         L2ChainId::default(),
+        test_tree_api_client(),
     );
 
     let response =
@@ -638,6 +645,7 @@ async fn submit_snark_proof_rejects_when_not_picked_for_snark() {
         db_conn_pool,
         test_config(),
         L2ChainId::default(),
+        test_tree_api_client(),
     );
 
     let response =

--- a/core/node/airbender_proof_data_handler/src/tests.rs
+++ b/core/node/airbender_proof_data_handler/src/tests.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use axum::{
     body::{to_bytes, Body},
@@ -19,9 +19,12 @@ use zksync_contracts::BaseSystemContractsHashes;
 use zksync_dal::{ConnectionPool, Core, CoreDal};
 use zksync_object_store::MockObjectStore;
 use zksync_prover_interface::outputs::SnarkWrapperProof;
+use zksync_shared_resources::tree::{
+    MerkleTreeInfo, TreeApiClient, TreeApiError, TreeEntryWithProof,
+};
 use zksync_types::{
     block::L1BatchHeader, settlement::SettlementLayer, L1BatchNumber, L2ChainId, ProtocolVersion,
-    ProtocolVersionId, H256,
+    ProtocolVersionId, H256, U256,
 };
 
 use crate::create_proof_processing_router;
@@ -31,6 +34,30 @@ use crate::create_proof_processing_router;
 /// protocol version from the batch number (mirroring Boojum proofs).
 fn snark_wrapper_proof() -> SnarkWrapperProof {
     serde_json::from_slice(include_bytes!("test_data/snark_wrapper_proof.json")).unwrap()
+}
+
+/// Minimal tree API client for tests. The airbender tests use batches with no
+/// read-proof gap, so an empty proof set is sufficient.
+#[derive(Debug)]
+struct EmptyTreeApiClient;
+
+#[async_trait::async_trait]
+impl TreeApiClient for EmptyTreeApiClient {
+    async fn get_info(&self) -> Result<MerkleTreeInfo, TreeApiError> {
+        Err(TreeApiError::NotReady(None))
+    }
+
+    async fn get_proofs(
+        &self,
+        _l1_batch_number: L1BatchNumber,
+        _hashed_keys: Vec<U256>,
+    ) -> Result<Vec<TreeEntryWithProof>, TreeApiError> {
+        Ok(vec![])
+    }
+}
+
+fn test_tree_api_client() -> Arc<dyn TreeApiClient> {
+    Arc::new(EmptyTreeApiClient)
 }
 
 fn test_config() -> AirbenderProofDataHandlerConfig {
@@ -53,6 +80,7 @@ async fn request_airbender_proof_inputs() {
         db_conn_pool.clone(),
         test_config(),
         L2ChainId::default(),
+        test_tree_api_client(),
     );
 
     let response = app
@@ -79,6 +107,7 @@ async fn request_airbender_proof_inputs_no_lock_returns_404_for_missing_batch() 
         db_conn_pool,
         test_config(),
         L2ChainId::default(),
+        test_tree_api_client(),
     );
 
     let response = app
@@ -106,6 +135,7 @@ async fn request_airbender_proof_inputs_no_lock_returns_404_for_missing_blob_dat
         db_conn_pool,
         test_config(),
         L2ChainId::default(),
+        test_tree_api_client(),
     );
 
     let response = app
@@ -130,6 +160,7 @@ async fn present_batches_returns_null_fields_when_empty() {
         db_conn_pool,
         test_config(),
         L2ChainId::default(),
+        test_tree_api_client(),
     );
 
     let response = app
@@ -161,6 +192,7 @@ async fn present_batches_returns_oldest_and_latest_batches() {
         db_conn_pool,
         test_config(),
         L2ChainId::default(),
+        test_tree_api_client(),
     );
 
     let response = app
@@ -210,6 +242,7 @@ async fn submit_airbender_proof() {
         db_conn_pool.clone(),
         test_config(),
         L2ChainId::default(),
+        test_tree_api_client(),
     );
 
     let response = send_submit_airbender_proof_request(&app, &uri, &airbender_proof_request).await;
@@ -265,6 +298,7 @@ async fn submit_airbender_proof_rejects_when_not_picked() {
         db_conn_pool.clone(),
         test_config(),
         L2ChainId::default(),
+        test_tree_api_client(),
     );
 
     let response = send_submit_airbender_proof_request(


### PR DESCRIPTION
## What

Producer side of the storage-soundness fix (verifier: matter-labs/eravm-airbender-verifier#57). Emits `read_proofs` — Merkle proofs against `old_root_hash` for slots the VM reads that the committed `merkle_paths` omits (reverted-frame reads).

- `ReadProof` type + additive `read_proofs` field on `AirbenderVerifierInput`.
- Inject `Arc<dyn TreeApiClient>` into the proof-data-handler.
- Gap = (`read_storage_key` ∪ `is_write_initial`) − `merkle_paths`; fetch `get_proofs(N-1, gap)`; map → `read_proofs`.

## Tests

`read_proof_gap` set logic; `ReadProof` round-trips a real Merkle proof.

## Draft — needs node-env validation

- Handler DB tests require `TEST_DATABASE_URL`; the full proof-generation path is not exercised here.
- New requirement: any deployment running `AirbenderProofDataHandler` must set `tree_api_url`, or wiring hard-fails (intentional — degrading would silently produce un-provable inputs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
