### PR TITLE
ci: reclaim root-owned workspace before the VM benchmark PR checkout

### DIFF
--- a/.github/workflows/vm-perf-comparison.yml
+++ b/.github/workflows/vm-perf-comparison.yml
@@ -54,6 +54,16 @@ jobs:
           ci_run cargo run --manifest-path ./core/Cargo.toml \
             --package vm-benchmark --release --bin instruction_counts | tee base-opcodes
 
+      # `ci_run` is `docker compose exec zk`, which runs as root against a bind mount of
+      # the workspace, so the contracts build above rewrites the tracked artifacts under
+      # `contracts/l1-contracts/zkstack-out/` as root. The git commands below run as the
+      # unprivileged runner user and cannot replace them, which fails the submodule
+      # checkout. Same workaround as in ci-airbender-prover-e2e.yml.
+      - name: Reclaim workspace from the containerized contracts build
+        run: |
+          if command -v sudo >/dev/null 2>&1; then SUDO=sudo; fi
+          ${SUDO} chown -R "$(id -u):$(id -g)" "${GITHUB_WORKSPACE}" || true
+
       - name: checkout PR
         run: |
           git checkout --force FETCH_HEAD


### PR DESCRIPTION
## What ❔

Adds one step to `vm-perf-comparison.yml` that chowns the workspace back to the runner
user between `run benchmarks on base branch` and `checkout PR`.

## Why ❔

**The `Run VM benchmarks` job has failed on every run since at least 2026-07-15** — ~130
consecutive runs, on every branch (`release-please`, `deniallugo-update-vm2`,
`airbender-prover-key-upgrade`, …). It is not flaky; the job poisons its own workspace:

1. `checkout base branch` runs `actions/checkout` as the unprivileged runner user, so the
   workspace starts runner-owned.
2. `run benchmarks on base branch` runs `ci_run zkstack dev contracts`. `bin/ci_run` is
   `docker-compose exec -T zk` with **no `--user`**, and `docker-compose.yml` bind-mounts
   the repo at `/usr/src/zksync` — so the container's root rewrites
   `contracts/l1-contracts/zkstack-out/**` as `root:root` on the host.
3. `checkout PR` runs plain `git` as the runner user again. The 76 `zkstack-out/*.json`
   files are tracked in `era-contracts` and not gitignored, so git has to restore them and
   cannot:

```
error: unable to unlink old 'l1-contracts/zkstack-out/AdminFunctions.s.sol/AdminFunctions.json': Permission denied
... x76 ...
fatal: Unable to checkout '...' in submodule path 'contracts'
##[error]Process completed with exit code 1
```

(`unlink` needs write permission on the *parent directory*, and the contracts build
recreates those `.sol/` directories as root.)

The practical impact: **no PR touching `core/**` has produced VM performance regression
data for roughly three weeks**, and every such PR carries a permanently red check.

The fix is the workaround already used for the same root cause in
`ci-airbender-prover-e2e.yml` (*"ci_run leaves root-owned files on this persistent
runner"*). `sudo` is available on the `matterlabs-ci-runner-*` pool, and the
`command -v sudo` guard keeps the step safe if it is not.

## Is this a breaking change?

- [ ] Yes
- [x] No — CI-only, adds a step to a single workflow.

## Operational changes

None.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated. (n/a — CI workflow change; verified
      by this workflow running green on this PR.)
- [ ] Documentation comments have been added / updated. (n/a — rationale is inline in the
      workflow.)
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`. (n/a — `.github`
      is in `.prettierignore`; YAML validated by parsing and checking step order.)
