### PR TITLE
ci(release-please,publish-crates): bump reusable CI versions and remove deprecated inputs

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -20,11 +20,6 @@ on:
         description: 'Run tests before release.'
         required: false
         default: false
-      org-owner:
-        type: string
-        description: 'Organization to add as owner of the crates.'
-        required: false
-        default: 'github:matter-labs:crates-io'
 
 
 jobs:
@@ -34,14 +29,15 @@ jobs:
     runs-on: matterlabs-ci-runner-highdisk
     env:
       ZKSYNC_USE_CUDA_STUBS: true
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Publish crates
-        uses: matter-labs/zksync-ci-common/.github/actions/publish-crates@3f8620bc332855fd588321f4486ecdbcddee9ec3 # v1
+        uses: matter-labs/zksync-ci-common/.github/actions/publish-crates@c488e5a187bfa5b667ec31061045be3ad7f3245a
         with:
           slack_webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }} # Slack webhook for notifications
-          cargo_registry_token: ${{ secrets.CRATES_IO_TOKEN }} # Crates.io token for publishing
           workspace_path: ${{ inputs.component || 'core' }}
-          org_owner: ${{ inputs.org-owner }}
           run_build: ${{ inputs.run-build }}
           run_tests: ${{ inputs.run-tests }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,11 +19,10 @@ jobs:
 
   # Prepare the release PR with changelog updates and create github releases
   release-please:
-    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@3f8620bc332855fd588321f4486ecdbcddee9ec3 # v1
+    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@c3b31c6f11bada204069c8b4621044e4c1cbc1df
     secrets:
       slack_webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }}  # Slack webhook for notifications
       gh_token: ${{ secrets.RELEASE_TOKEN }}                # GitHub token for release-please
-      cargo_registry_token: ${{ secrets.CRATES_IO_TOKEN }}  # Crates.io token for publishing
     with:
       config: '.github/release-please/config.json'          # Path to the configuration file
       manifest: '.github/release-please/manifest.json'      # Path to the manifest file


### PR DESCRIPTION
## What ❔

- update versions of reusable workflows used to publish crates to crates.io. New version of those workflows use trusted publishing instead of static API tokens
- due to the limitation of trusted publishing, new crates in crates.io will have to be initially created by DevOps:
> Your crate must already be published to crates.io (initial publish requires an API token)

## Why ❔

- trusted publishing replaces long-lived crates.io API tokens with short-lived, OIDC-issued credentials scoped to a specific repo and workflow. This removes a standing secret that could leak and would need manual rotation, and follows crates.io's recommended publishing setup.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
