### PR TITLE
ci: shallow checkouts and checkout action v7

### DIFF
--- a/.github/workflows/build-airbender-prover-server-template.yml
+++ b/.github/workflows/build-airbender-prover-server-template.yml
@@ -44,7 +44,7 @@ jobs:
           - image: eravm-airbender-verifier-cpu
             dockerfile: docker/airbender-prover-server/Dockerfile.cpu
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 

--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -27,7 +27,7 @@ jobs:
         arch: [ amd64, arm64 ]
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 

--- a/.github/workflows/build-circuit-prover-gpu-gar.yml
+++ b/.github/workflows/build-circuit-prover-gpu-gar.yml
@@ -21,7 +21,7 @@ jobs:
     name: Build prover FRI GPU GAR
     runs-on: [matterlabs-ci-runner-high-performance]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 

--- a/.github/workflows/build-contract-verifier-template.yml
+++ b/.github/workflows/build-contract-verifier-template.yml
@@ -28,7 +28,7 @@ jobs:
     name: Prepare contracts
     runs-on: matterlabs-ci-runner-high-performance
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 
@@ -160,7 +160,7 @@ jobs:
           - linux/amd64
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 
@@ -258,7 +258,7 @@ jobs:
     env:
       IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: login to Docker registries
         run: |

--- a/.github/workflows/build-core-template.yml
+++ b/.github/workflows/build-core-template.yml
@@ -33,7 +33,7 @@ jobs:
     name: Prepare contracts
     runs-on: matterlabs-ci-runner-high-performance
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 
@@ -153,10 +153,9 @@ jobs:
     name: Prepare proof manager contracts
     runs-on: matterlabs-ci-runner-high-performance
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
-          fetch-depth: 0
 
       - name: Prepare ENV
         shell: bash
