### PR TITLE
feat(airbender): report real guest cycles from prover to server

### DIFF
--- a/airbender_prover_server/src/client.rs
+++ b/airbender_prover_server/src/client.rs
@@ -103,13 +103,14 @@ impl JobServerClient {
         }))
     }
 
-    pub fn submit_fri(&self, batch_number: u32, proof: &Proof) -> Result<()> {
+    pub fn submit_fri(&self, batch_number: u32, proof: &Proof, cycles_used: u64) -> Result<()> {
         let proof_bytes = bincode::serde::encode_to_vec(proof, bincode::config::standard())
             .context("failed to bincode-encode FRI proof")?;
         self.submit_with_retries(FRI_LABEL, batch_number, |attempt, attempts| {
             info!(
                 batch_number,
                 proof_bytes = proof_bytes.len(),
+                cycles_used,
                 attempt,
                 attempts,
                 "Submitting FRI proof"
@@ -119,6 +120,7 @@ impl JobServerClient {
                 prover_id: self.prover_id.clone(),
                 proof: Some(&proof_bytes),
                 error: None,
+                cycles_used: Some(cycles_used),
             };
             self.post_payload(FRI_LABEL, batch_number, SUBMIT_FRI_PATH, &payload)
         })
@@ -148,6 +150,7 @@ impl JobServerClient {
                 prover_id: self.prover_id.clone(),
                 proof: None,
                 error: Some(error.to_owned()),
+                cycles_used: None,
             };
             self.post_payload(FRI_LABEL, batch_number, SUBMIT_FRI_PATH, &payload)
         })

--- a/airbender_prover_server/src/jobs.rs
+++ b/airbender_prover_server/src/jobs.rs
@@ -157,8 +157,10 @@ impl JobWorker {
             Ok(ProofOutcome::Fri {
                 batch_number,
                 proof,
+                cycles_used,
             }) => {
-                self.client.submit_fri(batch_number, proof.as_ref())?;
+                self.client
+                    .submit_fri(batch_number, proof.as_ref(), cycles_used)?;
                 // In `fri-snark` mode, the SNARK job needs the FRI proof, so we can set the new pending job immediately instead of waiting for the next fetch cycle. The in-memory `Proof` is fed directly to the SNARK pipeline without an extra encode/decode round trip.
                 if self.mode == ProverMode::FriSnark {
                     // FRI jobs are processed serially, so the previous SNARK

--- a/airbender_prover_server/src/types.rs
+++ b/airbender_prover_server/src/types.rs
@@ -55,6 +55,9 @@ pub enum ProofOutcome {
     Fri {
         batch_number: u32,
         proof: Box<Proof>,
+        /// Guest cycles executed by the FRI prover's RISC-V run for this batch,
+        /// reported to the server alongside the proof.
+        cycles_used: u64,
     },
     Snark {
         batch_number: u32,
@@ -112,6 +115,11 @@ pub struct SubmitFriProofRequest<'a> {
     pub proof: Option<&'a [u8]>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Guest cycles the prover actually executed for this batch. Sent with a
+    /// successful proof and omitted on failure submissions; the server's
+    /// `#[serde(default)]` defaults the missing field to `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cycles_used: Option<u64>,
 }
 
 /// SNARK submission payload. Like [`SubmitFriProofRequest`], carries either a
@@ -140,11 +148,14 @@ mod tests {
             prover_id: "prover-1".to_string(),
             proof: Some(&[10, 11, 12, 13, 14]),
             error: None,
+            cycles_used: Some(123_456_789),
         })
         .unwrap();
         assert_eq!(json["l1_batch_number"], 42);
         assert_eq!(json["prover_id"], "prover-1");
         assert_eq!(json["proof"], "0a0b0c0d0e");
+        // A successful submission reports the batch's measured guest cycles.
+        assert_eq!(json["cycles_used"], 123_456_789);
         // The server defaults `error` to `None`, so a success submission omits it.
         assert!(json.get("error").is_none());
     }
@@ -156,10 +167,13 @@ mod tests {
             prover_id: "prover-1".to_string(),
             proof: None,
             error: Some("prover ran out of memory".to_string()),
+            cycles_used: None,
         })
         .unwrap();
         assert_eq!(json["error"], "prover ran out of memory");
         assert!(json.get("proof").is_none());
+        // No proof means no cycle count; the field is omitted on failure.
+        assert!(json.get("cycles_used").is_none());
     }
 
     #[test]

--- a/airbender_prover_server/src/worker.rs
+++ b/airbender_prover_server/src/worker.rs
@@ -102,7 +102,6 @@ impl ProverWorker {
                     let started = Instant::now();
                     let result = catch_prover_panic("FRI prover", || {
                         fri.prove_input(batch_number as u64, &input_words)
-                            .map(|out| out.proof)
                     });
                     record_proof_metrics(
                         batch_number,
@@ -111,9 +110,10 @@ impl ProverWorker {
                         started.elapsed(),
                     );
                     result
-                        .map(|proof| ProofOutcome::Fri {
+                        .map(|out| ProofOutcome::Fri {
                             batch_number,
-                            proof: Box::new(proof),
+                            proof: Box::new(out.proof),
+                            cycles_used: out.cycles,
                         })
                         .map_err(|err| FailedProof::new(batch_number, ProofType::Fri, err))
                 }


### PR DESCRIPTION
## What

The FRI prover already measures the guest cycles it executed for a batch (`ProveOutput.cycles`), but the prover server's worker discarded them (`.map(|out| out.proof)`). This carries the count all the way through to the FRI proof submission so the main node can persist real vs. predicted cycles.

This is the prover-side counterpart to #4891 (`feat(state_keeper): persist predicted vs prover-reported Airbender cycles`), which added `cycles_used` to `SubmitAirbenderProofRequest` and the `save_real_cycles` persistence path. Without this change, the server always receives `cycles_used: None`.

## Changes (`airbender_prover_server`)

- **`worker.rs`** — stop discarding `out.cycles`; carry it in `ProofOutcome::Fri`.
- **`types.rs`** — `ProofOutcome::Fri` gains `cycles_used: u64`; `SubmitFriProofRequest` gains `cycles_used: Option<u64>` (omitted on failure, so the server defaults it to `None`).
- **`jobs.rs`** — thread `cycles_used` into `submit_fri`.
- **`client.rs`** — send `Some(cycles)` on a successful FRI submission, `None` on the failure path; log the count.

## End-to-end path

GPU FRI prove → `ProveOutput.cycles` → `ProofOutcome::Fri.cycles_used` → `SubmitFriProofRequest.cycles_used` → POST `/airbender/submit_proofs` → server `save_real_cycles(l1_batch, cycles_used)` → `l1_batch_cycle_stats.real_cycles`.

Only FRI submissions carry cycles (`fri-only` / `fri-snark` modes); `snark-only` provers run no FRI and report none.

## Testing

- `cargo check --no-default-features --tests` (CPU-only) passes.
- `SubmitFriProofRequest` serialization unit tests updated and passing (`cycles_used` present on success, omitted on failure).
- Integration tests are GPU/LFS-gated (ignored in CI here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)