### PR TITLE
ci: bind build-core template inputs via env before shell

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -18,6 +18,8 @@ runs:
 
     - name: Setup misc environment variables
       shell: bash
+      env:
+        RUNNER_COMPOSE_FILE: ${{ inputs.runner-compose-file }}
       run: |
         echo CACHE_DIR=/usr/src/cache >> .env
         echo CACHE_DIR=/usr/src/cache >> $GITHUB_PATH
@@ -28,17 +30,19 @@ runs:
         echo IN_DOCKER=1 >> .env
         echo CI=1 >> .env
         echo DOCKER_PWD=$(pwd) >> .env
-        echo RUNNER_COMPOSE_FILE=${{ inputs.runner-compose-file }} >> $GITHUB_ENV
+        echo "RUNNER_COMPOSE_FILE=${RUNNER_COMPOSE_FILE}" >> $GITHUB_ENV
 
     - name: Setup sccache for building rust code outside Docker
       if: inputs.sccache == 'true'
       shell: bash
+      env:
+        SCCACHE_MODE: ${{ inputs.sccache_mode }}
       run: |
         echo SCCACHE_CACHE_SIZE=50G >> $GITHUB_ENV
         echo SCCACHE_GCS_BUCKET=matterlabs-infra-sccache-storage >> $GITHUB_ENV
         echo SCCACHE_GCS_SERVICE_ACCOUNT=gha-ci-runners@matterlabs-infra.iam.gserviceaccount.com >> $GITHUB_ENV
         echo SCCACHE_ERROR_LOG=/tmp/sccache_log.txt >> $GITHUB_ENV
-        echo SCCACHE_GCS_RW_MODE=${{ inputs.sccache_mode }} >> $GITHUB_ENV
+        echo SCCACHE_GCS_RW_MODE=${SCCACHE_MODE} >> $GITHUB_ENV
         echo RUSTC_WRAPPER=sccache >> $GITHUB_ENV
 
         # sccache outside docker will run it's own server
@@ -47,12 +51,14 @@ runs:
     - name: Setup sccache for building rust code inside Docker
       if: inputs.sccache == 'true'
       shell: bash
+      env:
+        SCCACHE_MODE: ${{ inputs.sccache_mode }}
       run: |
         echo SCCACHE_CACHE_SIZE=50G >> .env
         echo SCCACHE_GCS_BUCKET=matterlabs-infra-sccache-storage >> .env
         echo SCCACHE_GCS_SERVICE_ACCOUNT=gha-ci-runners@matterlabs-infra.iam.gserviceaccount.com >> .env
         echo SCCACHE_ERROR_LOG=/tmp/sccache_log.txt >> .env
-        echo SCCACHE_GCS_RW_MODE=${{ inputs.sccache_mode }} >> .env
+        echo SCCACHE_GCS_RW_MODE=${SCCACHE_MODE} >> .env
         echo RUSTC_WRAPPER=sccache >> .env
 
     # The zk-environment image bakes in RUSTC_WRAPPER=sccache; empty means "no wrapper" to cargo.

--- a/.github/workflows/build-airbender-prover-server-template.yml
+++ b/.github/workflows/build-airbender-prover-server-template.yml
@@ -53,10 +53,12 @@ jobs:
 
       - name: Set env vars
         shell: bash
+        env:
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
         run: |
           # Support for custom tag suffix; fall back to a short-sha + timestamp.
-          if [ -n "${{ inputs.image_tag_suffix }}" ]; then
-            echo IMAGE_TAG_SUFFIX="${{ inputs.image_tag_suffix }}" >> $GITHUB_ENV
+          if [ -n "${IMAGE_TAG_SUFFIX}" ]; then
+            echo "IMAGE_TAG_SUFFIX=${IMAGE_TAG_SUFFIX}" >> $GITHUB_ENV
           else
             echo IMAGE_TAG_SUFFIX="$(git rev-parse --short HEAD)-$(date +%s)" >> $GITHUB_ENV
           fi

--- a/.github/workflows/build-circuit-prover-gpu-gar.yml
+++ b/.github/workflows/build-circuit-prover-gpu-gar.yml
@@ -26,8 +26,10 @@ jobs:
           submodules: "recursive"
 
       - name: Download Setup data
