### PR TITLE
feat(airbender): round-robin prover fetching across multiple chain job servers

### DIFF
--- a/airbender_prover_server/README.md
+++ b/airbender_prover_server/README.md
@@ -55,7 +55,9 @@ at boot, and the scan resumes after the chain last served — so when every chai
 of the prover regardless of how many batches it produces, and idle chains donate their share to busy ones. Proofs (and
 failure reports) are always submitted back to the server the job was fetched from. Provers coordinate through nothing
 but the job servers themselves, so any number of provers can compete for the same set of chains; per-chain contention is
-resolved by the servers' locking. Metrics carry a `chain` label with the URL's index in the configured list.
+resolved by the servers' locking. Proof metrics and job logs carry a `chain_id` label with the actual L2 chain id
+reported by the job server (from `system_env` for FRI inputs, from the response body for SNARK inputs; 0 if the server
+predates chain-id reporting).
 
 ## Building
 

--- a/airbender_prover_server/README.md
+++ b/airbender_prover_server/README.md
@@ -38,7 +38,7 @@ Selected with `--mode` / `PROVER_MODE`:
 
 | Flag               | Env                     | Default                        |
 | ------------------ | ----------------------- | ------------------------------ |
-| `--server-url`     | `PROVER_SERVER_URL`     | (required)                     |
+| `--server-url`     | `PROVER_SERVER_URL`     | (required, repeatable)         |
 | `--mode`           | `PROVER_MODE`           | `fri-only`                     |
 | `--fri-vk`         | `FRI_VK`                | downloaded `vks/fri_vk.bin`    |
 | `--snark-vk`       | `SNARK_VK`              | downloaded `vks/snark_vk.json` |
@@ -46,6 +46,16 @@ Selected with `--mode` / `PROVER_MODE`:
 | `--metrics-port`   | —                       | off                            |
 
 The server loads VKs from disk and never derives them on the fly.
+
+## Proving for multiple chains
+
+One prover can serve several chains running the same guest program: pass several job-server URLs (comma-separated in
+`PROVER_SERVER_URL`, or by repeating `--server-url`). Fetches round-robin across the servers, starting from a random one
+at boot, and the scan resumes after the chain last served — so when every chain has a backlog, each gets an equal share
+of the prover regardless of how many batches it produces, and idle chains donate their share to busy ones. Proofs (and
+failure reports) are always submitted back to the server the job was fetched from. Provers coordinate through nothing
+but the job servers themselves, so any number of provers can compete for the same set of chains; per-chain contention is
+resolved by the servers' locking. Metrics carry a `chain` label with the URL's index in the configured list.
 
 ## Building
 

