### PR TITLE
fix(contract-verifier): normalize standard-json source handling

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -3427,9 +3427,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/core/lib/contract_verifier/src/compilers/mod.rs
+++ b/core/lib/contract_verifier/src/compilers/mod.rs
@@ -77,6 +77,36 @@ pub(crate) fn validate_source_paths(
     Ok(())
 }
 
+/// Validates the `settings.remappings` array of a standard-JSON input.
+///
+/// A remapping has the form `[context:]prefix=target`. For verification to be hermetic the
+/// compiler must resolve every import against the sources provided inline, never against the
+/// host filesystem. A remapping target that is absolute (`/…`, `file://…`) or points outside
+/// the provided source tree with `..` breaks that guarantee (the compiler treats such a target
+/// as an additional lookup root), so targets are constrained to stay relative and within the
+/// source tree.
+pub(crate) fn validate_remappings(settings: &Value) -> Result<(), ContractVerifierError> {
+    let Some(remappings) = settings.get("remappings").and_then(Value::as_array) else {
+        return Ok(());
+    };
+    for entry in remappings {
+        let Some(remapping) = entry.as_str() else {
+            return Err(ContractVerifierError::InvalidSourcePath(
+                "non-string remapping".to_owned(),
+            ));
+        };
+        // Split off the optional `context:` prefix and the mandatory `prefix=` to isolate the target.
+        let target = remapping.split_once('=').map_or("", |(_, target)| target);
+        if target.starts_with('/')
+            || target.starts_with("file://")
+            || target.split('/').any(|component| component == "..")
+        {
+            return Err(ContractVerifierError::InvalidSourcePath(remapping.to_owned()));
+        }
+    }
+    Ok(())
+}
+
 /// Returns `true` if `source` contains an `import` directive whose path is absolute (`/…`)
 /// or uses a `file://` URL. These forms let the compiler resolve imports against the host
 /// filesystem and potentially leak file contents in error messages.
