### PR TITLE
fix(verifier): patch zksolc factory dependency hashes

### DIFF
--- a/core/lib/contract_verifier/src/compilers/mod.rs
+++ b/core/lib/contract_verifier/src/compilers/mod.rs
@@ -194,6 +194,38 @@ fn parse_immutable_refs(
     }
 }
 
+fn parse_factory_dependency_refs(contract: &Value, bytecode: &[u8]) -> Vec<ImmutableReference> {
+    let Some(deps) = contract
+        .get("factoryDependencies")
+        .and_then(serde_json::Value::as_object)
+    else {
+        return Vec::new();
+    };
+
+    let mut refs = Vec::new();
+    for hash in deps.keys() {
+        let Ok(hash) = hex::decode(hash.strip_prefix("0x").unwrap_or(hash)) else {
+            continue;
+        };
+        if hash.len() != 32 {
+            continue;
+        }
+
+        refs.extend(
+            bytecode
+                .windows(hash.len())
+                .enumerate()
+                .filter_map(|(start, window)| {
+                    (window == hash.as_slice()).then_some(ImmutableReference {
+                        start,
+                        length: hash.len(),
+                    })
+                }),
+        );
+    }
+    refs
+}
+
 /// Parsing logic shared between `solc` and `zksolc`.
 fn parse_standard_json_output(
     output: &serde_json::Value,
@@ -266,6 +298,7 @@ fn parse_standard_json_output(
     let immutable_refs =
         parse_immutable_refs(contract.pointer("/evm/deployedBytecode/immutableReferences"))
             .unwrap_or_default();
+    let factory_dependency_refs = parse_factory_dependency_refs(contract, &bytecode);
 
     let mut abi = contract["abi"].clone();
     if abi.is_null() {
@@ -285,6 +318,7 @@ fn parse_standard_json_output(
         deployed_bytecode,
         abi,
         immutable_refs,
+        factory_dependency_refs,
     })
 }
 
@@ -362,5 +396,50 @@ mod parser_tests {
                 field_path: "/evm/deployedBytecode/object",
             } if contract_name == "Counter"
         ));
+    }
+
+    #[test]
+    fn parses_factory_dependency_hash_refs() {
+        let dependency_hash = "010002f3aa6cac6815f2300b1a4ed078983900fa5a0268f6575db307b09ae610";
+        let bytecode = format!("11223344{dependency_hash}55667788{dependency_hash}");
+        let output = serde_json::json!({
+            "contracts": {
+                "Counter.sol": {
+                    "Counter": {
+                        "abi": [],
+                        "evm": {
+                            "bytecode": {
+                                "object": bytecode,
+                            }
+                        },
+                        "factoryDependencies": {
+                            dependency_hash: "CounterDependency.sol:CounterDependency"
+                        }
+                    }
+                }
+            }
+        });
+
+        let artifacts = parse_standard_json_output(
+            &output,
+            "Counter".to_owned(),
+            "Counter.sol".to_owned(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            artifacts.factory_dependency_refs,
+            vec![
+                zksync_types::contract_verification::api::ImmutableReference {
+                    start: 4,
+                    length: 32,
+                },
+                zksync_types::contract_verification::api::ImmutableReference {
+                    start: 40,
+                    length: 32,
+                },
+            ]
+        );
     }
 }

--- a/core/lib/contract_verifier/src/compilers/zksolc.rs
+++ b/core/lib/contract_verifier/src/compilers/zksolc.rs
@@ -192,6 +192,7 @@ impl ZkSolc {
             deployed_bytecode: None,
             abi: serde_json::Value::Array(Vec::new()),
             immutable_refs: Default::default(),
+            factory_dependency_refs: Default::default(),
         })
     }
 

