### PR TITLE
fix(vm): port logical fixes back from eravm-airbender-verifier

### DIFF
--- a/core/lib/multivm/src/versions/vm_fast/tests/mod.rs
+++ b/core/lib/multivm/src/versions/vm_fast/tests/mod.rs
@@ -165,7 +165,7 @@ where
         let main_storage = &mut self.world.storage;
         storage_changes
             .get(&(*key.account().address(), h256_to_u256(*key.key())))
-            .copied()
+            .map(|entry| entry.value)
             .unwrap_or_else(|| h256_to_u256(main_storage.read_value(&key)))
     }
 

--- a/core/lib/multivm/src/versions/vm_fast/vm.rs
+++ b/core/lib/multivm/src/versions/vm_fast/vm.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, fmt, mem, rc::Rc};
 
+use circuit_sequencer_api::sort_storage_access::sort_storage_access_queries;
 use zk_evm_1_5_0::{
     aux_structures::LogQuery, zkevm_opcode_defs::system_params::INITIAL_FRAME_FORMAL_EH_LOCATION,
 };
@@ -364,14 +365,32 @@ impl<S: ReadStorage, Tr: Tracer, Val: ValidationTracer> Vm<S, Tr, Val> {
 
         CurrentExecutionState {
             events,
-            deduplicated_storage_logs: world_diff
-                .get_storage_changes()
-                .map(|((address, key), change)| StorageLog {
-                    key: StorageKey::new(AccountTreeId::new(address), u256_to_h256(key)),
-                    value: u256_to_h256(change.after),
-                    kind: StorageLogKind::RepeatedWrite, // Initialness doesn't matter here
-                })
-                .collect(),
+            deduplicated_storage_logs: {
+                // `world_diff` exposes log queries via vm2's `zk_evm_abstractions` fork, which is
+                // a different crate instance than the one `circuit_sequencer_api` links against;
+                // map the fields to bridge the two.
+                let storage_log_queries = world_diff.storage_log_queries().iter().map(|query| {
+                    zk_evm_1_5_2::aux_structures::LogQuery {
+                        timestamp: zk_evm_1_5_2::aux_structures::Timestamp(query.timestamp.0),
+                        tx_number_in_block: query.tx_number_in_block,
+                        aux_byte: query.aux_byte,
+                        shard_id: query.shard_id,
+                        address: query.address,
+                        key: query.key,
+                        read_value: query.read_value,
+                        written_value: query.written_value,
+                        rw_flag: query.rw_flag,
+                        rollback: query.rollback,
+                        is_service: query.is_service,
+                    }
+                });
+                let (_, deduped_storage_log_queries) =
+                    sort_storage_access_queries(storage_log_queries);
+                deduped_storage_log_queries
+                    .into_iter()
+                    .map(|log_query| StorageLog::from_log_query(&log_query.glue_into()))
+                    .collect()
+            },
             used_contract_hashes: self.decommitted_hashes().collect(),
             system_logs: vm.l2_to_l1_logs().map(GlueInto::glue_into).collect(),
             user_l2_to_l1_logs,

--- a/core/lib/multivm/src/versions/vm_fast/world.rs
+++ b/core/lib/multivm/src/versions/vm_fast/world.rs
@@ -136,6 +136,17 @@ impl<S: ReadStorage, T: Tracer> zksync_vm2::StorageInterface for World<S, T> {
 /// - `decommit()` is called during far calls, which obtains address -> bytecode hash mapping beforehand.
 ///
 /// Thus, if storage is reverted correctly, additional EVM bytecodes occupy the cache, but are unreachable.
+///
+/// The cache keys are additionally bound to the cached content at insertion
+/// time: `insert_bytecodes` and `TransactionData::new` compute factory-dep
+/// hashes from the supplied bytecodes, the EVM deploy tracer hashes the
+/// published bytecode before inserting it, and the storage fallback in
+/// `decommit()` caches what storage resolved for the requested hash. No path
+/// re-verifies content when serving a cache hit — reachability is gated by the
+/// storage checks above — but a leftover entry from a reverted transaction
+/// attempt can only return the same bytecode the requesting hash already
+/// resolves to. For that reason these caches are intentionally left out of VM
+/// snapshot/rollback — there is nothing to undo.
 impl<S: ReadStorage, T: Tracer> zksync_vm2::World<T> for World<S, T> {
     fn decommit(&mut self, hash: U256) -> Program<T, Self> {
         self.program_cache

--- a/core/lib/types/src/storage/writes/mod.rs
+++ b/core/lib/types/src/storage/writes/mod.rs
@@ -151,7 +151,7 @@ impl StateDiffRecord {
 }
 
 /// Compresses a vector of state diff records according to the following:
-/// num_initial writes (u32) || compressed initial writes || compressed repeated writes
+/// num_initial writes (u16) || compressed initial writes || compressed repeated writes
 pub fn compress_state_diffs(mut state_diffs: Vec<StateDiffRecord>) -> Vec<u8> {
     let mut res = vec![];
 
@@ -162,7 +162,13 @@ pub fn compress_state_diffs(mut state_diffs: Vec<StateDiffRecord>) -> Vec<u8> {
         .iter()
         .partition(|rec| rec.enumeration_index == 0);
 
-    res.extend((initial_writes.len() as u16).to_be_bytes());
+    // The pubdata format encodes the initial-writes count as a u16. A bare
+    // `as u16` would silently truncate above 65_535 and produce malformed
+    // pubdata; fail loudly instead. Unreachable under current blob size limits,
+    // but reachable with larger-blob DA.
+    let num_initial_writes = u16::try_from(initial_writes.len())
+        .expect("number of initial writes exceeds u16::MAX and cannot be encoded in pubdata");
+    res.extend(num_initial_writes.to_be_bytes());
     for state_diff in initial_writes {
         res.extend(state_diff.compress());
     }
@@ -181,7 +187,15 @@ fn prepend_header(compressed_state_diffs: Vec<u8>) -> Vec<u8> {
     let mut res = vec![0u8; 5];
     res[0] = COMPRESSION_VERSION_NUMBER;
 
-    res[1..4].copy_from_slice(&(compressed_state_diffs.len() as u32).to_be_bytes()[1..4]);
+    // The compressed length is packed into a 3-byte (u24) field. A bare `as u32`
+    // truncated to `[1..4]` would silently drop the high byte above 2^24 bytes and
+    // produce malformed pubdata; fail loudly instead. Unreachable under current
+    // blob size limits.
+    let compressed_len = u32::try_from(compressed_state_diffs.len())
+        .ok()
+        .filter(|&len| len <= 0x00FF_FFFF)
+        .expect("compressed state diffs length exceeds the 3-byte pubdata length field");
+    res[1..4].copy_from_slice(&compressed_len.to_be_bytes()[1..4]);
 
     res[4] = BYTES_PER_ENUMERATION_INDEX;
 
@@ -609,5 +623,14 @@ mod tests {
 
         let deserialized: TreeWrite = bincode::deserialize(&serialized).unwrap();
         assert_eq!(tree_write, deserialized);
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds u16::MAX")]
+    fn rejects_more_than_u16_initial_writes() {
+        // > u16::MAX initial writes (enumeration_index == 0) cannot be encoded in
+        // the pubdata format; must fail loudly rather than silently truncate.
+        let diffs = vec![StateDiffRecord::default(); u16::MAX as usize + 1];
+        let _ = compress_state_diffs(diffs);
     }
 }

--- a/core/lib/vm_interface/src/types/errors/vm_revert_reason.rs
+++ b/core/lib/vm_interface/src/types/errors/vm_revert_reason.rs
@@ -13,6 +13,20 @@ pub enum VmRevertReasonParsingError {
     IncorrectStringLength(Vec<u8>),
 }
 
+/// Parse a 32-byte big-endian word as `usize`, returning `None` if it does not
+/// fit. `U256::as_usize` panics when the value exceeds `usize::MAX`, so an
+/// oversized word in attacker-supplied revert data would otherwise panic
+/// mid-parsing instead of yielding a clean parse error (and aborts outright on
+/// 32-bit targets such as the RISC-V proving guest).
+fn word_to_usize(word: &[u8; 32]) -> Option<usize> {
+    let value = U256::from_big_endian(word);
+    if value > U256::from(usize::MAX as u64) {
+        None
+    } else {
+        Some(value.as_usize())
+    }
+}
+
 /// Rich Revert Reasons `https://github.com/0xProject/ZEIPs/issues/32`
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
@@ -37,7 +51,12 @@ impl VmRevertReason {
         if bytes.len() < 32 {
             return Err(VmRevertReasonParsingError::InputIsTooShort(bytes.to_vec()));
         }
-        let data_offset = U256::from_big_endian(&bytes[0..32]).as_usize();
+        // A word exceeding `usize::MAX` can't be a valid in-bounds offset; map it
+        // to the offset error rather than panicking in `as_usize`. The `bytes.len() < 32`
+        // guard above makes the fixed-size conversion infallible.
+        let offset_word = <&[u8; 32]>::try_from(&bytes[..32]).expect("checked bytes.len() >= 32");
+        let data_offset = word_to_usize(offset_word)
+            .ok_or_else(|| VmRevertReasonParsingError::IncorrectDataOffset(bytes.to_vec()))?;
 
         // Data offset couldn't be less than 32 because data offset size is 32 bytes
         // and data offset bytes are part of the offset. Also data offset couldn't be greater than
@@ -54,9 +73,17 @@ impl VmRevertReason {
             return Err(VmRevertReasonParsingError::InputIsTooShort(bytes.to_vec()));
         };
 
-        let string_length = U256::from_big_endian(&data[0..32]).as_usize();
+        // The `data.len() < 32` guard above makes this conversion infallible.
+        let length_word = <&[u8; 32]>::try_from(&data[..32]).expect("checked data.len() >= 32");
+        let string_length = word_to_usize(length_word)
+            .ok_or_else(|| VmRevertReasonParsingError::IncorrectStringLength(bytes.to_vec()))?;
 
-        if string_length + 32 > data.len() {
+        // `string_length + 32` can itself overflow `usize` (e.g. on 32-bit targets),
+        // so add with overflow detection rather than a bare `+`.
+        if string_length
+            .checked_add(32)
+            .is_none_or(|end| end > data.len())
+        {
             return Err(VmRevertReasonParsingError::IncorrectStringLength(
                 bytes.to_vec(),
             ));
@@ -171,7 +198,7 @@ impl fmt::Display for VmRevertReason {
 mod tests {
     use assert_matches::assert_matches;
 
-    use super::VmRevertReason;
+    use super::{VmRevertReason, VmRevertReasonParsingError};
 
     #[test]
     fn revert_reason_parsing() {
@@ -252,5 +279,47 @@ mod tests {
         ];
         let reason = VmRevertReason::try_from_bytes(msg.as_slice());
         assert!(reason.is_err());
+    }
+
+    /// 32-byte big-endian word from a `u64` (high bytes zero).
+    fn word(value: u64) -> [u8; 32] {
+        let mut w = [0u8; 32];
+        w[24..].copy_from_slice(&value.to_be_bytes());
+        w
+    }
+
+    /// A word whose value (2^248) exceeds `usize::MAX` on any platform.
+    fn oversized_word() -> [u8; 32] {
+        let mut w = [0u8; 32];
+        w[0] = 1;
+        w
+    }
+
+    fn general_error(words: &[[u8; 32]], tail: &[u8]) -> Vec<u8> {
+        let mut bytes = vec![8, 195, 121, 160]; // general error selector
+        for w in words {
+            bytes.extend_from_slice(w);
+        }
+        bytes.extend_from_slice(tail);
+        bytes
+    }
+
+    #[test]
+    fn data_offset_overflow_is_rejected_not_panicked() {
+        let raw = general_error(&[oversized_word()], &[]);
+        assert_matches!(
+            VmRevertReason::try_from_bytes(&raw),
+            Err(VmRevertReasonParsingError::IncorrectDataOffset(_))
+        );
+    }
+
+    #[test]
+    fn string_length_overflow_is_rejected_not_panicked() {
+        // offset = 32 (valid), then an oversized string-length word.
+        let raw = general_error(&[word(32), oversized_word()], &[]);
+        assert_matches!(
+            VmRevertReason::try_from_bytes(&raw),
+            Err(VmRevertReasonParsingError::IncorrectStringLength(_))
+        );
     }
 }


### PR DESCRIPTION
The verifier repo's crates/ were copied from core/lib and accumulated fixes that were never merged back. This ports the three logical ones:

- vm_fast: compute `deduplicated_storage_logs` via `sort_storage_access_queries` over raw storage log queries, matching vm_latest, instead of `get_storage_changes()` which drops write-then-restore slots. Includes a field-by-field LogQuery bridge because vm2's `zk_evm_abstractions` (git branch) is a different crate instance than circuit_sequencer_api's (crates.io) at the same version.
- types: fail loudly on >u16::MAX initial writes and >u24 compressed length in state-diff compression instead of silently truncating pubdata.
- vm_interface: reject revert-reason words exceeding usize::MAX with a parse error instead of panicking in `U256::as_usize`; overflow-safe length bound.

Also fixes the vm_fast test helper broken by the vm2 update (`get_storage_state()` now returns `StorageWriteEntry`) and documents the bytecode-cache safety invariant in `world.rs`.

## What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- The `Why` has to be clear to non-Matter Labs entities running their own ZK Chain -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Operational changes
<!-- Any config changes? Any new flags? Any changes to any scripts? -->
<!-- Please add anything that non-Matter Labs entities running their own ZK Chain may need to know -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.
