### PR TITLE
feat(airbender): make prover idleness observable and rollouts overlappable

### DIFF
--- a/airbender_prover_server/README.md
+++ b/airbender_prover_server/README.md
@@ -44,8 +44,21 @@ Selected with `--mode` / `PROVER_MODE`:
 | `--snark-vk`       | `SNARK_VK`              | downloaded `vks/snark_vk.json` |
 | `--guest-dist-dir` | `PROVER_GUEST_DIST_DIR` | downloaded `guest/dist/app`    |
 | `--metrics-port`   | —                       | off                            |
+| `--ready-file`     | `PROVER_READY_FILE`     | off                            |
 
 The server loads VKs from disk and never derives them on the fly.
+
+## Zero-downtime rollouts
+
+Startup is dominated by the FRI prover setup (several minutes of GPU precomputation per guest binary), during which the
+server can't take jobs. To avoid paying that as proving downtime on every deploy, set `--ready-file` and overlap
+instances: the file is created only once the setups are computed and polling has started (and removed again on graceful
+shutdown), so a Kubernetes readiness probe like `test -f /tmp/prover-ready` gates the rollout — bring the new prover up,
+wait for it to report ready, then terminate the old one. Concurrent provers are safe: job handout is serialized by the
+job server's row locking, so the two instances simply share the queue for the overlap window.
+
+While idle, the server logs an INFO heartbeat once a minute (`No jobs available on any chain; still polling`) so a quiet
+log stream is distinguishable from a stalled one; per-poll "no job" responses log at DEBUG only.
 
 ## Proving for multiple chains
 

--- a/airbender_prover_server/src/jobs.rs
+++ b/airbender_prover_server/src/jobs.rs
@@ -3,7 +3,7 @@ use std::hash::{BuildHasher, Hasher};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, TrySendError};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use tracing::{debug, error, info, warn};
@@ -11,6 +11,11 @@ use zksync_prover_metrics::{ProofType, METRICS};
 
 use crate::client::JobServerClient;
 use crate::types::{ProofOutcome, ProverMode, ProverResult, WorkerJob};
+
+/// How often the worker emits an INFO-level heartbeat while idle. Empty polls
+/// log only at DEBUG, so without this a healthy-but-idle prover is
+/// indistinguishable in production logs from one that is stuck.
+const IDLE_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Orchestrates the network side of the prover: fetches jobs from the
 /// [`JobServerClient`]s, forwards them to the prover thread, and submits
@@ -39,6 +44,10 @@ pub struct JobWorker {
     shutdown: Arc<AtomicBool>,
     pending_job: Option<WorkerJob>,
     snark_followup: Option<WorkerJob>,
+    /// Present while no work is flowing: (idle start, last heartbeat log).
+    /// Cleared by any activity — a fetched job, a dispatched job, or a
+    /// handled result.
+    idle: Option<(Instant, Instant)>,
 }
 
 impl JobWorker {
@@ -66,6 +75,7 @@ impl JobWorker {
             shutdown,
             pending_job: None,
             snark_followup: None,
+            idle: None,
         }
     }
 
@@ -128,8 +138,31 @@ impl JobWorker {
                 }
             }
 
-            if !did_work {
+            if did_work {
+                self.idle = None;
+            } else {
+                self.log_idle_heartbeat();
                 std::thread::sleep(self.poll_interval);
+            }
+        }
+    }
+
+    /// Emits a rate-limited INFO log while the worker sits idle, so the log
+    /// stream shows "polling fine, no work offered" instead of going silent.
+    /// Long idle stretches usually mean the job servers have nothing eligible
+    /// — e.g. an upstream input producer is lagging — not a prover problem.
+    fn log_idle_heartbeat(&mut self) {
+        let now = Instant::now();
+        match &mut self.idle {
+            None => self.idle = Some((now, now)),
+            Some((idle_since, last_heartbeat)) => {
+                if now.duration_since(*last_heartbeat) >= IDLE_HEARTBEAT_INTERVAL {
+                    info!(
+                        idle_secs = now.duration_since(*idle_since).as_secs(),
+                        "No jobs available on any chain; still polling"
+                    );
+                    *last_heartbeat = now;
+                }
             }
         }
     }