--- a/core/lib/contract_verifier/src/compilers/zkvyper.rs
+++ b/core/lib/contract_verifier/src/compilers/zkvyper.rs
@@ -84,6 +84,7 @@ impl ZkVyper {
                     bytecode,
                     deployed_bytecode: None,
                     immutable_refs: Default::default(),
+                    factory_dependency_refs: Default::default(),
                 });
             }
         }

--- a/core/lib/contract_verifier/src/lib.rs
+++ b/core/lib/contract_verifier/src/lib.rs
@@ -288,28 +288,16 @@ impl ContractVerifier {
             BytecodeMarker::EraVm => deployed_contract.bytecode.as_slice(),
             BytecodeMarker::Evm => Self::deployed_evm_bytecode(&deployed_contract)?,
         };
-        let mut deployed_code = deployed_bytecode.to_vec();
+        let deployed_code = deployed_bytecode.to_vec();
         let deployed_identifier =
             ContractIdentifier::from_bytecode(bytecode_marker, &deployed_code);
 
         let artifacts = self
-            .get_compilation_artifacts(&mut request, &deployed_identifier)
+            .get_compilation_artifacts(&mut request, &deployed_identifier, &deployed_code)
             .await?;
 
-        let mut compiled_code = artifacts.deployed_bytecode().to_vec();
-
-        // If contract contains immutable references (e.g. places to be filled during constructor execution),
-        // rewrite them with zeroes, as we can't know the values just yet.
-        // We're checking the constructor arguments as well, so assuming tha constructor arguments
-        // are the same, the immutable values should also be the same.
-        artifacts.patch_immutable_bytecodes(&mut compiled_code, &mut deployed_code);
-
-        let compiled_identifier =
-            ContractIdentifier::from_bytecode(bytecode_marker, &compiled_code);
-
-        // regenerate the deployed identifier after patching the immutable bytecode
-        let deployed_identifier =
-            ContractIdentifier::from_bytecode(bytecode_marker, &deployed_code);
+        let (compiled_identifier, deployed_identifier) =
+            Self::patched_identifiers(bytecode_marker, &artifacts, deployed_code);
 
         let constructor_args = match bytecode_marker {
             BytecodeMarker::EraVm => self
@@ -396,6 +384,7 @@ impl ContractVerifier {
         &self,
         request: &mut VerificationRequest,
         deployed_identifier: &ContractIdentifier,
+        deployed_code: &[u8],
     ) -> Result<CompilationArtifacts, ContractVerifierError> {
         // If compiler versions from the metadata don't match with the request,
         // we'll first try to use info from metadata.
@@ -419,13 +408,14 @@ impl ContractVerifier {
                 .await;
 
             if let Ok(artifacts) = artifacts {
-                let compiled_identifier = ContractIdentifier::from_bytecode(
+                let (compiled_identifier, deployed_identifier) = Self::patched_identifiers(
                     deployed_identifier.bytecode_marker,
-                    artifacts.deployed_bytecode(),
+                    &artifacts,
+                    deployed_code.to_vec(),
                 );
                 // Check if the compiled bytecode matches the deployed bytecode
                 if matches!(
-                    compiled_identifier.matches(deployed_identifier),
+                    compiled_identifier.matches(&deployed_identifier),
                     Match::Full | Match::Partial
                 ) {
                     tracing::info!(
@@ -459,6 +449,25 @@ impl ContractVerifier {
         // We either have no alternative request or it didn't succeed
         self.compile(request.req.clone(), deployed_identifier.bytecode_marker)
             .await
+    }
+
+    fn patched_identifiers(
+        bytecode_marker: BytecodeMarker,
+        artifacts: &CompilationArtifacts,
+        mut deployed_code: Vec<u8>,
+    ) -> (ContractIdentifier, ContractIdentifier) {
+        let mut compiled_code = artifacts.deployed_bytecode().to_vec();
+
+        // If contract contains immutable references (e.g. places to be filled during constructor execution),
+        // rewrite them with zeroes, as we can't know the values just yet.
+        // We're checking the constructor arguments as well, so assuming the constructor arguments
+        // are the same, the immutable values should also be the same.
+        artifacts.patch_immutable_bytecodes(&mut compiled_code, &mut deployed_code);
+
+        (
+            ContractIdentifier::from_bytecode(bytecode_marker, &compiled_code),
+            ContractIdentifier::from_bytecode(bytecode_marker, &deployed_code),
+        )
     }
 
     // Updates request compiler versions in the DB.

--- a/core/lib/contract_verifier/src/tests/mod.rs
+++ b/core/lib/contract_verifier/src/tests/mod.rs
@@ -264,13 +264,15 @@ async fn mock_deployment_inner(
         .unwrap();
 }
 
-type SharedMockFn<In> =
-    Arc<dyn Fn(In) -> Result<CompilationArtifacts, ContractVerifierError> + Send + Sync>;
+type SharedMockFn<In> = Arc<
+    dyn Fn(In, Option<&str>) -> Result<CompilationArtifacts, ContractVerifierError> + Send + Sync,
+>;
 
 #[derive(Clone)]
 struct MockCompilerResolver {
     zksolc: SharedMockFn<ZkSolcInput>,
     solc: SharedMockFn<SolcInput>,
+    zksolc_version: Option<String>,
 }
 
 impl fmt::Debug for MockCompilerResolver {
@@ -286,15 +288,27 @@ impl MockCompilerResolver {
         zksolc: impl Fn(ZkSolcInput) -> CompilationArtifacts + 'static + Send + Sync,
     ) -> Self {
         Self {
-            zksolc: Arc::new(move |input| Ok(zksolc(input))),
-            solc: Arc::new(|input| panic!("unexpected solc call: {input:?}")),
+            zksolc: Arc::new(move |input, _version| Ok(zksolc(input))),
+            solc: Arc::new(|input, _version| panic!("unexpected solc call: {input:?}")),
+            zksolc_version: None,
+        }
+    }
+
+    fn zksolc_with_version(
+        zksolc: impl Fn(ZkSolcInput, &str) -> CompilationArtifacts + 'static + Send + Sync,
+    ) -> Self {
+        Self {
+            zksolc: Arc::new(move |input, version| Ok(zksolc(input, version.unwrap()))),
+            solc: Arc::new(|input, _version| panic!("unexpected solc call: {input:?}")),
+            zksolc_version: None,
         }
     }
 
     fn solc(solc: impl Fn(SolcInput) -> CompilationArtifacts + 'static + Send + Sync) -> Self {
         Self {
-            solc: Arc::new(move |input| Ok(solc(input))),
-            zksolc: Arc::new(|input| panic!("unexpected zksolc call: {input:?}")),
+            solc: Arc::new(move |input, _version| Ok(solc(input))),
+            zksolc: Arc::new(|input, _version| panic!("unexpected zksolc call: {input:?}")),
+            zksolc_version: None,
         }
     }
 }
@@ -305,7 +319,7 @@ impl Compiler<ZkSolcInput> for MockCompilerResolver {
         self: Box<Self>,
         input: ZkSolcInput,
     ) -> Result<CompilationArtifacts, ContractVerifierError> {
-        (self.zksolc)(input)
+        (self.zksolc)(input, self.zksolc_version.as_deref())
     }
 }
 
@@ -315,7 +329,7 @@ impl Compiler<SolcInput> for MockCompilerResolver {
         self: Box<Self>,
         input: SolcInput,
     ) -> Result<CompilationArtifacts, ContractVerifierError> {
-        (self.solc)(input)
+        (self.solc)(input, None)
     }
 }
 
@@ -358,13 +372,17 @@ impl CompilerResolver for MockCompilerResolver {
                 version.base.clone(),
             ));
         }
-        if version.zk != ZKSOLC_VERSION && version.zk != ZKSOLC_VERSION_WITH_CBOR {
+        let zk_version = version.zk.strip_prefix('v').unwrap_or(&version.zk);
+        if zk_version != ZKSOLC_VERSION && zk_version != ZKSOLC_VERSION_WITH_CBOR {
             return Err(ContractVerifierError::UnknownCompilerVersion(
                 "zksolc",
                 version.zk.clone(),
             ));
         }
-        Ok(Box::new(self.clone()))
+        Ok(Box::new(Self {
+            zksolc_version: Some(version.zk.clone()),
+            ..self.clone()
+        }))
     }
 
     async fn resolve_vyper(
@@ -471,6 +489,7 @@ async fn contract_verifier_basics(contract: TestContract) {
             deployed_bytecode: None,
             abi: counter_contract_abi(),
             immutable_refs: Default::default(),
+            factory_dependency_refs: Default::default(),
         }
     });
     let verifier = ContractVerifier::with_resolver(
@@ -593,6 +612,7 @@ async fn verifying_evm_bytecode(contract: TestContract) {
         deployed_bytecode: Some(deployed_bytecode),
         abi: counter_contract_abi(),
         immutable_refs: Default::default(),
+        factory_dependency_refs: Default::default(),
     };
     let mock_resolver = MockCompilerResolver::solc(move |input| {
         assert_eq!(input.standard_json.language, "Solidity");
@@ -650,6 +670,7 @@ async fn verifying_evm_with_raw_stored_bytecode() {
         deployed_bytecode: Some(deployed_bytecode),
         abi: counter_contract_abi(),
         immutable_refs: Default::default(),
+        factory_dependency_refs: Default::default(),
     };
     let mock_resolver = MockCompilerResolver::solc(move |_| artifacts.clone());
     let verifier = ContractVerifier::with_resolver(
@@ -687,6 +708,7 @@ async fn bytecode_mismatch_error() {
         deployed_bytecode: None,
         abi: counter_contract_abi(),
         immutable_refs: Default::default(),
+        factory_dependency_refs: Default::default(),
     });
     let verifier = ContractVerifier::with_resolver(
         Duration::from_secs(60),
@@ -793,6 +815,7 @@ async fn no_metadata_final_word_mismatch_is_rejected(
         deployed_bytecode: None,
         abi: counter_contract_abi(),
         immutable_refs: Default::default(),
+        factory_dependency_refs: Default::default(),
     });
     let verifier = ContractVerifier::with_resolver(
         Duration::from_secs(60),
@@ -848,6 +871,7 @@ async fn metadata_final_word_mismatch_is_partial_match() {
         deployed_bytecode: None,
         abi: counter_contract_abi(),
         immutable_refs: Default::default(),
+        factory_dependency_refs: Default::default(),
     });
     let verifier = ContractVerifier::with_resolver(
         Duration::from_secs(60),
@@ -929,12 +953,14 @@ async fn args_mismatch_error(contract: TestContract, bytecode_kind: BytecodeMark
             deployed_bytecode: None,
             abi: counter_contract_abi(),
             immutable_refs: Default::default(),
+            factory_dependency_refs: Default::default(),
         }),
         BytecodeMarker::Evm => MockCompilerResolver::solc(move |_| CompilationArtifacts {
             bytecode: vec![3_u8; 48],
             deployed_bytecode: Some(bytecode.clone()),
             abi: counter_contract_abi(),
             immutable_refs: Default::default(),
+            factory_dependency_refs: Default::default(),
         }),
     };
     let verifier = ContractVerifier::with_resolver(
@@ -1002,6 +1028,7 @@ async fn creation_bytecode_mismatch() {
             deployed_bytecode: Some(deployed_bytecode.clone()),
             abi: counter_contract_abi(),
             immutable_refs: Default::default(),
+            factory_dependency_refs: Default::default(),
         }
     });
     let verifier = ContractVerifier::with_resolver(
@@ -1127,6 +1154,7 @@ async fn verifying_evm_with_immutables() {
         deployed_bytecode: Some(deployed_bytecode_compiled),
         abi: counter_contract_abi(),
         immutable_refs: imm_map,
+        factory_dependency_refs: Default::default(),
     };
 
     let mock_resolver = MockCompilerResolver::solc(move |_| artifacts.clone());
@@ -1144,4 +1172,133 @@ async fn verifying_evm_with_immutables() {
     verifier.run(stop_receiver, Some(1)).await.unwrap();
 
     assert_request_success(&mut storage, request_id, address, &creation_bytecode, &[]).await;
+}
+
+#[tokio::test]
+async fn verifying_era_vm_with_factory_dependency_hash_ref() {
+    let pool = ConnectionPool::test_pool().await;
+    let mut storage = pool.connection().await.unwrap();
+    prepare_storage(&mut storage).await;
+
+    let mut compiled_bytecode = vec![0x11; 96];
+    compiled_bytecode[32..64].copy_from_slice(&[0xaa; 32]);
+    let mut deployed_bytecode = compiled_bytecode.clone();
+    deployed_bytecode[32..64].copy_from_slice(&[0xbb; 32]);
+
+    let address = Address::repeat_byte(1);
+    mock_deployment(&mut storage, address, deployed_bytecode, &[]).await;
+    let req = test_request(address, COUNTER_CONTRACT);
+    let request_id = storage
+        .contract_verification_dal()
+        .add_contract_verification_request(&req)
+        .await
+        .unwrap();
+
+    let artifacts = CompilationArtifacts {
+        bytecode: compiled_bytecode.clone(),
+        deployed_bytecode: None,
+        abi: counter_contract_abi(),
+        immutable_refs: Default::default(),
+        factory_dependency_refs: vec![ImmutableReference {
+            start: 32,
+            length: 32,
+        }],
+    };
+
+    let mock_resolver = MockCompilerResolver::zksolc(move |_| artifacts.clone());
+    let verifier = ContractVerifier::with_resolver(
+        Duration::from_secs(60),
+        pool.clone(),
+        Arc::new(mock_resolver),
+        false,
+    )
+    .await
+    .unwrap();
+
+    let (_stop_sender, stop_receiver) = watch::channel(false);
+    verifier.run(stop_receiver, Some(1)).await.unwrap();
+
+    assert_request_success(&mut storage, request_id, address, &compiled_bytecode, &[]).await;
+}
+
+#[tokio::test]
+async fn metadata_version_fallback_patches_factory_dependency_hash_refs() {
+    let pool = ConnectionPool::test_pool().await;
+    let mut storage = pool.connection().await.unwrap();
+    prepare_storage(&mut storage).await;
+
+    let cbor_metadata = eravm_cbor_metadata_suffix_for_zksolc(ZKSOLC_VERSION_WITH_CBOR);
+    let mut matching_bytecode = vec![0x11; 96];
+    matching_bytecode[32..64].copy_from_slice(&[0xaa; 32]);
+    matching_bytecode.extend_from_slice(&[0; 32]);
+    matching_bytecode.extend_from_slice(&cbor_metadata);
+    assert_eq!(matching_bytecode.len() / 32 % 2, 1);
+
+    let mut deployed_bytecode = matching_bytecode.clone();
+    deployed_bytecode[32..64].copy_from_slice(&[0xbb; 32]);
+
+    let mut wrong_version_bytecode = matching_bytecode.clone();
+    wrong_version_bytecode[0..32].copy_from_slice(&[0xcc; 32]);
+
+    let address = Address::repeat_byte(1);
+    mock_deployment(&mut storage, address, deployed_bytecode, &[]).await;
+    let req = test_request(address, COUNTER_CONTRACT);
+    let request_id = storage
+        .contract_verification_dal()
+        .add_contract_verification_request(&req)
+        .await
+        .unwrap();
+
+    let expected_bytecode = matching_bytecode.clone();
+    let metadata_zksolc_version = format!("v{ZKSOLC_VERSION_WITH_CBOR}");
+    let mock_resolver = MockCompilerResolver::zksolc_with_version(move |_input, version| {
+        let bytecode = if version == metadata_zksolc_version {
+            matching_bytecode.clone()
+        } else {
+            wrong_version_bytecode.clone()
+        };
+
+        CompilationArtifacts {
+            bytecode,
+            deployed_bytecode: None,
+            abi: counter_contract_abi(),
+            immutable_refs: Default::default(),
+            factory_dependency_refs: vec![ImmutableReference {
+                start: 32,
+                length: 32,
+            }],
+        }
+    });
+    let verifier = ContractVerifier::with_resolver(
+        Duration::from_secs(60),
+        pool.clone(),
+        Arc::new(mock_resolver),
+        false,
+    )
+    .await
+    .unwrap();
+
+    let (_stop_sender, stop_receiver) = watch::channel(false);
+    verifier.run(stop_receiver, Some(1)).await.unwrap();
+
+    assert_request_success(&mut storage, request_id, address, &expected_bytecode, &[]).await;
+}
+
+fn eravm_cbor_metadata_suffix_for_zksolc(version: &str) -> Vec<u8> {
+    let compiler = format!("zksolc:{version}");
+    let compiler = compiler.as_bytes();
+    assert!(compiler.len() < 24);
+
+    let mut metadata = vec![0xa1, 0x64];
+    metadata.extend_from_slice(b"solc");
+    metadata.push(0x60 + compiler.len() as u8);
+    metadata.extend_from_slice(compiler);
+
+    let aligned_metadata_len = metadata.len().div_ceil(32) * 32;
+    assert!(metadata.len() + 2 <= aligned_metadata_len);
+
+    let mut suffix = vec![0; aligned_metadata_len - metadata.len() - 2];
+    suffix.extend_from_slice(&metadata);
+    suffix.extend_from_slice(&(metadata.len() as u16).to_be_bytes());
+    suffix
 }

--- a/core/lib/types/src/contract_verification/api.rs
+++ b/core/lib/types/src/contract_verification/api.rs
@@ -329,10 +329,14 @@ pub struct CompilationArtifacts {
     /// Defaults to empty if no immutables are found.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub immutable_refs: HashMap<String, Vec<ImmutableReference>>,
+    /// Offsets of linked factory dependency bytecode hashes in EraVM bytecode.
+    /// These hashes may differ for dependencies with deployment-specific bytecode.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub factory_dependency_refs: Vec<ImmutableReference>,
 }
 
 /// Stores each immutable reference offset and length in deployed bytecode.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ImmutableReference {
     pub start: usize,
     pub length: usize,
@@ -354,6 +358,14 @@ impl CompilationArtifacts {
                     compiled_code[start..end].fill(0);
                     deployed_code[start..end].fill(0);
                 }
+            }
+        }
+        for span in &self.factory_dependency_refs {
+            let start = span.start;
+            let end = start + span.length;
+            if end <= compiled_code.len() && end <= deployed_code.len() {
+                compiled_code[start..end].fill(0);
+                deployed_code[start..end].fill(0);
             }
         }
     }
@@ -736,5 +748,26 @@ mod tests {
                 compiler_zkvyper_version: Some("v1.5.10".to_string()),
             }
         );
