### PR TITLE
ci: publish airbender prover server images on push to main

### DIFF
--- a/.github/workflows/release-test-stage.yml
+++ b/.github/workflows/release-test-stage.yml
@@ -15,6 +15,7 @@ jobs:
     outputs:
       core: ${{ steps.changed-files-yaml.outputs.core_any_changed }}
       prover: ${{ steps.changed-files-yaml.outputs.prover_any_changed }}
+      airbender_prover_server: ${{ steps.changed-files-yaml.outputs.airbender_prover_server_any_changed }}
       all: ${{ steps.changed-files-yaml.outputs.all_any_changed }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -34,9 +35,15 @@ jobs:
               - '!core/lib/zksync_core/**'
             core:
               - core/**
+            airbender_prover_server:
+              - airbender_prover_server/**
+              - docker/airbender-prover-server/**
+              - .github/workflows/build-airbender-prover-server-template.yml
             all:
               - '!core/**'
               - '!prover/**'
+              - '!airbender_prover_server/**'
+              - '!docker/airbender-prover-server/**'
   setup:
     name: Setup
     runs-on: [ubuntu-latest]
@@ -90,6 +97,18 @@ jobs:
     with:
       image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}
       ERA_BELLMAN_CUDA_RELEASE: ${{ vars.ERA_BELLMAN_CUDA_RELEASE }}
+      action: "push"
+    secrets:
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  build-push-airbender-prover-server-images:
+    name: Build and push images
+    needs: [setup, changed_files]
+    uses: ./.github/workflows/build-airbender-prover-server-template.yml
+    if: needs.changed_files.outputs.airbender_prover_server == 'true' || needs.changed_files.outputs.all == 'true'
+    with:
+      image_tag_suffix: ${{ needs.setup.outputs.image_tag_suffix }}
       action: "push"
     secrets:
       DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}


### PR DESCRIPTION
## What

Adds a `build-push-airbender-prover-server-images` job to the stage release workflow (`release-test-stage.yml`, runs on every push to `main`) so the airbender prover server images are built and pushed when the airbender workspace is touched.

## Why

The airbender prover server was wired into PR CI (`build`-only) and the tag-release path (`build-docker-from-tag.yml`, gated on `airbender_prover_server-*` tags), but was **missing entirely from the stage release flow**. As a result it never got published to stage on a push to `main` — unlike core, contract-verifier, and prover images.

## Changes

- New `changed_files` output `airbender_prover_server`, computed from `airbender_prover_server/**`, `docker/airbender-prover-server/**`, and the build template.
- Excluded airbender paths from the `all` catch-all (mirroring `core/**` and `prover/**`) so an airbender-only change builds just the airbender images instead of triggering a full rebuild.
- New `build-push-airbender-prover-server-images` job calling `build-airbender-prover-server-template.yml` with `action: "push"`, gated on `airbender_prover_server == 'true' || all == 'true'`.

## Scope

Stage release only. The tag-release path is unchanged (still publishes airbender for `airbender_prover_server-v*` tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)