--- a/airbender_prover_server/crates/lib/prover_metrics/src/lib.rs
+++ b/airbender_prover_server/crates/lib/prover_metrics/src/lib.rs
@@ -31,6 +31,10 @@ impl std::fmt::Display for ProofType {
 /// Labels attached to proof generation metrics.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, EncodeLabelSet)]
 pub struct ProofLabels {
+    /// Index of the job server (one per chain) the batch was fetched from,
+    /// matching the order of the configured server URLs. Distinguishes chains
+    /// when one prover serves several; a single-chain prover always reports 0.
+    pub chain: usize,
     pub batch_number: u32,
     pub proof_type: ProofType,
     pub status: ProofStatus,

--- a/airbender_prover_server/crates/lib/prover_metrics/src/lib.rs
+++ b/airbender_prover_server/crates/lib/prover_metrics/src/lib.rs
@@ -31,10 +31,10 @@ impl std::fmt::Display for ProofType {
 /// Labels attached to proof generation metrics.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, EncodeLabelSet)]
 pub struct ProofLabels {
-    /// Index of the job server (one per chain) the batch was fetched from,
-    /// matching the order of the configured server URLs. Distinguishes chains
-    /// when one prover serves several; a single-chain prover always reports 0.
-    pub chain: usize,
+    /// L2 chain id of the chain the batch belongs to, as reported by the job
+    /// server it was fetched from. Distinguishes chains when one prover serves
+    /// several; 0 when the server predates chain-id reporting.
+    pub chain_id: u64,
     pub batch_number: u32,
     pub proof_type: ProofType,
     pub status: ProofStatus,

--- a/airbender_prover_server/src/client.rs
+++ b/airbender_prover_server/src/client.rs
@@ -7,7 +7,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use tracing::{info, warn};
 use zksync_airbender_verifier::types::AirbenderVerifierInput;
 
-use crate::types::{SubmitFriProofRequest, SubmitSnarkProofRequest, WorkerJob};
+use crate::types::{JobOrigin, SubmitFriProofRequest, SubmitSnarkProofRequest, WorkerJob};
 
 const FRI_INPUTS_PATH: &str = "/airbender/proof_inputs";
 const SNARK_INPUTS_PATH: &str = "/airbender/snark_inputs";
@@ -30,8 +30,9 @@ pub struct JobServerClient {
     /// latter is larger for big SNARK payloads) is applied per call.
     client: reqwest::blocking::Client,
     /// Index of this client in the configured job-server list; stamped onto
-    /// every fetched job so results route back to the originating chain.
-    chain: usize,
+    /// every fetched job (as [`JobOrigin::server`]) so results route back to
+    /// the originating server.
+    server_index: usize,
     server_url: String,
     prover_id: String,
     submit_attempts: usize,
@@ -41,7 +42,7 @@ pub struct JobServerClient {
 
 impl JobServerClient {
     pub fn new(
-        chain: usize,
+        server_index: usize,
         prover_id: String,
         submit_attempts: usize,
         server_url: String,
@@ -55,7 +56,7 @@ impl JobServerClient {
             .context("while building HTTP client")?;
         Ok(Self {
             client,
-            chain,
+            server_index,
             server_url,
             prover_id,
             submit_attempts,
@@ -75,12 +76,20 @@ impl JobServerClient {
             return Ok(None);
         };
         let batch_number = input.vm_run_data.l1_batch_number.0;
+        // The chain id rides inside the input's `system_env` — the input is
+        // encoded verbatim into the guest program's words, so the server
+        // cannot add a separate top-level field without changing what the
+        // (hash-committed) guest sees.
+        let chain_id = input.system_env.chain_id.as_u64();
         let mut inputs = Inputs::new();
         inputs
             .push(&input)
             .context("failed to encode AirbenderVerifierInput")?;
         Ok(Some(WorkerJob::Fri {
-            chain: self.chain,
+            origin: JobOrigin {
+                server: self.server_index,
+                chain_id,
+            },
             batch_number,
             input_words: inputs.words().to_vec(),
         }))
@@ -91,6 +100,10 @@ impl JobServerClient {
         #[derive(serde::Deserialize)]
         struct SnarkInputBody {
             l1_batch_number: u32,
+            /// `Option` + default so job servers predating the field still
+            /// parse; they report as chain id 0 in metrics/logs.
+            #[serde(default)]
+            chain_id: Option<u64>,
             #[serde_as(as = "serde_with::hex::Hex")]
             fri_proof: Vec<u8>,
         }
@@ -104,18 +117,27 @@ impl JobServerClient {
             anyhow::bail!("incoming FRI proof envelope has trailing bytes");
         }
         Ok(Some(WorkerJob::Snark {
-            chain: self.chain,
+            origin: JobOrigin {
+                server: self.server_index,
+                chain_id: body.chain_id.unwrap_or(0),
+            },
             batch_number: body.l1_batch_number,
             proof: Box::new(proof),
         }))
     }
 
-    pub fn submit_fri(&self, batch_number: u32, proof: &Proof, cycles_used: u64) -> Result<()> {
+    pub fn submit_fri(
+        &self,
+        chain_id: u64,
+        batch_number: u32,
+        proof: &Proof,
+        cycles_used: u64,
+    ) -> Result<()> {
         let proof_bytes = bincode::serde::encode_to_vec(proof, bincode::config::standard())
             .context("failed to bincode-encode FRI proof")?;
-        self.submit_with_retries(FRI_LABEL, batch_number, |attempt, attempts| {
+        self.submit_with_retries(FRI_LABEL, chain_id, batch_number, |attempt, attempts| {
             info!(
-                chain = self.chain,
+                chain_id,
                 batch_number,
                 proof_bytes = proof_bytes.len(),
                 cycles_used,
@@ -134,10 +156,15 @@ impl JobServerClient {
         })
     }
 
-    pub fn submit_snark(&self, batch_number: u32, proof: Box<SnarkWrapperProof>) -> Result<()> {
-        self.submit_with_retries(SNARK_LABEL, batch_number, |attempt, attempts| {
+    pub fn submit_snark(
+        &self,
+        chain_id: u64,
+        batch_number: u32,
+        proof: Box<SnarkWrapperProof>,
+    ) -> Result<()> {
+        self.submit_with_retries(SNARK_LABEL, chain_id, batch_number, |attempt, attempts| {
             info!(
-                chain = self.chain,
+                chain_id,
                 batch_number, attempt, attempts, "Submitting SNARK proof"
             );
             let payload = SubmitSnarkProofRequest {
@@ -153,10 +180,10 @@ impl JobServerClient {
     /// Reports a FRI proving failure to the server, releasing the batch for
     /// retry without waiting for the proving timeout. Posts to the same
     /// endpoint as [`Self::submit_fri`] but carries `error` instead of a proof.
-    pub fn submit_fri_error(&self, batch_number: u32, error: &str) -> Result<()> {
-        self.submit_with_retries(FRI_LABEL, batch_number, |attempt, attempts| {
+    pub fn submit_fri_error(&self, chain_id: u64, batch_number: u32, error: &str) -> Result<()> {
+        self.submit_with_retries(FRI_LABEL, chain_id, batch_number, |attempt, attempts| {
             info!(
-                chain = self.chain,
+                chain_id,
                 batch_number, attempt, attempts, "Submitting FRI failure"
             );
             let payload = SubmitFriProofRequest {
@@ -173,10 +200,10 @@ impl JobServerClient {
     /// Reports a SNARK proving failure to the server. The server reverts the
     /// batch to `generated`, preserving the FRI proof so only the SNARK stage
     /// is retried.
-    pub fn submit_snark_error(&self, batch_number: u32, error: &str) -> Result<()> {
-        self.submit_with_retries(SNARK_LABEL, batch_number, |attempt, attempts| {
+    pub fn submit_snark_error(&self, chain_id: u64, batch_number: u32, error: &str) -> Result<()> {
+        self.submit_with_retries(SNARK_LABEL, chain_id, batch_number, |attempt, attempts| {
             info!(
-                chain = self.chain,
+                chain_id,
                 batch_number, attempt, attempts, "Submitting SNARK failure"
             );
             let payload = SubmitSnarkProofRequest {
@@ -250,6 +277,7 @@ impl JobServerClient {
     fn submit_with_retries<F>(
         &self,
         label: &str,
+        chain_id: u64,
         batch_number: u32,
         mut attempt_fn: F,
     ) -> Result<()>
@@ -272,7 +300,7 @@ impl JobServerClient {
                     }
                     warn!(
                         label,
-                        chain = self.chain,
+                        chain_id,
                         batch_number,
                         attempt,
                         attempts,

--- a/airbender_prover_server/src/client.rs
+++ b/airbender_prover_server/src/client.rs
@@ -21,14 +21,17 @@ const SNARK_LABEL: &str = "SNARK";
 /// transport-level errors that have no server status.
 type RequestResult = Result<(), (Option<reqwest::StatusCode>, anyhow::Error)>;
 
-/// Thin HTTP client for the job server: fetches inputs and submits results.
-/// Stateless beyond its configured endpoints and HTTP clients — owns no
-/// scheduling, channels, or in-flight job state.
+/// Thin HTTP client for one job server (one chain): fetches inputs and
+/// submits results. Stateless beyond its configured endpoints and HTTP
+/// clients — owns no scheduling, channels, or in-flight job state.
 pub struct JobServerClient {
     /// One client for both polling and submitting; the per-request timeout
     /// (`poll_timeout` for fetches, `submit_timeout` for submissions — the
     /// latter is larger for big SNARK payloads) is applied per call.
     client: reqwest::blocking::Client,
+    /// Index of this client in the configured job-server list; stamped onto
+    /// every fetched job so results route back to the originating chain.
+    chain: usize,
     server_url: String,
     prover_id: String,
     submit_attempts: usize,
@@ -38,6 +41,7 @@ pub struct JobServerClient {
 
 impl JobServerClient {
     pub fn new(
+        chain: usize,
         prover_id: String,
         submit_attempts: usize,
         server_url: String,
@@ -51,12 +55,17 @@ impl JobServerClient {
             .context("while building HTTP client")?;
         Ok(Self {
             client,
+            chain,
             server_url,
             prover_id,
             submit_attempts,
             poll_timeout,
             submit_timeout,
         })
+    }
+
+    pub fn server_url(&self) -> &str {
+        &self.server_url
     }
 
     pub fn fetch_fri_job(&self) -> Result<Option<WorkerJob>> {
@@ -71,6 +80,7 @@ impl JobServerClient {
             .push(&input)
             .context("failed to encode AirbenderVerifierInput")?;
         Ok(Some(WorkerJob::Fri {
+            chain: self.chain,
             batch_number,
             input_words: inputs.words().to_vec(),
         }))
@@ -94,6 +104,7 @@ impl JobServerClient {
             anyhow::bail!("incoming FRI proof envelope has trailing bytes");
         }
         Ok(Some(WorkerJob::Snark {
+            chain: self.chain,
             batch_number: body.l1_batch_number,
             proof: Box::new(proof),
         }))
@@ -104,6 +115,7 @@ impl JobServerClient {
             .context("failed to bincode-encode FRI proof")?;
         self.submit_with_retries(FRI_LABEL, batch_number, |attempt, attempts| {
             info!(
+                chain = self.chain,
                 batch_number,
                 proof_bytes = proof_bytes.len(),
                 cycles_used,
@@ -124,7 +136,10 @@ impl JobServerClient {
 
     pub fn submit_snark(&self, batch_number: u32, proof: Box<SnarkWrapperProof>) -> Result<()> {
         self.submit_with_retries(SNARK_LABEL, batch_number, |attempt, attempts| {
-            info!(batch_number, attempt, attempts, "Submitting SNARK proof");
+            info!(
+                chain = self.chain,
+                batch_number, attempt, attempts, "Submitting SNARK proof"
+            );
             let payload = SubmitSnarkProofRequest {
                 l1_batch_number: batch_number,
                 prover_id: self.prover_id.clone(),
@@ -140,7 +155,10 @@ impl JobServerClient {
     /// endpoint as [`Self::submit_fri`] but carries `error` instead of a proof.
     pub fn submit_fri_error(&self, batch_number: u32, error: &str) -> Result<()> {
         self.submit_with_retries(FRI_LABEL, batch_number, |attempt, attempts| {
-            info!(batch_number, attempt, attempts, "Submitting FRI failure");
+            info!(
+                chain = self.chain,
+                batch_number, attempt, attempts, "Submitting FRI failure"
+            );
             let payload = SubmitFriProofRequest {
                 l1_batch_number: batch_number,
                 prover_id: self.prover_id.clone(),
@@ -157,7 +175,10 @@ impl JobServerClient {
     /// is retried.
     pub fn submit_snark_error(&self, batch_number: u32, error: &str) -> Result<()> {
         self.submit_with_retries(SNARK_LABEL, batch_number, |attempt, attempts| {
-            info!(batch_number, attempt, attempts, "Submitting SNARK failure");
+            info!(
+                chain = self.chain,
+                batch_number, attempt, attempts, "Submitting SNARK failure"
+            );
             let payload = SubmitSnarkProofRequest {
                 l1_batch_number: batch_number,
                 prover_id: self.prover_id.clone(),
@@ -251,6 +272,7 @@ impl JobServerClient {
                     }
                     warn!(
                         label,
+                        chain = self.chain,
                         batch_number,
                         attempt,
                         attempts,

--- a/airbender_prover_server/src/jobs.rs
+++ b/airbender_prover_server/src/jobs.rs
@@ -27,10 +27,10 @@ use crate::types::{ProofOutcome, ProverMode, ProverResult, WorkerJob};
 /// chain producing more batches never crowds the others out.
 pub struct JobWorker {
     mode: ProverMode,
-    /// One client per configured job server; a job's `chain` indexes this.
+    /// One client per configured job server; a job origin's `server` indexes this.
     clients: Vec<JobServerClient>,
-    /// Rotation cursor: the chain the next fetch scan starts from.
-    next_chain: usize,
+    /// Rotation cursor: the server the next fetch scan starts from.
+    next_server: usize,
     // `Option` so shutdown can drop the sender (telling the prover no more jobs
     // are coming) while keeping the rest of the worker alive to drain results.
     job_tx: Option<SyncSender<WorkerJob>>,
@@ -51,15 +51,15 @@ impl JobWorker {
         poll_interval: Duration,
     ) -> Self {
         assert!(!clients.is_empty(), "at least one job server is required");
-        // Start the rotation at a random chain so a fleet of provers booted
-        // together doesn't scan the chain list in lockstep, all competing for
+        // Start the rotation at a random server so a fleet of provers booted
+        // together doesn't scan the server list in lockstep, all competing for
         // the first chain's batches before spilling onto the next.
         // `RandomState` is seeded per process — cheap std-only entropy.
-        let next_chain = RandomState::new().build_hasher().finish() as usize % clients.len();
+        let next_server = RandomState::new().build_hasher().finish() as usize % clients.len();
         Self {
             mode,
             clients,
-            next_chain,
+            next_server,
             job_tx: Some(job_tx),
             result_rx,
             poll_interval,
@@ -115,7 +115,7 @@ impl JobWorker {
                 match self.fetch_job() {
                     Some(job) => {
                         info!(
-                            chain = job.chain(),
+                            chain_id = job.origin().chain_id,
                             batch_number = job.batch_number(),
                             kind = %job.kind(),
                             "Received job"
@@ -163,31 +163,31 @@ impl JobWorker {
         info!("All in-flight results submitted; prover stopped");
     }
 
-    /// One round-robin scan over the chains, starting at the rotation cursor;
-    /// returns the first job found and moves the cursor to the chain after the
-    /// one served. A per-chain fetch error is logged and the scan moves on, so
-    /// one unreachable job server can't stall the others; the caller sleeps
-    /// one poll interval only when the whole scan comes up empty.
+    /// One round-robin scan over the job servers, starting at the rotation
+    /// cursor; returns the first job found and moves the cursor to the server
+    /// after the one served. A per-server fetch error is logged and the scan
+    /// moves on, so one unreachable job server can't stall the others; the
+    /// caller sleeps one poll interval only when the whole scan comes up empty.
     fn fetch_job(&mut self) -> Option<WorkerJob> {
-        let chains = self.clients.len();
-        for offset in 0..chains {
-            let chain = (self.next_chain + offset) % chains;
-            let client = &self.clients[chain];
+        let servers = self.clients.len();
+        for offset in 0..servers {
+            let server = (self.next_server + offset) % servers;
+            let client = &self.clients[server];
             let fetched = match self.mode {
                 ProverMode::FriOnly | ProverMode::FriSnark => client.fetch_fri_job(),
                 ProverMode::SnarkOnly => client.fetch_snark_job(),
             };
             match fetched {
                 Ok(Some(job)) => {
-                    self.next_chain = (chain + 1) % chains;
+                    self.next_server = (server + 1) % servers;
                     return Some(job);
                 }
                 Ok(None) => {}
                 Err(err) => warn!(
-                    chain,
+                    server,
                     server_url = client.server_url(),
                     ?err,
-                    "Failed to fetch job from chain, trying the next one"
+                    "Failed to fetch job from server, trying the next one"
                 ),
             }
         }
@@ -200,57 +200,66 @@ impl JobWorker {
             Err(f) => f.kind,
         };
         METRICS.pending_jobs[&kind].dec_by(1);
-        let (chain, batch_number) = match outcome {
+        let (origin, batch_number) = match outcome {
             Ok(ProofOutcome::Fri {
-                chain,
+                origin,
                 batch_number,
                 proof,
                 cycles_used,
             }) => {
-                self.clients[chain].submit_fri(batch_number, proof.as_ref(), cycles_used)?;
+                self.clients[origin.server].submit_fri(
+                    origin.chain_id,
+                    batch_number,
+                    proof.as_ref(),
+                    cycles_used,
+                )?;
                 // In `fri-snark` mode, the SNARK job needs the FRI proof, so we can set the new pending job immediately instead of waiting for the next fetch cycle. The in-memory `Proof` is fed directly to the SNARK pipeline without an extra encode/decode round trip.
                 if self.mode == ProverMode::FriSnark {
                     // FRI jobs are processed serially, so the previous SNARK
                     // follow-up must have been drained before this one lands.
                     METRICS.pending_jobs[&ProofType::Snark].inc_by(1);
                     self.snark_followup = Some(WorkerJob::Snark {
-                        chain,
+                        origin,
                         batch_number,
                         proof,
                     });
                 }
-                (chain, batch_number)
+                (origin, batch_number)
             }
             Ok(ProofOutcome::Snark {
-                chain,
+                origin,
                 batch_number,
                 proof,
             }) => {
-                self.clients[chain].submit_snark(batch_number, proof)?;
-                (chain, batch_number)
+                self.clients[origin.server].submit_snark(origin.chain_id, batch_number, proof)?;
+                (origin, batch_number)
             }
             Err(failure) => {
                 // Report the failure to the server so it can release the batch
                 // for retry (bounded by the server's attempts limit) without
                 // waiting for the proving timeout to elapse.
                 warn!(
-                    chain = failure.chain,
+                    chain_id = failure.origin.chain_id,
                     batch_number = failure.batch_number,
                     kind = %failure.kind,
                     reason = %failure.reason,
                     "Prover job failed; reporting to server",
                 );
-                let client = &self.clients[failure.chain];
+                let client = &self.clients[failure.origin.server];
                 match failure.kind {
-                    ProofType::Fri => {
-                        client.submit_fri_error(failure.batch_number, &failure.reason)?
-                    }
-                    ProofType::Snark => {
-                        client.submit_snark_error(failure.batch_number, &failure.reason)?
-                    }
+                    ProofType::Fri => client.submit_fri_error(
+                        failure.origin.chain_id,
+                        failure.batch_number,
+                        &failure.reason,
+                    )?,
+                    ProofType::Snark => client.submit_snark_error(
+                        failure.origin.chain_id,
+                        failure.batch_number,
+                        &failure.reason,
+                    )?,
                 }
                 info!(
-                    chain = failure.chain,
+                    chain_id = failure.origin.chain_id,
                     batch_number = failure.batch_number,
                     kind = %failure.kind,
                     "Reported failed proof to server",
@@ -258,7 +267,7 @@ impl JobWorker {
                 return Ok(());
             }
         };
-        info!(chain, batch_number, kind = %kind, "Successfully submitted proof");
+        info!(chain_id = origin.chain_id, batch_number, kind = %kind, "Successfully submitted proof");
         Ok(())
     }
 }

--- a/airbender_prover_server/src/jobs.rs
+++ b/airbender_prover_server/src/jobs.rs
@@ -1,3 +1,5 @@
+use std::collections::hash_map::RandomState;
+use std::hash::{BuildHasher, Hasher};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, TrySendError};
 use std::sync::Arc;
@@ -11,14 +13,24 @@ use crate::client::JobServerClient;
 use crate::types::{ProofOutcome, ProverMode, ProverResult, WorkerJob};
 
 /// Orchestrates the network side of the prover: fetches jobs from the
-/// [`JobServerClient`], forwards them to the prover thread, and submits
-/// completed proofs through the client. Uses a one-slot pending buffer so a
-/// server-fetched FRI job can be pre-fetched while the prover is busy. In
-/// `fri-snark` mode, a finished FRI produces a local SNARK follow-up that
-/// lives in its own slot so it never clobbers the prefetched FRI.
+/// [`JobServerClient`]s, forwards them to the prover thread, and submits
+/// completed proofs through the originating client. Uses a one-slot pending
+/// buffer so a server-fetched FRI job can be pre-fetched while the prover is
+/// busy. In `fri-snark` mode, a finished FRI produces a local SNARK follow-up
+/// that lives in its own slot so it never clobbers the prefetched FRI.
+///
+/// With several clients configured (one job server per chain), fetches
+/// round-robin across them: each fetch scans the chains starting right after
+/// the one last served, taking the first job found. Chains with no work cost
+/// one 204 poll and are skipped, so when every chain has a backlog each gets
+/// an equal share of this prover, and idle chains donate their share — a
+/// chain producing more batches never crowds the others out.
 pub struct JobWorker {
     mode: ProverMode,
-    client: JobServerClient,
+    /// One client per configured job server; a job's `chain` indexes this.
+    clients: Vec<JobServerClient>,
+    /// Rotation cursor: the chain the next fetch scan starts from.
+    next_chain: usize,
     // `Option` so shutdown can drop the sender (telling the prover no more jobs
     // are coming) while keeping the rest of the worker alive to drain results.
     job_tx: Option<SyncSender<WorkerJob>>,
@@ -31,16 +43,23 @@ pub struct JobWorker {
 
 impl JobWorker {
     pub fn new(
-        client: JobServerClient,
+        clients: Vec<JobServerClient>,
         job_tx: SyncSender<WorkerJob>,
         result_rx: Receiver<ProverResult>,
         shutdown: Arc<AtomicBool>,
         mode: ProverMode,
         poll_interval: Duration,
     ) -> Self {
+        assert!(!clients.is_empty(), "at least one job server is required");
+        // Start the rotation at a random chain so a fleet of provers booted
+        // together doesn't scan the chain list in lockstep, all competing for
+        // the first chain's batches before spilling onto the next.
+        // `RandomState` is seeded per process — cheap std-only entropy.
+        let next_chain = RandomState::new().build_hasher().finish() as usize % clients.len();
         Self {
             mode,
-            client,
+            clients,
+            next_chain,
             job_tx: Some(job_tx),
             result_rx,
             poll_interval,
@@ -94,14 +113,18 @@ impl JobWorker {
 
             if self.pending_job.is_none() {
                 match self.fetch_job() {
-                    Ok(Some(job)) => {
-                        info!(batch_number = job.batch_number(), kind = %job.kind(), "Received job");
+                    Some(job) => {
+                        info!(
+                            chain = job.chain(),
+                            batch_number = job.batch_number(),
+                            kind = %job.kind(),
+                            "Received job"
+                        );
                         METRICS.pending_jobs[&job.kind()].inc_by(1);
                         self.pending_job = Some(job);
                         did_work = true;
                     }
-                    Ok(None) => debug!("No jobs available, waiting..."),
-                    Err(err) => warn!(?err, "Failed to fetch job, retrying after poll interval"),
+                    None => debug!("No jobs available on any chain, waiting..."),
                 }
             }
 
@@ -140,11 +163,35 @@ impl JobWorker {
         info!("All in-flight results submitted; prover stopped");
     }
 
-    fn fetch_job(&self) -> Result<Option<WorkerJob>> {
-        match self.mode {
-            ProverMode::FriOnly | ProverMode::FriSnark => self.client.fetch_fri_job(),
-            ProverMode::SnarkOnly => self.client.fetch_snark_job(),
+    /// One round-robin scan over the chains, starting at the rotation cursor;
+    /// returns the first job found and moves the cursor to the chain after the
+    /// one served. A per-chain fetch error is logged and the scan moves on, so
+    /// one unreachable job server can't stall the others; the caller sleeps
+    /// one poll interval only when the whole scan comes up empty.
+    fn fetch_job(&mut self) -> Option<WorkerJob> {
+        let chains = self.clients.len();
+        for offset in 0..chains {
+            let chain = (self.next_chain + offset) % chains;
+            let client = &self.clients[chain];
+            let fetched = match self.mode {
+                ProverMode::FriOnly | ProverMode::FriSnark => client.fetch_fri_job(),
+                ProverMode::SnarkOnly => client.fetch_snark_job(),
+            };
+            match fetched {
+                Ok(Some(job)) => {
+                    self.next_chain = (chain + 1) % chains;
+                    return Some(job);
+                }
+                Ok(None) => {}
+                Err(err) => warn!(
+                    chain,
+                    server_url = client.server_url(),
+                    ?err,
+                    "Failed to fetch job from chain, trying the next one"
+                ),
+            }
         }
+        None
     }
 
     fn handle_prover_result(&mut self, outcome: ProverResult) -> Result<()> {
@@ -153,52 +200,57 @@ impl JobWorker {
             Err(f) => f.kind,
         };
         METRICS.pending_jobs[&kind].dec_by(1);
-        let batch_number = match outcome {
+        let (chain, batch_number) = match outcome {
             Ok(ProofOutcome::Fri {
+                chain,
                 batch_number,
                 proof,
                 cycles_used,
             }) => {
-                self.client
-                    .submit_fri(batch_number, proof.as_ref(), cycles_used)?;
+                self.clients[chain].submit_fri(batch_number, proof.as_ref(), cycles_used)?;
                 // In `fri-snark` mode, the SNARK job needs the FRI proof, so we can set the new pending job immediately instead of waiting for the next fetch cycle. The in-memory `Proof` is fed directly to the SNARK pipeline without an extra encode/decode round trip.
                 if self.mode == ProverMode::FriSnark {
                     // FRI jobs are processed serially, so the previous SNARK
                     // follow-up must have been drained before this one lands.
                     METRICS.pending_jobs[&ProofType::Snark].inc_by(1);
                     self.snark_followup = Some(WorkerJob::Snark {
+                        chain,
                         batch_number,
                         proof,
                     });
                 }
-                batch_number
+                (chain, batch_number)
             }
             Ok(ProofOutcome::Snark {
+                chain,
                 batch_number,
                 proof,
             }) => {
-                self.client.submit_snark(batch_number, proof)?;
-                batch_number
+                self.clients[chain].submit_snark(batch_number, proof)?;
+                (chain, batch_number)
             }
             Err(failure) => {
                 // Report the failure to the server so it can release the batch
                 // for retry (bounded by the server's attempts limit) without
                 // waiting for the proving timeout to elapse.
                 warn!(
+                    chain = failure.chain,
                     batch_number = failure.batch_number,
                     kind = %failure.kind,
                     reason = %failure.reason,
                     "Prover job failed; reporting to server",
                 );
+                let client = &self.clients[failure.chain];
                 match failure.kind {
-                    ProofType::Fri => self
-                        .client
-                        .submit_fri_error(failure.batch_number, &failure.reason)?,
-                    ProofType::Snark => self
-                        .client
-                        .submit_snark_error(failure.batch_number, &failure.reason)?,
+                    ProofType::Fri => {
+                        client.submit_fri_error(failure.batch_number, &failure.reason)?
+                    }
+                    ProofType::Snark => {
+                        client.submit_snark_error(failure.batch_number, &failure.reason)?
+                    }
                 }
                 info!(
+                    chain = failure.chain,
                     batch_number = failure.batch_number,
                     kind = %failure.kind,
                     "Reported failed proof to server",
@@ -206,7 +258,7 @@ impl JobWorker {
                 return Ok(());
             }
         };
-        info!(batch_number, kind = %kind, "Successfully submitted proof");
+        info!(chain, batch_number, kind = %kind, "Successfully submitted proof");
         Ok(())
     }
 }

--- a/airbender_prover_server/src/main.rs
+++ b/airbender_prover_server/src/main.rs
@@ -30,9 +30,18 @@ use worker::{ProverWorker, ProverWorkerBuilder};
     about = "Prover server: polls for jobs and submits prove results"
 )]
 struct Cli {
-    /// Base URL of the job server (e.g. http://localhost:8080)
-    #[arg(long, env = "PROVER_SERVER_URL")]
-    server_url: String,
+    /// Base URL(s) of the job server(s), e.g. http://localhost:8080.
+    /// Pass several — comma-separated or by repeating the flag — to prove for
+    /// multiple chains: fetches round-robin across the servers, so every chain
+    /// with pending work gets an equal share of this prover no matter how many
+    /// batches each chain produces.
+    #[arg(
+        long,
+        env = "PROVER_SERVER_URL",
+        value_delimiter = ',',
+        required = true
+    )]
+    server_url: Vec<String>,
 
     /// Pipeline this prover runs:
     /// `fri-only` (default) — proves FRI, submits FRI;
@@ -181,7 +190,7 @@ fn main() -> Result<()> {
     .context("while setting termination signal handler")?;
 
     info!(
-        server_url = %cli.server_url,
+        server_urls = ?cli.server_url,
         mode = ?cli.mode,
         "Starting prover server"
     );
@@ -201,18 +210,40 @@ fn main() -> Result<()> {
         .spawn(move || prover.run())
         .context("while spawning prover thread")?;
 
-    let client = JobServerClient::new(
-        cli.prover_id,
-        cli.submit_attempts,
-        cli.server_url,
-        Duration::from_millis(cli.http_connect_timeout_ms),
-        Duration::from_millis(cli.poll_timeout_ms),
-        Duration::from_millis(cli.submit_timeout_ms),
-    )
-    .context("while building job server client")?;
+    // One client per job server; the index doubles as the job's chain tag,
+    // so results are always submitted back to the server the job came from.
+    let clients = cli
+        .server_url
+        .iter()
+        .enumerate()
+        .map(|(chain, server_url)| {
+            anyhow::ensure!(
+                !server_url.trim().is_empty(),
+                "server URL #{chain} is empty; check PROVER_SERVER_URL for stray commas"
+            );
+            JobServerClient::new(
+                chain,
+                cli.prover_id.clone(),
+                cli.submit_attempts,
+                server_url.clone(),
+                Duration::from_millis(cli.http_connect_timeout_ms),
+                Duration::from_millis(cli.poll_timeout_ms),
+                Duration::from_millis(cli.submit_timeout_ms),
+            )
+        })
+        .collect::<Result<Vec<_>>>()
+        .context("while building job server clients")?;
 
     let job_worker_handle: std::thread::JoinHandle<()> = std::thread::spawn(move || {
-        JobWorker::new(client, job_tx, result_rx, shutdown, cli.mode, poll_interval).run()
+        JobWorker::new(
+            clients,
+            job_tx,
+            result_rx,
+            shutdown,
+            cli.mode,
+            poll_interval,
+        )
+        .run()
     });
 
     info!("Waiting for prover to finish current job...");

--- a/airbender_prover_server/src/main.rs
+++ b/airbender_prover_server/src/main.rs
@@ -210,19 +210,19 @@ fn main() -> Result<()> {
         .spawn(move || prover.run())
         .context("while spawning prover thread")?;
 
-    // One client per job server; the index doubles as the job's chain tag,
+    // One client per job server; the index becomes the job's routing tag,
     // so results are always submitted back to the server the job came from.
     let clients = cli
         .server_url
         .iter()
         .enumerate()
-        .map(|(chain, server_url)| {
+        .map(|(server_index, server_url)| {
             anyhow::ensure!(
                 !server_url.trim().is_empty(),
-                "server URL #{chain} is empty; check PROVER_SERVER_URL for stray commas"
+                "server URL #{server_index} is empty; check PROVER_SERVER_URL for stray commas"
             );
             JobServerClient::new(
-                chain,
+                server_index,
                 cli.prover_id.clone(),
                 cli.submit_attempts,
                 server_url.clone(),

--- a/airbender_prover_server/src/types.rs
+++ b/airbender_prover_server/src/types.rs
@@ -3,21 +3,31 @@ use clap::ValueEnum;
 use eravm_prover_host::SnarkWrapperProof;
 use zksync_prover_metrics::ProofType;
 
+/// Where a job came from. Travels with the job through the prover and back so
+/// results are submitted to the originating server — batch numbers alone are
+/// ambiguous because independent chains number their batches independently.
+#[derive(Copy, Clone, Debug)]
+pub struct JobOrigin {
+    /// Index of the job server in the configured server-URL list. Routing
+    /// only: results go back to this client. Deployment-local, so it never
+    /// appears in metrics.
+    pub server: usize,
+    /// L2 chain id reported by the job server (from `system_env` for FRI
+    /// inputs, from the response body for SNARK inputs). Used in metrics and
+    /// logs to identify the chain; 0 when the server predates reporting it.
+    pub chain_id: u64,
+}
+
 /// Jobs received from the job worker. Which variant is expected is implied
 /// by which pipelines the worker was built with; a mismatch is a job-worker bug.
-///
-/// `chain` is the index of the job server (one per chain) the job was fetched
-/// from. It travels with the job through the prover and back so results are
-/// submitted to the originating chain — batch numbers alone are ambiguous
-/// because independent chains number their batches independently.
 pub enum WorkerJob {
     Fri {
-        chain: usize,
+        origin: JobOrigin,
         batch_number: u32,
         input_words: Vec<u32>,
     },
     Snark {
-        chain: usize,
+        origin: JobOrigin,
         batch_number: u32,
         proof: Box<Proof>,
     },
@@ -32,9 +42,9 @@ impl WorkerJob {
         }
     }
 
-    pub fn chain(&self) -> usize {
+    pub fn origin(&self) -> JobOrigin {
         match self {
-            WorkerJob::Fri { chain, .. } | WorkerJob::Snark { chain, .. } => *chain,
+            WorkerJob::Fri { origin, .. } | WorkerJob::Snark { origin, .. } => *origin,
         }
     }
 
@@ -66,8 +76,8 @@ pub enum ProverMode {
 /// `pending_jobs` bucket (FRI then SNARK) as it lands.
 pub enum ProofOutcome {
     Fri {
-        /// Job-server index the job came from; the proof is submitted back there.
-        chain: usize,
+        /// Origin of the job; the proof is submitted back to its server.
+        origin: JobOrigin,
         batch_number: u32,
         proof: Box<Proof>,
         /// Guest cycles executed by the FRI prover's RISC-V run for this batch,
@@ -75,8 +85,8 @@ pub enum ProofOutcome {
         cycles_used: u64,
     },
     Snark {
-        /// Job-server index the job came from; the proof is submitted back there.
-        chain: usize,
+        /// Origin of the job; the proof is submitted back to its server.
+        origin: JobOrigin,
         batch_number: u32,
         proof: Box<SnarkWrapperProof>,
     },
@@ -92,10 +102,10 @@ impl ProofOutcome {
 }
 
 /// Failure detail carried in the `Err` arm of [`ProverResult`]. Holds the
-/// kind, batch number, and originating chain so the job worker can report the
+/// kind, batch number, and job origin so the job worker can report the
 /// failure to the right job server without inspecting the success type.
 pub struct FailedProof {
-    pub chain: usize,
+    pub origin: JobOrigin,
     pub batch_number: u32,
     pub kind: ProofType,
     /// Full anyhow error chain (`{err:#}`) captured at the point of failure.
@@ -103,9 +113,9 @@ pub struct FailedProof {
 }
 
 impl FailedProof {
-    pub fn new(chain: usize, batch_number: u32, kind: ProofType, err: anyhow::Error) -> Self {
+    pub fn new(origin: JobOrigin, batch_number: u32, kind: ProofType, err: anyhow::Error) -> Self {
         Self {
-            chain,
+            origin,
             batch_number,
             kind,
             reason: format!("{err:#}"),

--- a/airbender_prover_server/src/types.rs
+++ b/airbender_prover_server/src/types.rs
@@ -5,12 +5,19 @@ use zksync_prover_metrics::ProofType;
 
 /// Jobs received from the job worker. Which variant is expected is implied
 /// by which pipelines the worker was built with; a mismatch is a job-worker bug.
+///
+/// `chain` is the index of the job server (one per chain) the job was fetched
+/// from. It travels with the job through the prover and back so results are
+/// submitted to the originating chain — batch numbers alone are ambiguous
+/// because independent chains number their batches independently.
 pub enum WorkerJob {
     Fri {
+        chain: usize,
         batch_number: u32,
         input_words: Vec<u32>,
     },
     Snark {
+        chain: usize,
         batch_number: u32,
         proof: Box<Proof>,
     },
@@ -22,6 +29,12 @@ impl WorkerJob {
             WorkerJob::Fri { batch_number, .. } | WorkerJob::Snark { batch_number, .. } => {
                 *batch_number
             }
+        }
+    }
+
+    pub fn chain(&self) -> usize {
+        match self {
+            WorkerJob::Fri { chain, .. } | WorkerJob::Snark { chain, .. } => *chain,
         }
     }
 
@@ -53,6 +66,8 @@ pub enum ProverMode {
 /// `pending_jobs` bucket (FRI then SNARK) as it lands.
 pub enum ProofOutcome {
     Fri {
+        /// Job-server index the job came from; the proof is submitted back there.
+        chain: usize,
         batch_number: u32,
         proof: Box<Proof>,
         /// Guest cycles executed by the FRI prover's RISC-V run for this batch,
@@ -60,6 +75,8 @@ pub enum ProofOutcome {
         cycles_used: u64,
     },
     Snark {
+        /// Job-server index the job came from; the proof is submitted back there.
+        chain: usize,
         batch_number: u32,
         proof: Box<SnarkWrapperProof>,
     },
@@ -75,9 +92,10 @@ impl ProofOutcome {
 }
 
 /// Failure detail carried in the `Err` arm of [`ProverResult`]. Holds the
-/// kind and batch number so the job worker can route the failure log without
-/// inspecting the success type.
+/// kind, batch number, and originating chain so the job worker can report the
+/// failure to the right job server without inspecting the success type.
 pub struct FailedProof {
+    pub chain: usize,
     pub batch_number: u32,
     pub kind: ProofType,
     /// Full anyhow error chain (`{err:#}`) captured at the point of failure.
@@ -85,8 +103,9 @@ pub struct FailedProof {
 }
 
 impl FailedProof {
-    pub fn new(batch_number: u32, kind: ProofType, err: anyhow::Error) -> Self {
+    pub fn new(chain: usize, batch_number: u32, kind: ProofType, err: anyhow::Error) -> Self {
         Self {
+            chain,
             batch_number,
             kind,
             reason: format!("{err:#}"),

--- a/airbender_prover_server/src/worker.rs
+++ b/airbender_prover_server/src/worker.rs
@@ -94,18 +94,18 @@ impl ProverWorker {
     fn process(&mut self, job: WorkerJob) -> Result<(), SendError<ProverResult>> {
         let result = match job {
             WorkerJob::Fri {
-                chain,
+                origin,
                 batch_number,
                 input_words,
             } => match self.fri.as_mut() {
                 Some(fri) => {
-                    info!(chain, kind = %ProofType::Fri, "Started proving batch {batch_number}");
+                    info!(chain_id = origin.chain_id, kind = %ProofType::Fri, "Started proving batch {batch_number}");
                     let started = Instant::now();
                     let result = catch_prover_panic("FRI prover", || {
                         fri.prove_input(batch_number as u64, &input_words)
                     });
                     record_proof_metrics(
-                        chain,
+                        origin.chain_id,
                         batch_number,
                         ProofType::Fri,
                         status_of(&result),
@@ -113,35 +113,35 @@ impl ProverWorker {
                     );
                     result
                         .map(|out| ProofOutcome::Fri {
-                            chain,
+                            origin,
                             batch_number,
                             proof: Box::new(out.proof),
                             cycles_used: out.cycles,
                         })
-                        .map_err(|err| FailedProof::new(chain, batch_number, ProofType::Fri, err))
+                        .map_err(|err| FailedProof::new(origin, batch_number, ProofType::Fri, err))
                 }
                 // `snark-only` workers (including every CUDA-free build) carry
                 // no FRI prover and the job worker never enqueues FRI jobs;
                 // fail loudly if one ever arrives.
                 None => Err(FailedProof::new(
-                    chain,
+                    origin,
                     batch_number,
                     ProofType::Fri,
                     anyhow::anyhow!("received a FRI job but this worker has no FRI prover"),
                 )),
             },
             WorkerJob::Snark {
-                chain,
+                origin,
                 batch_number,
                 proof,
             } => match self.prepare_snark_input(batch_number, *proof) {
                 Ok(raw_proof) => {
-                    info!(chain, kind = %ProofType::Snark, "Started proving batch {batch_number}");
+                    info!(chain_id = origin.chain_id, kind = %ProofType::Snark, "Started proving batch {batch_number}");
                     let started = Instant::now();
                     let snark = self.snark.as_mut().unwrap();
                     let result = catch_prover_panic("SNARK prover", || snark.prove(raw_proof));
                     record_proof_metrics(
-                        chain,
+                        origin.chain_id,
                         batch_number,
                         ProofType::Snark,
                         status_of(&result),
@@ -149,13 +149,20 @@ impl ProverWorker {
                     );
                     result
                         .map(|proof| ProofOutcome::Snark {
-                            chain,
+                            origin,
                             batch_number,
                             proof: Box::new(proof),
                         })
-                        .map_err(|err| FailedProof::new(chain, batch_number, ProofType::Snark, err))
+                        .map_err(|err| {
+                            FailedProof::new(origin, batch_number, ProofType::Snark, err)
+                        })
                 }
-                Err(err) => Err(FailedProof::new(chain, batch_number, ProofType::Snark, err)),
+                Err(err) => Err(FailedProof::new(
+                    origin,
+                    batch_number,
+                    ProofType::Snark,
+                    err,
+                )),
             },
         };
         self.result_tx.send(result)
@@ -225,14 +232,14 @@ fn status_of<T>(result: &Result<T>) -> ProofStatus {
 }
 
 fn record_proof_metrics(
-    chain: usize,
+    chain_id: u64,
     batch_number: u32,
     proof_type: ProofType,
     status: ProofStatus,
     elapsed: Duration,
 ) {
     let labels = ProofLabels {
-        chain,
+        chain_id,
         batch_number,
         proof_type,
         status,

--- a/airbender_prover_server/src/worker.rs
+++ b/airbender_prover_server/src/worker.rs
@@ -94,16 +94,18 @@ impl ProverWorker {
     fn process(&mut self, job: WorkerJob) -> Result<(), SendError<ProverResult>> {
         let result = match job {
             WorkerJob::Fri {
+                chain,
                 batch_number,
                 input_words,
             } => match self.fri.as_mut() {
                 Some(fri) => {
-                    info!(kind = %ProofType::Fri, "Started proving batch {batch_number}");
+                    info!(chain, kind = %ProofType::Fri, "Started proving batch {batch_number}");
                     let started = Instant::now();
                     let result = catch_prover_panic("FRI prover", || {
                         fri.prove_input(batch_number as u64, &input_words)
                     });
                     record_proof_metrics(
+                        chain,
                         batch_number,
                         ProofType::Fri,
                         status_of(&result),
@@ -111,31 +113,35 @@ impl ProverWorker {
                     );
                     result
                         .map(|out| ProofOutcome::Fri {
+                            chain,
                             batch_number,
                             proof: Box::new(out.proof),
                             cycles_used: out.cycles,
                         })
-                        .map_err(|err| FailedProof::new(batch_number, ProofType::Fri, err))
+                        .map_err(|err| FailedProof::new(chain, batch_number, ProofType::Fri, err))
                 }
                 // `snark-only` workers (including every CUDA-free build) carry
                 // no FRI prover and the job worker never enqueues FRI jobs;
                 // fail loudly if one ever arrives.
                 None => Err(FailedProof::new(
+                    chain,
                     batch_number,
                     ProofType::Fri,
                     anyhow::anyhow!("received a FRI job but this worker has no FRI prover"),
                 )),
             },
             WorkerJob::Snark {
+                chain,
                 batch_number,
                 proof,
             } => match self.prepare_snark_input(batch_number, *proof) {
                 Ok(raw_proof) => {
-                    info!(kind = %ProofType::Snark, "Started proving batch {batch_number}");
+                    info!(chain, kind = %ProofType::Snark, "Started proving batch {batch_number}");
                     let started = Instant::now();
                     let snark = self.snark.as_mut().unwrap();
                     let result = catch_prover_panic("SNARK prover", || snark.prove(raw_proof));
                     record_proof_metrics(
+                        chain,
                         batch_number,
                         ProofType::Snark,
                         status_of(&result),
@@ -143,12 +149,13 @@ impl ProverWorker {
                     );
                     result
                         .map(|proof| ProofOutcome::Snark {
+                            chain,
                             batch_number,
                             proof: Box::new(proof),
                         })
-                        .map_err(|err| FailedProof::new(batch_number, ProofType::Snark, err))
+                        .map_err(|err| FailedProof::new(chain, batch_number, ProofType::Snark, err))
                 }
-                Err(err) => Err(FailedProof::new(batch_number, ProofType::Snark, err)),
+                Err(err) => Err(FailedProof::new(chain, batch_number, ProofType::Snark, err)),
             },
         };
         self.result_tx.send(result)
@@ -218,12 +225,14 @@ fn status_of<T>(result: &Result<T>) -> ProofStatus {
 }
 
 fn record_proof_metrics(
+    chain: usize,
     batch_number: u32,
     proof_type: ProofType,
     status: ProofStatus,
     elapsed: Duration,
 ) {
     let labels = ProofLabels {
+        chain,
         batch_number,
         proof_type,
         status,

--- a/core/lib/airbender_prover_interface/src/api.rs
+++ b/core/lib/airbender_prover_interface/src/api.rs
@@ -35,7 +35,9 @@ pub struct AirbenderSnarkInputsResponse {
     /// L2 chain id of the chain this server proves for. Lets a prover serving
     /// several chains attribute the job to the right chain in metrics/logs
     /// (FRI jobs carry it inside `system_env`; SNARK inputs have no other
-    /// chain marker).
+    /// chain marker). Defaults to 0 when deserializing a response from a job
+    /// server that predates the field, matching the prover's own fallback.
+    #[serde(default)]
     pub chain_id: u64,
     #[serde_as(as = "Hex")]
     pub fri_proof: Vec<u8>,

--- a/core/lib/airbender_prover_interface/src/api.rs
+++ b/core/lib/airbender_prover_interface/src/api.rs
@@ -32,6 +32,11 @@ pub enum SubmitAirbenderProofResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AirbenderSnarkInputsResponse {
     pub l1_batch_number: u32,
+    /// L2 chain id of the chain this server proves for. Lets a prover serving
+    /// several chains attribute the job to the right chain in metrics/logs
+    /// (FRI jobs carry it inside `system_env`; SNARK inputs have no other
+    /// chain marker).
+    pub chain_id: u64,
     #[serde_as(as = "Hex")]
     pub fri_proof: Vec<u8>,
 }

--- a/core/node/airbender_proof_data_handler/src/airbender_request_processor.rs
+++ b/core/node/airbender_proof_data_handler/src/airbender_request_processor.rs
@@ -511,6 +511,7 @@ impl AirbenderRequestProcessor {
 
             return Ok(Some(AirbenderSnarkInputsResponse {
                 l1_batch_number: batch_number.0,
+                chain_id: self.l2_chain_id.as_u64(),
                 fri_proof: proof.proof,
             }));
         }

--- a/core/node/airbender_proof_data_handler/src/tests.rs
+++ b/core/node/airbender_proof_data_handler/src/tests.rs
@@ -488,6 +488,7 @@ async fn snark_inputs_returns_fri_proof_and_locks_for_snark() {
     let body_bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let parsed: AirbenderSnarkInputsResponse = serde_json::from_slice(&body_bytes).unwrap();
     assert_eq!(parsed.l1_batch_number, batch_number.0);
+    assert_eq!(parsed.chain_id, L2ChainId::default().as_u64());
     assert_eq!(parsed.fri_proof, fri_payload);
 
     let mut conn = db_conn_pool.connection().await.unwrap();


### PR DESCRIPTION
## What ❔

One `airbender_prover_server` instance can now prove for several chains running the same guest program. `--server-url` / `PROVER_SERVER_URL` accepts a list of job-server URLs (comma-separated or by repeating the flag); a single URL behaves exactly as before.

- **Round-robin fetching**: each fetch scans the job servers starting from a rotation cursor and takes the first job found; the cursor then moves to the server after the one served. A chain with no work costs one 204 poll and is skipped; an unreachable server is logged and skipped so it cannot stall the other chains. The prover sleeps the poll interval only when a full scan over all servers comes up empty.
- **Random boot offset**: the cursor starts at a random server (std `RandomState` entropy, no new deps) so a fleet of provers booted together doesn't scan the server list in lockstep. Combined with the job servers' existing `FOR UPDATE SKIP LOCKED`, any number of provers can compete over the same set of chains with no coordination.
- **Job origin through the pipeline**: every job carries a `JobOrigin { server, chain_id }` through `WorkerJob` → prover → `ProofOutcome`/`FailedProof`. The server index routes proofs/failure reports back to the originating server — required for correctness, since independent chains number batches independently and the same batch number can be in flight for two chains at once. The `fri-snark` local SNARK follow-up inherits the FRI job's origin.
- **Real chain id in metrics/logs**: jobs are attributed to the actual L2 chain id, not the deployment-local URL index. FRI jobs read it from the input's `system_env` (no wire change — the verifier input is encoded verbatim into the hash-committed guest program's words, so it cannot grow new fields). `AirbenderSnarkInputsResponse` gains a `chain_id` field populated by the proof data handler; the prover treats it as optional, so job servers predating the field keep working (reported as chain id 0). `ProofLabels` metrics carry a `chain_id` label and all job lifecycle logs include it.

## Why ❔

Multiple chains share the same guest program, but a prover was hard-bound to a single chain's `airbender_proof_data_handler`, forcing one fleet per chain. Round-robin over the per-chain endpoints is work-conserving equal-share scheduling: when every chain has a backlog each gets ~1/N of the prover no matter how many batches it produces, and idle chains donate their share to busy ones — so a high-throughput chain can never starve the others.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zk_supervisor fmt` and `zk_supervisor lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)