### PR TITLE
feat(eth_watch): set vk hashes from CTM NewProtocolVersionVerifier event

### DIFF
--- a/core/node/eth_watch/src/client.rs
+++ b/core/node/eth_watch/src/client.rs
@@ -16,6 +16,7 @@ use zksync_types::{
     abi::ZkChainSpecificUpgradeData,
     api::{ChainAggProof, Log},
     ethabi::{decode, Contract, ParamType},
+    h256_to_address,
     protocol_version::ProtocolSemanticVersion,
     u256_to_h256,
     utils::encode_ntv_asset_id,
@@ -63,6 +64,15 @@ pub trait EthClient: 'static + fmt::Debug + Send + Sync {
         &self,
         version: ProtocolSemanticVersion,
     ) -> EnrichedClientResult<Option<Vec<u8>>>;
+
+    /// Returns the verifier address set on CTM for the new protocol version `new_version`.
+    /// It is read from the `NewProtocolVersionVerifier` event, which is emitted in the same block
+    /// as the upgrade diamond cut for `old_version`.
+    async fn verifier_address_for_version(
+        &self,
+        old_version: ProtocolSemanticVersion,
+        new_version: ProtocolSemanticVersion,
+    ) -> EnrichedClientResult<Option<Address>>;
 
     async fn get_published_preimages(
         &self,
@@ -113,6 +123,7 @@ pub struct EthHttpQueryClient<Net: Network> {
     client: Box<DynClient<Net>>,
     diamond_proxy_addr: Address,
     new_upgrade_cut_data_signature: H256,
+    new_protocol_version_verifier_signature: H256,
     bytecode_published_signature: H256,
     bytecode_supplier_addr: Option<Address>,
     wrapped_base_token_store: Option<Address>,
@@ -169,6 +180,11 @@ where
             new_upgrade_cut_data_signature: state_transition_manager_contract()
                 .event("NewUpgradeCutData")
                 .context("NewUpgradeCutData event is missing in ABI")
+                .unwrap()
+                .signature(),
+            new_protocol_version_verifier_signature: state_transition_manager_contract()
+                .event("NewProtocolVersionVerifier")
+                .context("NewProtocolVersionVerifier event is missing in ABI")
                 .unwrap()
                 .signature(),
             bytecode_published_signature: bytecode_supplier_contract()
@@ -506,6 +522,56 @@ where
         }
         Ok(logs.into_iter().map(|log| log.data.0).next())
     }
+
+    async fn verifier_address_for_version(
+        &self,
+        old_version: ProtocolSemanticVersion,
+        new_version: ProtocolSemanticVersion,
+    ) -> EnrichedClientResult<Option<Address>> {
+        let Some(state_transition_manager_address) = self.state_transition_manager_address else {
+            return Ok(None);
+        };
+
+        let Some(from_block) = self
+            .block_for_diamond_cut_for_version(old_version.pack())
+            .await
+            .map_err(|e| {
+                EnrichedClientError::custom(
+                    format!(
+                        "Failed to get block for diamond cut for version {old_version}: err {e}"
+                    ),
+                    "verifier_address_for_version",
+                )
+            })?
+        else {
+            return Ok(None);
+        };
+
+        let logs = self
+            .get_events_inner(
+                from_block.into(),
+                from_block.into(),
+                Some(vec![self.new_protocol_version_verifier_signature]),
+                Some(vec![u256_to_h256(new_version.pack())]),
+                Some(vec![state_transition_manager_address]),
+                RETRY_LIMIT,
+            )
+            .await?;
+
+        // If the verifier was set several times within the block, the last event matches
+        // the current `protocolVersionVerifier` mapping value.
+        let Some(log) = logs.last() else {
+            return Ok(None);
+        };
+        let verifier = log.topics.get(2).ok_or_else(|| {
+            EnrichedClientError::custom(
+                "NewProtocolVersionVerifier event is missing the verifier topic",
+                "verifier_address_for_version",
+            )
+        })?;
+        Ok(Some(h256_to_address(verifier)))
+    }
+
     async fn chain_id(&self) -> EnrichedClientResult<SLChainId> {
         self.client.fetch_chain_id().await
     }

--- a/core/node/eth_watch/src/event_processors/decentralized_upgrades.rs
+++ b/core/node/eth_watch/src/event_processors/decentralized_upgrades.rs
@@ -143,8 +143,19 @@ impl EventProcessor for DecentralizedUpgradesEventProcessor {
                 )));
             }
 