@@ -227,7 +226,7 @@ jobs:
             platforms: linux/arm64
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 
@@ -340,7 +339,7 @@ jobs:
     env:
       IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}${{ (inputs.en_alpha_release && matrix.component.name == 'external-node') && '-alpha' || '' }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: login to Docker registries
         run: |

--- a/.github/workflows/build-docker-from-tag.yml
+++ b/.github/workflows/build-docker-from-tag.yml
@@ -29,7 +29,7 @@ jobs:
       image_tag_suffix: ${{ steps.set.outputs.image_tag_suffix }}
       prover_fri_gpu_key_id: ${{ steps.extract-prover-fri-setup-key-ids.outputs.gpu_short_commit_sha }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Generate output with git tag
         id: set
         run: |

--- a/.github/workflows/build-private-rpc.yaml
+++ b/.github/workflows/build-private-rpc.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Private Rpc - Build and Push Docker Image
     runs-on: [ matterlabs-ci-runner-high-performance ]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 

--- a/.github/workflows/build-proof-fri-gpu-compressor-gar.yml
+++ b/.github/workflows/build-proof-fri-gpu-compressor-gar.yml
@@ -21,7 +21,7 @@ jobs:
     name: Build proof FRI GPU Compressor gar
     runs-on: [matterlabs-ci-runner-high-performance]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 

--- a/.github/workflows/build-prover-template.yml
+++ b/.github/workflows/build-prover-template.yml
@@ -49,7 +49,7 @@ jobs:
     outputs:
       protocol_version: ${{ steps.protocolversion.outputs.protocol_version }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 
@@ -91,7 +91,7 @@ jobs:
           - prover-autoscaler
           - circuit-prover-gpu
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 

--- a/.github/workflows/build-runtime-base.yml
+++ b/.github/workflows/build-runtime-base.yml
@@ -24,7 +24,7 @@ jobs:
         image_name: [ zksync-runtime-base ]
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 

--- a/.github/workflows/cargo-license.yaml
+++ b/.github/workflows/cargo-license.yaml
@@ -4,7 +4,7 @@ jobs:
   cargo-deny:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - uses: EmbarkStudios/cargo-deny-action@76cd80eb775d7bbbd2d80292136d74d39e1b4918 # v2.0.11
       with:
         manifest-path: "./core/Cargo.toml"

--- a/.github/workflows/ci-airbender-prover-server-reusable.yml
+++ b/.github/workflows/ci-airbender-prover-server-reusable.yml
@@ -9,7 +9,7 @@ jobs:
       RUNNER_COMPOSE_FILE: "docker-compose-runner-nightly.yml"
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 

--- a/.github/workflows/ci-core-lint-reusable.yml
+++ b/.github/workflows/ci-core-lint-reusable.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Get changed files
         id: changed-files
@@ -53,7 +53,7 @@ jobs:
   code_lint:
     runs-on: matterlabs-ci-runner-highmem-long
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 

--- a/.github/workflows/ci-core-reusable.yml
+++ b/.github/workflows/ci-core-reusable.yml
@@ -21,10 +21,9 @@ jobs:
     runs-on: [ matterlabs-ci-runner-highmem-long ]
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
-          fetch-depth: 0
 
       - name: Setup Environment
         uses: ./.github/actions/setup-env
@@ -86,10 +85,9 @@ jobs:
         vm_mode: [ "OLD", "NEW" ]
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
-          fetch-depth: 0
 
       - name: Loadtest configuration
         run: |
@@ -154,10 +152,9 @@ jobs:
       # In some cases it's useful to continue one job even if another fails.
       fail-fast: false
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
-          fetch-depth: 0
 
       - name: Setup environment
         run: |

--- a/.github/workflows/ci-docs-reusable.yml
+++ b/.github/workflows/ci-docs-reusable.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: matterlabs-default-infra-runners
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 

--- a/.github/workflows/ci-prover-e2e.yml
+++ b/.github/workflows/ci-prover-e2e.yml
@@ -17,10 +17,9 @@ jobs:
       PASSED_ENV_VARS: "CUDA_ARCH,CUDAARCHS"
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
-          fetch-depth: 0
 
       - name: Setup Environment
         uses: ./.github/actions/setup-env

--- a/.github/workflows/ci-prover-reusable.yml
+++ b/.github/workflows/ci-prover-reusable.yml
@@ -9,7 +9,7 @@ jobs:
       RUNNER_COMPOSE_FILE: "docker-compose-runner-nightly.yml"
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 
@@ -40,7 +40,7 @@ jobs:
       RUNNER_COMPOSE_FILE: "docker-compose-runner-nightly.yml"
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,15 @@ jobs:
       docs: ${{ steps.changed-files.outputs.docs_any_changed }}
       all: ${{ steps.changed-files.outputs.all_any_changed }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # `tj-actions/changed-files` compares submodule SHAs too. When a PR only updates
           # `contracts`, it needs enough submodule history to find the merge base there;
           # otherwise it can miss the change and warn about an invalid revision range.
           fetch-depth: 0
+          # Blobs are only needed for the checked-out working tree; history stays
+          # available for the merge base computation as commits and trees.
+          filter: blob:none
           submodules: "recursive"
 
       - name: Get changed files

--- a/.github/workflows/deploy-core-docs.yml
+++ b/.github/workflows/deploy-core-docs.yml
@@ -43,7 +43,7 @@ jobs:
       ENABLE_TESTS: false
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.ref || '' }}
 

--- a/.github/workflows/deploy-prover-docs.yml
+++ b/.github/workflows/deploy-prover-docs.yml
@@ -43,7 +43,7 @@ jobs:
       ENABLE_TESTS: false
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.ref || '' }}
 

--- a/.github/workflows/nodejs-license.yaml
+++ b/.github/workflows/nodejs-license.yaml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - run: |
           DIRS=$(find -not \( -path \*node_modules -prune \) -type f -name yarn.lock  | xargs dirname | awk -v RS='' -v OFS='","' 'NF { $1 = $1; print "\"" $0 "\"" }')
           echo "matrix=[${DIRS}]" >> $GITHUB_OUTPUT
