### PR TITLE
fix(eth_watch): support both CTM upgrade-event generations

### DIFF
--- a/core/node/eth_watch/src/client.rs
+++ b/core/node/eth_watch/src/client.rs
@@ -16,7 +16,7 @@ use zksync_types::{
     abi::ZkChainSpecificUpgradeData,
     api::{ChainAggProof, Log},
     ethabi::{decode, Contract, ParamType},
-    h256_to_address,
+    h256_to_address, h256_to_u256,
     protocol_version::ProtocolSemanticVersion,
     u256_to_h256,
     utils::encode_ntv_asset_id,
@@ -30,6 +30,16 @@ use zksync_web3_decl::{
 };
 
 const FFLONK_VERIFIER_TYPE: i32 = 0;
+
+/// Protocol version scheduled on the CTM, as read from its `NewProtocolVersion` event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScheduledProtocolVersion {
+    /// Protocol version the chain is scheduled to upgrade to.
+    pub version: ProtocolSemanticVersion,
+    /// SL block in which the upgrade was scheduled. The upgrade diamond cut and the verifier for
+    /// `version` are emitted in this very block, so it is a lower bound for looking them up.
+    pub block_number: u64,
+}
 
 /// Common L1 and L2 client functionality used by [`EthWatch`](crate::EthWatch) and constituent event processors.
 #[async_trait::async_trait]
@@ -59,19 +69,34 @@ pub trait EthClient: 'static + fmt::Debug + Send + Sync {
         verifier_address: Address,
     ) -> Result<Option<H256>, ContractCallError>;
 
-    /// Returns the latest upgrade diamond cut for the old/from protocol version.
+    /// Resolves the protocol version scheduled from `old_version`.
+    ///
+    /// It is read from the `NewProtocolVersion` event emitted by the CTM, where topic1 is the old
+    /// protocol version and topic2 is the new protocol version. Both CTM generations emit it.
+    async fn scheduled_protocol_version(
+        &self,
+        old_version: ProtocolSemanticVersion,
+    ) -> EnrichedClientResult<Option<ScheduledProtocolVersion>>;
+
+    /// Returns the latest upgrade diamond cut emitted for `version` at or after `from_block`.
+    ///
+    /// Which version the cut is keyed by depends on the CTM generation, see
+    /// [`DecentralizedUpgradesEventProcessor`](crate::event_processors::DecentralizedUpgradesEventProcessor).
     async fn diamond_cut_for_version(
         &self,
         version: ProtocolSemanticVersion,
+        from_block: u64,
     ) -> EnrichedClientResult<Option<Vec<u8>>>;
 