+            // The verifier for the new protocol version is set on the CTM and emitted via the
+            // `NewProtocolVersionVerifier` event next to the upgrade diamond cut. It takes
+            // precedence over the verifier address in the upgrade data, which may be absent
+            // (e.g. for verifier-only patch upgrades).
+            let verifier_address = self
+                .sl_client
+                .verifier_address_for_version(old_protocol_version, upgrade.version)
+                .await
+                .map_err(EventProcessorError::client)?
+                .or(upgrade.verifier_address);
+
             // Scheduler VK is not present in proposal event. It is hard coded in verifier contract.
-            let scheduler_vk_hash = if let Some(address) = upgrade.verifier_address {
+            let scheduler_vk_hash = if let Some(address) = verifier_address {
                 Some(
                     self.sl_client
                         .scheduler_vk_hash(address)
@@ -156,7 +167,7 @@ impl EventProcessor for DecentralizedUpgradesEventProcessor {
             };
 
             // Scheduler VK is not present in proposal event. It is hard coded in verifier contract.
-            let fflonk_scheduler_vk_hash = if let Some(address) = upgrade.verifier_address {
+            let fflonk_scheduler_vk_hash = if let Some(address) = verifier_address {
                 self.sl_client
                     .fflonk_scheduler_vk_hash(address)
                     .await

--- a/core/node/eth_watch/src/tests/client.rs
+++ b/core/node/eth_watch/src/tests/client.rs
@@ -7,6 +7,7 @@ use zksync_contracts::{
 use zksync_eth_client::{ContractCallError, EnrichedClientError, EnrichedClientResult};
 use zksync_types::{
     abi::{self, ProposedUpgrade, ZkChainSpecificUpgradeData},
+    address_to_h256,
     api::{ChainAggProof, Log},
     bytecode::BytecodeHash,
     ethabi::{self, Token},
@@ -35,6 +36,8 @@ pub struct FakeEthClientData {
     batch_roots: HashMap<u64, Vec<Log>>,
     chain_roots: HashMap<u64, H256>,
     bytecode_preimages: HashMap<H256, Vec<u8>>,
+    // Keyed by the packed *new* protocol version.
+    protocol_version_verifiers: HashMap<H256, Address>,
 }
 
 impl FakeEthClientData {
@@ -51,6 +54,7 @@ impl FakeEthClientData {
             batch_roots: Default::default(),
             chain_roots: Default::default(),
             bytecode_preimages: Default::default(),
+            protocol_version_verifiers: Default::default(),
         }
     }
 
@@ -128,6 +132,15 @@ impl FakeEthClientData {
                 upgrade,
                 eth_block,
             ));
+    }
+
+    fn add_protocol_version_verifier(
+        &mut self,
+        new_protocol_version: ProtocolSemanticVersion,
+        verifier: Address,
+    ) {
+        self.protocol_version_verifiers
+            .insert(u256_to_h256(new_protocol_version.pack()), verifier);
     }
 
     fn set_last_finalized_block_number(&mut self, number: u64) {
@@ -228,6 +241,17 @@ impl MockEthClient {
             .add_diamond_cut(old_protocol_version, upgrade, eth_block);
     }
 
+    pub async fn add_protocol_version_verifier(
+        &mut self,
+        new_protocol_version: ProtocolSemanticVersion,
+        verifier: Address,
+    ) {
+        self.inner
+            .write()
+            .await
+            .add_protocol_version_verifier(new_protocol_version, verifier);
+    }
+
     pub async fn set_last_finalized_block_number(&mut self, number: u64) {
         self.inner
             .write()
@@ -320,9 +344,10 @@ impl EthClient for MockEthClient {
 
     async fn scheduler_vk_hash(
         &self,
-        _verifier_address: Address,
+        verifier_address: Address,
     ) -> Result<H256, ContractCallError> {
-        Ok(H256::zero())
+        // Derive the hash from the address so that tests can check which verifier was used.
+        Ok(address_to_h256(&verifier_address))
     }
 
     async fn finalized_block_number(&self) -> EnrichedClientResult<u64> {
@@ -375,6 +400,20 @@ impl EthClient for MockEthClient {
             ));
         }
         Ok(logs.into_iter().map(|log| log.data.0).next())
+    }
+
+    async fn verifier_address_for_version(
+        &self,
+        _old_version: ProtocolSemanticVersion,
+        new_version: ProtocolSemanticVersion,
+    ) -> EnrichedClientResult<Option<Address>> {
+        Ok(self
+            .inner
+            .read()
+            .await
+            .protocol_version_verifiers
+            .get(&u256_to_h256(new_version.pack()))
+            .copied())
     }
 
     async fn get_total_priority_txs(&self) -> Result<u64, ContractCallError> {

--- a/core/node/eth_watch/src/tests/mod.rs
+++ b/core/node/eth_watch/src/tests/mod.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 
 use zksync_dal::{Connection, ConnectionPool, Core, CoreDal};
 use zksync_types::{
-    abi,
+    abi, address_to_h256,
     aggregated_operations::{AggregatedActionType, L1BatchAggregatedActionType},
     api::ChainAggProof,
     block::L1BatchHeader,
@@ -311,6 +311,54 @@ async fn test_rewritten_upgrade_cut_is_used() {
     let db_versions = storage.protocol_versions_dal().all_versions().await;
     assert_eq!(db_versions.len(), 2);
     assert_eq!(db_versions[1], replacement_version);
+}
+
+#[test_log::test(tokio::test)]
+async fn test_verifier_from_ctm_event_is_used_for_vk_hashes() {
+    let connection_pool = ConnectionPool::<Core>::test_pool().await;
+    setup_db(&connection_pool).await;
+    let (mut watcher, mut client) = create_l1_test_watcher(connection_pool.clone()).await;
+
+    let new_version = ProtocolSemanticVersion {
+        minor: ProtocolVersionId::next(),
+        patch: 0.into(),
+    };
+    let verifier = Address::repeat_byte(0x42);
+
+    let mut storage = connection_pool.connection().await.unwrap();
+    client
+        .add_upgrade_timestamp(&[(
+            ProtocolUpgrade {
+                version: new_version,
+                tx: None,
+                // No verifier in the upgrade data itself: it must be picked up from the
+                // CTM `NewProtocolVersionVerifier` event.
+                ..Default::default()
+            },
+            10,
+        )])
+        .await;
+    client
+        .add_protocol_version_verifier(new_version, verifier)
+        .await;
+    client.set_last_finalized_block_number(15).await;
+    watcher.loop_iteration(&mut storage).await.unwrap();
+
+    let db_versions = storage.protocol_versions_dal().all_versions().await;
+    assert_eq!(db_versions.len(), 2);
+    assert_eq!(db_versions[1], new_version);
+
+    let db_version = storage
+        .protocol_versions_dal()
+        .get_protocol_version_with_latest_patch(new_version.minor)
+        .await
+        .unwrap()
+        .expect("expected the new version to be present in DB");
+    // The mock client derives the VK hash from the verifier address.
+    assert_eq!(
+        db_version.l1_verifier_config.snark_wrapper_vk_hash,
+        address_to_h256(&verifier)
+    );
 }
 
 #[test_log::test(tokio::test)]


### PR DESCRIPTION
## What ❔

The upgrade system now emits `NewProtocolVersionVerifier(uint256 indexed protocolVersion, address indexed verifier)` on the CTM ([ChainTypeManagerBase.sol#L341](https://github.com/matter-labs/era-contracts/blob/draft-v31/l1-contracts/contracts/state-transition/ChainTypeManagerBase.sol#L341)). When eth_watch processes a decentralized protocol upgrade, it now reads this event and uses the verifier address from it to fetch the scheduler / fflonk vk hashes.

- `EthClient::verifier_address_for_version(old_version, new_version)`: the event is emitted in the same tx as the upgrade diamond cut (`_setNewVersionUpgrade` → `setUpgradeDiamondCutInner` records `upgradeCutDataBlock[oldVersion]`), so the implementation reuses that block lookup and scans it for the event filtered by the packed *new* protocol version topic. If the verifier is set multiple times in the block, the last event wins, matching the `protocolVersionVerifier` mapping semantics.
- `DecentralizedUpgradesEventProcessor` resolves the verifier as `event verifier || upgrade.verifier_address` — the event takes precedence, and the address embedded in the `ProposedUpgrade` data remains as a fallback for pre-v31 upgrades.
- `MockEthClient` supports registering per-version verifiers, and its `scheduler_vk_hash` now derives the hash from the verifier address so tests can observe which verifier was used. New test: an upgrade with no verifier in the upgrade data gets its vk hashes from the event-provided verifier.

## Why ❔

Verifier-only patch upgrades (created via `createNewPatchUpgrade`) carry no facet changes and no verifier address inside the upgrade data, so the server previously could not set the vk hashes for them. The verifier per protocol version is now the CTM's source of truth.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)