### PR TITLE
fix(test): reset providers around main node restarts

### DIFF
--- a/core/tests/ts-integration/tests/fees.test.ts
+++ b/core/tests/ts-integration/tests/fees.test.ts
@@ -25,6 +25,7 @@ import { NodeSpawner } from 'utils/src/node-spawner';
 import { sendTransfers } from '../src/context-owner';
 import { Reporter } from '../src/reporter';
 import { waitForNewL1Batch } from 'utils';
+import { EthersRetryProvider, RetryableWallet, RetryProvider } from '../src/retry-provider';
 
 declare global {
     var __ZKSYNC_TEST_CONTEXT_OWNER__: TestContextOwner;
@@ -59,7 +60,10 @@ const testFees = process.env.RUN_FEE_TEST ? describe : describe.skip;
 
 testFees('Test fees', function () {
     let testMaster: TestMaster;
-    let alice: zksync.Wallet;
+    let alice: RetryableWallet;
+    let alicePrivateKey: string;
+    let aliceL1Provider: EthersRetryProvider;
+    let l2PollingInterval: number;
 
     let tokenDetails: Token;
     let aliceErc20: zksync.Contract;
@@ -80,8 +84,49 @@ testFees('Test fees', function () {
         return await logsTestPath(chain, 'logs/server/fees', name);
     }
 
+    async function connectAliceToMainNode(): Promise<RetryableWallet> {
+        const l2Provider = new RetryProvider(
+            {
+                url: apiWeb3JsonRpcHttpUrl,
+                timeout: 1200 * 1000
+            },
+            undefined,
+            testMaster.reporter
+        );
+        l2Provider.pollingInterval = l2PollingInterval;
+        try {
+            // Complete ethers' network detection under this awaited lifecycle operation. This
+            // prevents an initialization failure from surfacing later as a background rejection.
+            await l2Provider.getNetwork();
+            return new RetryableWallet(alicePrivateKey, l2Provider, aliceL1Provider);
+        } catch (error) {
+            l2Provider.destroy();
+            throw error;
+        }
+    }
+
+    async function restartMainNode(
+        configOverrides: Parameters<NodeSpawner['killAndSpawnMainNode']>[0] = null
+    ): Promise<void> {
+        // The server is intentionally replaced by this suite. Stop the provider while the old
+        // process is still healthy, then bind a fresh provider to the replacement process. Reusing
+        // an ethers provider across the outage leaves its network-detection requests and pollers
+        // racing the shutdown.
+        alice._providerL2().destroy();
+        await mainNodeSpawner.killAndSpawnMainNode(configOverrides);
+        alice = await connectAliceToMainNode();
+    }
+
     beforeAll(async () => {
         testMaster = TestMaster.getInstance(__filename);
+        alice = testMaster.mainAccount();
+        alicePrivateKey = alice.privateKey;
+        aliceL1Provider = alice._providerL1() as EthersRetryProvider;
+        l2PollingInterval = alice._providerL2().pollingInterval;
+
+        // TestMaster creates its L2 provider for the node started by the test harness. This suite
+        // immediately replaces that node, so dispose the provider before terminating the process.
+        alice._providerL2().destroy();
         let l2Node = testMaster.environment().l2NodePid;
         if (l2Node !== undefined) {
             await killPidWithAllChilds(l2Node, 9);
@@ -126,7 +171,7 @@ testFees('Test fees', function () {
 
         await mainNodeSpawner.killAndSpawnMainNode();
 
-        alice = testMaster.mainAccount();
+        alice = await connectAliceToMainNode();
         tokenDetails = testMaster.environment().erc20Token;
         aliceErc20 = new ethers.Contract(tokenDetails.l1Address, zksync.utils.IERC20, alice.ethWallet());
 
@@ -212,7 +257,7 @@ testFees('Test fees', function () {
         ];
         for (const gasPrice of L1_GAS_PRICES_TO_TEST) {
             // For the sake of simplicity, we'll use the same pubdata price as the L1 gas price.
-            await mainNodeSpawner.killAndSpawnMainNode({
+            await restartMainNode({
                 newL1GasPrice: gasPrice,
                 newPubdataPrice: gasPrice
             });
@@ -256,7 +301,7 @@ testFees('Test fees', function () {
 
     test('Test gas price expected value', async () => {
         const l1GasPrice = 2_000_000_000n; /// set to 2 gwei
-        await mainNodeSpawner.killAndSpawnMainNode({
+        await restartMainNode({
             newL1GasPrice: l1GasPrice,
             newPubdataPrice: l1GasPrice
         });
@@ -308,7 +353,7 @@ testFees('Test fees', function () {
         // that the gasLimit is indeed over u32::MAX, which is the most important tested property.
         const requiredPubdataPrice = minimalL2GasPrice * 100_000n;
 
-        await mainNodeSpawner.killAndSpawnMainNode({
+        await restartMainNode({
             newL1GasPrice: requiredPubdataPrice,
             newPubdataPrice: requiredPubdataPrice
         });
@@ -355,15 +400,23 @@ testFees('Test fees', function () {
     });
 
     afterAll(async () => {
-        // Returning the pubdata price to the default one
-        // Spawning with no options restores defaults.
-        await mainNodeSpawner.killAndSpawnMainNode();
+        try {
+            // Returning the pubdata price to the default one
+            // Spawning with no options restores defaults.
+            await restartMainNode();
 
-        // Wait for current batch to close so gas price returns to normal.
-        await waitForNewL1Batch(alice);
+            // Wait for current batch to close so gas price returns to normal.
+            await waitForNewL1Batch(alice);
 
-        await testMaster.deinitialize();
-        __ZKSYNC_TEST_CONTEXT_OWNER__.setL2NodePid(mainNodeSpawner.mainNode!.proc.pid!);
+            await testMaster.deinitialize();
+        } finally {
+            // This suite creates replacement providers outside TestMaster, so it also owns their
+            // cleanup. The global context owner will terminate the final server process later.
+            alice?._providerL2().destroy();
+            if (mainNodeSpawner?.mainNode) {
+                __ZKSYNC_TEST_CONTEXT_OWNER__.setL2NodePid(mainNodeSpawner.mainNode.proc.pid!);
+            }
+        }
     });
 });
 

--- a/etc/utils/src/node-spawner.ts
+++ b/etc/utils/src/node-spawner.ts
@@ -85,16 +85,18 @@ export class Node<TYPE extends NodeType> {
         // Wait until it's really stopped.
         let iter = 0;
         while (iter < 30) {
+            const provider = new zksync.Provider(this.l2NodeUrl);
             try {
                 console.log(this.l2NodeUrl);
-                let provider = new zksync.Provider(this.l2NodeUrl);
                 await provider.getBlockNumber();
-                await sleep(2);
                 iter += 1;
             } catch (_) {
                 // When exception happens, we assume that server died.
                 return;
+            } finally {
+                provider.destroy();
             }
+            await sleep(2);
         }
         // It's going to panic anyway, since the server is a singleton entity, so better to exit early.
         throw new Error(`${this.type} didn't stop after a kill request`);
@@ -143,51 +145,11 @@ export class NodeSpawner {
     }
 
     public async killAndSpawnMainNode(configOverrides: MainNodeOptions | null = null): Promise<void> {
-        // Killing the node mid-flight will cause any in-flight HTTP request from ethers
-        // providers (background pollers, abandoned `tx.wait()` listeners that resolved
-        // but whose subscriptions haven't been torn down, etc.) to reject with
-        // "socket hang up" / ECONNRESET / ECONNREFUSED. Those rejections are expected
-        // here but, because they fire on listeners owned by zksync-ethers internals,
-        // they typically have no `.catch()` handler in user code and are surfaced by
-        // jest as "Test suite failed to run" entries (see fees.test.ts in CI).
-        //
-        // Install a scoped handler that absorbs those *specific* errors during the
-        // restart window and rethrows anything else.
-        const previous = process.listeners('unhandledRejection').slice();
-        process.removeAllListeners('unhandledRejection');
-        const isExpectedRestartError = (reason: unknown): boolean => {
-            const msg = (reason as { message?: string })?.message ?? String(reason);
-            return /socket hang up|ECONNRESET|ECONNREFUSED|other side closed/i.test(msg);
-        };
-        const swallowed: unknown[] = [];
-        const handler = (reason: unknown, promise: Promise<unknown>) => {
-            if (isExpectedRestartError(reason)) {
-                swallowed.push(reason);
-                return;
-            }
-            for (const listener of previous) {
-                (listener as (r: unknown, p: Promise<unknown>) => void)(reason, promise);
-            }
-        };
-        process.on('unhandledRejection', handler);
-        try {
-            if (this.mainNode != null) {
-                await this.mainNode.killAndWaitForShutdown();
-                this.mainNode = null;
-            }
-            this.mainNode = await this.spawnMainNode(configOverrides);
-        } finally {
-            // Give a brief moment for late rejections from already-aborted requests to
-            // settle into the handler, then restore the original listeners.
-            await sleep(1);
-            process.off('unhandledRejection', handler);
-            for (const listener of previous) {
-                process.on('unhandledRejection', listener as never);
-            }
-            if (swallowed.length > 0) {
-                console.log(`Absorbed ${swallowed.length} expected restart-time RPC rejection(s).`);
-            }
+        if (this.mainNode != null) {
+            await this.mainNode.killAndWaitForShutdown();
+            this.mainNode = null;
         }
+        this.mainNode = await this.spawnMainNode(configOverrides);
     }
 
     private async spawnMainNode(overrides: MainNodeOptions | null): Promise<Node<NodeType.MAIN>> {
@@ -344,19 +306,21 @@ export class NodeSpawner {
 
 async function waitForNodeToStart(proc: ChildProcessWithoutNullStreams, l2Url: string) {
     while (true) {
+        const l2Provider = new zksync.Provider(l2Url);
         try {
-            const l2Provider = new zksync.Provider(l2Url);
             const blockNumber = await l2Provider.getBlockNumber();
             if (blockNumber != 0) {
                 console.log(`Initialized node API on ${l2Url}; latest block: ${blockNumber}`);
-                break;
+                return;
             }
         } catch (err) {
             if (proc.exitCode != null) {
                 throw new Error(`server failed to start, exitCode = ${proc.exitCode}`);
             }
             console.log(`Node waiting for API on ${l2Url}`);
-            await sleep(1);
+        } finally {
+            l2Provider.destroy();
         }
+        await sleep(1);
     }
 }


### PR DESCRIPTION
## Summary

- destroy the fees suite's active L2 provider before every intentional main-node shutdown
- create a fresh provider and wallet after each replacement node is ready, and explicitly await network detection
- destroy the temporary providers used by node startup / shutdown probes
- remove the process-wide `unhandledRejection` interception from `NodeSpawner`

## Root cause

The WITH_GATEWAY validium failure in run 29753691249 was not a slow or crashed server. All five deliberately spawned server instances reached a healthy API state, and the server logs contain no panic or OOM evidence.

The fees suite was instead reusing one `RetryProvider` across five different server process lifetimes. Ethers starts network detection and maintains provider-internal work independently of the test's awaited transaction calls. When the suite killed the server, an old provider request for `eth_chainId` remained alive across the outage. Its transport retries eventually exhausted, producing the late `PromiseRejectionHandledWarning` and Jest suite failure.

The previous mitigation in `NodeSpawner` temporarily replaced all process-level `unhandledRejection` listeners and classified transport failures as expected. Extending that classifier to the retry wrapper would only hide the same ownership bug. This revision removes that handler entirely and gives each provider the same lifetime as the server process it targets. It follows the existing `TestContextOwner.teardownContext()` rule, which already destroys providers before terminating a node to prevent exactly these late network errors.

The spawner also created short-lived readiness and shutdown providers without destroying them. Those are now deterministically cleaned up after every probe.

Failed job: https://github.com/matter-labs/zksync-era/actions/runs/29753691249/job/88390774844?pr=4898

## Validation

- `yarn --cwd etc/utils build`
- `core/tests/ts-integration/node_modules/.bin/tsc --noEmit -p core/tests/ts-integration/tsconfig.json`
- Prettier on both changed TypeScript files
- `git diff --check`