+        env:
+          SETUP_KEYS_ID: ${{ inputs.setup_keys_id }}
         run: |
-          gsutil -m rsync -x "fflonk|plonk|setup_compression" -r gs://matterlabs-setup-data-us/${{ inputs.setup_keys_id }} docker/circuit-prover-gpu-gar
+          gsutil -m rsync -x "fflonk|plonk|setup_compression" -r gs://matterlabs-setup-data-us/${SETUP_KEYS_ID} docker/circuit-prover-gpu-gar
 
       - name: Login to us-central1 GAR
         run: |

--- a/.github/workflows/build-contract-verifier-template.yml
+++ b/.github/workflows/build-contract-verifier-template.yml
@@ -187,12 +187,14 @@ jobs:
 
       - name: Set env vars
         shell: bash
+        env:
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
         run: |
           echo PLATFORM=$(echo ${{ matrix.platforms }} | tr '/' '-') >> $GITHUB_ENV
           echo IMAGE_TAG_SHA=$(git rev-parse --short HEAD) >> $GITHUB_ENV
           # Support for custom tag suffix
-          if [ -n "${{ inputs.image_tag_suffix }}" ]; then
-            echo IMAGE_TAG_SHA_TS="${{ inputs.image_tag_suffix }}" >> $GITHUB_ENV
+          if [ -n "${IMAGE_TAG_SUFFIX}" ]; then
+            echo "IMAGE_TAG_SHA_TS=${IMAGE_TAG_SUFFIX}" >> $GITHUB_ENV
           else
             echo IMAGE_TAG_SHA_TS=$(git rev-parse --short HEAD)-$(date +%s) >> $GITHUB_ENV
           fi

--- a/.github/workflows/build-core-template.yml
+++ b/.github/workflows/build-core-template.yml
@@ -113,6 +113,8 @@ jobs:
       - name: Pre-download compilers
         if: env.BUILD_CONTRACTS == 'true'
         shell: bash
+        env:
+          COMPILERS_JSON: ${{ inputs.compilers }}
         run: |
           # Download needed versions of vyper compiler
           # Not sanitized due to unconventional path and tags
@@ -122,7 +124,6 @@ jobs:
           chmod +x  ./hardhat-nodejs/compilers-v2/vyper/linux/0.3.10
           chmod +x  ./hardhat-nodejs/compilers-v2/vyper/linux/0.3.3
 
-          COMPILERS_JSON='${{ inputs.compilers }}'
           echo "$COMPILERS_JSON" | jq -r '.[] | to_entries[] | .key as $compiler | .value[] | "\(.),\($compiler)"' | while IFS=, read -r version compiler; do
             mkdir -p "./hardhat-nodejs/compilers-v2/$compiler"
             wget -nv -O "./hardhat-nodejs/compilers-v2/$compiler/${compiler}-v${version}" "https://github.com/matter-labs/${compiler}-bin/releases/download/v${version}/${compiler}-linux-amd64-musl-v${version}"
@@ -253,10 +254,14 @@ jobs:
 
       - name: Set env vars
         shell: bash
+        env:
+          MATRIX_PLATFORMS: ${{ matrix.platforms }}
+          IMAGE_TAG_SUFFIX_INPUT: ${{ inputs.image_tag_suffix }}
+          IMAGE_TAG_SUFFIX_ENV: ${{ env.IMAGE_TAG_SUFFIX }}
         run: |
-          echo PLATFORM=$(echo ${{ matrix.platforms }} | tr '/' '-') >> $GITHUB_ENV
-          if [ -n "${{ inputs.image_tag_suffix }}" ]; then
-            echo IMAGE_TAG_SHA_TS="${{ env.IMAGE_TAG_SUFFIX }}" >> $GITHUB_ENV
+          echo PLATFORM=$(echo "$MATRIX_PLATFORMS" | tr '/' '-') >> $GITHUB_ENV
+          if [ -n "$IMAGE_TAG_SUFFIX_INPUT" ]; then
+            echo IMAGE_TAG_SHA_TS="$IMAGE_TAG_SUFFIX_ENV" >> $GITHUB_ENV
           else
             echo IMAGE_TAG_SHA_TS=$(git rev-parse --short HEAD)-$(date +%s) >> $GITHUB_ENV
           fi

