### PR TITLE
fix(db_pruner): handle future L1 batch timestamps in age condition

### DIFF
--- a/core/node/db_pruner/src/prune_conditions.rs
+++ b/core/node/db_pruner/src/prune_conditions.rs
@@ -12,6 +12,40 @@ pub(crate) trait PruneCondition: fmt::Debug + fmt::Display + Send + Sync + 'stat
     async fn is_batch_prunable(&self, l1_batch_number: L1BatchNumber) -> anyhow::Result<bool>;
 }
 
+fn is_l1_batch_old_enough(
+    now_timestamp: u64,
+    l1_batch_timestamp: u64,
+    minimum_age: Duration,
+) -> bool {
+    now_timestamp.saturating_sub(l1_batch_timestamp) > minimum_age.as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn l1_batch_age_check_handles_future_timestamps() {
+        let now_timestamp = 100;
+
+        assert!(!is_l1_batch_old_enough(
+            now_timestamp,
+            now_timestamp + 1,
+            Duration::ZERO
+        ));
+        assert!(!is_l1_batch_old_enough(
+            now_timestamp,
+            now_timestamp - 10,
+            Duration::from_secs(10)
+        ));
+        assert!(is_l1_batch_old_enough(
+            now_timestamp,
+            now_timestamp - 11,
+            Duration::from_secs(10)
+        ));
+    }
+}
+
 #[derive(Debug)]
 pub(super) struct L1BatchOlderThanPruneCondition {
     pub minimum_age: Duration,
@@ -36,9 +70,13 @@ impl PruneCondition for L1BatchOlderThanPruneCondition {
             .blocks_dal()
             .get_l1_batch_header(l1_batch_number)
             .await?;
-        let is_old_enough = l1_batch_header.is_some()
-            && (Utc::now().timestamp() as u64 - l1_batch_header.unwrap().timestamp
-                > self.minimum_age.as_secs());
+        let is_old_enough = l1_batch_header.is_some_and(|header| {
+            is_l1_batch_old_enough(
+                Utc::now().timestamp() as u64,
+                header.timestamp,
+                self.minimum_age,
+            )
+        });
         Ok(is_old_enough)
     }
 }


### PR DESCRIPTION
## What ❔

Fix a potential overflow in the DB pruner L1 batch age condition.

`L1BatchOlderThanPruneCondition` previously subtracted the stored L1 batch timestamp from the current timestamp directly. If a batch timestamp is ahead of the local wall-clock time, this can underflow in debug/test builds and panic. This change treats future-dated batches as not old enough to prune by using a saturating age calculation.

The age check is extracted into a small helper and covered with a regression test for:
- future timestamps
- the exact minimum-age boundary
- timestamps older than the configured minimum age

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