--- a/airbender_prover_server/src/main.rs
+++ b/airbender_prover_server/src/main.rs
@@ -141,6 +141,14 @@ struct Cli {
     #[arg(long, env = "SNARK_VK", default_value_os_t = default_snark_vk_path())]
     snark_vk: PathBuf,
 
+    /// File created once the prover is fully initialized (setups computed,
+    /// polling started) and removed on exit. Point a Kubernetes readiness
+    /// probe at it (`test -f <path>`) to overlap blue/green rollouts: bring
+    /// the new prover up, wait for the file, then terminate the old one —
+    /// the multi-minute setup phase then costs zero proving downtime.
+    #[arg(long, env = "PROVER_READY_FILE")]
+    ready_file: Option<PathBuf>,
+
     /// Sentry DSN for error reporting. When unset, Sentry is disabled and the
     /// server logs to stdout only.
     #[arg(long, env = "SENTRY_URL")]
@@ -246,12 +254,52 @@ fn main() -> Result<()> {
         .run()
     });
 
-    info!("Waiting for prover to finish current job...");
+    // Both threads are running and the expensive prover setup is behind us;
+    // publish readiness so a rollout can now safely retire the previous
+    // instance.
+    let _ready_marker = cli
+        .ready_file
+        .as_deref()
+        .map(ReadyMarker::publish)
+        .transpose()
+        .context("while publishing the readiness marker file")?;
+    info!("Prover ready; polling for jobs");
+
     prover_handle.join().expect("prover thread panicked");
     job_worker_handle
         .join()
         .expect("job worker thread panicked");
     Ok(())
+}
+
+/// RAII guard for the readiness marker file: created when the prover is ready
+/// to take jobs, best-effort removed on graceful shutdown so the pod stops
+/// reporting ready while it drains.
+struct ReadyMarker {
+    path: PathBuf,
+}
+
+impl ReadyMarker {
+    fn publish(path: &std::path::Path) -> Result<Self> {
+        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("while creating {}", parent.display()))?;
+        }
+        std::fs::write(path, b"ready\n")
+            .with_context(|| format!("while writing {}", path.display()))?;
+        info!(path = %path.display(), "Published readiness marker");
+        Ok(Self {
+            path: path.to_owned(),
+        })
+    }
+}
+
+impl Drop for ReadyMarker {
+    fn drop(&mut self) {
+        if let Err(err) = std::fs::remove_file(&self.path) {
+            tracing::warn!(path = %self.path.display(), ?err, "Failed to remove readiness marker");
+        }
+    }
 }
 
 fn build_prover(

--- a/core/lib/dal/.sqlx/query-d1e69f209af8adb155fe4686c36683ad6371130ff1d6ed4c145313a71a65f230.json
+++ b/core/lib/dal/.sqlx/query-d1e69f209af8adb155fe4686c36683ad6371130ff1d6ed4c145313a71a65f230.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                l1_batch_number,\n                EXTRACT(\n                    EPOCH\n                    FROM\n                    NOW() - created_at\n                )::BIGINT AS \"age_secs!\"\n            FROM\n                proof_generation_details\n            WHERE\n                l1_batch_number >= $1\n                AND (\n                    vm_run_data_blob_url IS NULL\n                    OR proof_gen_data_blob_url IS NULL\n                )\n            ORDER BY\n                l1_batch_number ASC\n            LIMIT\n                1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "l1_batch_number",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "age_secs!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "d1e69f209af8adb155fe4686c36683ad6371130ff1d6ed4c145313a71a65f230"
+}

--- a/core/lib/dal/src/proof_generation_dal.rs
+++ b/core/lib/dal/src/proof_generation_dal.rs
@@ -459,6 +459,53 @@ impl ProofGenerationDal<'_, '_> {
         Ok(result)
     }
 
+    /// Returns the oldest batch that has entered the proving pipeline but is
+    /// still missing at least one of its input blobs (`vm_run_data_blob_url` /
+    /// `proof_gen_data_blob_url`), together with how long it has been waiting.
+    /// Such a batch is invisible to provers — the job handout query requires
+    /// both URLs — so a growing age means an input producer (VM runner /
+    /// witness generation) is stalled while provers sit idle.
+    pub async fn get_oldest_batch_with_missing_proof_inputs(
+        &mut self,
+        min_batch_number: L1BatchNumber,
+    ) -> DalResult<Option<(L1BatchNumber, Duration)>> {
+        let row = sqlx::query!(
+            r#"
+            SELECT
+                l1_batch_number,
+                EXTRACT(
+                    EPOCH
+                    FROM
+                    NOW() - created_at
+                )::BIGINT AS "age_secs!"
+            FROM
+                proof_generation_details
+            WHERE
+                l1_batch_number >= $1
+                AND (
+                    vm_run_data_blob_url IS NULL
+                    OR proof_gen_data_blob_url IS NULL
+                )
+            ORDER BY
+                l1_batch_number ASC
+            LIMIT
+                1
+            "#,
+            i64::from(min_batch_number.0),
+        )
+        .instrument("get_oldest_batch_with_missing_proof_inputs")
+        .with_arg("min_batch_number", &min_batch_number)
+        .fetch_optional(self.storage)
+        .await?;
+
+        Ok(row.map(|row| {
+            (
+                L1BatchNumber(row.l1_batch_number as u32),
+                Duration::from_secs(row.age_secs.max(0) as u64),
+            )
+        }))
+    }
+
     pub async fn is_batch_present_for_airbender_proof_inputs(
         &mut self,
         batch_number: L1BatchNumber,

--- a/core/node/house_keeper/src/blocks_state_reporter.rs
+++ b/core/node/house_keeper/src/blocks_state_reporter.rs
@@ -163,6 +163,18 @@ impl BlockMetricsReporter {
             .airbender_batches_ready_for_snark
             .set(ready_for_snark_count as u64);
 
+        let (input_pending_batch, input_pending_age) = conn
+            .proof_generation_dal()
+            .get_oldest_batch_with_missing_proof_inputs(self.first_airbender_batch)
+            .await?
+            .map_or((0, 0), |(batch, age)| (u64::from(batch.0), age.as_secs()));
+        FRI_PROVER_METRICS
+            .airbender_oldest_input_pending_batch
+            .set(input_pending_batch);
+        FRI_PROVER_METRICS
+            .airbender_oldest_input_pending_batch_age_secs
+            .set(input_pending_age);
+
         Ok(())
     }
 }