--- a/.github/workflows/build-proof-fri-gpu-compressor-gar.yml
+++ b/.github/workflows/build-proof-fri-gpu-compressor-gar.yml
@@ -26,8 +26,10 @@ jobs:
           submodules: "recursive"
 
       - name: Download FFLONK key and setup data
+        env:
+          SETUP_KEYS_ID: ${{ inputs.setup_keys_id }}
         run: |
-          gsutil -m rsync -x "setup_(basic|leaf|node|recursion_tip|scheduler)" -r gs://matterlabs-setup-data-us/${{ inputs.setup_keys_id }} docker/proof-fri-gpu-compressor-gar
+          gsutil -m rsync -x "setup_(basic|leaf|node|recursion_tip|scheduler)" -r gs://matterlabs-setup-data-us/${SETUP_KEYS_ID} docker/proof-fri-gpu-compressor-gar
           gsutil -m cp -r gs://matterlabs-setup-keys-us/setup-keys/setup_compact.key docker/proof-fri-gpu-compressor-gar
 
       - name: Login to us-central1 GAR

--- a/.github/workflows/build-prover-template.yml
+++ b/.github/workflows/build-prover-template.yml
@@ -107,10 +107,12 @@ jobs:
 
       - name: Set env vars
         shell: bash
+        env:
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
         run: |
           # Support for custom tag suffix
-          if [ -n "${{ inputs.image_tag_suffix }}" ]; then
-            echo IMAGE_TAG_SHA_TS="${{ inputs.image_tag_suffix }}" >> $GITHUB_ENV
+          if [ -n "${IMAGE_TAG_SUFFIX}" ]; then
+            echo "IMAGE_TAG_SHA_TS=${IMAGE_TAG_SUFFIX}" >> $GITHUB_ENV
           else
             echo IMAGE_TAG_SHA_TS=$(git rev-parse --short HEAD)-$(date +%s) >> $GITHUB_ENV
           fi

--- a/.github/workflows/release-stable-en.yml
+++ b/.github/workflows/release-stable-en.yml
@@ -19,21 +19,25 @@ jobs:
           gcloud auth configure-docker us-docker.pkg.dev -q
 
       - name: Check if alpha image exists
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
         run: |
           set +e
-          docker manifest inspect matterlabs/external-node:${{ inputs.tag_name }}-alpha >/dev/null 2>&1
+          docker manifest inspect "matterlabs/external-node:${TAG_NAME}-alpha" >/dev/null 2>&1
           exitcode=$?
           set -e
           if [[ "$exitcode" -eq "1" ]]; then
-            echo "Image matterlabs/external-node:${{ inputs.tag_name }}-alpha doesn't exist"
+            echo "Image matterlabs/external-node:${TAG_NAME}-alpha doesn't exist"
             exit 1
           fi
 
       - name: Push stable image
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
         run: |
           docker_repositories=("matterlabs/external-node" "us-docker.pkg.dev/matterlabs-infra/matterlabs-docker/external-node")
           platforms=("linux/amd64" "linux/arm64")
-          tag_name="${{ inputs.tag_name }}"
+          tag_name="${TAG_NAME}"
           for repo in "${docker_repositories[@]}"; do
             platform_tags=""
             for platform in "${platforms[@]}"; do


### PR DESCRIPTION
## Summary
- Bind `inputs.compilers` through `env: COMPILERS_JSON` before the Pre-download compilers shell step.
- Bind `inputs.image_tag_suffix` / matrix platform through `env:` before the Set env vars shell step.
- Same class as GitHub’s documented script-injection guidance for interpolating caller-controlled workflow inputs into `run:` scripts.

## Test plan
- [ ] Contracts build path still downloads compiler versions from the `compilers` input JSON
- [ ] Image tag suffix behavior unchanged for empty vs non-empty `image_tag_suffix`


Made with [Cursor](https://cursor.com)