-    /// Returns the verifier address set on CTM for the new protocol version `new_version`.
-    /// It is read from the `NewProtocolVersionVerifier` event, which is emitted in the same block
-    /// as the upgrade diamond cut for `old_version`.
+    /// Returns the verifier address set on the CTM for `new_version`, as read from the
+    /// `NewProtocolVersionVerifier` event emitted at or after `from_block`.
+    ///
+    /// Legacy CTMs do not have this event; there the verifier is part of the upgrade calldata and
+    /// this returns `None`.
     async fn verifier_address_for_version(
         &self,
-        old_version: ProtocolSemanticVersion,
         new_version: ProtocolSemanticVersion,
+        from_block: u64,
     ) -> EnrichedClientResult<Option<Address>>;
 
     async fn get_published_preimages(
@@ -123,6 +148,7 @@ pub struct EthHttpQueryClient<Net: Network> {
     client: Box<DynClient<Net>>,
     diamond_proxy_addr: Address,
     new_upgrade_cut_data_signature: H256,
+    new_protocol_version_signature: H256,
     new_protocol_version_verifier_signature: H256,
     bytecode_published_signature: H256,
     bytecode_supplier_addr: Option<Address>,
@@ -136,7 +162,6 @@ pub struct EthHttpQueryClient<Net: Network> {
     bridgehub_proxy_addr: Option<Address>,
     verifier_contract_abi: Contract,
     getters_facet_contract_abi: Contract,
-    chain_type_manager_abi: Contract,
     message_root_abi: Contract,
     l1_asset_router_abi: Contract,
     settlement_layer_v31_upgrade_abi: Contract,
@@ -182,6 +207,11 @@ where
                 .context("NewUpgradeCutData event is missing in ABI")
                 .unwrap()
                 .signature(),
+            new_protocol_version_signature: state_transition_manager_contract()
+                .event("NewProtocolVersion")
+                .context("NewProtocolVersion event is missing in ABI")
+                .unwrap()
+                .signature(),
             new_protocol_version_verifier_signature: state_transition_manager_contract()
                 .event("NewProtocolVersionVerifier")
                 .context("NewProtocolVersionVerifier event is missing in ABI")
@@ -194,7 +224,6 @@ where
                 .signature(),
             verifier_contract_abi: verifier_contract(),
             getters_facet_contract_abi: getters_facet_contract(),
-            chain_type_manager_abi: state_transition_manager_contract(),
             message_root_abi: l2_message_root(),
             l1_asset_router_abi: l1_asset_router_contract(),
             settlement_layer_v31_upgrade_abi: settlement_layer_v31_upgrade_contract(),
@@ -327,25 +356,53 @@ where
         result
     }
 
-    async fn block_for_diamond_cut_for_version(
+    /// Fetches CTM events with `topic1 == signature` and `topic2 == packed_version`, ordered from
+    /// the oldest to the newest.
+    ///
+    /// `from_block` bounds the search below; `None` looks back [`LOOK_BACK_BLOCK_RANGE`] blocks. The
+    /// upper bound is [`EthClient::confirmed_block_number()`] — the same visibility rule `EthWatch`
+    /// applies to the `UpgradeTimestampUpdated` events that trigger these look-ups. Bounding by the
+    /// finalized block instead would miss an upgrade that was just scheduled, since finalization
+    /// lags the confirmed block whenever `confirmations_for_eth_event` is small.
+    ///
+    /// Returns an empty vector if the CTM address is not configured.
+    async fn ctm_events_for_version(
         &self,
+        signature: H256,
         packed_version: U256,
-    ) -> Result<Option<U64>, ContractCallError> {
+        from_block: Option<u64>,
+        method_name: &'static str,
+    ) -> EnrichedClientResult<Vec<Log>> {
         let Some(state_transition_manager_address) = self.state_transition_manager_address else {
-            return Ok(None);
+            return Ok(vec![]);
         };
 
-        let result: U256 = CallFunctionArgs::new("upgradeCutDataBlock", packed_version)
-            .for_contract(
-                state_transition_manager_address,
-                &self.chain_type_manager_abi,
+        let to_block = self.confirmed_block_number().await.map_err(|e| {
+            EnrichedClientError::custom(
+                format!("Failed to get confirmed block number: err {e}"),
+                method_name,
             )
-            .call(&self.client)
+        })?;
+        let from_block =
+            from_block.unwrap_or_else(|| to_block.saturating_sub(LOOK_BACK_BLOCK_RANGE));
+
+        let mut logs = self
+            .get_events_inner(
+                from_block.into(),
+                to_block.into(),
+                Some(vec![signature]),
+                Some(vec![u256_to_h256(packed_version)]),
+                Some(vec![state_transition_manager_address]),
+                RETRY_LIMIT,
+            )
             .await?;
-        if result.is_zero() {
-            return Ok(None);
-        }
-        Ok(Some(U64::from(result.as_u64())))
+        logs.sort_by_key(|log| {
+            (
+                log.block_number.unwrap_or_default(),
+                log.log_index.unwrap_or_default(),
+            )
+        });
+        Ok(logs)
     }
 }
 
@@ -480,86 +537,87 @@ where
         }
     }
 
-    async fn diamond_cut_for_version(
+    async fn scheduled_protocol_version(
         &self,
-        version: ProtocolSemanticVersion,
-    ) -> EnrichedClientResult<Option<Vec<u8>>> {
-        let Some(state_transition_manager_address) = self.state_transition_manager_address else {
-            return Ok(None);
-        };
-
-        let Some(from_block) = self
-            .block_for_diamond_cut_for_version(version.pack())
-            .await
-            .map_err(|e| {
-                EnrichedClientError::custom(
-                    format!("Failed to get block for diamond cut for version {version}: err {e}"),
-                    "diamond_cut_for_version",
-                )
-            })?
-        else {
-            return Ok(None);
-        };
-
+        old_version: ProtocolSemanticVersion,
+    ) -> EnrichedClientResult<Option<ScheduledProtocolVersion>> {
         let logs = self
-            .get_events_inner(
-                from_block.into(),
-                from_block.into(),
-                Some(vec![self.new_upgrade_cut_data_signature]),
-                Some(vec![u256_to_h256(version.pack())]),
-                Some(vec![state_transition_manager_address]),
-                RETRY_LIMIT,
+            .ctm_events_for_version(
+                self.new_protocol_version_signature,
+                old_version.pack(),
+                None,
+                "scheduled_protocol_version",
             )
             .await?;
 
-        if logs.len() > 1 {
-            return Err(EnrichedClientError::custom(
-                format!(
-                    "Multiple NewUpgradeCutData events in block {from_block} for version {version}"
-                ),
+        // If several upgrades were scheduled from the same old version, the one emitted in the
+        // latest block corresponds to the currently active upgrade path.
+        let Some(log) = logs.last() else {
+            return Ok(None);
+        };
+        let new_version = log.topics.get(2).ok_or_else(|| {
+            EnrichedClientError::custom(
+                "NewProtocolVersion event is missing the new version topic",
+                "scheduled_protocol_version",
+            )
+        })?;
+        let version = ProtocolSemanticVersion::try_from_packed(h256_to_u256(*new_version))
+            .map_err(|err| {
+                EnrichedClientError::custom(
+                    format!("Failed to parse new protocol version: {err}"),
+                    "scheduled_protocol_version",
+                )
+            })?;
+        let block_number = log
+            .block_number
+            .ok_or_else(|| {
+                EnrichedClientError::custom(
+                    "NewProtocolVersion event is missing the block number",
+                    "scheduled_protocol_version",
+                )
+            })?
+            .as_u64();
+        Ok(Some(ScheduledProtocolVersion {
+            version,
+            block_number,
+        }))
+    }
+
+    async fn diamond_cut_for_version(
+        &self,
+        version: ProtocolSemanticVersion,
+        from_block: u64,
+    ) -> EnrichedClientResult<Option<Vec<u8>>> {
+        let logs = self
+            .ctm_events_for_version(
+                self.new_upgrade_cut_data_signature,
+                version.pack(),
+                Some(from_block),
                 "diamond_cut_for_version",
-            ));
-        }
-        Ok(logs.into_iter().map(|log| log.data.0).next())
+            )
+            .await?;
+
+        // The cut may be rewritten after it was first scheduled, in which case the latest event
+        // holds the cut that will actually be applied.
+        Ok(logs.into_iter().next_back().map(|log| log.data.0))
     }
 
     async fn verifier_address_for_version(
         &self,
-        old_version: ProtocolSemanticVersion,
         new_version: ProtocolSemanticVersion,
+        from_block: u64,
     ) -> EnrichedClientResult<Option<Address>> {
-        let Some(state_transition_manager_address) = self.state_transition_manager_address else {
-            return Ok(None);
-        };
-
-        let Some(from_block) = self
-            .block_for_diamond_cut_for_version(old_version.pack())
-            .await
-            .map_err(|e| {
-                EnrichedClientError::custom(
-                    format!(
-                        "Failed to get block for diamond cut for version {old_version}: err {e}"
-                    ),
-                    "verifier_address_for_version",
-                )
-            })?
-        else {
-            return Ok(None);
-        };
-
         let logs = self
-            .get_events_inner(
-                from_block.into(),
-                from_block.into(),
-                Some(vec![self.new_protocol_version_verifier_signature]),
-                Some(vec![u256_to_h256(new_version.pack())]),
-                Some(vec![state_transition_manager_address]),
-                RETRY_LIMIT,
+            .ctm_events_for_version(
+                self.new_protocol_version_verifier_signature,
+                new_version.pack(),
+                Some(from_block),
+                "verifier_address_for_version",
             )
             .await?;
 
-        // If the verifier was set several times within the block, the last event matches
-        // the current `protocolVersionVerifier` mapping value.
+        // If the verifier was set several times, the last event matches the current
+        // `protocolVersionVerifier` mapping value.
         let Some(log) = logs.last() else {
             return Ok(None);
         };

--- a/core/node/eth_watch/src/event_processors/decentralized_upgrades.rs
+++ b/core/node/eth_watch/src/event_processors/decentralized_upgrades.rs
@@ -112,15 +112,50 @@ impl EventProcessor for DecentralizedUpgradesEventProcessor {
                 continue;
             }
 
-            let diamond_cut = self
+            // The CTM emits a `NewProtocolVersion` event mapping the old protocol version (topic1)
+            // to the new protocol version (topic2). Both CTM generations emit it, and it pins down
+            // the block in which the upgrade was scheduled.
+            let scheduled = self
                 .sl_client
-                .diamond_cut_for_version(old_protocol_version)
+                .scheduled_protocol_version(old_protocol_version)
                 .await
                 .map_err(EventProcessorError::client)?
                 .with_context(|| {
-                    format!("No diamond cuts found for protocol version {old_protocol_version}")
+                    format!(
+                        "No NewProtocolVersion event found for old protocol version \
+                         {old_protocol_version} in the CTM look-back window (event {event:?})"
+                    )
                 })
                 .map_err(EventProcessorError::internal)?;
+
+            // Modern CTMs key `NewUpgradeCutData` by the *old* protocol version, which lets
+            // governance rewrite the cut after the upgrade was scheduled. Legacy CTMs key it by the
+            // *new* protocol version and cannot express a rewrite at all, so the new-version key is
+            // only consulted when the old-version one yields nothing. Both look-ups start at the
+            // scheduling block so that cuts emitted for earlier upgrades are not picked up — on a
+            // modern CTM the previous upgrade also emitted a backwards-compatible
+            // `NewUpgradeCutData` keyed by what is now the old version.
+            let diamond_cut = match self
+                .sl_client
+                .diamond_cut_for_version(old_protocol_version, scheduled.block_number)
+                .await
+                .map_err(EventProcessorError::client)?
+            {
+                Some(diamond_cut) => diamond_cut,
+                None => self
+                    .sl_client
+                    .diamond_cut_for_version(scheduled.version, scheduled.block_number)
+                    .await
+                    .map_err(EventProcessorError::client)?
+                    .with_context(|| {
+                        format!(
+                            "No diamond cuts found for upgrade from protocol version \
+                             {old_protocol_version} to {} scheduled in block {}",
+                            scheduled.version, scheduled.block_number
+                        )
+                    })
+                    .map_err(EventProcessorError::internal)?,
+            };
 
             let upgrade = ProtocolUpgrade {
                 timestamp,
@@ -143,13 +178,23 @@ impl EventProcessor for DecentralizedUpgradesEventProcessor {
                 )));
             }
 
-            // The verifier for the new protocol version is set on the CTM and emitted via the
-            // `NewProtocolVersionVerifier` event next to the upgrade diamond cut. It takes
-            // precedence over the verifier address in the upgrade data, which may be absent
-            // (e.g. for verifier-only patch upgrades).
+            if upgrade.version != scheduled.version {
+                tracing::warn!(
+                    "Diamond cut for the upgrade from {old_protocol_version} declares version {}, \
+                     while the CTM scheduled {}",
+                    upgrade.version,
+                    scheduled.version
+                );
+            }
+
+            // Modern CTMs set the verifier for the new protocol version on the CTM itself and emit
+            // it via the `NewProtocolVersionVerifier` event next to the upgrade diamond cut. It
+            // takes precedence over the verifier address in the upgrade data, which may be absent
+            // (e.g. for verifier-only patch upgrades). Legacy CTMs have no such event, so there the
+            // verifier from the upgrade data is the only source.
             let verifier_address = self
                 .sl_client
-                .verifier_address_for_version(old_protocol_version, upgrade.version)
+                .verifier_address_for_version(upgrade.version, scheduled.block_number)
                 .await
                 .map_err(EventProcessorError::client)?
                 .or(upgrade.verifier_address);

--- a/core/node/eth_watch/src/lib.rs
+++ b/core/node/eth_watch/src/lib.rs
@@ -13,7 +13,10 @@ use zksync_types::{
     web3::BlockNumber as Web3BlockNumber, L1BatchNumber, L2ChainId, PriorityOpId,
 };
 
-pub use self::client::{EthClient, EthHttpQueryClient, GetLogsClient, ZkSyncExtentionEthClient};
+pub use self::client::{
+    EthClient, EthHttpQueryClient, GetLogsClient, ScheduledProtocolVersion,
+    ZkSyncExtentionEthClient,
+};
 use self::{
     client::RETRY_LIMIT,
     event_processors::{

--- a/core/node/eth_watch/src/tests/client.rs
+++ b/core/node/eth_watch/src/tests/client.rs
@@ -4,13 +4,14 @@ use tokio::sync::RwLock;
 use zksync_contracts::{
     hyperchain_contract, server_notifier_contract, state_transition_manager_contract,
 };
-use zksync_eth_client::{ContractCallError, EnrichedClientError, EnrichedClientResult};
+use zksync_eth_client::{ContractCallError, EnrichedClientResult};
 use zksync_types::{
     abi::{self, ProposedUpgrade, ZkChainSpecificUpgradeData},
     address_to_h256,
     api::{ChainAggProof, Log},
     bytecode::BytecodeHash,
     ethabi::{self, Token},
+    h256_to_address, h256_to_u256,
     l1::L1Tx,
     protocol_upgrade::ProtocolUpgradeTx,
     protocol_version::{ProtocolSemanticVersion, ProtocolVersionId},
@@ -21,12 +22,28 @@ use zksync_types::{
     H256, SHARED_BRIDGE_ETHER_TOKEN_ADDRESS, U256, U64,
 };
 
-use crate::client::{EthClient, ZkSyncExtentionEthClient, RETRY_LIMIT};
+use crate::client::{EthClient, ScheduledProtocolVersion, ZkSyncExtentionEthClient};
+
+/// Generation of the CTM the mock client emulates. The two generations announce upgrades with
+/// different events, and the server is expected to support both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CtmGeneration {
+    /// `NewUpgradeCutData` is keyed by the new protocol version and there is no
+    /// `NewProtocolVersionVerifier` event; the verifier comes from the upgrade calldata.
+    #[default]
+    Legacy,
+    /// `NewUpgradeCutData` is keyed by the old protocol version (plus a backwards-compatible copy
+    /// keyed by the new one), and the verifier is announced via `NewProtocolVersionVerifier`.
+    Modern,
+}
 
 #[derive(Debug)]
 pub struct FakeEthClientData {
+    ctm_generation: CtmGeneration,
     transactions: HashMap<u64, Vec<Log>>,
     diamond_upgrades: HashMap<u64, Vec<Log>>,
+    // `NewProtocolVersion` events mapping an old protocol version (topic1) to a new one (topic2).
+    new_protocol_versions: HashMap<u64, Vec<Log>>,
     upgrade_timestamp: HashMap<u64, Vec<Log>>,
     last_finalized_block_number: u64,
     chain_id: SLChainId,
@@ -36,15 +53,17 @@ pub struct FakeEthClientData {
     batch_roots: HashMap<u64, Vec<Log>>,
     chain_roots: HashMap<u64, H256>,
     bytecode_preimages: HashMap<H256, Vec<u8>>,
-    // Keyed by the packed *new* protocol version.
-    protocol_version_verifiers: HashMap<H256, Address>,
+    // `NewProtocolVersionVerifier` events keyed by the packed *new* protocol version.
+    protocol_version_verifiers: HashMap<u64, Vec<Log>>,
 }
 
 impl FakeEthClientData {
     fn new(chain_id: SLChainId) -> Self {
         Self {
+            ctm_generation: CtmGeneration::default(),
             transactions: Default::default(),
             diamond_upgrades: Default::default(),
+            new_protocol_versions: Default::default(),
             upgrade_timestamp: Default::default(),
             last_finalized_block_number: 0,
             chain_id,
@@ -56,6 +75,30 @@ impl FakeEthClientData {
             bytecode_preimages: Default::default(),
             protocol_version_verifiers: Default::default(),
         }
+    }
+
+    /// Emits the `NewUpgradeCutData` event(s) that the emulated CTM generation would emit when
+    /// scheduling `upgrade` as an upgrade from `old_protocol_version`.
+    fn push_diamond_cut_logs(
+        &mut self,
+        old_protocol_version: ProtocolSemanticVersion,
+        upgrade: &ProtocolUpgrade,
+        eth_block: u64,
+    ) {
+        let logs = self.diamond_upgrades.entry(eth_block).or_default();
+        if self.ctm_generation == CtmGeneration::Modern {
+            logs.push(diamond_upgrade_log(
+                old_protocol_version,
+                upgrade.clone(),
+                eth_block,
+            ));
+        }
+        // Legacy CTMs only emit this one; modern ones emit it for backwards compatibility.
+        logs.push(diamond_upgrade_log(
+            upgrade.version,
+            upgrade.clone(),
+            eth_block,
+        ));
     }
 
     fn add_transactions(&mut self, transactions: &[L1Tx]) {
@@ -83,12 +126,13 @@ impl FakeEthClientData {
                     u256_to_h256(old_protocol_version.pack()),
                     *eth_block,
                 ));
-            self.diamond_upgrades
+            self.push_diamond_cut_logs(old_protocol_version, upgrade, *eth_block);
+            self.new_protocol_versions
                 .entry(*eth_block)
                 .or_default()
-                .push(diamond_upgrade_log(
+                .push(new_protocol_version_log(
                     old_protocol_version,
-                    upgrade.clone(),
+                    upgrade.version,
                     *eth_block,
                 ));
             self.add_bytecode_preimages(&upgrade.tx);
@@ -124,12 +168,14 @@ impl FakeEthClientData {
         eth_block: u64,
     ) {
         self.add_bytecode_preimages(&upgrade.tx);
-        self.diamond_upgrades
+        let new_protocol_version = upgrade.version;
+        self.push_diamond_cut_logs(old_protocol_version, &upgrade, eth_block);
+        self.new_protocol_versions
             .entry(eth_block)
             .or_default()
-            .push(diamond_upgrade_log(
+            .push(new_protocol_version_log(
                 old_protocol_version,
-                upgrade,
+                new_protocol_version,
                 eth_block,
             ));
     }
@@ -138,9 +184,33 @@ impl FakeEthClientData {
         &mut self,
         new_protocol_version: ProtocolSemanticVersion,
         verifier: Address,
+        eth_block: u64,
     ) {
         self.protocol_version_verifiers
-            .insert(u256_to_h256(new_protocol_version.pack()), verifier);
+            .entry(eth_block)
+            .or_default()
+            .push(protocol_version_verifier_log(
+                new_protocol_version,
+                verifier,
+                eth_block,
+            ));
+    }
+
+    fn set_ctm_generation(&mut self, generation: CtmGeneration) {
+        self.ctm_generation = generation;
+    }
+
+    /// Iterates over logs in `[from_block, confirmed block]`, the range the real client queries the
+    /// CTM over. The mock reports the same number as both the confirmed and the finalized block.
+    fn confirmed_logs<'a>(
+        &self,
+        logs: &'a HashMap<u64, Vec<Log>>,
+        from_block: u64,
+    ) -> impl Iterator<Item = &'a Log> {
+        let range = from_block..=self.last_finalized_block_number;
+        logs.iter()
+            .filter(move |(block_number, _)| range.contains(block_number))
+            .flat_map(|(_, logs)| logs)
     }
 
     fn set_last_finalized_block_number(&mut self, number: u64) {
@@ -245,11 +315,17 @@ impl MockEthClient {
         &mut self,
         new_protocol_version: ProtocolSemanticVersion,
         verifier: Address,
+        eth_block: u64,
     ) {
-        self.inner
-            .write()
-            .await
-            .add_protocol_version_verifier(new_protocol_version, verifier);
+        self.inner.write().await.add_protocol_version_verifier(
+            new_protocol_version,
+            verifier,
+            eth_block,
+        );
+    }
+
+    pub async fn set_ctm_generation(&mut self, generation: CtmGeneration) {
+        self.inner.write().await.set_ctm_generation(generation);
     }
 
     pub async fn set_last_finalized_block_number(&mut self, number: u64) {
@@ -358,62 +434,73 @@ impl EthClient for MockEthClient {
         Ok(self.inner.read().await.last_finalized_block_number)
     }
 
+    async fn scheduled_protocol_version(
+        &self,
+        old_version: ProtocolSemanticVersion,
+    ) -> EnrichedClientResult<Option<ScheduledProtocolVersion>> {
+        let packed_old = u256_to_h256(old_version.pack());
+        let guard = self.inner.read().await;
+        // If several upgrades were scheduled from the same old version, the one in the latest
+        // block corresponds to the currently active upgrade path.
+        let scheduled = latest_log(
+            guard.confirmed_logs(&guard.new_protocol_versions, 0),
+            |log| {
+                log.topics.first()
+                    == Some(
+                        &state_transition_manager_contract()
+                            .event("NewProtocolVersion")
+                            .unwrap()
+                            .signature(),
+                    )
+                    && log.topics.get(1) == Some(&packed_old)
+            },
+        )
+        .map(|log| ScheduledProtocolVersion {
+            version: ProtocolSemanticVersion::try_from_packed(h256_to_u256(log.topics[2])).unwrap(),
+            block_number: log.block_number.unwrap().as_u64(),
+        });
+        Ok(scheduled)
+    }
+
     async fn diamond_cut_for_version(
         &self,
         version: ProtocolSemanticVersion,
+        from_block: u64,
     ) -> EnrichedClientResult<Option<Vec<u8>>> {
         let packed_version = u256_to_h256(version.pack());
-        let from_block = self
-            .inner
-            .read()
-            .await
-            .diamond_upgrades
-            .iter()
-            .filter_map(|(block_number, logs)| {
-                logs.iter()
-                    .any(|log| log.topics.get(1) == Some(&packed_version))
-                    .then_some(*block_number)
-            })
-            .max()
-            .unwrap_or(0);
-        let logs = self
-            .get_events(
-                U64::from(from_block).into(),
-                U64::from(from_block).into(),
-                Some(
-                    state_transition_manager_contract()
-                        .event("NewUpgradeCutData")
-                        .unwrap()
-                        .signature(),
-                ),
-                Some(packed_version),
-                RETRY_LIMIT,
-            )
-            .await?;
-
-        if logs.len() > 1 {
-            return Err(EnrichedClientError::custom(
-                format!(
-                    "Multiple NewUpgradeCutData events in block {from_block} for version {version}"
-                ),
-                "diamond_cut_for_version",
-            ));
-        }
-        Ok(logs.into_iter().map(|log| log.data.0).next())
+        let guard = self.inner.read().await;
+        // The cut may be rewritten after it was first scheduled, in which case the latest event
+        // holds the cut that will actually be applied.
+        Ok(latest_log(
+            guard.confirmed_logs(&guard.diamond_upgrades, from_block),
+            |log| {
+                log.topics.first()
+                    == Some(
+                        &state_transition_manager_contract()
+                            .event("NewUpgradeCutData")
+                            .unwrap()
+                            .signature(),
+                    )
+                    && log.topics.get(1) == Some(&packed_version)
+            },
+        )
+        .map(|log| log.data.0.clone()))
     }
 
     async fn verifier_address_for_version(
         &self,
-        _old_version: ProtocolSemanticVersion,
         new_version: ProtocolSemanticVersion,
+        from_block: u64,
     ) -> EnrichedClientResult<Option<Address>> {
-        Ok(self
-            .inner
-            .read()
-            .await
-            .protocol_version_verifiers
-            .get(&u256_to_h256(new_version.pack()))
-            .copied())
+        let packed_version = u256_to_h256(new_version.pack());
+        let guard = self.inner.read().await;
+        // If the verifier was set several times, the last event matches the current
+        // `protocolVersionVerifier` mapping value.
+        Ok(latest_log(
+            guard.confirmed_logs(&guard.protocol_version_verifiers, from_block),
+            |log| log.topics.get(1) == Some(&packed_version),
+        )
+        .map(|log| h256_to_address(&log.topics[2])))
     }
 
     async fn get_total_priority_txs(&self) -> Result<u64, ContractCallError> {
@@ -595,8 +682,24 @@ fn init_calldata(protocol_upgrade: ProtocolUpgrade) -> Vec<u8> {
     calldata
 }
 
+/// Returns the log matching `predicate` that the CTM emitted last, mirroring how the real client
+/// orders logs by `(block_number, log_index)`.
+fn latest_log<'a>(
+    logs: impl Iterator<Item = &'a Log>,
+    predicate: impl Fn(&Log) -> bool,
+) -> Option<&'a Log> {
+    logs.filter(|log| predicate(log)).max_by_key(|log| {
+        (
+            log.block_number.unwrap_or_default(),
+            log.log_index.unwrap_or_default(),
+        )
+    })
+}
+
+/// Builds a `NewUpgradeCutData` log carrying `upgrade`, keyed by `cut_key_version`, which is the old
+/// or the new protocol version depending on the [`CtmGeneration`].
 fn diamond_upgrade_log(
-    old_protocol_version: ProtocolSemanticVersion,
+    cut_key_version: ProtocolSemanticVersion,
     upgrade: ProtocolUpgrade,
     eth_block: u64,
 ) -> Log {
@@ -605,7 +708,7 @@ fn diamond_upgrade_log(
     //     address initAddress;
     //     bytes initCalldata;
     // }
-    let version = u256_to_h256(old_protocol_version.pack());
+    let version = u256_to_h256(cut_key_version.pack());
     let final_data = ethabi::encode(&[Token::Tuple(vec![
         Token::Array(vec![]),
         Token::Address(Address::zero()),
@@ -634,6 +737,64 @@ fn diamond_upgrade_log(
         block_timestamp: None,
     }
 }
+
+fn new_protocol_version_log(
+    old_protocol_version: ProtocolSemanticVersion,
+    new_protocol_version: ProtocolSemanticVersion,
+    eth_block: u64,
+) -> Log {
+    Log {
+        address: Address::repeat_byte(0x1),
+        topics: vec![
+            state_transition_manager_contract()
+                .event("NewProtocolVersion")
+                .unwrap()
+                .signature(),
+            u256_to_h256(old_protocol_version.pack()),
+            u256_to_h256(new_protocol_version.pack()),
+        ],
+        data: Default::default(),
+        block_hash: Some(H256::repeat_byte(0x11)),
+        block_number: Some(eth_block.into()),
+        l1_batch_number: None,
+        transaction_hash: Some(H256::random()),
+        transaction_index: Some(0u64.into()),
+        log_index: Some(0u64.into()),
+        transaction_log_index: Some(0u64.into()),
+        log_type: None,
+        removed: None,
+        block_timestamp: None,
+    }
+}
+fn protocol_version_verifier_log(
+    new_protocol_version: ProtocolSemanticVersion,
+    verifier: Address,
+    eth_block: u64,
+) -> Log {
+    Log {
+        address: Address::repeat_byte(0x1),
+        topics: vec![
+            state_transition_manager_contract()
+                .event("NewProtocolVersionVerifier")
+                .unwrap()
+                .signature(),
+            u256_to_h256(new_protocol_version.pack()),
+            address_to_h256(&verifier),
+        ],
+        data: Default::default(),
+        block_hash: Some(H256::repeat_byte(0x11)),
+        block_number: Some(eth_block.into()),
+        l1_batch_number: None,
+        transaction_hash: Some(H256::random()),
+        transaction_index: Some(0u64.into()),
+        log_index: Some(0u64.into()),
+        transaction_log_index: Some(0u64.into()),
+        log_type: None,
+        removed: None,
+        block_timestamp: None,
+    }
+}
+
 fn upgrade_timestamp_log(packed_version: H256, eth_block: u64) -> Log {
     upgrade_timestamp_log_for_chain(L2ChainId::default(), packed_version, eth_block)
 }

--- a/core/node/eth_watch/src/tests/client.rs
+++ b/core/node/eth_watch/src/tests/client.rs
@@ -180,6 +180,27 @@ impl FakeEthClientData {
             ));
     }
 
+    /// Emulates `setUpgradeDiamondCut` on a modern CTM: the cut for an already-scheduled upgrade is
+    /// rewritten in place, so only the `NewUpgradeCutData` keyed by the *old* protocol version is
+    /// re-emitted. There is no new `NewProtocolVersion`, and no backwards-compatible copy keyed by
+    /// the new version — this is the one shape that is discoverable solely under the old-version key.
+    fn rewrite_upgrade_cut(
+        &mut self,
+        old_protocol_version: ProtocolSemanticVersion,
+        upgrade: ProtocolUpgrade,
+        eth_block: u64,
+    ) {
+        self.add_bytecode_preimages(&upgrade.tx);
+        self.diamond_upgrades
+            .entry(eth_block)
+            .or_default()
+            .push(diamond_upgrade_log(
+                old_protocol_version,
+                upgrade,
+                eth_block,
+            ));
+    }
+
     fn add_protocol_version_verifier(
         &mut self,
         new_protocol_version: ProtocolSemanticVersion,
@@ -309,6 +330,18 @@ impl MockEthClient {
             .write()
             .await
             .add_diamond_cut(old_protocol_version, upgrade, eth_block);
+    }
+
+    pub async fn rewrite_upgrade_cut(
+        &mut self,
+        old_protocol_version: ProtocolSemanticVersion,
+        upgrade: ProtocolUpgrade,
+        eth_block: u64,
+    ) {
+        self.inner
+            .write()
+            .await
+            .rewrite_upgrade_cut(old_protocol_version, upgrade, eth_block);
     }
 
     pub async fn add_protocol_version_verifier(

--- a/core/node/eth_watch/src/tests/mod.rs
+++ b/core/node/eth_watch/src/tests/mod.rs
@@ -17,7 +17,10 @@ use zksync_types::{
     ProtocolUpgrade, ProtocolVersion, ProtocolVersionId, SLChainId, Transaction, H256, U256,
 };
 
-use crate::{tests::client::MockEthClient, EthWatch, ZkSyncExtentionEthClient};
+use crate::{
+    tests::client::{CtmGeneration, MockEthClient},
+    EthWatch, ZkSyncExtentionEthClient,
+};
 
 mod client;
 
@@ -264,10 +267,20 @@ async fn test_upgrade_timestamp_wrong_chain_ignored() {
 }
 
 #[test_log::test(tokio::test)]
-async fn test_rewritten_upgrade_cut_is_used() {
+async fn test_rewritten_upgrade_cut_is_used_on_legacy_ctm() {
+    test_rewritten_upgrade_cut_is_used(CtmGeneration::Legacy).await;
+}
+
+#[test_log::test(tokio::test)]
+async fn test_rewritten_upgrade_cut_is_used_on_modern_ctm() {
+    test_rewritten_upgrade_cut_is_used(CtmGeneration::Modern).await;
+}
+
+async fn test_rewritten_upgrade_cut_is_used(ctm_generation: CtmGeneration) {
     let connection_pool = ConnectionPool::<Core>::test_pool().await;
     setup_db(&connection_pool).await;
     let (mut watcher, mut client) = create_l1_test_watcher(connection_pool.clone()).await;
+    client.set_ctm_generation(ctm_generation).await;
 
     let old_protocol_version = ProtocolSemanticVersion {
         minor: (ProtocolVersionId::latest() as u16 - 1).try_into().unwrap(),
@@ -313,11 +326,15 @@ async fn test_rewritten_upgrade_cut_is_used() {
     assert_eq!(db_versions[1], replacement_version);
 }
 
+/// Modern CTMs announce the verifier for the new protocol version via
+/// `NewProtocolVersionVerifier`; it takes precedence over the upgrade calldata, which may not carry
+/// a verifier at all.
 #[test_log::test(tokio::test)]
 async fn test_verifier_from_ctm_event_is_used_for_vk_hashes() {
     let connection_pool = ConnectionPool::<Core>::test_pool().await;
     setup_db(&connection_pool).await;
     let (mut watcher, mut client) = create_l1_test_watcher(connection_pool.clone()).await;
+    client.set_ctm_generation(CtmGeneration::Modern).await;
 
     let new_version = ProtocolSemanticVersion {
         minor: ProtocolVersionId::next(),
@@ -339,7 +356,54 @@ async fn test_verifier_from_ctm_event_is_used_for_vk_hashes() {
         )])
         .await;
     client
-        .add_protocol_version_verifier(new_version, verifier)
+        .add_protocol_version_verifier(new_version, verifier, 10)
+        .await;
+    client.set_last_finalized_block_number(15).await;
+    watcher.loop_iteration(&mut storage).await.unwrap();
+
+    let db_versions = storage.protocol_versions_dal().all_versions().await;
+    assert_eq!(db_versions.len(), 2);
+    assert_eq!(db_versions[1], new_version);
+
+    let db_version = storage
+        .protocol_versions_dal()
+        .get_protocol_version_with_latest_patch(new_version.minor)
+        .await
+        .unwrap()
+        .expect("expected the new version to be present in DB");
+    // The mock client derives the VK hash from the verifier address.
+    assert_eq!(
+        db_version.l1_verifier_config.snark_wrapper_vk_hash,
+        address_to_h256(&verifier)
+    );
+}
+
+/// Legacy CTMs have no `NewProtocolVersionVerifier` event, so the verifier embedded in the upgrade
+/// calldata is the only source.
+#[test_log::test(tokio::test)]
+async fn test_verifier_from_upgrade_data_is_used_for_vk_hashes_on_legacy_ctm() {
+    let connection_pool = ConnectionPool::<Core>::test_pool().await;
+    setup_db(&connection_pool).await;
+    let (mut watcher, mut client) = create_l1_test_watcher(connection_pool.clone()).await;
+    client.set_ctm_generation(CtmGeneration::Legacy).await;
+
+    let new_version = ProtocolSemanticVersion {
+        minor: ProtocolVersionId::next(),
+        patch: 0.into(),
+    };
+    let verifier = Address::repeat_byte(0x42);
+
+    let mut storage = connection_pool.connection().await.unwrap();
+    client
+        .add_upgrade_timestamp(&[(
+            ProtocolUpgrade {
+                version: new_version,
+                tx: None,
+                verifier_address: Some(verifier),
+                ..Default::default()
+            },
+            10,
+        )])
         .await;
     client.set_last_finalized_block_number(15).await;
     watcher.loop_iteration(&mut storage).await.unwrap();
@@ -362,12 +426,22 @@ async fn test_verifier_from_ctm_event_is_used_for_vk_hashes() {
 }
 
 #[test_log::test(tokio::test)]
-async fn test_normal_operation_upgrade_timestamp() {
+async fn test_normal_operation_upgrade_timestamp_on_legacy_ctm() {
+    test_normal_operation_upgrade_timestamp(CtmGeneration::Legacy).await;
+}
+
+#[test_log::test(tokio::test)]
+async fn test_normal_operation_upgrade_timestamp_on_modern_ctm() {
+    test_normal_operation_upgrade_timestamp(CtmGeneration::Modern).await;
+}
+
+async fn test_normal_operation_upgrade_timestamp(ctm_generation: CtmGeneration) {
     zksync_concurrency::testonly::abort_on_panic();
     let connection_pool = ConnectionPool::<Core>::test_pool().await;
     setup_db(&connection_pool).await;
 
     let mut client = MockEthClient::new(SLChainId(42));
+    client.set_ctm_generation(ctm_generation).await;
     let mut watcher = EthWatch::new(
         Box::new(client.clone()),
         Box::new(client.clone()),

--- a/core/node/eth_watch/src/tests/mod.rs
+++ b/core/node/eth_watch/src/tests/mod.rs
@@ -326,6 +326,62 @@ async fn test_rewritten_upgrade_cut_is_used(ctm_generation: CtmGeneration) {
     assert_eq!(db_versions[1], replacement_version);
 }
 
+/// A cut rewritten in place via `setUpgradeDiamondCut` on a modern CTM re-emits only
+/// `NewUpgradeCutData` keyed by the *old* protocol version — no new `NewProtocolVersion` and no
+/// backwards-compatible copy keyed by the new version. This is the shape that is discoverable
+/// solely under the old-version key, so it is what the new-version fallback alone would miss.
+#[test_log::test(tokio::test)]
+async fn test_in_place_cut_rewrite_is_used_on_modern_ctm() {
+    let connection_pool = ConnectionPool::<Core>::test_pool().await;
+    setup_db(&connection_pool).await;
+    let (mut watcher, mut client) = create_l1_test_watcher(connection_pool.clone()).await;
+    client.set_ctm_generation(CtmGeneration::Modern).await;
+
+    let old_protocol_version = ProtocolSemanticVersion {
+        minor: (ProtocolVersionId::latest() as u16 - 1).try_into().unwrap(),
+        patch: 0.into(),
+    };
+    let replacement_version = ProtocolSemanticVersion {
+        minor: ProtocolVersionId::next(),
+        patch: 0.into(),
+    };
+
+    let mut storage = connection_pool.connection().await.unwrap();
+    client
+        .add_upgrade_timestamp(&[(
+            ProtocolUpgrade {
+                version: ProtocolSemanticVersion {
+                    minor: ProtocolVersionId::latest(),
+                    patch: 0.into(),
+                },
+                tx: None,
+                ..Default::default()
+            },
+            10,
+        )])
+        .await;
+
+    // Governance rewrites the cut in place at a later block; the upgrade is never re-scheduled, so
+    // the scheduling block stays at 10 and only the old-version key carries the new cut.
+    client
+        .rewrite_upgrade_cut(
+            old_protocol_version,
+            ProtocolUpgrade {
+                version: replacement_version,
+                tx: None,
+                ..Default::default()
+            },
+            15,
+        )
+        .await;
+    client.set_last_finalized_block_number(20).await;
+    watcher.loop_iteration(&mut storage).await.unwrap();
+
+    let db_versions = storage.protocol_versions_dal().all_versions().await;
+    assert_eq!(db_versions.len(), 2);
+    assert_eq!(db_versions[1], replacement_version);
+}
+
 /// Modern CTMs announce the verifier for the new protocol version via
 /// `NewProtocolVersionVerifier`; it takes precedence over the upgrade calldata, which may not carry
 /// a verifier at all.


### PR DESCRIPTION
## Problem

CTMs deployed before [`2733efc07` "feat: bundles"](https://github.com/matter-labs/era-contracts) announce upgrades differently from the ABI compiled into this repo, and `eth_watch` only understands the newer shape:

| | Legacy CTM | Modern CTM |
|---|---|---|
| `NewUpgradeCutData` key | **new** version | **old** version, + a backwards-compat copy keyed by the new version |
| `upgradeCutDataBlock[old]` | absent → call reverts | present |
| `NewProtocolVersionVerifier` | absent (verifier is in the upgrade calldata) | emitted |
| Cut rewrite via `setUpgradeDiamondCut` | emits no cut data at all | re-emits `NewUpgradeCutData(old)` |

Verified directly against `ChainTypeManagerBase.sol` on both sides of that commit.

Against a legacy CTM, `diamond_cut_for_version` reverts in `upgradeCutDataBlock`, and the verifier lookup that depends on that block never runs.

## Approach

Resolve the generation **from logs**, so there is no reverting contract call, no config flag and no hardcoded version gate:

1. `NewProtocolVersion(old → new)` yields both the new version and **the block the upgrade was scheduled in**. Both generations emit it.
2. The cut is looked up under the old-version key first, falling back to the new-version key. Both look-ups start at the scheduling block — that is what separates the modern CTM's backwards-compat event from the *previous* upgrade, which is keyed by what is now the old version but sits in an earlier block. It is equally what stops a legacy CTM's earlier `NewUpgradeCutData(v2)` (emitted when v2 was the *new* version) from shadowing the current upgrade.
3. The verifier is read from `NewProtocolVersionVerifier` at or after the scheduling block, falling back to the verifier in the upgrade calldata — the only source on a legacy CTM.

Because the modern CTM also emits the new-version-keyed copy, step 2's fallback degrades gracefully rather than incorrectly if the primary key ever misses: it yields the same cut, just without picking up a rewrite.

## Other changes

- `diamond_cut_for_version` takes the newest matching log instead of erroring on `len() > 1` — a rewrite legitimately produces several across blocks.
- CTM look-ups are bounded above by the **confirmed** block, not the finalized one; finalization lags the confirmed block whenever `confirmations_for_eth_event` is small, which would miss an upgrade that was just scheduled.
- `block_for_diamond_cut_for_version` and the `chain_type_manager_abi` field it was the only user of are removed.

## Tests

`MockEthClient` gained a `CtmGeneration` switch that emits the event shape of either generation, and the key upgrade tests run against both:

- `test_normal_operation_upgrade_timestamp_on_{legacy,modern}_ctm`
- `test_rewritten_upgrade_cut_is_used_on_{legacy,modern}_ctm`
- `test_verifier_from_ctm_event_is_used_for_vk_hashes` (modern)
- `test_verifier_from_upgrade_data_is_used_for_vk_hashes_on_legacy_ctm`
- `test_in_place_cut_rewrite_is_used_on_modern_ctm`

That last one covers the shape a `setUpgradeDiamondCut` rewrite actually produces: only `NewUpgradeCutData(old)` is re-emitted — no new `NewProtocolVersion`, no compat copy keyed by the new version — so it is discoverable *solely* under the old-version key. It is confirmed non-vacuous: switching the primary look-up back to the new-version key makes it fail, picking up v31 instead of the rewritten v32.

All 16 `zksync_eth_watch` tests pass locally against Postgres, along with `cargo clippy --tests --all-features` and `cargo fmt --check`.

## Known limitation

If two protocol upgrades were ever scheduled in the *same* block on a legacy CTM, the old-version look-up would match the earlier upgrade's cut and the fallback would not fire. Modern CTMs are unaffected (log-index ordering resolves it). This needs governance to batch two protocol upgrades into one block, so it is left unhandled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)