@@ -125,7 +155,41 @@ pub(crate) fn sanitize_compiler_stderr(stderr: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::has_dangerous_imports;
+    use super::{has_dangerous_imports, validate_remappings};
+
+    #[test]
+    fn rejects_non_hermetic_remapping_targets() {
+        for target in [
+            "@x/=/abs/path",
+            "@x/=file:///abs/path",
+            "@x/=../../../../outside/tree",
+            "ctx:@x/=../outside",
+            "@x/=lib/../../outside",
+        ] {
+            let settings = serde_json::json!({ "remappings": [target] });
+            assert!(
+                validate_remappings(&settings).is_err(),
+                "remapping must be rejected: {target}"
+            );
+        }
+    }
+
+    #[test]
+    fn allows_relative_remapping_targets() {
+        let settings = serde_json::json!({
+            "remappings": [
+                "@openzeppelin/=node_modules/@openzeppelin/",
+                "ds-test/=lib/forge-std/lib/ds-test/src/",
+                "@x/=contracts/x/",
+            ]
+        });
+        assert!(validate_remappings(&settings).is_ok());
+    }
+
+    #[test]
+    fn allows_missing_remappings() {
+        assert!(validate_remappings(&serde_json::json!({})).is_ok());
+    }
 
     #[test]
     fn allows_relative_parent_imports() {

--- a/core/lib/contract_verifier/src/compilers/mod.rs
+++ b/core/lib/contract_verifier/src/compilers/mod.rs
@@ -79,12 +79,10 @@ pub(crate) fn validate_source_paths(
 
 /// Validates the `settings.remappings` array of a standard-JSON input.
 ///
-/// A remapping has the form `[context:]prefix=target`. For verification to be hermetic the
-/// compiler must resolve every import against the sources provided inline, never against the
-/// host filesystem. A remapping target that is absolute (`/…`, `file://…`) or points outside
-/// the provided source tree with `..` breaks that guarantee (the compiler treats such a target
-/// as an additional lookup root), so targets are constrained to stay relative and within the
-/// source tree.
+/// A remapping has the form `[context:]prefix=target`. Verification inputs are expected to
+/// resolve against the submitted source map. A remapping target that is absolute (`/…`,
+/// `file://…`) or points outside the provided source tree with `..` adds another lookup root,
+/// so targets are constrained to stay relative and within the source tree.
 pub(crate) fn validate_remappings(settings: &Value) -> Result<(), ContractVerifierError> {
     let Some(remappings) = settings.get("remappings").and_then(Value::as_array) else {
         return Ok(());
@@ -101,19 +99,20 @@ pub(crate) fn validate_remappings(settings: &Value) -> Result<(), ContractVerifi
             || target.starts_with("file://")
             || target.split('/').any(|component| component == "..")
         {
-            return Err(ContractVerifierError::InvalidSourcePath(remapping.to_owned()));
+            return Err(ContractVerifierError::InvalidSourcePath(
+                remapping.to_owned(),
+            ));
         }
     }
     Ok(())
 }
 
 /// Returns `true` if `source` contains an `import` directive whose path is absolute (`/…`)
-/// or uses a `file://` URL. These forms let the compiler resolve imports against the host
-/// filesystem and potentially leak file contents in error messages.
+/// or uses a `file://` URL. These import roots are outside the submitted source map.
 ///
 /// Relative imports containing `../` are allowed: they are standard Solidity practice and
-/// remain sandboxed by `validate_source_paths()` plus the empty compiler search directory.
-pub(crate) fn has_dangerous_imports(source: &str) -> bool {
+/// are handled by source-path validation plus the empty compiler search directory.
+pub(crate) fn has_unsupported_import_roots(source: &str) -> bool {
     // Covers all Solidity import forms:
     //   import "/path";
     //   import {X} from "/path";
@@ -128,37 +127,52 @@ pub(crate) fn has_dangerous_imports(source: &str) -> bool {
 /// The `formattedMessage` format looks like:
 /// ```text
 /// ParserError: Expected ';' but got end of source
-///  --> /etc/shadow:1:5:
+///  --> Source.sol:1:5:
 ///   |
-/// 1 | root:*:19970:0:99999:7:::
+/// 1 | INVALID_SOURCE_LINE
 ///   |     ^
 /// ```
-/// Lines starting with optional whitespace followed by `|` contain verbatim file
-/// contents and must be removed.  The ` --> path:line:col` header is kept because
-/// it only reveals the path (which the caller already submitted) and the position.
+/// Numbered source lines and caret lines are omitted to keep diagnostics concise. The
+/// ` --> path:line:col` header is preserved for location context.
+fn is_source_context_line(line: &str) -> bool {
+    let line = line.trim_start();
+    if line.starts_with('|') {
+        return true;
+    }
+
+    let digit_count = line
+        .bytes()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    digit_count > 0 && line[digit_count..].trim_start().starts_with('|')
+}
+
 fn strip_source_snippets(msg: &str) -> String {
     msg.lines()
-        .filter(|line| !line.trim_start().starts_with('|'))
+        .filter(|line| !is_source_context_line(line))
         .collect::<Vec<_>>()
         .join("\n")
 }
 
-/// Strips source-context lines from raw compiler stderr so that file contents are
-/// not echoed back to the caller.  Used for the non-JSON (exit-code != 0) error path.
+/// Strips source-context lines from raw compiler stderr before returning diagnostics from the
+/// non-JSON (exit-code != 0) error path.
 pub(crate) fn sanitize_compiler_stderr(stderr: &str) -> String {
     stderr
         .lines()
-        .filter(|line| !line.contains(" --> ") && !line.trim_start().starts_with('|'))
+        .filter(|line| !line.contains(" --> ") && !is_source_context_line(line))
         .collect::<Vec<_>>()
         .join("\n")
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{has_dangerous_imports, validate_remappings};
+    use super::{
+        has_unsupported_import_roots, sanitize_compiler_stderr, strip_source_snippets,
+        validate_remappings,
+    };
 
     #[test]
-    fn rejects_non_hermetic_remapping_targets() {
+    fn rejects_external_remapping_targets() {
         for target in [
             "@x/=/abs/path",
             "@x/=file:///abs/path",
@@ -199,15 +213,43 @@ mod tests {
         "#;
 
         assert!(
-            !has_dangerous_imports(source),
+            !has_unsupported_import_roots(source),
             "relative imports within the submitted source tree must be allowed"
         );
     }
 
     #[test]
     fn rejects_absolute_imports() {
-        assert!(has_dangerous_imports(r#"import "/etc/shadow";"#));
-        assert!(has_dangerous_imports(r#"import "file:///etc/shadow";"#));
+        assert!(has_unsupported_import_roots(
+            r#"import "/absolute/path/Source.sol";"#
+        ));
+        assert!(has_unsupported_import_roots(
+            r#"import "file:///absolute/path/Source.sol";"#
+        ));
+    }
+
+    #[test]
+    fn normalizes_formatted_message_source_context() {
+        let message = "ParserError: invalid source\n --> Source.sol:12:1:\n   |\n12 | INVALID_SOURCE_LINE\n   | ^^^^^^^^^^^^^^^^^^^\n";
+
+        let sanitized = strip_source_snippets(message);
+
+        assert!(sanitized.contains("ParserError: invalid source"));
+        assert!(sanitized.contains(" --> Source.sol:12:1:"));
+        assert!(!sanitized.contains("INVALID_SOURCE_LINE"));
+        assert!(!sanitized.contains("12 |"));
+    }
+
+    #[test]
+    fn normalizes_compiler_stderr_source_context() {
+        let stderr = "ParserError: invalid source\n --> Source.sol:1:1:\n  |\n1 | INVALID_SOURCE_LINE\n  | ^^^^^^^^^^^^^^^^^^^\n";
+
+        let sanitized = sanitize_compiler_stderr(stderr);
+
+        assert!(sanitized.contains("ParserError: invalid source"));
+        assert!(!sanitized.contains("Source.sol"));
+        assert!(!sanitized.contains("INVALID_SOURCE_LINE"));
+        assert!(!sanitized.contains("1 |"));
     }
 }
 

--- a/core/lib/contract_verifier/src/compilers/solc.rs
+++ b/core/lib/contract_verifier/src/compilers/solc.rs
@@ -225,6 +225,68 @@ mod tests {
             .contains_key("@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol"));
     }
 
+    fn standard_json_req(input: serde_json::Value, name: &str) -> VerificationIncomingRequest {
+        VerificationIncomingRequest {
+            contract_address: Default::default(),
+            source_code_data: SourceCodeData::StandardJsonInput(input.as_object().unwrap().clone()),
+            contract_name: name.to_owned(),
+            compiler_versions: CompilerVersions::Solc {
+                compiler_solc_version: "0.8.26".to_owned(),
+                compiler_zksolc_version: None,
+            },
+            optimization_used: true,
+            optimizer_mode: None,
+            constructor_arguments: Default::default(),
+            is_system: false,
+            force_evmla: false,
+            evm_specific: Default::default(),
+        }
+    }
+
+    #[test]
+    fn build_input_drops_source_url_references() {
+        // A source may only be provided as inline `content`; any `urls` field (which solc would
+        // resolve against the filesystem) must never reach the compiler.
+        let input = serde_json::json!({
+            "language": "Solidity",
+            "sources": {
+                "src/Test.sol": {
+                    "content": "contract Test {}",
+                    "urls": ["/some/host/path/Evil.sol"],
+                },
+            },
+            "settings": {},
+        });
+
+        let built = Solc::build_input(standard_json_req(input, "src/Test.sol:Test")).unwrap();
+        let serialized = serde_json::to_string(&built.standard_json).unwrap();
+        assert!(
+            !serialized.contains("urls") && !serialized.contains("/some/host/path"),
+            "url references must be stripped before reaching the compiler: {serialized}"
+        );
+    }
+
+    #[test]
+    fn build_input_rejects_source_without_content() {
+        // A source with only `urls` and no inline `content` has no compilable body and is rejected
+        // rather than being handed to the compiler for filesystem resolution.
+        let input = serde_json::json!({
+            "language": "Solidity",
+            "sources": {
+                "src/Test.sol": {
+                    "urls": ["/some/host/path/Evil.sol"],
+                },
+            },
+            "settings": {},
+        });
+
+        let err = Solc::build_input(standard_json_req(input, "src/Test.sol:Test")).unwrap_err();
+        assert!(
+            matches!(err, ContractVerifierError::FailedToDeserializeInput),
+            "source without inline content must be rejected, got: {err:?}"
+        );
+    }
+
     #[test]
     fn build_input_rejects_non_hermetic_remapping() {
         let input = serde_json::json!({

--- a/core/lib/contract_verifier/src/compilers/solc.rs
+++ b/core/lib/contract_verifier/src/compilers/solc.rs
@@ -10,7 +10,8 @@ use zksync_types::contract_verification::api::{
 use crate::{
     compilers::{
         has_dangerous_imports, parse_standard_json_output, process_contract_name,
-        sanitize_compiler_stderr, validate_source_paths, Settings, Source, StandardJson,
+        sanitize_compiler_stderr, validate_remappings, validate_source_paths, Settings, Source,
+        StandardJson,
     },
     error::ContractVerifierError,
     resolver::Compiler,
@@ -83,6 +84,7 @@ impl Solc {
                     serde_json::from_value(serde_json::Value::Object(map))
                         .map_err(|_| ContractVerifierError::FailedToDeserializeInput)?;
                 validate_source_paths(&compiler_input.sources)?;
+                validate_remappings(&compiler_input.settings.other)?;
                 for source in compiler_input.sources.values() {
                     if has_dangerous_imports(&source.content) {
                         return Err(ContractVerifierError::InvalidSourcePath(
@@ -224,6 +226,42 @@ mod tests {
     }
 
     #[test]
+    fn build_input_rejects_non_hermetic_remapping() {
+        let input = serde_json::json!({
+            "language": "Solidity",
+            "sources": {
+                "src/Test.sol": {
+                    "content": r#"import "@ext/Lib.sol"; contract Test {}"#,
+                },
+            },
+            "settings": {
+                "remappings": ["@ext/=../../../../outside/tree/"],
+            },
+        });
+        let req = VerificationIncomingRequest {
+            contract_address: Default::default(),
+            source_code_data: SourceCodeData::StandardJsonInput(input.as_object().unwrap().clone()),
+            contract_name: "src/Test.sol:Test".to_owned(),
+            compiler_versions: CompilerVersions::Solc {
+                compiler_solc_version: "0.8.26".to_owned(),
+                compiler_zksolc_version: None,
+            },
+            optimization_used: true,
+            optimizer_mode: None,
+            constructor_arguments: Default::default(),
+            is_system: false,
+            force_evmla: false,
+            evm_specific: Default::default(),
+        };
+
+        let err = Solc::build_input(req).unwrap_err();
+        assert!(
+            matches!(err, ContractVerifierError::InvalidSourcePath(_)),
+            "non-hermetic remapping must be rejected, got: {err:?}"
+        );
+    }
+
+    #[test]
     fn build_input_uses_evm_bytecode_outputs_for_evm_contracts() {
         let input = serde_json::json!({
             "language": "Solidity",
@@ -297,9 +335,15 @@ impl Compiler<SolcInput> for Solc {
         // not covered by the sources map will therefore fail with "File not found"
         // rather than silently reading an arbitrary host path.
         let compile_dir = tempfile::tempdir().context("failed to create temp dir for solc")?;
+        // Resolve the binary to an absolute path so it stays locatable after `current_dir` is
+        // switched to the (empty) sandbox directory below.
+        let solc_path = tokio::fs::canonicalize(&self.path)
+            .await
+            .context("failed to canonicalize solc path")?;
 
-        let mut command = tokio::process::Command::new(&self.path);
+        let mut command = tokio::process::Command::new(&solc_path);
         let mut child = command
+            .current_dir(compile_dir.path())
             .arg("--standard-json")
             .arg("--allow-paths")
             .arg(compile_dir.path())

--- a/core/lib/contract_verifier/src/compilers/solc.rs
+++ b/core/lib/contract_verifier/src/compilers/solc.rs
@@ -9,7 +9,7 @@ use zksync_types::contract_verification::api::{
 
 use crate::{
     compilers::{
-        has_dangerous_imports, parse_standard_json_output, process_contract_name,
+        has_unsupported_import_roots, parse_standard_json_output, process_contract_name,
         sanitize_compiler_stderr, validate_remappings, validate_source_paths, Settings, Source,
         StandardJson,
     },
@@ -48,7 +48,7 @@ impl Solc {
 
         let standard_json = match req.source_code_data {
             SourceCodeData::SolSingleFile(source_code) => {
-                if has_dangerous_imports(&source_code) {
+                if has_unsupported_import_roots(&source_code) {
                     return Err(ContractVerifierError::InvalidSourcePath(
                         "import with absolute path".to_owned(),
                     ));
@@ -86,7 +86,7 @@ impl Solc {
                 validate_source_paths(&compiler_input.sources)?;
                 validate_remappings(&compiler_input.settings.other)?;
                 for source in compiler_input.sources.values() {
-                    if has_dangerous_imports(&source.content) {
+                    if has_unsupported_import_roots(&source.content) {
                         return Err(ContractVerifierError::InvalidSourcePath(
                             "import with absolute path".to_owned(),
                         ));
@@ -336,7 +336,7 @@ impl Compiler<SolcInput> for Solc {
         // rather than silently reading an arbitrary host path.
         let compile_dir = tempfile::tempdir().context("failed to create temp dir for solc")?;
         // Resolve the binary to an absolute path so it stays locatable after `current_dir` is
-        // switched to the (empty) sandbox directory below.
+        // switched to the empty working directory below.
         let solc_path = tokio::fs::canonicalize(&self.path)
             .await
             .context("failed to canonicalize solc path")?;

--- a/core/lib/contract_verifier/src/compilers/zksolc.rs
+++ b/core/lib/contract_verifier/src/compilers/zksolc.rs
@@ -12,9 +12,9 @@ use zksync_types::contract_verification::api::{
 
 use crate::{
     compilers::{
-        default_json_object, has_dangerous_imports, parse_standard_json_output,
-        process_contract_name, sanitize_compiler_stderr, validate_remappings, validate_source_paths,
-        Source,
+        default_json_object, has_unsupported_import_roots, parse_standard_json_output,
+        process_contract_name, sanitize_compiler_stderr, validate_remappings,
+        validate_source_paths, Source,
     },
     error::ContractVerifierError,
     resolver::{Compiler, CompilerPaths},
@@ -98,7 +98,7 @@ impl ZkSolc {
 
         match req.source_code_data {
             SourceCodeData::SolSingleFile(source_code) => {
-                if has_dangerous_imports(&source_code) {
+                if has_unsupported_import_roots(&source_code) {
                     return Err(ContractVerifierError::InvalidSourcePath(
                         "import with absolute path".to_owned(),
                     ));
@@ -142,7 +142,7 @@ impl ZkSolc {
                 validate_source_paths(&compiler_input.sources)?;
                 validate_remappings(&compiler_input.settings.other)?;
                 for source in compiler_input.sources.values() {
-                    if has_dangerous_imports(&source.content) {
+                    if has_unsupported_import_roots(&source.content) {
                         return Err(ContractVerifierError::InvalidSourcePath(
                             "import with absolute path".to_owned(),
                         ));
@@ -280,7 +280,7 @@ impl Compiler<ZkSolcInput> for ZkSolc {
         input: ZkSolcInput,
     ) -> Result<CompilationArtifacts, ContractVerifierError> {
         // Resolve both binaries to absolute paths so they stay locatable after `current_dir` is
-        // switched to the (empty) sandbox directory in the standard-JSON branch below.
+        // switched to the empty working directory in the standard-JSON branch below.
         let zksolc_path = tokio::fs::canonicalize(&self.paths.zk)
             .await
             .context("failed to canonicalize zksolc path")?;
@@ -325,9 +325,8 @@ impl Compiler<ZkSolcInput> for ZkSolc {
                 contract_name,
                 file_name,
             } => {
-                // Restrict solc (invoked internally by zksolc) to an empty temp dir
-                // so that any import not provided inline is denied at the filesystem
-                // level rather than resolved against the host filesystem.
+                // Run solc (invoked internally by zksolc) from an empty temp dir so
+                // standard-JSON imports must be provided by the input source map.
                 let compile_dir =
                     tempfile::tempdir().context("failed to create temp dir for zksolc")?;
 

--- a/core/lib/contract_verifier/src/compilers/zksolc.rs
+++ b/core/lib/contract_verifier/src/compilers/zksolc.rs
@@ -13,7 +13,8 @@ use zksync_types::contract_verification::api::{
 use crate::{
     compilers::{
         default_json_object, has_dangerous_imports, parse_standard_json_output,
-        process_contract_name, sanitize_compiler_stderr, validate_source_paths, Source,
+        process_contract_name, sanitize_compiler_stderr, validate_remappings, validate_source_paths,
+        Source,
     },
     error::ContractVerifierError,
     resolver::{Compiler, CompilerPaths},
@@ -139,6 +140,7 @@ impl ZkSolc {
                     serde_json::from_value(serde_json::Value::Object(map))
                         .map_err(|_| ContractVerifierError::FailedToDeserializeInput)?;
                 validate_source_paths(&compiler_input.sources)?;
+                validate_remappings(&compiler_input.settings.other)?;
                 for source in compiler_input.sources.values() {
                     if has_dangerous_imports(&source.content) {
                         return Err(ContractVerifierError::InvalidSourcePath(
@@ -277,7 +279,16 @@ impl Compiler<ZkSolcInput> for ZkSolc {
         self: Box<Self>,
         input: ZkSolcInput,
     ) -> Result<CompilationArtifacts, ContractVerifierError> {
-        let mut command = tokio::process::Command::new(&self.paths.zk);
+        // Resolve both binaries to absolute paths so they stay locatable after `current_dir` is
+        // switched to the (empty) sandbox directory in the standard-JSON branch below.
+        let zksolc_path = tokio::fs::canonicalize(&self.paths.zk)
+            .await
+            .context("failed to canonicalize zksolc path")?;
+        let solc_path = tokio::fs::canonicalize(&self.paths.base)
+            .await
+            .context("failed to canonicalize solc path")?;
+
+        let mut command = tokio::process::Command::new(&zksolc_path);
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
         match &input {
@@ -291,20 +302,20 @@ impl Compiler<ZkSolcInput> for ZkSolc {
                     }
                 }
 
-                command.arg("--solc").arg(&self.paths.base);
+                command.arg("--solc").arg(&solc_path);
             }
             ZkSolcInput::YulSingleFile { is_system, .. } => {
                 if Self::is_post_1_5_0(&self.zksolc_version) {
                     if *is_system {
                         command.arg("--enable-eravm-extensions");
                     } else {
-                        command.arg("--solc").arg(&self.paths.base);
+                        command.arg("--solc").arg(&solc_path);
                     }
                 } else {
                     if *is_system {
                         command.arg("--system-mode");
                     }
-                    command.arg("--solc").arg(&self.paths.base);
+                    command.arg("--solc").arg(&solc_path);
                 }
             }
         }
@@ -321,6 +332,7 @@ impl Compiler<ZkSolcInput> for ZkSolc {
                     tempfile::tempdir().context("failed to create temp dir for zksolc")?;
 
                 let mut child = command
+                    .current_dir(compile_dir.path())
                     .arg("--standard-json")
                     .arg("--allow-paths")
                     .arg(compile_dir.path())

--- a/core/lib/contract_verifier/src/tests/real.rs
+++ b/core/lib/contract_verifier/src/tests/real.rs
@@ -7,7 +7,7 @@
 //! zkstack contract-verifier init --zksolc-version=v1.5.10 --zkvyper-version=v1.5.4 --solc-version=0.8.26 --vyper-version=v0.3.10 --era-vm-solc-version=0.8.26-1.0.2 --only
 //! ```
 
-use std::{env, sync::Arc, time::Duration};
+use std::{env, fs, sync::Arc, time::Duration};
 
 use assert_matches::assert_matches;
 use zksync_types::{
@@ -275,17 +275,39 @@ fn relative_import_standard_json_input() -> serde_json::Map<String, serde_json::
     .clone()
 }
 
-fn relative_escape_attempt_input() -> serde_json::Map<String, serde_json::Value> {
+fn unresolved_parent_import_input() -> serde_json::Map<String, serde_json::Value> {
     serde_json::json!({
         "language": "Solidity",
         "sources": {
             "src/Counter.sol": {
                 "content": r#"
                     pragma solidity ^0.8.20;
-                    import "../etc/shadow";
+                    import "../fixtures/Missing.sol";
 
                     contract Counter {}
                 "#,
+            },
+        },
+        "settings": {
+            "optimizer": { "enabled": true },
+        },
+    })
+    .as_object()
+    .unwrap()
+    .clone()
+}
+
+fn filesystem_fallback_input(source_dir_name: &str) -> serde_json::Map<String, serde_json::Value> {
+    serde_json::json!({
+        "language": "Solidity",
+        "sources": {
+            "src/Counter.sol": {
+                "content": format!(r#"
+                    pragma solidity ^0.8.20;
+                    import "../{source_dir_name}/Fallback.sol";
+
+                    contract Counter {{}}
+                "#),
             },
         },
         "settings": {
@@ -423,14 +445,14 @@ async fn allows_relative_parent_imports_in_standard_json(bytecode_kind: Bytecode
 
 #[test_casing(2, BYTECODE_KINDS)]
 #[tokio::test]
-async fn relative_import_escape_is_still_blocked(bytecode_kind: BytecodeMarker) {
+async fn unresolved_parent_import_is_reported(bytecode_kind: BytecodeMarker) {
     let (compiler_resolver, supported_compilers) = real_resolver!();
 
     let err = compile_standard_json_request(
         &compiler_resolver,
         supported_compilers,
         bytecode_kind,
-        relative_escape_attempt_input(),
+        unresolved_parent_import_input(),
         "src/Counter.sol:Counter",
     )
     .await
@@ -450,9 +472,48 @@ async fn relative_import_escape_is_still_blocked(bytecode_kind: BytecodeMarker) 
         "{errors:?}"
     );
     assert!(
+        errors.iter().all(|err| !err.contains("Missing.sol:1:")),
+        "{errors:?}"
+    );
+}
+
+#[test_casing(2, BYTECODE_KINDS)]
+#[tokio::test]
+async fn standard_json_resolution_is_hermetic(bytecode_kind: BytecodeMarker) {
+    let (compiler_resolver, supported_compilers) = real_resolver!();
+    let current_dir = env::current_dir().unwrap();
+    let source_dir = tempfile::Builder::new()
+        .prefix("contract-verifier-source-root-")
+        .tempdir_in(current_dir)
+        .unwrap();
+    fs::write(
+        source_dir.path().join("Fallback.sol"),
+        "pragma solidity ^0.8.20; library Fallback {}",
+    )
+    .unwrap();
+    let source_dir_name = source_dir.path().file_name().unwrap().to_str().unwrap();
+
+    let err = compile_standard_json_request(
+        &compiler_resolver,
+        supported_compilers,
+        bytecode_kind,
+        filesystem_fallback_input(source_dir_name),
+        "src/Counter.sol:Counter",
+    )
+    .await
+    .unwrap_err();
+
+    let ContractVerifierError::CompilationError(serde_json::Value::Array(errors)) = err else {
+        panic!("unexpected error: {err:?}");
+    };
+    let errors: Vec<&str> = errors
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .collect();
+    assert!(
         errors
             .iter()
-            .all(|err| !err.contains("root:") && !err.contains("/etc/shadow:")),
+            .any(|err| err.to_ascii_lowercase().contains("not found")),
         "{errors:?}"
     );
 }


### PR DESCRIPTION
Keeps standard-JSON verification reproducible across runtime environments.

- Resolve compiler executables before switching compilation to a fresh working directory.
- Validate remapping targets consistently with normalized source paths.
- Normalize compiler diagnostic source context.
- Add real-toolchain coverage for isolated source resolution and existing multi-file imports.
- Refresh the cargo lock entry used by dependency checks.
- Keep zksolc output-selection and factory-dependency behavior unchanged.