### PR TITLE
feat(zkstack_cli): a ZKsync OS validium posts through blobs, never no-DA

### DIFF
--- a/zkstack_cli/crates/zkstack/src/commands/chain/deploy_l2_contracts.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/deploy_l2_contracts.rs
@@ -20,6 +20,7 @@ use zkstack_cli_config::{
     ChainConfig, ContractsConfig, DAValidatorType, EcosystemConfig, ZkStackConfig,
     ZkStackConfigTrait,
 };
+use zkstack_cli_types::VMOption;
 use zksync_basic_types::commitment::L1BatchCommitmentMode;
 
 use crate::{
@@ -395,13 +396,21 @@ async fn get_da_validator_type(config: &ChainConfig) -> anyhow::Result<DAValidat
         .unwrap_or_default();
 
     match (
+        config.vm_option,
         config.l1_batch_commit_data_generator_mode,
         da_client_type.as_deref(),
     ) {
-        (L1BatchCommitmentMode::Rollup, _) => Ok(DAValidatorType::Rollup),
-        (L1BatchCommitmentMode::Validium, None | Some("NoDA")) => Ok(DAValidatorType::NoDA),
-        (L1BatchCommitmentMode::Validium, Some("Avail")) => Ok(DAValidatorType::Avail),
-        (L1BatchCommitmentMode::Validium, Some("Eigen")) => Ok(DAValidatorType::NoDA), // TODO: change to EigenDA for M1
+        (_, L1BatchCommitmentMode::Rollup, _) => Ok(DAValidatorType::Rollup),
+        // A ZKsync OS validium publishes its logs-only pubdata through blobs, so it
+        // registers with the rollup validator type — see `get_l1_da_validator`.
+        (VMOption::ZKSyncOsVM, L1BatchCommitmentMode::Validium, None | Some("NoDA")) => {
+            Ok(DAValidatorType::Rollup)
+        }
+        (VMOption::EraVM, L1BatchCommitmentMode::Validium, None | Some("NoDA")) => {
+            Ok(DAValidatorType::NoDA)
+        }
+        (_, L1BatchCommitmentMode::Validium, Some("Avail")) => Ok(DAValidatorType::Avail),
+        (_, L1BatchCommitmentMode::Validium, Some("Eigen")) => Ok(DAValidatorType::NoDA), // TODO: change to EigenDA for M1
         _ => anyhow::bail!("DAValidatorType is not supported"),
     }
 }

--- a/zkstack_cli/crates/zkstack/src/commands/chain/init/mod.rs
+++ b/zkstack_cli/crates/zkstack/src/commands/chain/init/mod.rs
@@ -267,10 +267,13 @@ pub async fn send_priority_txs(
                 chain_config.get_general_config().await?.da_client_type()
             };
 
-            match da_client_type.as_deref() {
-                Some("Avail") | Some("Eigen") => L2DACommitmentScheme::PubdataKeccak256,
-                Some("NoDA") | None => L2DACommitmentScheme::EmptyNoDA,
-                Some(unsupported) => {
+            match (chain_config.vm_option, da_client_type.as_deref()) {
+                // Pairs with the blobs DA validator picked in `get_l1_da_validator`; the
+                // committer rejects any batch whose scheme differs from the registered one.
+                (VMOption::ZKSyncOsVM, None | Some("NoDA")) => L2DACommitmentScheme::BlobsZksyncOS,
+                (_, Some("Avail") | Some("Eigen")) => L2DACommitmentScheme::PubdataKeccak256,
+                (VMOption::EraVM, None | Some("NoDA")) => L2DACommitmentScheme::EmptyNoDA,
+                (_, Some(unsupported)) => {
                     anyhow::bail!("DA client config is not supported: {unsupported:?}");
                 }
             }
@@ -350,11 +353,21 @@ pub(crate) async fn get_l1_da_validator(
                 chain_config.get_general_config().await?.da_client_type()
             };
 
-            match da_client_type.as_deref() {
-                Some("Avail") => contracts_config.l1.avail_l1_da_validator_addr,
-                Some("NoDA") | None => contracts_config.l1.no_da_validium_l1_validator_addr,
-                Some("Eigen") => contracts_config.l1.no_da_validium_l1_validator_addr, // TODO: change for eigenda l1 validator for M1
-                Some(unsupported) => {
+            match (chain_config.vm_option, da_client_type.as_deref()) {
+                // A ZKsync OS validium is a *logs-only* chain: it still publishes the
+                // mandatory L2->L1 log region — which carries the interop commitment tree
+                // leaves — through blobs, exactly like a rollup, and only drops the state
+                // diffs. Registering it against the no-DA validator would put those leaves
+                // out of L1's reach and silently break interop for the chain.
+                (VMOption::ZKSyncOsVM, None | Some("NoDA")) => {
+                    contracts_config.l1.blobs_zksync_os_l1_da_validator_addr
+                }
+                (_, Some("Avail")) => contracts_config.l1.avail_l1_da_validator_addr,
+                (VMOption::EraVM, None | Some("NoDA")) => {
+                    contracts_config.l1.no_da_validium_l1_validator_addr
+                }
+                (_, Some("Eigen")) => contracts_config.l1.no_da_validium_l1_validator_addr, // TODO: change for eigenda l1 validator for M1
+                (_, Some(unsupported)) => {
                     anyhow::bail!("DA client config is not supported: {unsupported:?}");
                 }
             }

--- a/zkstack_cli/crates/zkstack/src/messages.rs
+++ b/zkstack_cli/crates/zkstack/src/messages.rs
@@ -192,7 +192,9 @@ pub(super) const MSG_PROVER_MODE_HELP: &str = "Prover options";
 pub(super) const MSG_CHAIN_ID_HELP: &str = "Chain ID";
 pub(super) const MSG_WALLET_CREATION_HELP: &str = "Wallet options";
 pub(super) const MSG_WALLET_PATH_HELP: &str = "Wallet path";
-pub(super) const MSG_L1_COMMIT_DATA_GENERATOR_MODE_HELP: &str = "Commit data generation mode";
+pub(super) const MSG_L1_COMMIT_DATA_GENERATOR_MODE_HELP: &str =
+    "Commit data generation mode. On ZKsync OS a validium is logs-only: it still publishes the \
+     mandatory L2->L1 log region through blobs, and only drops the state diffs";
 pub(super) const MSG_BASE_TOKEN_ADDRESS_HELP: &str = "Base token address";
 pub(super) const MSG_BASE_TOKEN_PRICE_NOMINATOR_HELP: &str = "Base token nominator";
 pub(super) const MSG_BASE_TOKEN_PRICE_DENOMINATOR_HELP: &str = "Base token denominator";


### PR DESCRIPTION
Stops `zkstack chain create --zksync-os` + `validium` from producing a chain that publishes nothing to L1 — such a chain's interop commitment tree (IMT) leaves are unreachable from L1, so atomic interop silently breaks for it, with no error at creation time.

**How:** a ZKsync OS validium is a *logs-only* chain — it still publishes the mandatory L2→L1 log region through blobs and only drops the state diffs — so `get_l1_da_validator` and `get_da_validator_type` now pick the blobs validator and `BlobsZksyncOS` for it instead of the no-DA validator and `EmptyNoDA`, keeping validator and scheme in sync. EraVM validiums are untouched; an explicit `--validium-type avail`/`eigen` still wins.

Follow-up (needs matter-labs/era-contracts#2420 in the contracts submodule): also set `PubdataContent::LOGS_ONLY` at chain init, so the chain drops state diffs rather than paying blob costs for them.