--- a/core/node/house_keeper/src/metrics.rs
+++ b/core/node/house_keeper/src/metrics.rs
@@ -9,6 +9,14 @@ pub(crate) struct FriProverMetrics {
     pub airbender_batches_ready_for_proving: Gauge<u64>,
     /// Number of batches whose FRI proof is ready and are waiting to be wrapped into a SNARK proof.
     pub airbender_batches_ready_for_snark: Gauge<u64>,
+    /// Oldest batch still waiting for its proof input blobs (VM run data / witness inputs).
+    /// Such a batch is invisible to airbender provers, so `airbender_batches_ready_for_proving`
+    /// stays at 0 while work silently queues behind a stalled input producer. 0 = none pending.
+    pub airbender_oldest_input_pending_batch: Gauge<u64>,
+    /// Seconds the oldest input-pending batch has been waiting for its input blobs.
+    /// The alerting signal for input-producer lag: provers idle + this growing = the gap is
+    /// upstream of the proving pipeline. 0 = none pending.
+    pub airbender_oldest_input_pending_batch_age_secs: Gauge<u64>,
 }
 
 #[vise::register]


### PR DESCRIPTION
## What

Cuts and instruments the post-deploy proving gap observed on stage (2026-07-20, ~16:04–16:34 UTC): batches 89129–89131 sat invisible to the prover for ~25 minutes behind a stalled input producer, while the freshly deployed prover pod looked like it was "computing something for 30 minutes" because idle polling logs only at DEBUG and the serial pod replacement paid the multi-minute FRI setup as proving downtime.

### Prover server (`airbender_prover_server`)

- **Idle heartbeat**: while no work is flowing, log at INFO once a minute (`No jobs available on any chain; still polling`, with `idle_secs`) so a quiet log stream is distinguishable from a stalled prover. Per-poll 204s stay at DEBUG.
- **`--ready-file` / `PROVER_READY_FILE`**: marker file created only once the prover setups are computed and polling has started; removed on graceful shutdown. Point a Kubernetes readiness probe (`test -f <path>`) at it and overlap blue/green rollouts — bring the new prover up, wait for ready, then terminate the old one — so FRI setup time no longer costs proving downtime. Concurrent provers are already safe under the job server's row locking (`FOR UPDATE SKIP LOCKED`).
- Reword the misleading `Waiting for prover to finish current job...` startup log to `Prover ready; polling for jobs`.

### Core

- New gauges **`fri_prover.airbender_oldest_input_pending_batch`** / **`..._age_secs`** (house_keeper reporter + DAL query): the oldest batch that entered `proof_generation_details` but is still missing `vm_run_data_blob_url` / `proof_gen_data_blob_url`, and how long it has been waiting. Such batches are invisible to the airbender job handout, so the existing `airbender_batches_ready_for_proving` reads 0 while work silently queues — exactly the blind spot in the incident. Alerting on the age gauge catches an input-producer stall within minutes.

## Testing

- `cargo check` / `clippy` / `fmt` clean on `eravm-prover-server` (CUDA-free), `zksync_dal`, `zksync_house_keeper`.
- The new DAL query was exercised against a fully migrated scratch database (returns the oldest row with a missing input URL and its age; verified with fixture rows). `.sqlx` metadata regenerated — one new entry, no churn.
- The server's only integration test is GPU-gated `#[ignore]`; unit tests are untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
