### PR TITLE
docs: fix grammar and doubled-slash links in developer guides

### DIFF
--- a/docs/src/guides/development.md
+++ b/docs/src/guides/development.md
@@ -35,11 +35,11 @@ zkstack --help
 ```
 
 ```admonish note
-NOTE: Whenever you want to update you local installation with your changes, just rerun:
+NOTE: Whenever you want to update your local installation with your changes, just rerun:
 
 `zkstackup --local`
 
-You might find convenient to add this alias to your shell profile:
+You might find it convenient to add this alias to your shell profile:
 
 `alias zkstackup='zkstackup --path /path/to/zksync-era'`
 ```
@@ -97,7 +97,7 @@ Currently the following criteria are checked:
 
 ## Testing
 
-ZKstack CLI offers multiple subcommands to run specific integration and unit test:
+ZKstack CLI offers multiple subcommands to run specific integration and unit tests:
 
 ```bash
 zkstack dev test --help
@@ -255,7 +255,7 @@ For more information check [Foundry's documentation](https://book.getfoundry.sh/
 
 ## How to generate the `genesis.yaml` file
 
-To generate the [`genesis.yaml`](https://github.com/matter-labs/zksync-era/blob/main//etc/env/file_based/genesis.yaml)
+To generate the [`genesis.yaml`](https://github.com/matter-labs/zksync-era/blob/main/etc/env/file_based/genesis.yaml)
 file checkout to the desired `zksync-era` branch, [build `zkstack`](#installing-the-local-zk-stack-cli) from it,
 [configure ecosystem](#configure-ecosystem) and run the following command:
 

--- a/docs/src/guides/launch.md
+++ b/docs/src/guides/launch.md
@@ -248,7 +248,7 @@ Running on machine without GPU is currently not supported by `zkstack`.
 ## Running the verification key generator
 
 ```bash
-# ensure that the setup_2^26.key in the current directory, the file can be download from  https://storage.googleapis.com/matterlabs-setup-keys-us/setup-keys/setup_2\^26.key
+# ensure that the setup_2^26.key is in the current directory, the file can be downloaded from  https://storage.googleapis.com/matterlabs-setup-keys-us/setup-keys/setup_2\^26.key
 
 # To generate all verification keys
 cargo run --release --bin zksync_verification_key_generator

--- a/docs/src/guides/repositories.md
+++ b/docs/src/guides/repositories.md
@@ -16,7 +16,7 @@
 | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
 | [era-compiler-tester](https://github.com/matter-labs/era-compiler-tester)             | Integration testing framework for running executable tests on zkEVM |
 | [era-compiler-tests](https://github.com/matter-labs/era-compiler-tests)               | Collection of executable tests for zkEVM                            |
-| [era-compiler-llvm](https://github.com/matter-labs//era-compiler-llvm)                | zkEVM fork of the LLVM framework                                    |
+| [era-compiler-llvm](https://github.com/matter-labs/era-compiler-llvm)                | zkEVM fork of the LLVM framework                                    |
 | [era-compiler-solidity](https://github.com/matter-labs/era-compiler-solidity)         | Solidity Yul/EVMLA compiler front end                               |
 | [era-compiler-vyper](https://github.com/matter-labs/era-compiler-vyper)               | Vyper LLL compiler front end                                        |
 | [era-compiler-llvm-context](https://github.com/matter-labs/era-compiler-llvm-context) | LLVM IR generator logic shared by multiple front ends               |
@@ -31,7 +31,7 @@
 | [era-zk_evm](https://github.com/matter-labs/era-zk_evm)                         | EVM implementation in pure rust, without circuits                                                                   |
 | [era-sync_vm](https://github.com/matter-labs/era-sync_vm)                       | EVM implementation using circuits                                                                                   |
 | [era-zkEVM-assembly](https://github.com/matter-labs/era-zkEVM-assembly)         | Code for parsing zkEVM assembly                                                                                     |
-| [era-zkevm_test_harness](https://github.com/matter-labs/era-zkevm_test_harness) | Tests that compare the two implementation of the zkEVM - the non-circuit one (zk_evm) and the circuit one (sync_vm) |
+| [era-zkevm_test_harness](https://github.com/matter-labs/era-zkevm_test_harness) | Tests that compare the two implementations of the zkEVM - the non-circuit one (zk_evm) and the circuit one (sync_vm) |
 | [era-zkevm_tester](https://github.com/matter-labs/era-zkevm_tester)             | Assembly runner for zkEVM testing                                                                                   |
 | [era-boojum](https://github.com/matter-labs/era-boojum)                         | New proving system library - containing gadgets and gates                                                           |
 | [era-shivini](https://github.com/matter-labs/era-shivini)                       | Cuda / GPU implementation for the new proving system                                                                |

--- a/docs/src/guides/setup-dev.md
+++ b/docs/src/guides/setup-dev.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-This is a shorter version of setup guide to make it easier subsequent initializations. If it's the first time you're
+This is a shorter version of the setup guide to make subsequent initializations easier. If it's the first time you're
 initializing the workspace, it's recommended that you read the whole guide below, as it provides more context and tips.
 
 If you run on 'clean' Ubuntu on GCP:
@@ -225,7 +225,7 @@ cargo install --locked sqlx-cli --version 0.8.1
 
 ## Foundry ZKsync
 
-ZKSync depends on Foundry ZKsync (which is is a specialized fork of Foundry, tailored for ZKsync). Please follow this
+ZKSync depends on Foundry ZKsync (which is a specialized fork of Foundry, tailored for ZKsync). Please follow this
 [installation guide](https://foundry-book.zksync.io/getting-started/installation) to get started with Foundry ZKsync.
 
 Foundry ZKsync can also be used for deploying smart contracts. For commands related to deployment, you can pass flags
@@ -233,8 +233,8 @@ for Foundry integration.
 
 ## Non-GPU setup
 
-Circuit Prover requires a CUDA bindings to run. If you still want to be able to build everything locally on non-CUDA
-setup, you'll need use CUDA stubs.
+Circuit Prover requires CUDA bindings to run. If you still want to be able to build everything locally on non-CUDA
+setup, you'll need to use CUDA stubs.
 
 For a single run, it's enough to export it on the shell:
 


### PR DESCRIPTION
## What ❔

Grammar and link cleanup across the getting-started developer guides. No behaviour changes —
these just make the guides read the way they were clearly meant to:

- `setup-dev.md` — "make it easier subsequent initializations" → "make subsequent
  initializations easier"; a doubled "is is"; "a CUDA bindings" → "CUDA bindings";
  "you'll need use" → "you'll need to use".
- `development.md` — "update you local installation" → "your"; "find convenient to add" →
  "find it convenient"; singular "unit test" → "unit tests"; and a GitHub link with a doubled
  slash (`blob/main//etc/...`) normalised to a single slash.
- `launch.md` — "the setup_2^26.key in the current directory, the file can be download from"
  → the key "is in" the directory and "can be downloaded".
- `repositories.md` — another doubled-slash URL (`matter-labs//era-compiler-llvm`) and a
  singular "two implementation" → "two implementations".

## Why ❔

These are the first pages a new contributor (including non-Matter Labs ZK Chain operators)
reads when setting up the repo. The doubled-slash URLs render as broken-looking links and are
easy to copy incorrectly, and the missing/duplicated words make several sentences hard to
parse. Fixing them lowers onboarding friction.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

None. Documentation only — no config, flags or scripts are changed.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