+    }
+
+    #[test]
+    fn patches_factory_dependency_refs() {
+        let artifacts = CompilationArtifacts {
+            bytecode: vec![],
+            deployed_bytecode: None,
+            abi: serde_json::Value::Array(vec![]),
+            immutable_refs: Default::default(),
+            factory_dependency_refs: vec![ImmutableReference {
+                start: 4,
+                length: 4,
+            }],
+        };
+        let mut compiled = vec![1, 2, 3, 4, 0xaa, 0xaa, 0xaa, 0xaa, 9];
+        let mut deployed = vec![1, 2, 3, 4, 0xbb, 0xbb, 0xbb, 0xbb, 9];
+
+        artifacts.patch_immutable_bytecodes(&mut compiled, &mut deployed);
+
+        assert_eq!(compiled, vec![1, 2, 3, 4, 0, 0, 0, 0, 9]);
+        assert_eq!(deployed, vec![1, 2, 3, 4, 0, 0, 0, 0, 9]);
     }
 }

--- a/core/lib/types/src/contract_verification/etherscan.rs
+++ b/core/lib/types/src/contract_verification/etherscan.rs
@@ -735,6 +735,7 @@ mod tests {
             bytecode: vec![],
             deployed_bytecode: None,
             immutable_refs: Default::default(),
+            factory_dependency_refs: Default::default(),
         };
 
         let verification_info = VerificationInfo {

--- a/core/node/contract_verification_server/src/tests/mod.rs
+++ b/core/node/contract_verification_server/src/tests/mod.rs
@@ -62,6 +62,7 @@ fn eravm_verification_info(
             deployed_bytecode: None,
             abi: serde_json::json!([]),
             immutable_refs: Default::default(),
+            factory_dependency_refs: Default::default(),
         },
         verified_at: Default::default(),
         verification_problems: Vec::new(),

--- a/core/node/contract_verification_server/src/tests/utils.rs
+++ b/core/node/contract_verification_server/src/tests/utils.rs
@@ -173,6 +173,7 @@ pub(super) fn mock_verification_info(
             deployed_bytecode: None,
             abi: abi.unwrap_or_default(),
             immutable_refs: Default::default(),
+            factory_dependency_refs: Default::default(),
         },
         verified_at: Default::default(),
         verification_problems: Vec::new(),


### PR DESCRIPTION
## What ❔

This PR updates contract verification for `zksolc` standard JSON outputs that contain linked `factoryDependencies` hashes in the emitted EraVM bytecode.

The verifier now:

- parses `factoryDependencies` from compiler output
- finds exact occurrences of those 32-byte dependency hashes in the compiled bytecode
- records those byte ranges as factory-dependency references
- zeroes those ranges during compiled-vs-deployed bytecode comparison, similar to how immutable references are already patched

This is a narrow edge case. It occurs when a verified contract embeds a factory dependency bytecode hash in its own runtime bytecode, and that dependency's bytecode is deployment-specific.

The concrete scenario is:

- parent contract `A` deploys child contract `B` in its constructor
- parent contract `A` stores or uses `B`'s bytecode hash in an immutable or runtime constant
- child contract `B` has deployment-specific immutables, for example it stores `msg.sender` / the parent address in its own bytecode
- therefore `B`'s bytecode hash differs depending on which parent instance deployed it
- the recompiled parent bytecode contains the compiler-produced dependency hash for `B`
- the deployed parent bytecode contains the actual deployment-specific hash for `B`
- without patching that dependency-hash span, the verifier reports a runtime bytecode mismatch even though the source and settings are otherwise correct

## Why ❔

The verifier should compare stable runtime code while ignoring byte ranges that are expected to vary per deployment and are identified by compiler output.

The verifier already does this for Solidity immutable references. However, for this EraVM factory-dependency-hash case, `zksolc` does not emit the differing byte range as `evm.deployedBytecode.immutableReferences`. It does emit the relevant dependency hash in `factoryDependencies`, and that hash appears directly in the parent bytecode.

Using the compiler's `factoryDependencies` output gives the verifier a narrow source of truth for which 32-byte values are dependency hash literals. This avoids treating deployment-specific dependency hashes as ordinary bytecode mismatches while preserving strict comparison for all other runtime bytes.

This allows verification contracts that use factory dependencies and deployment-specific child bytecode without needing client-side workarounds or special API parameters.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

No config changes, new flags, script changes, or operator action are required.

The behavior change is limited to contract verifier bytecode comparison for compiler-reported factory dependency hash literals.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
