### PR TITLE
feat(eth_sender): default settlementFeePayer to zero address

### DIFF
--- a/core/node/eth_sender/src/eth_tx_aggregator.rs
+++ b/core/node/eth_sender/src/eth_tx_aggregator.rs
@@ -1122,10 +1122,8 @@ impl EthTxAggregator {
                         (calldata, None)
                     }
                     L1BatchAggregatedOperation::Execute(op) => {
-                        let settlement_fee_payer = self
-                            .config
-                            .settlement_fee_payer
-                            .unwrap_or(self.eth_client.sender_account());
+                        let settlement_fee_payer =
+                            self.config.settlement_fee_payer.unwrap_or(Address::zero());
                         args.extend(
                             op.encode_for_eth_tx(chain_protocol_version_id, settlement_fee_payer),
                         );

--- a/core/tests/highlevel-test-tools/src/gateway.ts
+++ b/core/tests/highlevel-test-tools/src/gateway.ts
@@ -3,7 +3,7 @@ import { FileMutex } from './file-mutex';
 import { findHome } from './zksync-home';
 import { withDeadline } from './deadline';
 import { GW_ASSET_TRACKER_ADDRESS, ArtifactWrappedBaseToken, ArtifactGWAssetTracker } from 'utils/src/constants';
-import { ConfigName, loadConfig } from 'utils/build/file-configs';
+import { ConfigName, loadConfig, setSettlementFeePayer } from 'utils/build/file-configs';
 import * as ethers from 'ethers';
 import * as zksync from 'zksync-ethers';
 
@@ -140,6 +140,11 @@ export async function setSettlementFeePayerAgreement(chainName: string): Promise
     await (await gwWrappedZkToken.deposit({ value: ethers.parseEther('1') })).wait();
     await (await gwWrappedZkToken.approve(GW_ASSET_TRACKER_ADDRESS, ethers.parseEther('1'))).wait();
     await (await gwAssetTracker.setSettlementFeePayerAgreement(l2ChainId, true)).wait();
+
+    // The eth_sender defaults the settlement fee payer to the zero address when unset, which cannot pay
+    // gateway settlement fees. Point it at the operator we just registered and funded above, so that
+    // `executeBatches` on the gateway can charge the fee instead of reverting with `SettlementFeePayerNotAgreed`.
+    setSettlementFeePayer(pathToHome, chainName, operator.address);
 
     console.log(`✅ Successfully set up payment of settlement fees for ${chainName}`);
 }

--- a/etc/utils/src/file-configs.ts
+++ b/etc/utils/src/file-configs.ts
@@ -170,3 +170,16 @@ export function replaceL1BatchMinAgeBeforeExecuteSeconds(pathToHome: string, cha
     const newGeneralConfig = yaml.stringify(generalConfigObject);
     fs.writeFileSync(generalConfigPath, newGeneralConfig, 'utf8');
 }
+
+// Explicitly pins the account that pays gateway settlement fees for `executeBatches`.
+// The eth_sender defaults this to the zero address when unset, which cannot pay fees on
+// the gateway, so tests that settle on the gateway must point it at the operator (which is
+// registered as an agreed fee payer and holds approved wrapped ZK).
+export function setSettlementFeePayer(pathToHome: string, chain: string, address: string) {
+    const generalConfigPath = getConfigPath({ pathToHome, chain, config: 'general.yaml' });
+    const generalConfig = fsSync.readFileSync(generalConfigPath, 'utf8');
+    const generalConfigObject = yaml.parse(generalConfig);
+    generalConfigObject['eth']['sender']['settlement_fee_payer'] = address;
+    const newGeneralConfig = yaml.stringify(generalConfigObject);
+    fs.writeFileSync(generalConfigPath, newGeneralConfig, 'utf8');
+}


### PR DESCRIPTION
## What ❔

- **eth-sender**: default `settlement_fee_payer` to the zero address when it is not set in the config, instead of falling back to the operator's sender account.

  ```rust
  let settlement_fee_payer =
      self.config.settlement_fee_payer.unwrap_or(Address::zero());
  ```

  The `settlement_fee_payer` config field is kept and is still honored when explicitly set; only the fallback changes.

- **gateway integration tests**: because the zero address is not allowed to pay gateway settlement fees (`GWAssetTracker` reverts with `SettlementFeePayerNotAgreed`, and a zero payer holds no wrapped ZK), the `WITH_GATEWAY` test harness now writes the operator address into the chain's `eth.sender.settlement_fee_payer` before the server starts. The operator already wraps ETH, approves the `GWAssetTracker` and calls `setSettlementFeePayerAgreement`, so it is the correct opted-in payer. Added a `setSettlementFeePayer` helper in `etc/utils/src/file-configs.ts`.

## Why ❔

The config doc comment for `settlement_fee_payer` already states *"If not set, defaults to Address::zero()"*, but the implementation actually fell back to the operator's sender account. This aligns the behavior with the documented default: operators that need a fee payer on Gateway now set it explicitly in the config.

## Checklist

- [x] PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Code compiles (`cargo check -p zksync_eth_sender`) and is formatted (`cargo fmt`).