@@ -44,7 +44,7 @@ jobs:
         dir: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Checkout latest code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Use Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0

--- a/.github/workflows/protobuf.yaml
+++ b/.github/workflows/protobuf.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       # before
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ env.BASE }}
           path: before
@@ -58,7 +58,7 @@ jobs:
           | xargs cat > ./before.binpb
 
       # after
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ env.HEAD }}
           path: after

--- a/.github/workflows/release-test-stage.yml
+++ b/.github/workflows/release-test-stage.yml
@@ -18,7 +18,7 @@ jobs:
       airbender_prover_server: ${{ steps.changed-files-yaml.outputs.airbender_prover_server_any_changed }}
       all: ${{ steps.changed-files-yaml.outputs.all_any_changed }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 2
 
@@ -51,7 +51,7 @@ jobs:
       image_tag_suffix: ${{ steps.generate-tag-suffix.outputs.image_tag_suffix }}
       prover_fri_gpu_key_id: ${{ steps.extract-prover-fri-setup-key-ids.outputs.gpu_short_commit_sha }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Generate image tag suffix
         id: generate-tag-suffix

--- a/.github/workflows/release-zkstack-bins.yml
+++ b/.github/workflows/release-zkstack-bins.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.tag || '' }}
 
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.tag || '' }}
 

--- a/.github/workflows/secrets_scanner.yaml
+++ b/.github/workflows/secrets_scanner.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: TruffleHog OSS

--- a/.github/workflows/vm-perf-comparison.yml
+++ b/.github/workflows/vm-perf-comparison.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: checkout base branch
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
           fetch-depth: 0

--- a/.github/workflows/vm-perf-to-prometheus.yml
+++ b/.github/workflows/vm-perf-to-prometheus.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [ matterlabs-ci-runner-highmem-long ]
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 

--- a/.github/workflows/zk-environment-publish.yml
+++ b/.github/workflows/zk-environment-publish.yml
@@ -36,7 +36,7 @@ jobs:
       zk_environment_cuda_12: ${{ steps.changed-files-yaml.outputs.zk_env_cuda_12_any_changed }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
           fetch-depth: 0
@@ -63,7 +63,7 @@ jobs:
     outputs:
       short_sha: ${{ steps.set_short_sha.outputs.short_sha }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
       - name: Set short SHA
@@ -89,7 +89,7 @@ jobs:
             arch: arm64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
       - name: Set up Docker Buildx
@@ -216,7 +216,7 @@ jobs:
 
       - name: Checkout code
         if: ${{ (steps.condition.outputs.should_run == 'true') || (github.event_name == 'workflow_dispatch' && inputs.build_cuda) }}
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: "recursive"
 


### PR DESCRIPTION
CI checkouts pull full history, all 600+ branches/tags, and full-history recursive submodules (~600 MB of git data per job - era-contracts alone is bigger packed than this repo) while no test job actually uses history. Healthy checkout takes 60-75s per job and the fat transfer widens the window for the frequent "runner lost communication" checkout deaths.

- drop `fetch-depth: 0` from test/build jobs that don't need history; default depth 1 also shallow-clones submodules. Kept where merge-base/history is genuinely needed: changed_files, protobuf, vm-perf-comparison, secrets scanner
- bump `actions/checkout` v4.2.2 -> v7.0.0 (SHA-pinned) across all workflows; kills the node20 deprecation warnings. Audited v5-v7 breaking changes: no workflow relies on in-repo persisted creds, and the only `pull_request_target` workflow does no checkout
- `filter: blob:none` for the changed_files job: keeps full history for merge-base computation, skips blob download. If changed-files misdetects on a contracts-only PR, revert this single line

🤖 Generated with [Claude Code](https://claude.com/claude-code)