### PR TITLE
perf(dal): disable sort for `get_l2_blocks_to_reexecute` query

### DIFF
--- a/core/lib/dal/src/transactions_dal.rs
+++ b/core/lib/dal/src/transactions_dal.rs
@@ -2013,6 +2013,17 @@ impl TransactionsDal<'_, '_> {
     /// but not included to L1 batch. The order of the transactions is the same as it was
     /// during the previous execution.
     pub async fn get_l2_blocks_to_reexecute(&mut self) -> DalResult<Vec<L2BlockExecutionData>> {
+        // The query below is served by the `pending_l1_batch_txs` partial index, which matches both its
+        // filter and its ordering. Still, on a large `transactions` table the planner sometimes prefers
+        // a full scan followed by an explicit sort, which is orders of magnitude slower. Disabling sorts
+        // for the duration of the transaction forces the planner to use the index ordering.
+        // `SET LOCAL` only has an effect inside a transaction, hence the explicit transaction here.
+        let mut db_transaction = self.storage.start_transaction().await?;
+        sqlx::query("SET LOCAL enable_sort = OFF")
+            .instrument("get_l2_blocks_to_reexecute#disable_sort")
+            .execute(&mut db_transaction)
+            .await?;
+
         let transactions = sqlx::query_as!(
             StorageTransaction,
             r#"
@@ -2029,8 +2040,9 @@ impl TransactionsDal<'_, '_> {
             "#,
         )
         .instrument("get_l2_blocks_to_reexecute#transactions")
-        .fetch_all(self.storage)
+        .fetch_all(&mut db_transaction)
         .await?;
+        db_transaction.commit().await?;
 
         self.map_transactions_to_execution_data(transactions, None)
             .await


### PR DESCRIPTION
## What ❔

Runs the `get_l2_blocks_to_reexecute` transactions query inside a DB transaction with `SET LOCAL enable_sort = OFF`.

```sql
SET LOCAL enable_sort = OFF;

SELECT * FROM transactions
WHERE miniblock_number IS NOT NULL AND l1_batch_number IS NULL
ORDER BY miniblock_number, index_in_block
```

## Why ❔

This query is fully covered by the `pending_l1_batch_txs` partial index — both its filter (`miniblock_number IS NOT NULL AND l1_batch_number IS NULL`) and its ordering (`miniblock_number, index_in_block`). On a large `transactions` table the planner nevertheless sometimes picks a full scan plus an explicit sort, which is drastically slower. Disabling sorts for the duration of the transaction forces the planner to use the index ordering.

`SET LOCAL` only takes effect inside a transaction, hence the explicit transaction wrapping just this query; the setting is reverted on commit and does not leak to other queries on the pooled connection.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] No new tests: behaviour is unchanged, the existing DB-backed `load_pending_batch` tests in `core/node/state_keeper/src/io/common/tests.rs` cover this code path.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` (`zkstack dev fmt` could not run locally — prettier is not installed in this environment; no non-Rust files are touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)