### PR TITLE
chore: bump contracts submodule, fix cargo-deny advisories, and unbreak the VM benchmark job

### DIFF
--- a/.github/workflows/vm-perf-comparison.yml
+++ b/.github/workflows/vm-perf-comparison.yml
@@ -54,6 +54,16 @@ jobs:
           ci_run cargo run --manifest-path ./core/Cargo.toml \
             --package vm-benchmark --release --bin instruction_counts | tee base-opcodes
 
+      # `ci_run` is `docker compose exec zk`, which runs as root against a bind mount of
+      # the workspace, so the contracts build above rewrites the tracked artifacts under
+      # `contracts/l1-contracts/zkstack-out/` as root. The git commands below run as the
+      # unprivileged runner user and cannot replace them, which fails the submodule
+      # checkout. Same workaround as in ci-airbender-prover-e2e.yml.
+      - name: Reclaim workspace from the containerized contracts build
+        run: |
+          if command -v sudo >/dev/null 2>&1; then SUDO=sudo; fi
+          ${SUDO} chown -R "$(id -u):$(id -g)" "${GITHUB_WORKSPACE}" || true
+
       - name: checkout PR
         run: |
           git checkout --force FETCH_HEAD

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1495,7 +1495,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -1522,7 +1522,7 @@ dependencies = [
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.4.0",
+ "event-listener 5.4.2",
  "futures-lite",
  "rustix 1.0.7",
  "tracing",
@@ -4448,11 +4448,10 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -4463,7 +4462,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener 5.4.2",
  "pin-project-lite",
 ]
 
@@ -10636,7 +10635,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener 5.4.0",
+ "event-listener 5.4.2",
  "futures-core",
  "futures-intrusive",
  "futures-io",

--- a/core/deny.toml
+++ b/core/deny.toml
@@ -47,6 +47,13 @@ ignore = [
   # ^0.39.2, and bumping it pulls in crates requiring Rust 1.88 which our nightly toolchain lacks).
   "RUSTSEC-2026-0194",
   "RUSTSEC-2026-0195",
+  # `ruint` <1.20.0 returns wrong overflow flags from `overflowing_shl`/`overflowing_shr`
+  # (and thus from `checked_*`/`strict_*`/`saturating_*`), plus a `to_base_be` infinite loop on
+  # no-alloc builds. The fix requires ruint >=1.20.0, which needs Rust 1.90 while we pin
+  # nightly-2025-03-19. `ruint` is only transitive here (alloy-primitives, celestia-types,
+  # nybbles); we call none of the affected shift APIs ourselves and build with alloc, so the
+  # DoS path is unreachable. Revisit when the toolchain is bumped.
+  "RUSTSEC-2026-0220",
 ]
 
 [licenses]


### PR DESCRIPTION
## What ❔

Combines #4930 (by @StanislavBreadfulAI, commits preserved as authored) with the CI fix
from #4932:

1. **Bump `contracts` `42c2b1a86` → `101ab952b`** — a strict fast-forward on the branch the
   pointer was already tracking, dropping the nested `lib/@matterlabs/zksync-contracts`
   submodule.
2. **`cargo-deny` advisories** — `event-listener` 5.4.0 → 5.4.2 (RUSTSEC-2026-0221);
   RUSTSEC-2026-0220 (`ruint`) added to `advisories.ignore` with justification.
3. **`ci: reclaim root-owned workspace before the VM benchmark PR checkout`** — the fix for
   the `Run VM benchmarks` failure.

See #4930 and #4932 for the full reasoning behind each part.

## Why ❔

These are combined deliberately rather than landed separately: **#4930 could not go green
on its own.** Its `Run VM benchmarks` check fails, but not for any reason related to the
submodule bump — that job has failed on *every* run since at least 2026-07-15, on every
branch, because it poisons its own workspace:

`bin/ci_run` is `docker-compose exec -T zk` with no `--user`, so `ci_run zkstack dev
contracts` in the base-branch step runs as root against the bind-mounted workspace and
rewrites the tracked artifacts under `contracts/l1-contracts/zkstack-out/` as `root:root`.
The next step, `checkout PR`, runs plain `git` as the unprivileged runner user and cannot
unlink them:

```
error: unable to unlink old 'l1-contracts/zkstack-out/AdminFunctions.s.sol/AdminFunctions.json': Permission denied
... x76 ...
fatal: Unable to checkout '...' in submodule path 'contracts'
```

Combining also **lets the CI fix verify itself**. #4932 changes only `.github/`, and the
workflow triggers on `paths: ['core/**']` — so it never runs there. This branch touches
`core/Cargo.lock` and `core/deny.toml`, so `Run VM benchmarks` does run, and a green result
here is direct evidence the chown fix works.

If you prefer these split, #4930 and #4932 remain open and this can be closed.

## Is this a breaking change?

- [ ] Yes
- [x] No — submodule fast-forward, lockfile/deny-config, and a CI-only workflow step.

## Operational changes

None.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated. (n/a — the CI fix is verified by
      `Run VM benchmarks` running on this PR.)
- [ ] Documentation comments have been added / updated. (n/a — rationale is inline in the
      workflow.)
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`. (`.github` is in
      `.prettierignore`; YAML validated by parsing and checking step order.)
