### PR TITLE
docs(prover): fix broken relative links in prover documentation

### DIFF
--- a/core/bin/snapshots_creator/README.md
+++ b/core/bin/snapshots_creator/README.md
@@ -12,7 +12,7 @@ Compared to Postgres dumps, app-level snapshots are much more compact; as of Feb
 
 ## Local testing
 
-Usage for local development (assuming the development environment [has been set up](../../../docs/guides/setup-dev.md)):
+Usage for local development (assuming the development environment [has been set up](../../../docs/src/guides/setup-dev.md)):
 
 1. Run `zk env dev`
 2. Generate storage logs, e.g. by running a load test with a command like

--- a/prover/README.md
+++ b/prover/README.md
@@ -4,9 +4,9 @@ This directory contains all the libraries and binaries related to proving of the
 
 ## Documentation
 
-- [Intro](docs/00_intro.md)
-- [Setting up a GCP VM](docs/01_gcp_vm.md)
-- [Workspace setup](docs/02_setup.md)
-- [Running prover subsystem](docs/03_launch.md)
-- [Proof generation flow](docs/04_flow.md)
-- [Further reading](docs/99_further_reading.md)
+- [Intro](docs/src/00_intro.md)
+- [Setting up a GCP VM](docs/src/01_gcp_vm.md)
+- [Workspace setup](docs/src/02_setup.md)
+- [Running prover subsystem](docs/src/03_launch.md)
+- [Proof generation flow](docs/src/04_flow.md)
+- [Further reading](docs/src/99_further_reading.md)

--- a/prover/crates/bin/prover_autoscaler/README.md
+++ b/prover/crates/bin/prover_autoscaler/README.md
@@ -84,7 +84,7 @@ installed, see `protocol_versions` config option.
 
 ## Dependencies
 
-- [prover-job-monitor](.../prover_job_monitor/)
+- [prover-job-monitor](../prover_job_monitor/)
 - Kubernetes API
 - GCP API (optional)
 

--- a/prover/docs/README.md
+++ b/prover/docs/README.md
@@ -1,6 +1,6 @@
 # Prover subsystem documentation
 
-This is technical documentation for the prover subsystem.It aims to help developers to set up a development environment
+This is technical documentation for the prover subsystem. It aims to help developers to set up a development environment
 for working with provers. This documentation assumes that you are already familiar with how ZKsync works, and you need
 to be able to work with the prover code.
 
@@ -8,9 +8,9 @@ It does not cover topics such as basics of ZK or production deployment for prove
 
 ## Table of contents
 
-- [Intro](00_intro.md)
-- [Setting up a GCP VM](01_gcp_vm.md)
-- [Workspace setup](02_setup.md)
-- [Running prover subsystem](03_launch.md)
-- [Proof generation flow](04_flow.md)
-- [Further reading](99_further_reading.md)
+- [Intro](src/00_intro.md)
+- [Setting up a GCP VM](src/01_gcp_vm.md)
+- [Workspace setup](src/02_setup.md)
+- [Running prover subsystem](src/03_launch.md)
+- [Proof generation flow](src/04_flow.md)
+- [Further reading](src/99_further_reading.md)


### PR DESCRIPTION
## What ❔

This PR repairs broken relative links in the prover documentation and in two related
`README.md` files. After the prover docs were moved under a `docs/src/` directory (mdBook
layout), the link tables in `prover/README.md` and `prover/docs/README.md` were never updated
and now point at files that do not exist. Two more stale links are fixed at the same time.

Concretely:

- `prover/README.md` — the six documentation links pointed at `docs/<file>.md`; the files
  actually live in `docs/src/`, so they are re-pointed to `docs/src/<file>.md`.
- `prover/docs/README.md` — the six table-of-contents links pointed at `<file>.md` relative
  to `prover/docs/`; they are re-pointed to `src/<file>.md`. A missing space in
  "subsystem.It" is corrected to "subsystem. It".
- `core/bin/snapshots_creator/README.md` — the "has been set up" link pointed at
  `../../../docs/guides/setup-dev.md`; the guide lives under `docs/src/guides/`, so the link
  is corrected.
- `prover/crates/bin/prover_autoscaler/README.md` — the dependency link used an invalid
  `.../prover_job_monitor/` prefix (three dots); corrected to the sibling `../prover_job_monitor/`.

## Why ❔

Every one of these links currently 404s (locally and on GitHub). New contributors onboarding
to the prover subsystem follow exactly these tables, so the broken navigation is a real
friction point. The `Why` is relevant to any ZK Chain operator reading the prover docs.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Operational changes

None. Documentation-only.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
