### PR TITLE
fix(eth_sender): read the chain-specific execution delay from ValidatorTimelock

### DIFF
--- a/core/lib/contracts/src/lib.rs
+++ b/core/lib/contracts/src/lib.rs
@@ -241,7 +241,10 @@ pub fn proof_manager_contract() -> Contract {
 }
 
 pub fn validator_timelock_contract() -> Contract {
-    // Create a simple contract definition for ValidatorTimelock with the executionDelay function
+    // Create a simple contract definition for ValidatorTimelock with the execution delay getters.
+    // `executionDelay` is the ecosystem-wide floor, while `getExecutionDelay` returns the delay
+    // that is actually enforced for a given chain: `max(executionDelay, chainExecutionDelay[chain])`.
+    // The latter is only present starting from v29 timelocks.
     let abi = r#"[
         {
             "inputs": [],
@@ -251,6 +254,25 @@ pub fn validator_timelock_contract() -> Contract {
                     "internalType": "uint256",
                     "name": "",
                     "type": "uint256"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_chainAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "getExecutionDelay",
+            "outputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "",
+                    "type": "uint32"
                 }
             ],
             "stateMutability": "view",

--- a/core/node/eth_sender/src/eth_tx_aggregator.rs
+++ b/core/node/eth_sender/src/eth_tx_aggregator.rs
@@ -74,7 +74,8 @@ pub struct MulticallData {
     pub stm_validator_timelock_address: Address,
     pub stm_protocol_version_id: ProtocolVersionId,
     pub da_validator_pair: DAValidatorPair,
-    /// Execution delay in seconds from the ValidatorTimelock contract
+    /// The execution delay enforced by the ValidatorTimelock contract for this chain, i.e. the
+    /// maximum of the ecosystem-wide delay and the chain-specific one
     pub execution_delay: Duration,
 }
 
@@ -368,7 +369,7 @@ impl EthTxAggregator {
             calldata: get_da_validator_pair_input,
         };
 
-        // Get execution delay from ValidatorTimelock contract
+        // Get the ecosystem-wide execution delay from the ValidatorTimelock contract
         let get_execution_delay_input = self
             .functions
             .validator_timelock_contract
@@ -380,6 +381,26 @@ impl EthTxAggregator {
             target: self.config_timelock_contract_address,
             allow_failure: true,
             calldata: get_execution_delay_input,
+        };
+
+        // Get the delay that is actually enforced for this chain in
+        // `ValidatorTimelock.executeBatchesSharedBridge`, i.e.
+        // `max(executionDelay, chainExecutionDelay[chain])`. A chain admin can raise its own delay
+        // above the ecosystem-wide one, in which case scheduling execute transactions based on
+        // `executionDelay` alone would make them revert with `TimeNotReached`.
+        let get_chain_execution_delay_input = self
+            .functions
+            .validator_timelock_contract
+            .function("getExecutionDelay")
+            .unwrap()
+            .encode_input(&[Token::Address(self.state_transition_chain_contract)])
+            .unwrap();
+        let get_chain_execution_delay_call = Multicall3Call {
+            target: self.config_timelock_contract_address,
+            // Note, that this call is allowed to fail, as the corresponding function is not present
+            // in the pre-v29 timelocks. In that case we fall back to the ecosystem-wide delay.
+            allow_failure: true,
+            calldata: get_chain_execution_delay_input,
         };
 
         let get_post_v29_upgradeable_validator_timelock_input = self
@@ -407,6 +428,7 @@ impl EthTxAggregator {
             get_stm_pre_v29_validator_timelock_call.into_token(),
             get_da_validator_pair_call.into_token(),
             get_execution_delay_call.into_token(),
+            get_chain_execution_delay_call.into_token(),
             get_post_v29_upgradeable_validator_timelock_call.into_token(),
         ];
 
@@ -443,8 +465,9 @@ impl EthTxAggregator {
         };
 
         if let Token::Array(call_results) = token {
-            let number_of_calls = if evm_emulator_hash_requested { 11 } else { 10 };
-            // 10 or 11 calls are aggregated in multicall (added execution delay call and post-v29 validator timelock call)
+            let number_of_calls = if evm_emulator_hash_requested { 12 } else { 11 };
+            // 11 or 12 calls are aggregated in multicall (added ecosystem-wide and chain-specific
+            // execution delay calls and post-v29 validator timelock call)
             if call_results.len() != number_of_calls {
                 return parse_error(&call_results);
             }
@@ -522,10 +545,20 @@ impl EthTxAggregator {
                 chain_protocol_version_id,
             )?;
 
-            let execution_delay = Self::parse_execution_delay(
+            let ecosystem_execution_delay = Self::parse_execution_delay(
                 call_results_iterator.next().unwrap(),
-                "execution delay",
+                "ecosystem-wide execution delay",
             )?;
+            let chain_execution_delay = Self::parse_execution_delay(
+                call_results_iterator.next().unwrap(),
+                "chain-specific execution delay",
+            )?;
+            // `getExecutionDelay` already returns the maximum of the two delays, but it is missing
+            // on pre-v29 timelocks; taking the maximum here keeps the ecosystem-wide value as a
+            // floor regardless of which of the two getters is available.
+            let execution_delay = chain_execution_delay
+                .unwrap_or_default()
+                .max(ecosystem_execution_delay.unwrap_or_default());
 
             let stm_validator_timelock_address =
                 if chain_protocol_version_id.is_pre_interop_fast_blocks() {
@@ -658,19 +691,24 @@ impl EthTxAggregator {
         Ok(pair)
     }
 
-    fn parse_execution_delay(data: Token, name: &'static str) -> Result<Duration, EthSenderError> {
+    /// Returns `None` if the getter call itself has failed, which is the case when it is not
+    /// present on the deployed timelock.
+    fn parse_execution_delay(
+        data: Token,
+        name: &'static str,
+    ) -> Result<Option<Duration>, EthSenderError> {
         let multicall_data = Multicall3Result::from_token(data)?;
 
         if !multicall_data.success {
             tracing::warn!(
-                "multicall3 {name} data is not of the len of 32: {:?}, returning zero delay",
+                "multicall3 {name} call has failed: {:?}, ignoring the returned delay",
                 multicall_data.return_data
             );
-            return Ok(Duration::ZERO);
+            return Ok(None);
         }
 
         let delay_seconds = U256::from_big_endian(&multicall_data.return_data);
-        Ok(Duration::from_secs(delay_seconds.as_u64()))
+        Ok(Some(Duration::from_secs(delay_seconds.as_u64())))
     }
 
     fn timelock_contract_address(

--- a/core/node/eth_sender/src/tests.rs
+++ b/core/node/eth_sender/src/tests.rs
@@ -109,6 +109,11 @@ pub(crate) fn mock_multicall_response(
         .function("executionDelay")
         .unwrap()
         .short_signature();
+    let chain_execution_delay_selector = functions
+        .validator_timelock_contract
+        .function("getExecutionDelay")
+        .unwrap()
+        .short_signature();
 
     let calls = tokens.into_iter().map(Multicall3Call::from_token);
     let response = calls.map(|call| {
@@ -167,6 +172,14 @@ pub(crate) fn mock_multicall_response(
             selector if selector == execution_delay_selector => {
                 // The target is config_timelock_contract_address which is a random address in tests
                 // Return a mock execution delay (e.g., 3600 seconds = 1 hour)
+                let execution_delay: u32 = 3600;
+                let mut result = vec![0u8; 32];
+                result[28..32].copy_from_slice(&execution_delay.to_be_bytes());
+                result
+            }
+            selector if selector == chain_execution_delay_selector => {
+                // The enforced per-chain delay: the same as the ecosystem-wide one, as no
+                // chain-specific delay is set in tests.
                 let execution_delay: u32 = 3600;
                 let mut result = vec![0u8; 32];
                 result[28..32].copy_from_slice(&execution_delay.to_be_bytes());
@@ -877,6 +890,70 @@ async fn parsing_multicall_data(with_evm_emulator: bool) {
     )
     .await;
 
+    // The chain raised its own delay above the ecosystem-wide one, so the chain-specific delay is
+    // the one that gets enforced.
+    let mock_response = mock_parsing_multicall_response(with_evm_emulator, Some(3600), Some(7200));
+
+    let parsed = tester
+        .aggregator
+        .parse_multicall_data(mock_response, with_evm_emulator)
+        .unwrap();
+    assert_eq!(
+        parsed.base_system_contracts_hashes.bootloader,
+        H256::repeat_byte(1)
+    );
+    assert_eq!(
+        parsed.base_system_contracts_hashes.default_aa,
+        H256::repeat_byte(2)
+    );
+    let expected_evm_emulator_hash = with_evm_emulator.then(|| H256::repeat_byte(3));
+    assert_eq!(
+        parsed.base_system_contracts_hashes.evm_emulator,
+        expected_evm_emulator_hash
+    );
+    assert_eq!(parsed.verifier_address, Address::repeat_byte(5));
+    assert_eq!(
+        parsed.chain_protocol_version_id,
+        ProtocolVersionId::latest()
+    );
+    assert_eq!(
+        parsed.stm_validator_timelock_address,
+        Address::repeat_byte(7)
+    );
+    assert_eq!(parsed.stm_protocol_version_id, ProtocolVersionId::latest());
+    assert_eq!(parsed.execution_delay, Duration::from_secs(7200));
+}
+
+/// A pre-v29 timelock has no `getExecutionDelay` getter, so the corresponding call fails and the
+/// ecosystem-wide delay must still be observed.
+#[test_casing(2, [false, true])]
+#[test_log::test(tokio::test)]
+async fn parsing_multicall_data_without_chain_execution_delay(with_evm_emulator: bool) {
+    let tester = EthSenderTester::new(
+        ConnectionPool::<Core>::test_pool().await,
+        vec![100; 100],
+        false,
+        true,
+        L1BatchCommitmentMode::Rollup,
+        SettlementLayer::L1(10.into()),
+    )
+    .await;
+
+    let mock_response = mock_parsing_multicall_response(with_evm_emulator, Some(3600), None);
+    let parsed = tester
+        .aggregator
+        .parse_multicall_data(mock_response, with_evm_emulator)
+        .unwrap();
+    assert_eq!(parsed.execution_delay, Duration::from_secs(3600));
+}
+
+/// Builds a mock multicall response with the provided execution delays. A `None` delay emulates a
+/// failed getter call.
+fn mock_parsing_multicall_response(
+    with_evm_emulator: bool,
+    ecosystem_delay_seconds: Option<u32>,
+    chain_delay_seconds: Option<u32>,
+) -> Token {
     let mut mock_response = vec![
         Token::Tuple(vec![Token::Bool(true), Token::Bytes(vec![1u8; 32])]),
         Token::Tuple(vec![Token::Bool(true), Token::Bytes(vec![2u8; 32])]),
@@ -911,16 +988,11 @@ async fn parsing_multicall_data(with_evm_emulator: bool) {
                 .concat(),
             ),
         ]),
-        // Execution delay response (3600 seconds = 0xe10, padded to 32 bytes)
-        Token::Tuple(vec![
-            Token::Bool(true),
-            Token::Bytes({
-                let execution_delay: u32 = 3600;
-                let mut result = vec![0u8; 32];
-                result[28..32].copy_from_slice(&execution_delay.to_be_bytes());
-                result
-            }),
-        ]),
+        // Ecosystem-wide execution delay response
+        execution_delay_response(ecosystem_delay_seconds),
+        // Chain-specific execution delay response; `None` emulates a pre-v29 timelock without
+        // the `getExecutionDelay` getter, for which the call is allowed to fail.
+        execution_delay_response(chain_delay_seconds),
         Token::Tuple(vec![Token::Bool(true), Token::Bytes(vec![7u8; 32])]),
     ];
     if with_evm_emulator {
@@ -929,36 +1001,18 @@ async fn parsing_multicall_data(with_evm_emulator: bool) {
             Token::Tuple(vec![Token::Bool(true), Token::Bytes(vec![3u8; 32])]),
         );
     }
-    let mock_response = Token::Array(mock_response);
+    Token::Array(mock_response)
+}
 
-    let parsed = tester
-        .aggregator
-        .parse_multicall_data(mock_response, with_evm_emulator)
-        .unwrap();
-    assert_eq!(
-        parsed.base_system_contracts_hashes.bootloader,
-        H256::repeat_byte(1)
-    );
-    assert_eq!(
-        parsed.base_system_contracts_hashes.default_aa,
-        H256::repeat_byte(2)
-    );
-    let expected_evm_emulator_hash = with_evm_emulator.then(|| H256::repeat_byte(3));
-    assert_eq!(
-        parsed.base_system_contracts_hashes.evm_emulator,
-        expected_evm_emulator_hash
-    );
-    assert_eq!(parsed.verifier_address, Address::repeat_byte(5));
-    assert_eq!(
-        parsed.chain_protocol_version_id,
-        ProtocolVersionId::latest()
-    );
-    assert_eq!(
-        parsed.stm_validator_timelock_address,
-        Address::repeat_byte(7)
-    );
-    assert_eq!(parsed.stm_protocol_version_id, ProtocolVersionId::latest());
-    assert_eq!(parsed.execution_delay, Duration::from_secs(3600));
+fn execution_delay_response(delay_seconds: Option<u32>) -> Token {
+    match delay_seconds {
+        Some(delay_seconds) => {
+            let mut result = vec![0u8; 32];
+            result[28..32].copy_from_slice(&delay_seconds.to_be_bytes());
+            Token::Tuple(vec![Token::Bool(true), Token::Bytes(result)])
+        }
+        None => Token::Tuple(vec![Token::Bool(false), Token::Bytes(vec![])]),
+    }
 }
 
 #[test_log::test(tokio::test)]


### PR DESCRIPTION
## What ❔

The eth_sender tx aggregator now reads the execution delay that `ValidatorTimelock` actually enforces for the chain, instead of only the ecosystem-wide one.

- Added `getExecutionDelay(address)` to the `ValidatorTimelock` ABI in `zksync_contracts`.
- The multicall in `EthTxAggregator` now queries `getExecutionDelay(chainAddress)` alongside the existing `executionDelay()`, and the effective delay is the maximum of the two. The new call is `allow_failure: true`, since the getter is not present on pre-v29 timelocks — in that case the ecosystem-wide delay is used as before.
- `parse_execution_delay` now returns `Option<Duration>` (`None` when the getter call itself failed) instead of silently collapsing a failed call into a zero delay, so the two values can be distinguished.
- Tests: the multicall mock answers the new selector; `parsing_multicall_data` asserts the chain-specific delay takes precedence over a lower ecosystem-wide one, and a new `parsing_multicall_data_without_chain_execution_delay` case covers the pre-v29 fallback.

## Why ❔

`ValidatorTimelock.executeBatchesSharedBridge` gates execution on `getExecutionDelay(chain)`, i.e. `max(executionDelay, chainExecutionDelay[chain])`, where a chain admin can raise its own chain's delay via `increaseChainExecutionDelay`. The node was reading only the ecosystem-wide `executionDelay()`, so a chain that raised its delay would have its operator schedule execute transactions too early, and those transactions would revert with `TimeNotReached` until the enforced delay elapsed.

This was raised as L-01 in the OpenZeppelin audit of chain-specific execution delays (matter-labs/era-contracts#2439), which flagged the missing server-side counterpart.

## Is this a breaking change?
- [ ] Yes
- [x] No

## Operational changes

None. The added multicall call is allowed to fail, so nodes talking to a timelock without `getExecutionDelay` keep the current behaviour. Chains that have not set a chain-specific delay see no change either, as `getExecutionDelay` then returns the ecosystem-wide value.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
